### PR TITLE
Refactor ServiceUrlBuilder to use KnownRoute enum

### DIFF
--- a/clio.tests/Common/ServiceUrlBuilder.cs
+++ b/clio.tests/Common/ServiceUrlBuilder.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using Clio.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[Author("Kirill Krylov", "k.krylov@creatio.com")]
+[Category("UnitTests")]
+[TestFixture]
+internal class ServiceUrlBuilderCommandTests
+{
+
+	#region Properties: Public
+
+	public static IEnumerable<TestCaseData> TestCases {
+		get {
+			yield return new TestCaseData(false, "http://localhost", "somepath1", "http://localhost/0/somepath1");
+			yield return new TestCaseData(true, "http://localhost", "somepath1", "http://localhost/somepath1");
+
+			yield return new TestCaseData(false, "http://localhost/", "somepath1", "http://localhost/0/somepath1");
+			yield return new TestCaseData(true, "http://localhost/", "somepath1", "http://localhost/somepath1");
+
+			yield return new TestCaseData(false, "http://localhost:81", "somepath1", "http://localhost:81/0/somepath1");
+			yield return new TestCaseData(true, "http://localhost:81", "somepath1", "http://localhost:81/somepath1");
+
+			yield return new TestCaseData(false, "http://localhost:81/sub", "somepath1",
+				"http://localhost:81/sub/0/somepath1");
+			yield return new TestCaseData(true, "http://localhost:81/sub", "somepath1",
+				"http://localhost:81/sub/somepath1");
+
+			yield return new TestCaseData(false, "https://localhost", "somepath1", "https://localhost/0/somepath1");
+			yield return new TestCaseData(true, "https://localhost", "somepath1", "https://localhost/somepath1");
+
+			yield return new TestCaseData(false, "https://localhost/", "somepath1", "https://localhost/0/somepath1");
+			yield return new TestCaseData(true, "https://localhost/", "somepath1", "https://localhost/somepath1");
+
+			yield return new TestCaseData(false, "https://localhost:81", "somepath1",
+				"https://localhost:81/0/somepath1");
+			yield return new TestCaseData(true, "https://localhost:81", "somepath1", "https://localhost:81/somepath1");
+
+			yield return new TestCaseData(false, "https://localhost:81/sub", "somepath1",
+				"https://localhost:81/sub/0/somepath1");
+			yield return new TestCaseData(true, "https://localhost:81/sub", "somepath1",
+				"https://localhost:81/sub/somepath1");
+		}
+	}
+
+	public static IEnumerable<TestCaseDataWithEnvSetting> TestCasesWithEnvSettings {
+		get {
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost"}, "http://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost"}, "http://localhost/somepath1");
+
+			
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost"}, "http://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost"}, "http://localhost/somepath1");
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost/"}, "http://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost/"}, "http://localhost/somepath1");
+			
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost/"}, "http://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost/"}, "http://localhost/somepath1");
+			
+			
+			
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/"},
+				"http://localhost:81/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/"},
+				"http://localhost:81/somepath1");
+			
+			
+			
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/"},
+				"http://localhost:81/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/"},
+				"http://localhost:81/somepath1");
+			
+			
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/somepath1");
+			
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/somepath1");
+			
+			
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/sub/"},
+				"http://localhost:81/sub/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("/somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/sub/"},
+				"http://localhost:81/sub/somepath1");
+			
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "https://localhost"},
+				"https://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "https://localhost"}, "https://localhost/somepath1");
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "https://localhost/"},
+				"https://localhost/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "https://localhost/"}, "https://localhost/somepath1");
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "https://localhost:81/"},
+				"https://localhost:81/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "https://localhost:81/"},
+				"https://localhost:81/somepath1");
+
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/0/somepath1");
+			yield return new TestCaseDataWithEnvSetting("somepath1",
+				new EnvironmentSettings {IsNetCore = true, Uri = "http://localhost:81/sub"},
+				"http://localhost:81/sub/somepath1");
+		}
+	}
+
+	public static IEnumerable<TestCaseDataWithEnvSettingAndKnownRoutes> TestCasesWithEnvSettingsAndKnownRoutes {
+		get {
+			yield return new TestCaseDataWithEnvSettingAndKnownRoutes(
+				ServiceUrlBuilder.KnownRoute.RestoreFromPackageBackup,
+				new EnvironmentSettings {IsNetCore = false, Uri = "http://localhost"},
+				"http://localhost/0/ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup");
+		}
+	}
+
+	public static IEnumerable<TestCaseDataWithKnownRoutes> TestCasesWithKnownRoute {
+		get {
+			yield return new TestCaseDataWithKnownRoutes(false, "http://localhost",
+				ServiceUrlBuilder.KnownRoute.RestoreFromPackageBackup,
+				"http://localhost/0/ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup");
+			yield return new TestCaseDataWithKnownRoutes(true, "http://localhost",
+				ServiceUrlBuilder.KnownRoute.RestoreFromPackageBackup,
+				"http://localhost/ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup");
+
+			yield return new TestCaseDataWithKnownRoutes(false, "http://localhost/",
+				ServiceUrlBuilder.KnownRoute.RestoreFromPackageBackup,
+				"http://localhost/0/ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup");
+			yield return new TestCaseDataWithKnownRoutes(true, "http://localhost/",
+				ServiceUrlBuilder.KnownRoute.RestoreFromPackageBackup,
+				"http://localhost/ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup");
+		}
+	}
+
+	#endregion
+
+	#region Methods: Public
+
+	[TestCaseSource(nameof(TestCases))]
+	public void Build_Returns_CorrectUrl(TestCaseData testCaseData){
+		//Arrange
+		EnvironmentSettings environmentSettingsMock = new() {
+			Uri = testCaseData.Uri,
+			IsNetCore = testCaseData.IsNetCore
+		};
+		ServiceUrlBuilder sut = new(environmentSettingsMock);
+
+		//Act
+		string actual = sut.Build(testCaseData.Route);
+
+		//Assert
+		actual.Should().Be(testCaseData.ExpectedUrl);
+	}
+
+	[TestCase("")]
+	[TestCase("Fdgbzdf")]
+	public void Build_Throws_When_Invalid_Url(string url){
+		EnvironmentSettings environmentSettingsMock = new() {
+			Uri = url
+		};
+		ServiceUrlBuilder sut = new(environmentSettingsMock);
+
+		//Act
+		Action act = () => sut.Build("");
+
+		//Assert
+
+		act.Should().Throw<ArgumentException>().WithMessage("Misconfigured Url, check settings and try again *");
+	}
+
+	[TestCaseSource(nameof(TestCasesWithEnvSettings))]
+	public void BuildWithEnvs_Returns_CorrectUrl(TestCaseDataWithEnvSetting testCaseData){
+		//Arrange
+		EnvironmentSettings environmentSettingsMock = new() {
+			Uri = testCaseData.EnvironmentSettings.Uri,
+			IsNetCore = testCaseData.EnvironmentSettings.IsNetCore
+		};
+		ServiceUrlBuilder sut = new(new EnvironmentSettings());
+
+		//Act
+
+		string actual = sut.Build(testCaseData.Route, environmentSettingsMock);
+
+		//Assert
+		actual.Should().Be(testCaseData.ExpectedUrl);
+	}
+
+	[TestCaseSource(nameof(TestCasesWithEnvSettingsAndKnownRoutes))]
+	public void BuildWithEnvsAndKnownRoute_Returns_CorrectUrl(TestCaseDataWithEnvSettingAndKnownRoutes testCaseData){
+		//Arrange
+		EnvironmentSettings environmentSettingsMock = new() {
+			Uri = testCaseData.EnvironmentSettings.Uri,
+			IsNetCore = testCaseData.EnvironmentSettings.IsNetCore
+		};
+		ServiceUrlBuilder sut = new(new EnvironmentSettings());
+
+		//Act
+
+		string actual = sut.Build(testCaseData.KnownRoute, environmentSettingsMock);
+
+		//Assert
+		actual.Should().Be(testCaseData.ExpectedUrl);
+	}
+
+	[TestCaseSource(nameof(TestCasesWithKnownRoute))]
+	public void BuildWithKnownRoute_Returns_CorrectUrl(TestCaseDataWithKnownRoutes testCaseData){
+		//Arrange
+		EnvironmentSettings environmentSettingsMock = new() {
+			Uri = testCaseData.Uri,
+			IsNetCore = testCaseData.IsNetCore
+		};
+		ServiceUrlBuilder sut = new(environmentSettingsMock);
+
+		//Act
+		string actual = sut.Build(testCaseData.KnownRoute);
+
+		//Assert
+		actual.Should().Be(testCaseData.ExpectedUrl);
+	}
+
+	
+	[Test]
+	public void AllEnumsHaveRoutes(){
+		ServiceUrlBuilder sut = new (new EnvironmentSettings());
+		foreach(ServiceUrlBuilder.KnownRoute route in Enum.GetValues<ServiceUrlBuilder.KnownRoute>()) {
+			sut.KnownRoutes[route].Should().NotBeNullOrWhiteSpace();
+		}
+	}
+	
+	#endregion
+
+	public record TestCaseData(bool IsNetCore, string Uri, string Route, string ExpectedUrl);
+
+	public record TestCaseDataWithKnownRoutes(bool IsNetCore, string Uri, ServiceUrlBuilder.KnownRoute KnownRoute,
+		string ExpectedUrl);
+
+	public record TestCaseDataWithEnvSetting(string Route, EnvironmentSettings EnvironmentSettings, string ExpectedUrl);
+
+	public record TestCaseDataWithEnvSettingAndKnownRoutes(ServiceUrlBuilder.KnownRoute KnownRoute,
+		EnvironmentSettings EnvironmentSettings, string ExpectedUrl);
+
+}

--- a/clio/Common/IServiceUrlBuilder.cs
+++ b/clio/Common/IServiceUrlBuilder.cs
@@ -1,20 +1,18 @@
-﻿namespace Clio.Common
+﻿namespace Clio.Common;
+
+public interface IServiceUrlBuilder
 {
-	public interface IServiceUrlBuilder
-	{
 
-		#region Properties: Public
+	#region Methods: Public
 
-		public string RootPath { get; }
+	string Build(string serviceEndpoint);
 
-		#endregion
+	string Build(ServiceUrlBuilder.KnownRoute knownRoute);
 
-		#region Methods: Public
+	string Build(string serviceEndpoint, EnvironmentSettings environmentSettings);
 
-		string Build(string serviceEndpoint);
-		string Build(string serviceEndpoint, EnvironmentSettings environmentSettings);
+	string Build(ServiceUrlBuilder.KnownRoute knownRoute, EnvironmentSettings environmentSettings);
 
-		#endregion
+	#endregion
 
-	}
 }

--- a/clio/Common/ServiceUrlBuilder.cs
+++ b/clio/Common/ServiceUrlBuilder.cs
@@ -1,60 +1,147 @@
-﻿namespace Clio.Common
+﻿using System;
+using System.Collections.Generic;
+
+namespace Clio.Common;
+
+#region Class: ServiceUrlBuilder
+
+public class ServiceUrlBuilder : IServiceUrlBuilder
 {
 
-	#region Class: ServiceUrlBuilder
+	#region Enum: Public
 
-	public class ServiceUrlBuilder : IServiceUrlBuilder
+	public enum KnownRoute
 	{
 
-		#region Fields: Private
+		/// <summary>
+		///     DataService Select Query
+		/// </summary>
+		Select = 1,
 
-		private readonly EnvironmentSettings _environmentSettings;
+		/// <summary>
+		///     DataService Insert Query
+		/// </summary>
+		Insert = 2,
 
-		#endregion
+		/// <summary>
+		///     DataService Update Query
+		/// </summary>
+		Update = 3,
 
+		/// <summary>
+		///     DataService Delete Query
+		/// </summary>
+		Delete = 4,
+		
+		
+		GetBusinessRules = 5,
 
-		#region Constructors: Public
+		/// <summary>
+		///     Start Business Process
+		/// </summary>
+		RunProcess = 6,
 
-		public ServiceUrlBuilder(EnvironmentSettings environmentSettings) {
-			environmentSettings.CheckArgumentNull(nameof(environmentSettings));
-			_environmentSettings = environmentSettings;
-		}
-
-		#endregion
-
-		#region Methods: Private
-
-		private string GetRootPath(EnvironmentSettings environmentSettings) => environmentSettings.IsNetCore
-			? environmentSettings.Uri
-			: $@"{environmentSettings.Uri}/0";
-
-		#endregion
-
-		#region Properties: Public
-
-		public string RootPath => GetRootPath(_environmentSettings);
-
-		#endregion
-
-		#region Methods: Private
-
-		private string Normalize(string serviceEndpoint) =>
-			serviceEndpoint.StartsWith('/')
-				? serviceEndpoint
-				: $"/{serviceEndpoint}";
-
-		#endregion
-
-		#region Methods: Public
-
-		public string Build(string serviceEndpoint) => $"{RootPath}{Normalize(serviceEndpoint.Replace(RootPath, string.Empty))}";
-		public string Build(string serviceEndpoint, EnvironmentSettings environmentSettings) =>
-			$"{GetRootPath(environmentSettings)}{serviceEndpoint.Replace(GetRootPath(environmentSettings), string.Empty)}";
-
-		#endregion
+		/// <summary>
+		///     Completes or continues business process
+		/// </summary>
+		CompleteExecuting = 7,
+		
+		/// <summary>
+		/// Restores configuration from backup
+		/// </summary>
+		RestoreFromPackageBackup = 8,
+		GetZipPackage = 9,
+		BuildPackage = 10,
+		RebuildPackage = 11,
+		Compile = 12,
+		CompileAll = 13,
 
 	}
 
 	#endregion
 
+	#region Constants: Private
+
+	private const string WebAppAlias = "0/";
+
+	#endregion
+
+	#region Fields: Private
+
+	internal readonly IReadOnlyDictionary<KnownRoute, string> KnownRoutes = new Dictionary<KnownRoute, string> {
+		{KnownRoute.Select, "DataService/json/SyncReply/SelectQuery"},
+		{KnownRoute.Insert, "DataService/json/SyncReply/InsertQuery"},
+		{KnownRoute.Update, "DataService/json/SyncReply/UpdateQuery"},
+		{KnownRoute.Delete, "DataService/json/SyncReply/DeleteQuery"},
+		{KnownRoute.GetBusinessRules, "ServiceModel/BusinessRulesManagerService.svc/GetBusinessRules"},
+		{KnownRoute.RunProcess, "ServiceModel/ProcessEngineService.svc/RunProcess"},
+		{KnownRoute.CompleteExecuting, "ServiceModel/ProcessEngineService.svc/CompleteExecuting"},
+		{KnownRoute.RestoreFromPackageBackup, "ServiceModel/PackageInstallerService.svc/RestoreFromPackageBackup"},
+		{KnownRoute.GetZipPackage, "ServiceModel/PackageInstallerService.svc/GetZipPackages"},
+		{KnownRoute.BuildPackage, "ServiceModel/WorkspaceExplorerService.svc/BuildPackage"},
+		{KnownRoute.RebuildPackage, "ServiceModel/WorkspaceExplorerService.svc/RebuildPackage"},
+		{KnownRoute.Compile, "ServiceModel/WorkspaceExplorerService.svc/Build"},
+		{KnownRoute.CompileAll, "ServiceModel/WorkspaceExplorerService.svc/Rebuild"},
+	};
+
+	private EnvironmentSettings _environmentSettings;
+
+	#endregion
+
+	#region Constructors: Public
+
+	public ServiceUrlBuilder(EnvironmentSettings environmentSettings){
+		environmentSettings.CheckArgumentNull(nameof(environmentSettings));
+		_environmentSettings = environmentSettings;
+	}
+
+	#endregion
+
+	#region Methods: Private
+
+	private string CreateUrl(string route){
+		bool isBase = Uri.TryCreate(_environmentSettings.Uri, UriKind.Absolute, out Uri baseUri);
+		if (!isBase) {
+			throw new ArgumentException("Misconfigured Url, check settings and try again ", nameof(_environmentSettings.Uri));
+		}
+		
+		return baseUri switch {
+			_ when baseUri.ToString().EndsWith('/') && route.StartsWith('/') =>$"{baseUri}{route[1..]}",
+			_ when (baseUri.ToString().EndsWith('/') && !route.StartsWith('/')) 
+				|| (!baseUri.ToString().EndsWith('/') && route.StartsWith('/')) 
+				=> $"{baseUri}{route}",
+			_ => $"{baseUri}/{route}"
+		};
+	}
+
+	#endregion
+
+	#region Methods: Public
+
+	public string Build(string serviceEndpoint){
+		return _environmentSettings.IsNetCore switch {
+			true => CreateUrl(serviceEndpoint),
+			false => CreateUrl(
+				$"{WebAppAlias}{(serviceEndpoint.StartsWith('/') ? serviceEndpoint[1..] : serviceEndpoint)}")
+		};
+	}
+
+	public string Build(KnownRoute knownRoute) => Build(KnownRoutes[knownRoute]);
+
+	public string Build(string serviceEndpoint, EnvironmentSettings environmentSettings){
+		_environmentSettings = environmentSettings;
+		return _environmentSettings.IsNetCore switch {
+			true => CreateUrl(serviceEndpoint),
+			false => CreateUrl(
+				$"{WebAppAlias}{(serviceEndpoint.StartsWith('/') ? serviceEndpoint[1..] : serviceEndpoint)}")
+		};
+	}
+
+	public string Build(KnownRoute knownRoute, EnvironmentSettings environmentSettings) =>
+		Build(KnownRoutes[knownRoute], environmentSettings);
+
+	#endregion
+
 }
+
+#endregion

--- a/clio/Package/PackageBuilder.cs
+++ b/clio/Package/PackageBuilder.cs
@@ -24,14 +24,7 @@ namespace Clio.Package
 
 	public class PackageBuilder : IPackageBuilder
 	{
-
-		#region Constants: Private
-
-		private static string BuildPackageUrl = @"/ServiceModel/WorkspaceExplorerService.svc/BuildPackage";
-		private static string RebuildPackageUrl = @"/ServiceModel/WorkspaceExplorerService.svc/RebuildPackage";
-
-		#endregion
-
+		
 		#region Fields: Private
 
 		private readonly EnvironmentSettings _environmentSettings;
@@ -44,7 +37,7 @@ namespace Clio.Package
 		#region Constructors: Public
 
 		public PackageBuilder(EnvironmentSettings environmentSettings,
-			IApplicationClientFactory applicationClientFactory, IServiceUrlBuilder serviceUrlBuilder, ILogger logger) {
+			IApplicationClientFactory applicationClientFactory, IServiceUrlBuilder serviceUrlBuilder, ILogger logger){
 			environmentSettings.CheckArgumentNull(nameof(environmentSettings));
 			applicationClientFactory.CheckArgumentNull(nameof(applicationClientFactory));
 			serviceUrlBuilder.CheckArgumentNull(nameof(serviceUrlBuilder));
@@ -54,25 +47,28 @@ namespace Clio.Package
 			_serviceUrlBuilder = serviceUrlBuilder;
 			_logger = logger;
 		}
+
 		#endregion
 
 		#region Methods: Private
 
-		private static string CreateRequestData(string packageName) =>
-			"{ \"packageName\":\"" + packageName + "\" }";
+		private static string CreateRequestData(string packageName) => "{ \"packageName\":\"" + packageName + "\" }";
 
-		private IApplicationClient CreateClient() =>
-			_applicationClientFactory.CreateClient(_environmentSettings);
+		private IApplicationClient CreateClient() => _applicationClientFactory.CreateClient(_environmentSettings);
 
-		private string GetSafePackageName(string packageName) => packageName
-			.Replace(" ", string.Empty)
-			.Replace(",", "\",\"");
+		private string GetSafePackageName(string packageName) =>
+			packageName
+				.Replace(" ", string.Empty)
+				.Replace(",", "\",\"");
 
-		private void Compilation(IEnumerable<string> packagesNames, bool force) {
+		private void Compilation(IEnumerable<string> packagesNames, bool force){
 			IApplicationClient applicationClient = CreateClient();
-			string compilationUrl = force ? RebuildPackageUrl : BuildPackageUrl;
 			string compilationName = force ? "rebuild" : "build";
-			string fullBuildPackageUrl = _serviceUrlBuilder.Build(compilationUrl);
+			string fullBuildPackageUrl = _serviceUrlBuilder.Build(
+				force
+				? ServiceUrlBuilder.KnownRoute.RebuildPackage 
+				: ServiceUrlBuilder.KnownRoute.BuildPackage);
+
 			foreach (string packageName in packagesNames) {
 				string safePackageName = GetSafePackageName(packageName);
 				_logger.WriteLine($"Start {compilationName} packages ({safePackageName}).");
@@ -86,16 +82,13 @@ namespace Clio.Package
 
 		#region Methods: Public
 
-		public void Build(IEnumerable<string> packagesNames) =>
-			Compilation(packagesNames, false);
+		public void Build(IEnumerable<string> packagesNames) => Compilation(packagesNames, false);
 
-		public void Rebuild(IEnumerable<string> packagesNames) =>
-			Compilation(packagesNames, true);
+		public void Rebuild(IEnumerable<string> packagesNames) => Compilation(packagesNames, true);
 
 		#endregion
 
 	}
 
 	#endregion
-
 }

--- a/clio/Package/PackageDownloader.cs
+++ b/clio/Package/PackageDownloader.cs
@@ -12,12 +12,7 @@ namespace Clio.Package
 
 	public class PackageDownloader : IPackageDownloader
 	{
-
-		#region Constants: Private
-
-		private static string GetZipPackageUrl = @"/ServiceModel/PackageInstallerService.svc/GetZipPackages";
-
-		#endregion
+		
 
 		#region Fields: Private
 
@@ -65,8 +60,8 @@ namespace Clio.Package
 
 		#region Methods: Private
 
-		private string GetCompleteUrl(string url, EnvironmentSettings environmentSettings) =>
-			_serviceUrlBuilder.Build(url, environmentSettings);
+		private string GetCompleteUrl(ServiceUrlBuilder.KnownRoute knownRoute, EnvironmentSettings environmentSettings) =>
+			_serviceUrlBuilder.Build(knownRoute, environmentSettings);
 
 		private IApplicationClient CreateApplicationClient(EnvironmentSettings environmentSettings) =>
 			_applicationClientFactory.CreateClient(environmentSettings);
@@ -88,7 +83,7 @@ namespace Clio.Package
 				string requestData = $"[\"{safePackageName}\"]";
 				string packageZipPath = GetPackageZipPath(packageName, destinationPath);
 				IApplicationClient applicationClient = CreateApplicationClient(environmentSettings);
-				string url = GetCompleteUrl(GetZipPackageUrl, environmentSettings);
+				string url = GetCompleteUrl(ServiceUrlBuilder.KnownRoute.GetZipPackage, environmentSettings);
 				applicationClient.DownloadFile(url, packageZipPath, requestData);
 				_logger.WriteLine($"Download packages ({safePackageName}) completed.");
 			} catch (Exception) {


### PR DESCRIPTION
Refactored the ServiceUrlBuilder class to make use of a KnownRoute enum for defining URL paths. Also removed some unnecessary constants having URLs from various classes such as PackageBuilder and PackageDownloader and made them use the ServiceUrlBuilder's KnownRoute enum instead. This helps consolidate the URL path definitions within ServiceUrlBuilder, simplifying their usage and maintenance.