### PR TITLE
Добавил команду получения версии пакета

### DIFF
--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -28,6 +28,7 @@ namespace Clio
 			containerBuilder.RegisterType<RestoreNugetPackageCommand>();
 			containerBuilder.RegisterType<InstallNugetPackageCommand>();
 			containerBuilder.RegisterType<SetPackageVersionCommand>();
+			containerBuilder.RegisterType<GetPackageVersionCommand>();
 			containerBuilder.RegisterType<CheckNugetUpdateCommand>();
 			containerBuilder.RegisterType<DeletePackageCommand>();
 			return containerBuilder.Build();

--- a/clio/Command/PackageCommand/GetPackageVersionCommand.cs
+++ b/clio/Command/PackageCommand/GetPackageVersionCommand.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using Clio.Common;
+using Clio.Package;
+using CommandLine;
+
+namespace Clio.Command.PackageCommand
+{
+
+	#region Class: GetPackageVersionOptions
+
+	[Verb("get-pkg-version", Aliases = new string[] { "getpkgversion" }, HelpText = "Get package version")]
+	public class GetPackageVersionOptions
+	{
+		[Value(0, MetaName = "PackagePath", Required = true, HelpText = "Package path")]
+		public string PackagePath { get; set; }
+	}
+
+	#endregion
+
+	#region Class: GetPackageVersionCommand
+
+	public class GetPackageVersionCommand : Command<GetPackageVersionOptions>
+	{
+
+		#region Fields: Public
+
+		protected readonly IJsonConverter _jsonConverter;
+
+		#endregion
+
+		#region Constructors: Public
+
+		public GetPackageVersionCommand(IJsonConverter jsonConverter)
+		{
+			jsonConverter.CheckArgumentNull(nameof(jsonConverter));
+			_jsonConverter = jsonConverter;
+		}
+
+		#endregion
+
+		#region Methods: Public
+
+		public override int Execute(GetPackageVersionOptions options)
+		{
+			string packageDescriptorPath = Path.Combine(options.PackagePath, CreatioPackage.DescriptorName);
+			try
+			{
+				var dto = _jsonConverter.DeserializeObjectFromFile<PackageDescriptorDto>(packageDescriptorPath);
+				Console.WriteLine(dto.Descriptor.PackageVersion);
+			}
+			catch (FileNotFoundException)
+			{
+				throw new Exception($"Package descriptor not found by path: '{packageDescriptorPath}'");
+			}
+			return 0;
+		}
+
+		#endregion
+
+	}
+
+	#endregion
+
+}

--- a/clio/ParserExtensions.cs
+++ b/clio/ParserExtensions.cs
@@ -12,13 +12,13 @@ namespace Clio
 
 		#region Methods: Public
 
-		public static ParserResult<object> ParseArguments<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32>(
+		public static ParserResult<object> ParseArguments<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32, T33>(
 			this Parser parser,
 			IEnumerable<string> args)
 		{
 			if (parser == null)
 				throw new ArgumentNullException(nameof (parser));
-			return parser.ParseArguments(args, typeof (T1), typeof (T2), typeof (T3), typeof (T4), typeof (T5), typeof (T6), typeof (T7), typeof (T8), typeof (T9), typeof (T10), typeof (T11), typeof (T12), typeof (T13), typeof (T14), typeof (T15), typeof (T16), typeof (T17), typeof (T18), typeof (T19), typeof (T20), typeof (T21), typeof (T22), typeof (T23), typeof (T24), typeof (T25), typeof (T26), typeof (T27), typeof (T28), typeof (T29), typeof (T30), typeof (T31), typeof (T32));
+			return parser.ParseArguments(args, typeof (T1), typeof (T2), typeof (T3), typeof (T4), typeof (T5), typeof (T6), typeof (T7), typeof (T8), typeof (T9), typeof (T10), typeof (T11), typeof (T12), typeof (T13), typeof (T14), typeof (T15), typeof (T16), typeof (T17), typeof (T18), typeof (T19), typeof (T20), typeof (T21), typeof (T22), typeof (T23), typeof (T24), typeof (T25), typeof (T26), typeof (T27), typeof (T28), typeof (T29), typeof (T30), typeof (T31), typeof (T32), typeof(T33));
 		}
 
 		#endregion

--- a/clio/ParserResultExtensions.cs
+++ b/clio/ParserResultExtensions.cs
@@ -13,7 +13,7 @@ namespace Clio
 		#region Methods: Public
 
 		public static TResult MapResult<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
-			T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32, TResult>(
+			T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32, T33, TResult>(
 			this ParserResult<object> result,
 			Func<T1, TResult> parsedFunc1,
 			Func<T2, TResult> parsedFunc2,
@@ -47,6 +47,7 @@ namespace Clio
 			Func<T30, TResult> parsedFunc30,
 			Func<T31, TResult> parsedFunc31,
 			Func<T32, TResult> parsedFunc32,
+			Func<T33, TResult> parsedFunc33,
 			Func<IEnumerable<Error>, TResult> notParsedFunc)
 		{
 			if (!(result is Parsed<object> parsed))
@@ -115,6 +116,8 @@ namespace Clio
 				return parsedFunc31((T31) parsed.Value);
 			if (parsed.Value is T32)
 				return parsedFunc32((T32) parsed.Value);
+			if (parsed.Value is T33)
+				return parsedFunc33((T33)parsed.Value);
 			throw new InvalidOperationException();
 		}
 

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -209,7 +209,7 @@ namespace Clio
 					PullPkgOptions,	ExecuteSqlScriptOptions, InstallGateOptions, ItemOptions,
 					DeveloperModeOptions, SysSettingsOptions, FeatureOptions, UnzipPkgOptions, PingAppOptions,
 					OpenAppOptions, PkgListOptions, CompileOptions, PushNuGetPkgsOptions, PackNuGetPkgOptions,
-					RestoreNugetPkgOptions, InstallNugetPkgOptions, SetPackageVersionOptions, CheckNugetUpdateOptions>(args)
+					RestoreNugetPkgOptions, InstallNugetPkgOptions, SetPackageVersionOptions, GetPackageVersionOptions, CheckNugetUpdateOptions>(args)
 				.MapResult(
 					(ExecuteAssemblyOptions opts) => CreateRemoteCommand<AssemblyCommand>(opts).Execute(opts),
 					(RestartOptions opts) => CreateRemoteCommand<RestartCommand>(opts).Execute(opts),
@@ -247,6 +247,7 @@ namespace Clio
 					(RestoreNugetPkgOptions opts) => Resolve<RestoreNugetPackageCommand>(opts).Execute(opts),
 					(InstallNugetPkgOptions opts) => Resolve<InstallNugetPackageCommand>(opts).Execute(opts),
 					(SetPackageVersionOptions opts) => Resolve<SetPackageVersionCommand>().Execute(opts),
+					(GetPackageVersionOptions opts) => Resolve<GetPackageVersionCommand>().Execute(opts),
 					(CheckNugetUpdateOptions opts) => Resolve<CheckNugetUpdateCommand>(opts).Execute(opts),
 					errs => 1);
 		}


### PR DESCRIPTION
### Description
Get a specified package version from descriptor.json by specified package path.

### Synopsis
`clio get-pkg-version <PACKAGE PATH>`

### Short name
`getpkgversion`

### Options
| Option name           | Alias | Description                                     |
|-----------------------|-------|-------------------------------------------------|
| Package path (pos. 0) |       | Path of package folder                          |

### Examples
Get a specified package version from descriptor.json by specified package path.

`clio get-pkg-version C:/Packages/Base/`
