### PR TITLE
Add command to retrieve the last compilation log

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,13 @@ for compile all
 ```bash
 clio compile-configuration --all
 ```
+
+Get last compilation log
+
+```bash
+clio last-compilation-log -e <ENVIRONMENT_NAME>
+```
+
 ## System settings
 
 To set system settings value

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -182,7 +182,8 @@ namespace Clio
 			containerBuilder.RegisterType<MockDataCommand>();
 			containerBuilder.RegisterType<ConsoleProgressbar>();
 			containerBuilder.RegisterType<ApplicationLogProvider>();
-			var configuration = MediatRConfigurationBuilder
+            containerBuilder.RegisterType<LastCompilationLogCommand>();
+            var configuration = MediatRConfigurationBuilder
 				.Create(typeof(BindingsModule).Assembly)
 				.WithAllOpenGenericHandlerTypesRegistered()
 				.Build();

--- a/clio/Command/LastCompilationLogCommand.cs
+++ b/clio/Command/LastCompilationLogCommand.cs
@@ -1,0 +1,37 @@
+﻿using Clio.Common;
+using CommandLine;
+using System;
+
+namespace Clio.Command
+{
+    [Verb("last-compilation-log", Aliases = new[] { "lcl" }, HelpText = "Get last compilation log")]
+    public class LastCompilationLogOptions : RemoteCommandOptions
+    {
+    }
+
+    public class LastCompilationLogCommand : RemoteCommand<LastCompilationLogOptions>
+    {
+        public LastCompilationLogCommand(IApplicationClient applicationClient, EnvironmentSettings settings)
+            : base(applicationClient, settings)
+        {
+            EnvironmentSettings = settings;
+        }
+
+        public override int Execute(LastCompilationLogOptions opts)
+        {
+            try
+            {
+                ServicePath = "/api/ConfigurationStatus/GetLastCompilationResult";
+                string result = ApplicationClient.ExecuteGetRequest(ServiceUri);
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
+                Console.WriteLine(result);
+                return 0;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+                return 1;
+            }
+        }
+    }
+}

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -625,8 +625,9 @@ class Program
 		typeof(UninstallCreatioCommandOptions),
 		typeof(AddSchemaOptions),
 		typeof(SetApplicationIconOption),
+		typeof(LastCompilationLogOptions)
 
-	};
+    };
 	public static Func<object, int> ExecuteCommandWithOption = (instance) => {
 		return instance switch {
 			ExecuteAssemblyOptions opts => CreateRemoteCommand<AssemblyCommand>(opts).Execute(opts),
@@ -729,7 +730,8 @@ class Program
 			UninstallCreatioCommandOptions opts => Resolve<UninstallCreatioCommand>(opts).Execute(opts),
 			AddSchemaOptions opts => Resolve<AddSchemaCommand>(opts).Execute(opts),
 			SetApplicationIconOption opts => Resolve<SetApplicationIconCommand>(opts).Execute(opts),
-			_ => 1,
+            LastCompilationLogOptions opts => Resolve<LastCompilationLogCommand>(opts).Execute(opts),
+            _ => 1,
 		};
 	};
 


### PR DESCRIPTION
- Implemented `clio last-compilation-log -e <ENVIRONMENT_NAME>` command to fetch the last compilation log for a specified environment.
- Updated README with usage instructions.
