### PR TITLE
Add docs for undocumented commands

### DIFF
--- a/documentation/commands/add-item.md
+++ b/documentation/commands/add-item.md
@@ -1,0 +1,40 @@
+# add-item
+
+## Summary
+item - Add new class to current project. Aviable 3 types of items:
+
+## Description
+Add package item to project based on template. You can add data model for
+    work with class oriented entity throuth repository (Detailed
+    https://github.com/Advance-Technologies-Foundation/repository).
+    Supported by default web service and entity-listener template for creatio.
+    You can add your own template in tpl folder in clio directory for
+    frequently used code constructions.
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Item type (pos. 0)` | `` | specify type of item |
+| `` | `` |  |
+| `Item name (pos. 1)` | `` | specify class name |
+| `` | `` |  |
+| `--Namespace` | `-n` | Namespace for generated class |
+| `` | `` |  |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio add-item model <ENTITY_NAME>
+        add class model for <ENTITY_NAME> (ATF.Repository required)
+
+    clio add-item service <SERVICE_NAME>
+        add new service in package based on template
+
+    clio add-item entity-listener <ENTITY_NAME>
+        add new entity-listener for <ENTITY_NAME> based on template
+```

--- a/documentation/commands/delete-pkg-remote.md
+++ b/documentation/commands/delete-pkg-remote.md
@@ -1,0 +1,38 @@
+# delete-pkg-remote
+
+## Summary
+pkg-remote - delete package from application
+
+## Description
+delete-pkg-remote command can be used in CI/CD pipeline or in development
+    when you need delete package from a web application (website).
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0)	Name/path of package folder or path for zip or gz package file` | `` |  |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission required) |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio delete-pkg-remote <PACKAGE_NAME>
+        delete package with <PACKAGE_NAME> from default application
+
+    clio delete-pkg-remote <PACKAGE_NAME> -e dev
+        delete package with <PACKAGE_NAME> from specify application with name dev
+```

--- a/documentation/commands/execute-assembly-code.md
+++ b/documentation/commands/execute-assembly-code.md
@@ -1,0 +1,37 @@
+# execute-assembly-code
+
+## Summary
+assembly-code - execute class code that implements IExecuter
+
+## Description
+execute-assembly-code helps developers execute class code without package
+    installation. This feature is useful in application development flow
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Name (pos. 0)` | `` | Required. Path to executed assembly |
+| `` | `` |  |
+| `--ExecutorType` | `-t` | Required. Assembly type name for proceed |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission required) |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio execute-assembly-code myassembly.dll -t MyNamespace.CodeExecutor
+```

--- a/documentation/commands/execute-sql-script.md
+++ b/documentation/commands/execute-sql-script.md
@@ -1,0 +1,39 @@
+# execute-sql-script
+
+## Summary
+sql-script - Execute SQL script on a web application
+
+## Description
+Executes custom SQL script on a web application.
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Value (pos. 0)` | `` | Sql script |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission required) |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+| `--File` | `-f` | Path to the sql script file |
+| `` | `` |  |
+| `--View` | `-v` | View type |
+| `` | `` |  |
+| `--DestinationPath` | `-d` | Path to results file |
+| `` | `` |  |
+
+## Examples
+
+```bash
+execute-sql-script "SELECT Id FROM SysSettings WHERE Code = 'CustomPackageId'"
+```

--- a/documentation/commands/extract-pkg-zip.md
+++ b/documentation/commands/extract-pkg-zip.md
@@ -1,0 +1,31 @@
+# extract-pkg-zip
+
+## Summary
+pkg-zip
+
+## Description
+extract-pkg-zip command unzip package from *.gz archive to directory
+    that contain package folder
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0)` | `` | Name/path of package acrhive file |
+| `` | `` |  |
+| `--DestinationPath` | `-d` | Destionation path for extract package (Optional) |
+| `` | `` |  |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio extract-pkg-zip MyPackage
+        unzip MyPackage.gz in current folder to directory MyPackage in current folder
+
+    clio extract-pkg-zip c:\MyPackage.gz -f c:\App\Pkg
+        extract MyPackage.gz file to c:\App\MyPackage folder
+```

--- a/documentation/commands/generate-pkg-zip.md
+++ b/documentation/commands/generate-pkg-zip.md
@@ -1,0 +1,43 @@
+# generate-pkg-zip
+
+## Summary
+pkg-zip
+
+## Description
+generate-pkg-zip command compress package into *.gz archive for directory
+    that contain package folder
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0)` | `` | Name/path of package folder |
+| `` | `` |  |
+| `--DestinationPath` | `-d` | Destionation path for result gz file (Optional) |
+| `` | `` |  |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio generate-pkg-zip
+        compress package to .gz file if command run from package directory
+
+    clio generate-pkg-zip <PACKAGE_NAME>
+        compress package to .gz file if command run from package containing
+        directory
+
+    clio generate-pkg-zip <PACKAGE_NAME> -d "C:\STORE\<PACKAGE>.gz"
+        compress package to specified .gz file if command run from package
+        containing directory
+
+    clio generate-pkg-zip "C:\DEV\PKG\<PACKAG_NAME>" -d "C:\STORE\<PACKAGE>.gz"
+        compress package from specify directory to specify .gz file
+
+    clio generate-pkg-zip <PACKAGE_NAME_1>,<PACKAGE_NAME_2>,<PACKAGE_NAME_3>
+        compress more than one packages to single .gz file if command run from
+        packages containing directory
+```

--- a/documentation/commands/help.md
+++ b/documentation/commands/help.md
@@ -1,0 +1,19 @@
+# help
+
+## Summary
+
+
+## Description
+clio - is a Creatio command line interface utility that makes possible
+    development in the local file system and to build automation CI.
+
+## Aliases
+None
+
+## Options
+
+None
+
+## Examples
+
+None

--- a/documentation/commands/install-gate.md
+++ b/documentation/commands/install-gate.md
@@ -1,0 +1,23 @@
+# install-gate
+
+## Summary
+gate - installs a service package that expands clio commands
+
+## Description
+Installs on the selected web application(website) a service package
+    "cliogate" that makes available all Creatio's commands.
+
+## Aliases
+None
+
+## Options
+
+None
+
+## Examples
+
+```bash
+clio install-gate
+
+    clio install-gate -e <ENVIRONMENT NAME>
+```

--- a/documentation/commands/new-pkg.md
+++ b/documentation/commands/new-pkg.md
@@ -1,0 +1,40 @@
+# new-pkg
+
+## Summary
+pkg - create new package in a web application
+
+## Description
+new-pkg command can be used in development when you need to create
+    new creatio package
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0)	Name of package to create` | `` |  |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission required) |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio new-pkg <PACKAGE_NAME>
+        create new package in current folder
+
+    clio new-pkg <PACKAGE_NAME> -r bin
+        create new package in current folder and set reference on local
+        core assembly with using creatio file design mode with command in
+        Pkg directory
+```

--- a/documentation/commands/pull-pkg.md
+++ b/documentation/commands/pull-pkg.md
@@ -1,0 +1,38 @@
+# pull-pkg
+
+## Summary
+pkg - download package to local file system from default a web application
+
+## Description
+pull-pkg command can be used in CI/CD pipeline or in development
+    when you need download package from a web application (website).
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0)	Name of package for download` | `` |  |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission required) |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio pull-pkg <PACKAGE_NAME>
+        download package to local file system from default application
+
+    clio pull-pkg <PACKAGE_NAME> -e <ENVIRONMENT_NAME>
+        download package to local file system from non default application
+```

--- a/documentation/commands/push-pkg.md
+++ b/documentation/commands/push-pkg.md
@@ -1,0 +1,53 @@
+# push-pkg
+
+## Summary
+pkg - Install package from directory you can use the next command:
+
+## Description
+push-pkg command can be used in CI/CD pipeline or in development
+    when you need install package to a web application (website).
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Package name (pos. 0) Name/path of package folder or path for zip or gz` | `` |  |
+| `package file` | `` |  |
+| `` | `` |  |
+| `--uri` | `-u` | Application uri |
+| `` | `` |  |
+| `--Password` | `-p` | User password |
+| `` | `` |  |
+| `--Login` | `-l` | User login (administrator permission |
+| `required)` | `` |  |
+| `` | `` |  |
+| `--Environment` | `-e` | Environment name |
+| `` | `` |  |
+| `--Maintainer` | `-m` | Maintainer name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio push-pkg <PACKAGE_NAME>
+        install package from directory you can use the next command: for non
+        compressed package
+        in current folder
+
+    clio push-pkg package.gz
+        install package from .gz packages you can use command
+
+    clio push-pkg package.gz --InstallSqlScript false --InstallPackageData false
+            --ContinueIfError true --SkipConstraints false --SkipValidateActions false
+            --ExecuteValidateActions false --IsForceUpdateAllColumns false
+        install package from .gz packages, with options, you can use command
+
+    clio push-pkg C:\Packages\package.gz
+        install package from .gz packages you can use command
+
+    clio push-pkg <PACKAGE_NAME> -r log.txt
+        installation log file specify report path parameter
+```

--- a/documentation/commands/set-dev-mode.md
+++ b/documentation/commands/set-dev-mode.md
@@ -1,0 +1,25 @@
+# set-dev-mode
+
+## Summary
+dev-mode - Setup develepment mode for selected web application(website)
+
+## Description
+System settings Maintainer will be updated by Maintainer value from
+    environment setting.
+    All package for this maintainer will be unlocked on application. After this
+    application will be automaitaly restarted.
+
+## Aliases
+None
+
+## Options
+
+None
+
+## Examples
+
+```bash
+clio set-dev-mode
+
+    clio set-dev-mode -e <ENVIRONMENT NAME>
+```

--- a/documentation/commands/set-feature.md
+++ b/documentation/commands/set-feature.md
@@ -1,0 +1,28 @@
+# set-feature
+
+## Summary
+feature - Set feature state
+
+## Description
+set-feature command set feature state.
+    set-feature command can be used in CI/CD pipeline or in development
+    when you need create or update feature state on web application (website).
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Code (pos. 0)` | `` | Feature code |
+| `` | `` |  |
+| `State (pos. 1)` | `` | Feature state |
+| `` | `` |  |
+
+## Examples
+
+```bash
+set-feature ExampleCode 1 enable feature with code ExampleCode for all users, if feature doesn`t exists it will be created
+	set-feature ExampleCode 0 disable feature with code ExampleCode for all users
+```

--- a/documentation/commands/set-pkg-version.md
+++ b/documentation/commands/set-pkg-version.md
@@ -1,0 +1,20 @@
+# set-pkg-version
+
+## Summary
+pkg-version - set package version
+
+## Description
+Set specified package version into descriptor.json by specified package path.
+
+## Aliases
+None
+
+## Options
+
+None
+
+## Examples
+
+```bash
+clio set-pkg-version <PACKAGE PATH> -v <PACKAGE VERSION>
+```

--- a/documentation/commands/set-syssetting.md
+++ b/documentation/commands/set-syssetting.md
@@ -1,0 +1,30 @@
+# set-syssetting
+
+## Summary
+syssetting - Set setting value
+
+## Description
+set-syssetting command set setting value.
+    set-syssetting command can be used in CI/CD pipeline or in development
+    when you need create or update settings on web application (website).
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Code (pos. 0)` | `` | Sys setting code |
+| `` | `` |  |
+| `Value (pos. 1)` | `` | Sys setting Value |
+| `` | `` |  |
+| `Type (pos. 2)` | `` | Sys setting Type |
+| `` | `` |  |
+
+## Examples
+
+```bash
+set-syssetting ExampleCode True Boolean - create boolean sys setting with code ExampleCode and value True
+	set-syssetting Maintainer ATF - update Maintainer sys setting with value ATF
+```

--- a/documentation/commands/show-web-app-list.md
+++ b/documentation/commands/show-web-app-list.md
@@ -1,0 +1,27 @@
+# show-web-app-list
+
+## Summary
+web-app-list - show applications options list
+
+## Description
+View list of all web applications
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Name (pos. 0)` | `` | Environment(application) name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio show-web-app-list
+        shows all applications options list
+
+    clio show-web-app-list <ENVIRONMENT_NAME>
+            shows <ENVIRONMENT_NAME> application options list
+```

--- a/documentation/commands/toc.yml
+++ b/documentation/commands/toc.yml
@@ -1,14 +1,53 @@
 items:
 - name: Application Management
   items:
+  - name: Register Web Application
+    href: reg-web-app.md
+  - name: Unregister Web Application
+    href: unreg-web-app.md
+  - name: Show Web Application List
+    href: show-web-app-list.md
   - name: Restart
     href: restart-web-app.md
   - name: Clear Redis
     href: clear-redis-db.md
-  - name: Register Web Application
-    href: reg-web-app.md
+  - name: Install Gate
+    href: install-gate.md
 - name: Package Management
+  items:
+  - name: Push Package
+    href: push-pkg.md
+  - name: Pull Package
+    href: pull-pkg.md
+  - name: Delete Package
+    href: delete-pkg-remote.md
+  - name: Generate Package Zip
+    href: generate-pkg-zip.md
+  - name: Extract Package Zip
+    href: extract-pkg-zip.md
+  - name: New Package
+    href: new-pkg.md
+  - name: Set Package Version
+    href: set-pkg-version.md
 - name: Environment Settings
-- name: Workspaces
+  items:
+  - name: Set System Setting
+    href: set-syssetting.md
+  - name: Set Feature
+    href: set-feature.md
+  - name: Set Dev Mode
+    href: set-dev-mode.md
 - name: Development
+  items:
+  - name: Add Item
+    href: add-item.md
+  - name: Execute Assembly Code
+    href: execute-assembly-code.md
+  - name: Execute SQL Script
+    href: execute-sql-script.md
+  - name: Update CLI
+    href: update-cli.md
+  - name: Help
+    href: help.md
+- name: Workspaces
 - name: GitOps

--- a/documentation/commands/unreg-web-app.md
+++ b/documentation/commands/unreg-web-app.md
@@ -1,0 +1,24 @@
+# unreg-web-app
+
+## Summary
+web-app - delete environment
+
+## Description
+Delete existing application settings
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `Name (pos. 0)` | `` | Environment(application) name |
+| `` | `` |  |
+
+## Examples
+
+```bash
+clio unreg-web-app <ENVIRONMENT_NAME>
+        deletes existing environment, named <ENVIRONMENT_NAME>
+```

--- a/documentation/commands/update-cli.md
+++ b/documentation/commands/update-cli.md
@@ -1,0 +1,29 @@
+# update-cli
+
+## Summary
+cli - updates the clio to the latest version
+
+## Description
+update-cli updates the clio to the latest version. Any time when you run
+    any commands by clio it checks the current version, and if it available
+    clio show the message about it.
+    Recommended to use the latest version of clio with fixed bugs and
+    extended features.
+
+## Aliases
+None
+
+## Options
+
+| Name | Short | Description |
+|------|-------|-------------|
+| `` | `` |  |
+| `--CurrentVersion` | `-v` | Show current version |
+| `` | `` |  |
+
+## Examples
+
+```bash
+update-cli
+    update-cli -v
+```


### PR DESCRIPTION
## Summary
- generate documentation for missing commands in `documentation/commands`
- update `toc.yml` with new entries

## Testing
- `dotnet build clio/clio.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687ccaeb594c8333a0f8fb5e066d6fa5