### PR TITLE
Fix large backup copy via k8s API

### DIFF
--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -228,30 +228,17 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			throw new FileNotFoundException("Backup file not found in the specified directory.");
 		}
 		
-		bool useFs = false;
-		string dest = Path.Join("\\\\wsl.localhost","rancher-desktop","mnt","clio-infrastructure","mssql","data", $"{siteName}.bak");
-		if(src.Length < int.MaxValue) {
-			_k8.CopyBackupFileToPod(k8Commands.PodType.Mssql, src.FullName, $"{siteName}.bak");
-		}else {
-			//This is a hack, we have to fix Cp class to allow large files
-			useFs = true;
-			_logger.WriteWarning($"Copying large file to local directory {dest}" );
-			_fileSystem.CopyFile(src.FullName, dest, true);
-		}
-		k8Commands.ConnectionStringParams csp = _k8.GetMssqlConnectionString();
-		Mssql mssql = new(csp.DbPort, csp.DbUsername, csp.DbPassword);
+                _k8.CopyBackupFileToPod(k8Commands.PodType.Mssql, src.FullName, $"{siteName}.bak");
+                k8Commands.ConnectionStringParams csp = _k8.GetMssqlConnectionString();
+                Mssql mssql = new(csp.DbPort, csp.DbUsername, csp.DbPassword);
 
-		bool exists = mssql.CheckDbExists(siteName);
-		if (!exists) {
-			mssql.CreateDb(siteName, $"{siteName}.bak");
-		}
-		if(useFs) {
-			_fileSystem.DeleteFile(dest);
-		}else {
-			_k8.DeleteBackupImage(k8Commands.PodType.Mssql, $"{siteName}.bak");
-		}
-		return 0;
-	}
+                bool exists = mssql.CheckDbExists(siteName);
+                if (!exists) {
+                        mssql.CreateDb(siteName, $"{siteName}.bak");
+                }
+                _k8.DeleteBackupImage(k8Commands.PodType.Mssql, $"{siteName}.bak");
+                return 0;
+        }
 
 	private int DoPgWork(DirectoryInfo unzippedDirectory, string destDbName){
 		string tmpDbName = "template_" + unzippedDirectory.Name;


### PR DESCRIPTION
## Summary
- stream backup files directly into kubernetes exec instead of using `MemoryStream`
- remove file size workaround in `CreatioInstallerService`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test clio.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b57fc26c8333bd8a03c3dd795b6e