### PR TITLE
Update CheckWindowsFeatureCommand.cs

### DIFF
--- a/clio/Command/CheckWindowsFeatureCommand.cs
+++ b/clio/Command/CheckWindowsFeatureCommand.cs
@@ -34,13 +34,13 @@ namespace Clio.Command
 			}
 			_logger.WriteLine("");
 			if (missedComponents.Count > 0) {
-				_logger.WriteInfo("Windows has missed components:");
+				_logger.WriteError("Windows has missed components:");
 				foreach (var item in missedComponents) {
 					_logger.WriteInfo($"{item}");
 				}
 				return 1;
 			} else {
-				_logger.WriteError("All requirment components installed");
+				_logger.WriteInfo("All requirement components installed");
 				return 0;
 			}
 		}


### PR DESCRIPTION
Fixed summary logging to write an error message when required components are missing (instead of an info message) and write an info message when all required components are installed (instead of an error message). See issue #391 Also fixed spelling of "requirement".