### PR TITLE
add supporting run clio with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+﻿clio/bin
+clio/obj
+install/Dockerfile

--- a/README.md
+++ b/README.md
@@ -3,7 +3,22 @@ Command Line Interface clio is the utility for integration Creatio platform with
 
 # Installation and features
 
-You can dowload release binaries from [latest release](https://github.com/Advance-Technologies-Foundation/clio/releases). Unpack the archive with clio.
+You can download release binaries from [latest release](https://github.com/Advance-Technologies-Foundation/clio/releases). Unpack the archive with clio.
+
+## Run with docker
+
+### Build
+
+```
+docker build -f ./install/Dockerfile -t clio .
+```
+
+### Run
+
+```
+docker run -it --rm clio help
+docker run -it --rm clio reg-web-app -help
+```
 
 # Content table
 - [Introduction](#introduction)

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,0 +1,19 @@
+﻿FROM mcr.microsoft.com/dotnet/aspnet:3.1 as base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /app
+
+COPY clio clio
+COPY clio.sln clio.sln
+
+WORKDIR /app/clio
+RUN dotnet publish -c Release -o /app/published
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/published .
+LABEL service=clio
+
+ENTRYPOINT ["dotnet", "/app/clio.dll"]


### PR DESCRIPTION
Example usage:
`docker build -f ./install/Dockerfile -t clio .`
`docker run -it --rm clio reg-web-app -help`

It makes sense to upload at release to upload to dockerhub. In order to make it easier to use, without installation.
For us to deploy global search to onsite, this would greatly simplify, since it will be possible to execute arbitrary scripts on the deployed application.