### PR TITLE
Add ConsoleLogger to NewPkgCommand instantiation

### DIFF
--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -650,7 +650,7 @@ class Program
 			DeletePkgOptions opts => Resolve<DeletePackageCommand>(opts).Execute(opts),
 			ReferenceOptions opts => CreateCommand<ReferenceCommand>(new CreatioPkgProjectCreator()).Execute(opts),
 			NewPkgOptions opts => CreateCommand<NewPkgCommand>(new SettingsRepository(), CreateCommand<ReferenceCommand>(
-				new CreatioPkgProjectCreator())).Execute(opts),
+				new CreatioPkgProjectCreator()), ConsoleLogger.Instance).Execute(opts),
 			ConvertOptions opts => ConvertPackage(opts),
 			RegisterOptions opts => CreateCommand<RegisterCommand>().Execute(opts),
 			UnregisterOptions opts => CreateCommand<UnregisterCommand>().Execute(opts),


### PR DESCRIPTION
Previously, the `NewPkgCommand` was instantiated without a logger, potentially missing important debug information. This change appends `ConsoleLogger.Instance` to the `NewPkgCommand` creation, ensuring log output is properly captured for new package operations.