### PR TITLE
Update push-pkg to compile by default

### DIFF
--- a/clio/Command/PushPackageCommand.cs
+++ b/clio/Command/PushPackageCommand.cs
@@ -40,8 +40,8 @@
 		[Option("id", Required = false, HelpText = "Marketplace application id")]
 		public IEnumerable<int> MarketplaceIds { get; set; }
 
-		[Option("force-compilation", Required = false, HelpText = "Runs compilation after install package")]
-		public bool ForceCompilation { get; set; }
+                [Option("force-compilation", Required = false, HelpText = "Runs compilation after install package", Default = true)]
+                public bool ForceCompilation { get; set; }
 
 		#endregion
 

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -167,6 +167,9 @@ for get installation log file specify report path parameter
 clio push-pkg <PACKAGE_NAME> -r log.txt
 ```
 
+By default the command runs compilation after a successful installation.
+To skip compilation specify `--force-compilation false`.
+
 install one or more applications from marketplace.creatio.com
 
 ```

--- a/clio/help/en/push-pkg.txt
+++ b/clio/help/en/push-pkg.txt
@@ -27,6 +27,8 @@ OPTIONS
 
     --Maintainer            -m          Maintainer name
 
+    --force-compilation                 Runs compilation after install package. Enabled by default.
+
 EXAMPLE
     clio push-pkg <PACKAGE_NAME>
         install package from directory you can use the next command: for non 


### PR DESCRIPTION
## Summary
- default `--force-compilation` option to `true` for `push-pkg`
- document the new default in help and commands documentation

## Testing
- `dotnet test /property:GenerateFullPaths=true -c Release` *(fails: Could not find file '/workspace/clio/clio.tests/bin/Release/net8.0/..\..\..\..\clio\Commands.md' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68669a927df08333a3c199574d413736