### PR TITLE
assert-fs

### DIFF
--- a/clio.tests/Common/Assertions/FsPathAssertionTests.cs
+++ b/clio.tests/Common/Assertions/FsPathAssertionTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Clio.Common;
+using Clio.Common.Assertions;
+using Clio.UserEnvironment;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common.Assertions
+{
+	[TestFixture]
+	[Category("Unit")]
+	public class FsPathAssertionTests
+	{
+		private ISettingsRepository _settingsRepository;
+		private ILogger _logger;
+		private FsPathAssertion _sut;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_settingsRepository = Substitute.For<ISettingsRepository>();
+			_logger = Substitute.For<ILogger>();
+			_sut = new FsPathAssertion(_settingsRepository, _logger);
+		}
+
+		[Test]
+		[Description("Should return failure when path parameter is null")]
+		public void Execute_WhenPathIsNull_ShouldReturnFailure()
+		{
+			// Arrange
+			string path = null;
+
+			// Act
+			var result = _sut.Execute(path);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "null path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation phase");
+			result.Reason.Should().Contain("required", because: "error message should indicate path is required");
+		}
+
+		[Test]
+		[Description("Should return failure when path parameter is empty string")]
+		public void Execute_WhenPathIsEmpty_ShouldReturnFailure()
+		{
+			// Arrange
+			string path = string.Empty;
+
+			// Act
+			var result = _sut.Execute(path);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "empty path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation phase");
+		}
+
+		[Test]
+		[Description("Should return failure when path parameter is whitespace")]
+		public void Execute_WhenPathIsWhitespace_ShouldReturnFailure()
+		{
+			// Arrange
+			string path = "   ";
+
+			// Act
+			var result = _sut.Execute(path);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "whitespace-only path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation phase");
+		}
+
+		[Test]
+		[Description("Should return failure when directory does not exist")]
+		public void Execute_WhenDirectoryDoesNotExist_ShouldReturnFailure()
+		{
+			// Arrange
+			string nonExistentPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+			// Act
+			var result = _sut.Execute(nonExistentPath);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "non-existent path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation phase");
+			result.Reason.Should().Contain("does not exist", because: "error should indicate path doesn't exist");
+			result.Details["resolvedPath"].Should().Be(nonExistentPath, because: "details should include the resolved path");
+		}
+
+		[Test]
+		[Description("Should return success when directory exists")]
+		public void Execute_WhenDirectoryExists_ShouldReturnSuccess()
+		{
+			// Arrange
+			string existingPath = Path.GetTempPath();
+
+			// Act
+			var result = _sut.Execute(existingPath);
+
+			// Assert
+			result.Status.Should().Be("pass", because: "existing path should pass validation");
+			result.Scope.Should().Be(AssertionScope.Fs, because: "scope should be filesystem");
+			result.Resolved["path"].Should().Be(existingPath, because: "resolved path should be included in result");
+		}
+
+		[Test]
+		[Description("Should resolve iis-clio-root-path setting key to configured path")]
+		public void Execute_WhenPathIsIisClioRootPathKey_ShouldResolveFromSettings()
+		{
+			// Arrange
+			string settingKey = "iis-clio-root-path";
+			string configuredPath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+				? @"C:\inetpub\wwwroot\clio" 
+				: "/tmp/clio";
+			_settingsRepository.GetIISClioRootPath().Returns(configuredPath);
+
+			// Create the directory if it doesn't exist for the test
+			if (!Directory.Exists(configuredPath))
+			{
+				try
+				{
+					Directory.CreateDirectory(configuredPath);
+				}
+				catch
+				{
+					// Skip test if we can't create the directory
+					Assert.Inconclusive($"Cannot create test directory: {configuredPath}");
+					return;
+				}
+			}
+
+			try
+			{
+				// Act
+				var result = _sut.Execute(settingKey);
+
+				// Assert
+				_settingsRepository.Received(1).GetIISClioRootPath();
+				result.Details["requestedPath"].Should().Be(settingKey, 
+					because: "details should show the original setting key that was requested");
+				result.Resolved["path"].Should().Be(configuredPath, 
+					because: "resolved path should be the configured path from settings");
+			}
+			finally
+			{
+				// Cleanup
+				try
+				{
+					if (Directory.Exists(configuredPath) && configuredPath.Contains("tmp"))
+					{
+						Directory.Delete(configuredPath);
+					}
+				}
+				catch
+				{
+					// Ignore cleanup errors
+				}
+			}
+		}
+
+		[Test]
+		[Description("Should be case-insensitive when matching iis-clio-root-path key")]
+		public void Execute_WhenPathKeyHasDifferentCase_ShouldStillResolve()
+		{
+			// Arrange
+			string settingKey = "IIS-CLIO-ROOT-PATH"; // Different case
+			string configuredPath = Path.GetTempPath();
+			_settingsRepository.GetIISClioRootPath().Returns(configuredPath);
+
+			// Act
+			var result = _sut.Execute(settingKey);
+
+			// Assert
+			_settingsRepository.Received(1).GetIISClioRootPath();
+			result.Details["requestedPath"].Should().Be(settingKey, 
+				because: "original key with different case should be preserved in details");
+		}
+
+		[Test]
+		[Description("Should log validation message when checking path")]
+		public void Execute_WhenValidatingPath_ShouldLogMessage()
+		{
+			// Arrange
+			string path = Path.GetTempPath();
+
+			// Act
+			var result = _sut.Execute(path);
+
+			// Assert
+			_logger.Received(1).WriteInfo(Arg.Is<string>(msg => msg.Contains("Validating path")));
+		}
+	}
+}

--- a/clio.tests/Common/Assertions/FsPermissionAssertionTests.cs
+++ b/clio.tests/Common/Assertions/FsPermissionAssertionTests.cs
@@ -1,0 +1,367 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Clio.Common;
+using Clio.Common.Assertions;
+using Clio.UserEnvironment;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common.Assertions
+{
+	[TestFixture]
+	[Category("Unit")]
+	public class FsPermissionAssertionTests
+	{
+		private ISettingsRepository _settingsRepository;
+		private ILogger _logger;
+		private FsPermissionAssertion _sut;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_settingsRepository = Substitute.For<ISettingsRepository>();
+			_logger = Substitute.For<ILogger>();
+			_sut = new FsPermissionAssertion(_settingsRepository, _logger);
+		}
+
+		[Test]
+		[Description("Should return failure when not running on Windows")]
+		public void Execute_WhenNotOnWindows_ShouldReturnFailure()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on non-Windows platforms");
+				return;
+			}
+
+			// Arrange
+			string path = "/tmp/test";
+			string user = "testuser";
+			string permission = "full-control";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "permission checks are Windows-only");
+			result.FailedAt.Should().Be(AssertionPhase.FsPerm, because: "failure is at permission phase");
+			result.Reason.Should().Contain("Windows", because: "error should mention Windows requirement");
+		}
+
+		[Test]
+		[Description("Should return failure when path parameter is null")]
+		public void Execute_WhenPathIsNull_ShouldReturnFailure()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = null;
+			string user = "BUILTIN\\IIS_IUSRS";
+			string permission = "full-control";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "null path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation");
+		}
+
+		[Test]
+		[Description("Should return failure when user parameter is null")]
+		public void Execute_WhenUserIsNull_ShouldReturnFailure()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = Path.GetTempPath();
+			string user = null;
+			string permission = "full-control";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "null user should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsUser, because: "failure occurs at user validation");
+		}
+
+		[Test]
+		[Description("Should return failure when permission parameter is null")]
+		public void Execute_WhenPermissionIsNull_ShouldReturnFailure()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = Path.GetTempPath();
+			string user = "BUILTIN\\IIS_IUSRS";
+			string permission = null;
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "null permission should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPerm, because: "failure occurs at permission validation");
+		}
+
+		[Test]
+		[Description("Should return failure when directory does not exist")]
+		public void Execute_WhenDirectoryDoesNotExist_ShouldReturnFailure()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+			string user = "BUILTIN\\IIS_IUSRS";
+			string permission = "full-control";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "non-existent path should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPath, because: "failure occurs at path validation");
+			result.Reason.Should().Contain("does not exist", because: "error should indicate path doesn't exist");
+		}
+
+		[Test]
+		[Description("Should return failure for invalid permission level")]
+		public void Execute_WhenPermissionIsInvalid_ShouldReturnFailure()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = Path.GetTempPath();
+			string user = "BUILTIN\\IIS_IUSRS";
+			string permission = "invalid-permission";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			result.Status.Should().Be("fail", because: "invalid permission level should fail validation");
+			result.FailedAt.Should().Be(AssertionPhase.FsPerm, because: "failure occurs at permission validation");
+			result.Reason.Should().Contain("Invalid permission", because: "error should mention invalid permission");
+		}
+
+		[Test]
+		[Description("Should accept 'full' as alias for 'full-control'")]
+		public void Execute_WhenPermissionIsFull_ShouldAcceptAsFullControl()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+			Directory.CreateDirectory(testDir);
+
+			try
+			{
+				// Get current user
+				var currentUser = WindowsIdentity.GetCurrent();
+				string user = currentUser.Name;
+
+				// Act
+				var result = _sut.Execute(testDir, user, "full");
+
+				// Assert
+				// We can't guarantee the current user has full control, but we should not get
+				// an "invalid permission" error - we should get either success or permission denied
+				result.Reason.Should().NotContain("Invalid permission", 
+					because: "'full' should be recognized as a valid permission level");
+			}
+			finally
+			{
+				// Cleanup
+				try
+				{
+					Directory.Delete(testDir, true);
+				}
+				catch
+				{
+					// Ignore cleanup errors
+				}
+			}
+		}
+
+		[Test]
+		[Description("Should resolve iis-clio-root-path setting key")]
+		public void Execute_WhenPathIsSettingKey_ShouldResolveFromSettings()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string settingKey = "iis-clio-root-path";
+			string configuredPath = Path.GetTempPath();
+			string user = "BUILTIN\\Users";
+			string permission = "read";
+
+			_settingsRepository.GetIISClioRootPath().Returns(configuredPath);
+
+			// Act
+			var result = _sut.Execute(settingKey, user, permission);
+
+			// Assert
+			_settingsRepository.Received(1).GetIISClioRootPath();
+			result.Details["requestedPath"].Should().Be(settingKey, 
+				because: "details should show the original setting key");
+		}
+
+		[Test]
+		[Description("Should handle case-insensitive permission levels")]
+		[TestCase("READ")]
+		[TestCase("Read")]
+		[TestCase("read")]
+		[TestCase("WRITE")]
+		[TestCase("MODIFY")]
+		[TestCase("FULL-CONTROL")]
+		[TestCase("Full-Control")]
+		public void Execute_WhenPermissionHasDifferentCase_ShouldStillParse(string permission)
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+			Directory.CreateDirectory(testDir);
+
+			try
+			{
+				var currentUser = WindowsIdentity.GetCurrent();
+				string user = currentUser.Name;
+
+				// Act
+				var result = _sut.Execute(testDir, user, permission);
+
+				// Assert
+				result.Reason.Should().NotContain("Invalid permission", 
+					because: $"permission '{permission}' should be recognized regardless of case");
+			}
+			finally
+			{
+				// Cleanup
+				try
+				{
+					Directory.Delete(testDir, true);
+				}
+				catch
+				{
+					// Ignore cleanup errors
+				}
+			}
+		}
+
+		[Test]
+		[Description("Should validate current user has permissions on temp directory")]
+		public void Execute_WhenCurrentUserOnTempDir_ShouldReturnSuccess()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+			Directory.CreateDirectory(testDir);
+
+			try
+			{
+				// Get current user
+				var currentUser = WindowsIdentity.GetCurrent();
+				string user = currentUser.Name;
+
+				// Grant current user full control explicitly
+				DirectoryInfo dirInfo = new DirectoryInfo(testDir);
+				DirectorySecurity security = dirInfo.GetAccessControl();
+				security.AddAccessRule(new FileSystemAccessRule(
+					currentUser.Name,
+					FileSystemRights.FullControl,
+					InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+					PropagationFlags.None,
+					AccessControlType.Allow));
+				dirInfo.SetAccessControl(security);
+
+				// Act
+				var result = _sut.Execute(testDir, user, "full-control");
+
+				// Assert
+				result.Status.Should().Be("pass", because: "current user should have full control on created directory");
+				result.Scope.Should().Be(AssertionScope.Fs, because: "scope should be filesystem");
+				result.Resolved["path"].Should().Be(testDir, because: "resolved path should match test directory");
+				result.Resolved["userIdentity"].Should().Be(user, because: "user identity should be preserved");
+				result.Resolved["permission"].Should().Be("full-control", because: "permission level should be preserved");
+			}
+			finally
+			{
+				// Cleanup
+				try
+				{
+					Directory.Delete(testDir, true);
+				}
+				catch
+				{
+					// Ignore cleanup errors
+				}
+			}
+		}
+
+		[Test]
+		[Description("Should log validation message when checking permissions")]
+		public void Execute_WhenValidatingPermissions_ShouldLogMessage()
+		{
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				Assert.Inconclusive("This test only runs on Windows");
+				return;
+			}
+
+			// Arrange
+			string path = Path.GetTempPath();
+			string user = "BUILTIN\\Users";
+			string permission = "read";
+
+			// Act
+			var result = _sut.Execute(path, user, permission);
+
+			// Assert
+			_logger.Received(1).WriteInfo(Arg.Is<string>(msg => 
+				msg.Contains("Validating permissions") && msg.Contains(user)));
+		}
+	}
+}

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -129,6 +129,8 @@ public class BindingsModule {
 		containerBuilder.RegisterType<DatabaseCapabilityChecker>().As<IDatabaseCapabilityChecker>();
 		containerBuilder.RegisterType<K8DatabaseAssertion>();
 		containerBuilder.RegisterType<K8RedisAssertion>();
+		containerBuilder.RegisterType<Common.Assertions.FsPathAssertion>();
+		containerBuilder.RegisterType<Common.Assertions.FsPermissionAssertion>();
 		containerBuilder.RegisterType<k8Commands>();
 	
 		containerBuilder.RegisterType<InstallerCommand>();

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -651,7 +651,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		string deploymentFolder = DetermineFolderPath(options);
 		_logger.WriteInfo($"[Starting unzipping] - {options.ZipFile} to {deploymentFolder}");
 		//DirectoryInfo unzippedDirectory = InstallerHelper.UnzipOrTakeExisting(options.ZipFile, deploymentFolder, _packageArchiver); //TODO: BUG, this no longer creates an unzipped folder as a template
-		DirectoryInfo unzippedDirectory = InstallerHelper.UnzipOrTakeExistingOld(options.ZipFile, _packageArchiver); //TODO: BUG, this no longer creates an unzipped folder as a template
+		DirectoryInfo unzippedDirectory = InstallerHelper.UnzipOrTakeExistingOld(options.ZipFile, _packageArchiver);
 		
 		if (!_fileSystem.ExistsDirectory(deploymentFolder)) {
 			_fileSystem.CreateDirectory(deploymentFolder);

--- a/clio/Common/Assertions/FsPathAssertion.cs
+++ b/clio/Common/Assertions/FsPathAssertion.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Clio.UserEnvironment;
+
+namespace Clio.Common.Assertions
+{
+	/// <summary>
+	/// Handles filesystem path validation assertions.
+	/// </summary>
+	public class FsPathAssertion
+	{
+		private readonly ISettingsRepository _settingsRepository;
+		private readonly ILogger _logger;
+
+		public FsPathAssertion(ISettingsRepository settingsRepository, ILogger logger)
+		{
+			_settingsRepository = settingsRepository;
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Validates that a filesystem path exists.
+		/// Supports special setting keys like "iis-clio-root-path" or absolute paths.
+		/// </summary>
+		/// <param name="pathOrSettingKey">Path to validate or setting key (e.g., "iis-clio-root-path")</param>
+		/// <returns>AssertionResult with resolved path</returns>
+		public AssertionResult Execute(string pathOrSettingKey)
+		{
+			if (string.IsNullOrWhiteSpace(pathOrSettingKey))
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPath,
+					"Path parameter is required but was not provided"
+				);
+			}
+
+			// Resolve path: check if it's a setting key or a direct path
+			string resolvedPath = ResolvePath(pathOrSettingKey);
+
+			_logger.WriteInfo($"Validating path: {resolvedPath}");
+
+			// Validate path exists
+			if (!Directory.Exists(resolvedPath))
+			{
+				var result = AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPath,
+					$"Path does not exist: {resolvedPath}"
+				);
+				result.Details["requestedPath"] = pathOrSettingKey;
+				result.Details["resolvedPath"] = resolvedPath;
+				return result;
+			}
+
+			// Success
+			var successResult = AssertionResult.Success();
+			successResult.Scope = AssertionScope.Fs;
+			successResult.Resolved["path"] = resolvedPath;
+			successResult.Details["requestedPath"] = pathOrSettingKey;
+			
+			return successResult;
+		}
+
+		/// <summary>
+		/// Resolves a path string which may be either a setting key or an absolute path.
+		/// </summary>
+		private string ResolvePath(string pathOrSettingKey)
+		{
+			// Check if this is a known setting key
+			if (pathOrSettingKey.Equals("iis-clio-root-path", StringComparison.OrdinalIgnoreCase))
+			{
+				return _settingsRepository.GetIISClioRootPath();
+			}
+
+			// Otherwise, treat it as a direct path
+			return pathOrSettingKey;
+		}
+	}
+}

--- a/clio/Common/Assertions/FsPermissionAssertion.cs
+++ b/clio/Common/Assertions/FsPermissionAssertion.cs
@@ -1,0 +1,221 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Clio.UserEnvironment;
+
+namespace Clio.Common.Assertions
+{
+	/// <summary>
+	/// Handles filesystem permission validation assertions.
+	/// </summary>
+	public class FsPermissionAssertion
+	{
+		private readonly ISettingsRepository _settingsRepository;
+		private readonly ILogger _logger;
+
+		public FsPermissionAssertion(ISettingsRepository settingsRepository, ILogger logger)
+		{
+			_settingsRepository = settingsRepository;
+			_logger = logger;
+		}
+
+		/// <summary>
+		/// Validates that a user has the specified permissions on a path.
+		/// </summary>
+		/// <param name="pathOrSettingKey">Path to validate or setting key</param>
+		/// <param name="userIdentity">Windows user/group identity (e.g., "BUILTIN\IIS_IUSRS" or "IIS APPPOOL\MyApp")</param>
+		/// <param name="requiredPermission">Required permission level: read, write, modify, full-control</param>
+		/// <returns>AssertionResult with permission validation details</returns>
+		public AssertionResult Execute(string pathOrSettingKey, string userIdentity, string requiredPermission)
+		{
+			// Validate Windows platform
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPerm,
+					"Permission assertions are only supported on Windows platform"
+				);
+			}
+
+			// Validate inputs
+			if (string.IsNullOrWhiteSpace(pathOrSettingKey))
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPath,
+					"Path parameter is required"
+				);
+			}
+
+			if (string.IsNullOrWhiteSpace(userIdentity))
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsUser,
+					"User identity parameter is required"
+				);
+			}
+
+			if (string.IsNullOrWhiteSpace(requiredPermission))
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPerm,
+					"Permission parameter is required"
+				);
+			}
+
+			// Resolve path
+			string resolvedPath = ResolvePath(pathOrSettingKey);
+
+			// Validate path exists
+			if (!Directory.Exists(resolvedPath))
+			{
+				var result = AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPath,
+					$"Path does not exist: {resolvedPath}"
+				);
+				result.Details["requestedPath"] = pathOrSettingKey;
+				result.Details["resolvedPath"] = resolvedPath;
+				return result;
+			}
+
+			_logger.WriteInfo($"Validating permissions for '{userIdentity}' on '{resolvedPath}'");
+
+			// Parse required permission level
+			FileSystemRights requiredRights;
+			try
+			{
+				requiredRights = ParsePermissionLevel(requiredPermission);
+			}
+			catch (ArgumentException ex)
+			{
+				return AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPerm,
+					ex.Message
+				);
+			}
+
+			// Check permissions
+			try
+			{
+				bool hasPermission = ValidatePermissions(resolvedPath, userIdentity, requiredRights);
+
+				if (!hasPermission)
+				{
+					var result = AssertionResult.Failure(
+						AssertionScope.Fs,
+						AssertionPhase.FsPerm,
+						$"User '{userIdentity}' does not have '{requiredPermission}' permission on path '{resolvedPath}'"
+					);
+					result.Details["requestedPath"] = pathOrSettingKey;
+					result.Details["resolvedPath"] = resolvedPath;
+					result.Details["userIdentity"] = userIdentity;
+					result.Details["requiredPermission"] = requiredPermission;
+					return result;
+				}
+
+				// Success
+				var successResult = AssertionResult.Success();
+				successResult.Scope = AssertionScope.Fs;
+				successResult.Resolved["path"] = resolvedPath;
+				successResult.Resolved["userIdentity"] = userIdentity;
+				successResult.Resolved["permission"] = requiredPermission;
+				successResult.Details["requestedPath"] = pathOrSettingKey;
+
+				return successResult;
+			}
+			catch (Exception ex)
+			{
+				var result = AssertionResult.Failure(
+					AssertionScope.Fs,
+					AssertionPhase.FsPerm,
+					$"Error validating permissions: {ex.Message}"
+				);
+				result.Details["requestedPath"] = pathOrSettingKey;
+				result.Details["resolvedPath"] = resolvedPath;
+				result.Details["userIdentity"] = userIdentity;
+				result.Details["exception"] = ex.GetType().Name;
+				return result;
+			}
+		}
+
+		/// <summary>
+		/// Resolves a path string which may be either a setting key or an absolute path.
+		/// </summary>
+		private string ResolvePath(string pathOrSettingKey)
+		{
+			if (pathOrSettingKey.Equals("iis-clio-root-path", StringComparison.OrdinalIgnoreCase))
+			{
+				return _settingsRepository.GetIISClioRootPath();
+			}
+			return pathOrSettingKey;
+		}
+
+		/// <summary>
+		/// Parses permission level string into FileSystemRights.
+		/// </summary>
+		private FileSystemRights ParsePermissionLevel(string permission)
+		{
+			return permission.ToLowerInvariant() switch
+			{
+				"read" => FileSystemRights.Read,
+				"write" => FileSystemRights.Write,
+				"modify" => FileSystemRights.Modify,
+				"full-control" => FileSystemRights.FullControl,
+				"full" => FileSystemRights.FullControl,
+				_ => throw new ArgumentException(
+					$"Invalid permission level: '{permission}'. Valid options are: read, write, modify, full-control")
+			};
+		}
+
+		/// <summary>
+		/// Validates that a user has the required permissions on a directory.
+		/// </summary>
+		private bool ValidatePermissions(string directoryPath, string userIdentity, FileSystemRights requiredRights)
+		{
+			DirectoryInfo dirInfo = new DirectoryInfo(directoryPath);
+			DirectorySecurity dirSecurity = dirInfo.GetAccessControl();
+			AuthorizationRuleCollection rules = dirSecurity.GetAccessRules(true, true, typeof(NTAccount));
+
+			// Resolve user identity to account
+			IdentityReference identity;
+			try
+			{
+				identity = new NTAccount(userIdentity);
+			}
+			catch
+			{
+				_logger.WriteWarning($"Could not resolve user identity: {userIdentity}");
+				return false;
+			}
+
+			// Check each access rule
+			foreach (FileSystemAccessRule rule in rules)
+			{
+				// Check if rule applies to our user
+				if (rule.IdentityReference.Value.Equals(identity.Value, StringComparison.OrdinalIgnoreCase))
+				{
+					// Check if this is an Allow rule
+					if (rule.AccessControlType == AccessControlType.Allow)
+					{
+						// Check if the rule grants the required rights
+						if ((rule.FileSystemRights & requiredRights) == requiredRights)
+						{
+							_logger.WriteInfo($"Found matching Allow rule with sufficient permissions");
+							return true;
+						}
+					}
+				}
+			}
+
+			_logger.WriteWarning($"No matching access rule found for '{userIdentity}' with required permissions");
+			return false;
+		}
+	}
+}

--- a/clio/Common/DeploymentStrategies/IISDeploymentStrategy.cs
+++ b/clio/Common/DeploymentStrategies/IISDeploymentStrategy.cs
@@ -51,11 +51,13 @@ public class IISDeploymentStrategy : IDeploymentStrategy
 	/// </summary>
 	public async Task<int> Deploy(DirectoryInfo appDirectory, PfInstallerOptions options)
 	{
-		if (appDirectory == null)
+		if (appDirectory == null) {
 			throw new ArgumentNullException(nameof(appDirectory));
+		}
 
-		if (options == null)
+		if (options == null) {
 			throw new ArgumentNullException(nameof(options));
+		}
 
 		_logger.WriteInfo("[Create IIS Site] - Started");
 

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -10,7 +10,7 @@
 	  <PackageTags>cli ATF clio creatio</PackageTags>
 	  <NeutralLanguage>en</NeutralLanguage>
 	  <!-- Default version for local development. Will be overridden during release from tag -->
-      <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.0.1.88</AssemblyVersion>
+      <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.0.1.89</AssemblyVersion>
 	  <FileVersion>$(AssemblyVersion)</FileVersion>
 	  <Version>$(AssemblyVersion)</Version>
 	  <Description>CLI interface for Creatio</Description>

--- a/clio/help/en/assert.txt
+++ b/clio/help/en/assert.txt
@@ -10,15 +10,17 @@ DESCRIPTION
     failure attribution and exit codes.
 
     The assert command ensures that clio can discover and connect to the 
-    required infrastructure components (databases, Redis) using the same 
-    discovery logic that clio uses during normal operations. This validates 
-    that:
+    required infrastructure components (databases, Redis, filesystem paths, 
+    and permissions) using the same discovery logic that clio uses during 
+    normal operations. This validates that:
     
     1. StatefulSets/Deployments exist with correct labels
     2. Services are discoverable and have correct labels (app=clio-*)
     3. Pods are running and ready
     4. Network connectivity works (TCP connection tests)
     5. Services are functional (database version queries, Redis PING)
+    6. Filesystem paths exist and are accessible
+    7. Windows ACL permissions are correctly configured
     
     The command uses label-based discovery matching clio's k8Commands 
     implementation, ensuring that if assert passes, clio operations will 
@@ -34,7 +36,7 @@ SYNOPSIS
 
 SCOPES
     k8          Kubernetes resource assertions
-    fs          Filesystem assertions (Windows only)
+    fs          Filesystem path and permission assertions
 
 KUBERNETES OPTIONS
 
@@ -58,11 +60,23 @@ KUBERNETES OPTIONS
     --redis-connect                 Validate Redis connectivity via TCP
     --redis-ping                    Execute Redis PING command
 
-FILESYSTEM OPTIONS (Windows only)
-    --path                          Filesystem path to validate
-    --user                          Windows user identity to validate
-    --perm                          Required permission level
-                                    Supported: read, write, modify, full
+FILESYSTEM OPTIONS
+    --path                          Filesystem path to validate (required)
+                                    Can be an absolute path or a setting key
+                                    Setting keys: iis-clio-root-path
+    
+    --user                          Windows user/group identity to validate
+                                    Format: "BUILTIN\IIS_IUSRS" or "IIS APPPOOL\AppName"
+                                    Requires --perm (Windows only)
+    
+    --perm                          Required permission level (Windows only)
+                                    Valid values:
+                                      read          - Read permissions
+                                      write         - Write permissions
+                                      modify        - Modify permissions (read+write+delete)
+                                      full-control  - Full control permissions
+                                      full          - Alias for full-control
+                                    Requires --user
 
 KUBERNETES EXAMPLES
 
@@ -102,17 +116,28 @@ KUBERNETES EXAMPLES
             --db postgres,mssql --db-min 2 --db-connect --db-check version \
             --redis --redis-connect --redis-ping
 
-FILESYSTEM EXAMPLES (Not yet implemented)
+FILESYSTEM EXAMPLES
 
-    Path validation:
-        clio assert fs --path "C:\inetpub\wwwroot\app\data"
+    Path validation (absolute path):
+        clio assert fs --path "C:\inetpub\wwwroot\clio\s_n8\"
 
-    Path with user permissions:
-        clio assert fs --path "C:\data" --user "IIS APPPOOL\MyApp" --perm full
+    Path validation (using setting key):
+        clio assert fs --path iis-clio-root-path
 
+    Path with user permissions (setting key):
+        clio assert fs --path iis-clio-root-path --user "BUILTIN\IIS_IUSRS" --perm full-control
+
+    Path with user permissions (absolute path):
+        clio assert fs --path "C:\inetpub\wwwroot\clio\s_n8\" --user "BUILTIN\IIS_IUSRS" --perm full-control
+
+    Path with modify permissions:
+        clio assert fs --path iis-clio-root-path --user "BUILTIN\IIS_IUSRS" --perm modify
+
+    Path with read permissions:
+        clio assert fs --path "C:\data" --user "BUILTIN\Users" --perm read
 OUTPUT FORMAT
 
-    Success example:
+    Kubernetes success example:
     {
       "status": "pass",
       "context": {
@@ -139,7 +164,21 @@ OUTPUT FORMAT
       }
     }
 
-    Failure example:
+    Filesystem success example:
+    {
+      "status": "pass",
+      "scope": "Fs",
+      "resolved": {
+        "path": "C:\\inetpub\\wwwroot\\clio",
+        "userIdentity": "BUILTIN\\IIS_IUSRS",
+        "permission": "full-control"
+      },
+      "details": {
+        "requestedPath": "iis-clio-root-path"
+      }
+    }
+
+    Kubernetes failure example:
     {
       "status": "fail",
       "scope": "K8",
@@ -149,6 +188,20 @@ OUTPUT FORMAT
         "engine": "postgres",
         "host": "clio-postgres-lb",
         "port": 5432
+      }
+    }
+
+    Filesystem failure example:
+    {
+      "status": "fail",
+      "scope": "Fs",
+      "failedAt": "FsPerm",
+      "reason": "User 'BUILTIN\\IIS_IUSRS' does not have 'full-control' permission on path 'C:\\inetpub\\wwwroot\\clio'",
+      "details": {
+        "requestedPath": "iis-clio-root-path",
+        "resolvedPath": "C:\\inetpub\\wwwroot\\clio",
+        "userIdentity": "BUILTIN\\IIS_IUSRS",
+        "requiredPermission": "full-control"
       }
     }
 
@@ -210,10 +263,28 @@ KUBERNETES DETECTION RULES
 
 NOTES
 
-    - Requires kubectl configured with access to target cluster
+    - Kubernetes assertions require kubectl configured with access to target cluster
     - Database version checks require valid credentials
-    - Filesystem assertions require Windows platform
+    - Filesystem path validation works on all platforms
+    - Filesystem permission checks are Windows-only (use ACLs)
+    - Setting key 'iis-clio-root-path' resolves from appsettings.json
     - All I/O operations have configurable timeouts
+
+USE CASES
+
+    Pre-deployment validation:
+        clio assert k8 --db postgres --redis
+        clio assert fs --path iis-clio-root-path
+
+    IIS setup validation:
+        clio assert fs --path iis-clio-root-path --user "BUILTIN\IIS_IUSRS" --perm full-control
+
+    Application directory permissions:
+        clio assert fs --path "C:\inetpub\wwwroot\myapp" --user "IIS APPPOOL\MyAppPool" --perm modify
+
+    CI/CD pipeline checks:
+        clio assert k8 --db postgres --db-connect --redis --redis-ping
+        clio assert fs --path iis-clio-root-path
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio


### PR DESCRIPTION
feat: add filesystem path and permission validation to assert command

- Enhanced assert command to validate filesystem paths and permissions.
- Implemented FsPathAssertion for checking path existence.
- Implemented FsPermissionAssertion for validating user permissions on paths.
- Updated documentation to reflect new filesystem validation features.
- Added examples for filesystem assertions in Commands.md.