### PR TITLE
Timeout option

### DIFF
--- a/clio.tests/Command/ApplicationCommand/CompileConfigurationOptionsTestFixture.cs
+++ b/clio.tests/Command/ApplicationCommand/CompileConfigurationOptionsTestFixture.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using Clio.Command;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.ApplicationCommand;
+
+[TestFixture]
+public class CompileConfigurationOptionsTestFixture {
+
+	[Test]
+	public void CanSetTimeout(){
+		//Arrange
+		RemoteCommandOptions options = new() {
+			TimeOut = 50
+		};
+
+		//Assert
+		options.TimeOut.Should().Be(50);
+	}
+
+	[Test]
+	public void DefaultTimeout_ShouldBe_Infinite(){
+		//Arrange
+		CompileConfigurationOptions options = new();
+
+		//Assert
+		options.TimeOut.Should().Be(Timeout.Infinite);
+	}
+
+	[Test]
+	public void DefaultTimeoutInReomoe_ShouldBe_100K(){
+		//Arrange
+		RemoteCommandOptions options = new();
+
+		//Assert
+		options.TimeOut.Should().Be(100_000);
+	}
+
+}

--- a/clio.tests/Command/ApplicationCommand/CompileConfigurationOptionsTestFixture.cs
+++ b/clio.tests/Command/ApplicationCommand/CompileConfigurationOptionsTestFixture.cs
@@ -37,4 +37,13 @@ public class CompileConfigurationOptionsTestFixture {
 		options.TimeOut.Should().Be(100_000);
 	}
 
+	
+	[Test]
+	public void RestartOPtions(){
+		//Arrange
+		RestartOptions options = new();
+
+		//Assert
+		options.TimeOut.Should().Be(100_000);
+	}
 }

--- a/clio.tests/Command/RedisCommand.Tests.cs
+++ b/clio.tests/Command/RedisCommand.Tests.cs
@@ -18,7 +18,7 @@
 				IsNetCore = false
 			};
 			RedisCommand redisCommand = new RedisCommand(applicationClient, settings);
-			var clearRedisOptions = Substitute.For<ClearRedisOptions>();
+			ClearRedisOptions clearRedisOptions = new();
 
 			//Act
 			redisCommand.Execute(clearRedisOptions);
@@ -39,7 +39,7 @@
 				IsNetCore = true
 			};
 			RedisCommand redisCommand = new RedisCommand(applicationClient, settings);
-			var clearRedisOptions = Substitute.For<ClearRedisOptions>();
+			ClearRedisOptions clearRedisOptions = new();
 
 			//Act
 			redisCommand.Execute(clearRedisOptions);

--- a/clio.tests/Command/RestartCommand.Tests.cs
+++ b/clio.tests/Command/RestartCommand.Tests.cs
@@ -20,7 +20,7 @@
 				Uri = "http://test.domain.com"
 			};
 			RestartCommand restartCommand = new RestartCommand(applicationClient, environmentSettings);
-			var options = Substitute.For<RestartOptions>();
+			RestartOptions options = new();
 
 			//Act
 			restartCommand.Execute(options);
@@ -44,7 +44,7 @@
 				Uri = "http://test.domain.com"
 			};
 			RestartCommand restartCommand = new RestartCommand(applicationClient, environmentSettings);
-			var options = Substitute.For<RestartOptions>();
+			RestartOptions options = new();
 
 			//Act
 			restartCommand.Execute(options);

--- a/clio/Command/CompileConfigurationCommand.cs
+++ b/clio/Command/CompileConfigurationCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Clio.Common;
 using CommandLine;
 
@@ -15,7 +16,8 @@ namespace Clio.Command
 		public bool All {
 			get; set;
 		}
-
+		protected override int DefaultTimeout => Timeout.Infinite;
+		
 	}
 
 	#endregion

--- a/clio/Command/RemoteCommand.cs
+++ b/clio/Command/RemoteCommand.cs
@@ -4,12 +4,23 @@ using System.Net.Http;
 using System.Reflection;
 using Clio.Common;
 using CommandLine;
+using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace Clio.Command;
 
 public class RemoteCommandOptions : EnvironmentOptions
 {
-	public int TimeOut { get; internal set; } = 100_000;
+
+	private int? _timeOut;
+	protected virtual int DefaultTimeout { get; set; } = 100_000;
+	
+
+	[Option("timeout", Required = false, HelpText = "Request timeout in milliseconds", Default = 100_000)]
+	public int TimeOut {
+		get => _timeOut ?? DefaultTimeout;
+		internal set => _timeOut = value;
+	}
+
 	public int RetryCount { get; internal set; } = 3;
 	public int RetryDelay { get; internal set; } = 1;
 


### PR DESCRIPTION
- Intoduced timeout infinite as default value for Compile-comfiguration command.
- add `--timeout` option for all remote commands.