### PR TITLE
fix docker build error: error NETSDK1152: Found multiple publish outp…

### DIFF
--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -26,6 +26,7 @@
 	  <CodeAnalysisRuleSet>clio.ruleset</CodeAnalysisRuleSet>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <LangVersion>11</LangVersion>
+          <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 	</PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
…ut files with the same relative path

https://github.com/dotnet/sdk/issues/22716

71.16 /usr/share/dotnet/sdk/8.0.204/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ConflictResolution.targets(112,5): error NETSDK1152: Found multiple publish output files with the same relative path: /app/clio/clio, /app/clio/obj/Release/net6.0/apphost. [/app/clio/clio.csproj]