### PR TITLE
Add functionality to restart app after turning on FSM

### DIFF
--- a/clio/Command/TurnFsmCommand.cs
+++ b/clio/Command/TurnFsmCommand.cs
@@ -4,6 +4,8 @@ using CommandLine;
 
 namespace Clio.Command;
 
+using Clio.Common;
+
 [Verb("turn-fsm", Aliases = new[] {"tfsm", "fsm"}, HelpText = "Turn file system mode on or off for an environment")]
 public class TurnFsmCommandOptions : SetFsmConfigOptions
 { }
@@ -16,6 +18,8 @@ public class TurnFsmCommand : Command<TurnFsmCommandOptions>
 	private readonly SetFsmConfigCommand _setFsmConfigCommand;
 	private readonly LoadPackagesToFileSystemCommand _loadPackagesToFileSystemCommand;
 	private readonly LoadPackagesToDbCommand _loadPackagesToDbCommand;
+	private readonly IApplicationClient _applicationClient;
+	private readonly EnvironmentSettings _environmentSettings;
 
 	#endregion
 
@@ -23,10 +27,12 @@ public class TurnFsmCommand : Command<TurnFsmCommandOptions>
 
 	public TurnFsmCommand(SetFsmConfigCommand setFsmConfigCommand,
 		LoadPackagesToFileSystemCommand loadPackagesToFileSystemCommand,
-		LoadPackagesToDbCommand loadPackagesToDbCommand){
+		LoadPackagesToDbCommand loadPackagesToDbCommand, IApplicationClient applicationClient, EnvironmentSettings environmentSettings){
 		_setFsmConfigCommand = setFsmConfigCommand;
 		_loadPackagesToFileSystemCommand = loadPackagesToFileSystemCommand;
 		_loadPackagesToDbCommand = loadPackagesToDbCommand;
+		_applicationClient = applicationClient;
+		_environmentSettings = environmentSettings;
 	}
 
 	#endregion
@@ -37,6 +43,23 @@ public class TurnFsmCommand : Command<TurnFsmCommandOptions>
 		if (options.IsFsm == "on") {
 			if (_setFsmConfigCommand.Execute(options) == 0) {
 				Thread.Sleep(TimeSpan.FromSeconds(3));
+				
+				options.IsNetCore = _environmentSettings.IsNetCore;
+				if(options.IsNetCore == true) {
+					//restart app
+					
+					var opt = new RestartOptions
+					{
+						EnvironmentName = options.Environment,
+						Uri = options.Uri,
+						Login = options.Login,
+						Password = options.Password,
+						IsNetCore = options.IsNetCore
+					};
+					var restartCommand = new RestartCommand(_applicationClient, _environmentSettings);
+					restartCommand.Execute(opt);
+					_applicationClient.Login();
+				}
 				return _loadPackagesToFileSystemCommand.Execute(options);
 			}
 		} else {


### PR DESCRIPTION
This update revolves around the TurnFsmCommand in the clio Command namespace. Two new variables were added: IApplicationClient and EnvironmentSettings. The primary change is the addition of a check if .NetCore is turned on, and if so, the app is restarted after the file system mode (FSM) has been turned on.