### PR TITLE
Replace --quiet/-q with --silent for clio stop command

### DIFF
--- a/clio.tests/Command/StopCommand.Tests.cs
+++ b/clio.tests/Command/StopCommand.Tests.cs
@@ -49,7 +49,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\inetpub\wwwroot\Creatio";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "production", Quiet = true };
+		StopOptions options = new() { Environment = "production", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("production").Returns(env);
 
@@ -85,7 +85,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\Creatio\Test";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "test", Quiet = true };
+		StopOptions options = new() { Environment = "test", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("test").Returns(env);
 		_iisSiteDetector.GetSitesByPath(envPath).Returns(Task.FromResult(new List<IISSiteInfo>()));
@@ -107,7 +107,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\Creatio\Test";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "test", Quiet = true };
+		StopOptions options = new() { Environment = "test", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("test").Returns(env);
 		_iisSiteDetector.GetSitesByPath(envPath).Returns(Task.FromResult(new List<IISSiteInfo>()));
@@ -127,7 +127,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\inetpub\wwwroot\Creatio";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "production", Quiet = true };
+		StopOptions options = new() { Environment = "production", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("production").Returns(env);
 
@@ -156,7 +156,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\inetpub\wwwroot\Creatio";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "production", Quiet = true };
+		StopOptions options = new() { Environment = "production", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("production").Returns(env);
 
@@ -183,7 +183,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\Creatio\Test";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "test", Quiet = true };
+		StopOptions options = new() { Environment = "test", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("test").Returns(env);
 		_iisSiteDetector.GetSitesByPath(envPath).Returns(Task.FromResult(new List<IISSiteInfo>()));
@@ -204,7 +204,7 @@ public class StopCommandTestCase : BaseCommandTests<StopOptions>
 		// Arrange
 		string envPath = @"C:\inetpub\wwwroot\Creatio";
 		EnvironmentSettings env = new() { EnvironmentPath = envPath };
-		StopOptions options = new() { Environment = "production", Quiet = true };
+		StopOptions options = new() { Environment = "production", IsSilent = true };
 
 		_settingsRepository.GetEnvironment("production").Returns(env);
 

--- a/clio/Command/StopCommand.cs
+++ b/clio/Command/StopCommand.cs
@@ -19,9 +19,6 @@ namespace Clio.Command
 	{
 		[Option("all", Required = false, HelpText = "Stop all Creatio services/processes")]
 		public bool All { get; set; }
-
-		[Option("quiet", Required = false, HelpText = "Stop without confirmation prompt")]
-		public bool Quiet { get; set; }
 	}
 
 	public class StopCommand : Command<StopOptions>
@@ -59,8 +56,8 @@ namespace Clio.Command
 					return 1;
 				}
 
-				// Show confirmation unless --quiet flag is set
-				if (!options.Quiet && !ConfirmStop(environmentsToStop))
+				// Show confirmation unless --silent flag is set
+				if (!options.IsSilent && !ConfirmStop(environmentsToStop))
 				{
 					_logger.WriteInfo("Operation cancelled by user.");
 					return 0;

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -1239,14 +1239,14 @@ clio stop -e <ENV_NAME>
 clio stop --all
 
 # Stop without confirmation prompt
-clio stop -e <ENV_NAME> --quiet
-clio stop --all -q
+clio stop -e <ENV_NAME> --silent
+clio stop --all --silent
 ```
 
 ### Options
 - `-e, --environment <ENV_NAME>` - Stop specific environment
 - `--all` - Stop all registered Creatio environments
-- `-q, --quiet` - Skip confirmation prompt
+- `--silent` - Skip confirmation prompt
 
 ### Behavior
 
@@ -1305,13 +1305,12 @@ clio stop -e production
 
 Stop a specific environment without confirmation:
 ```bash
-clio stop -e production --quiet
-clio stop -e production -q
+clio stop -e production --silent
 ```
 
 Stop all registered environments:
 ```bash
-clio stop --all --quiet
+clio stop --all --silent
 ```
 
 Using alias:
@@ -1323,7 +1322,7 @@ clio stop-creatio -e dev
 
 **IIS Deployment (Windows)**:
 ```bash
-$ clio stop -e prod --quiet
+$ clio stop -e prod --silent
 
 Stopping environment: prod
 Stopping IIS application pool: prod
@@ -1335,7 +1334,7 @@ Stopped: 1
 
 **Background Process**:
 ```bash
-$ clio stop -e dev --quiet
+$ clio stop -e dev --silent
 
 Stopping environment: dev
 Killing process dotnet (PID: 12345)
@@ -1348,7 +1347,7 @@ Stopped: 1
 
 **Multiple Environments**:
 ```bash
-$ clio stop --all --quiet
+$ clio stop --all --silent
 
 Stopping environment: dev
 ✓ IIS application pool 'dev' stopped successfully
@@ -4559,7 +4558,7 @@ clio stop --all
 ### Options
 - `-e, --environment <ENV_NAME>` - Stop specific environment
 - `--all` - Stop all registered Creatio environments
-- `-q, --quiet` - Skip confirmation prompt
+- `--silent` - Skip confirmation prompt
 
 ### Behavior
 
@@ -4601,12 +4600,12 @@ clio stop -e dev1
 
 Stop a specific environment without confirmation:
 ```bash
-clio stop -e dev1 --quiet
+clio stop -e dev1 --silent
 ```
 
 Stop all registered environments:
 ```bash
-clio stop --all --quiet
+clio stop --all --silent
 ```
 
 ### Example Output

--- a/clio/DeployCreatioMacOS.md
+++ b/clio/DeployCreatioMacOS.md
@@ -381,13 +381,13 @@ clio stop -e ENV_NAME
 clio stop -e dev1
 
 # Stop without confirmation
-clio stop -e dev1 --quiet
+clio stop -e dev1 --silent
 
 # Stop all environments
 clio stop --all
 
 # Stop all environments without confirmation
-clio stop --all --quiet
+clio stop --all --silent
 ```
 
 > **Important:** The `stop` command does NOT delete application files, database, or environment configuration. For complete removal, use `clio uninstall-creatio -e ENV_NAME`.

--- a/clio/help/en/stop.txt
+++ b/clio/help/en/stop.txt
@@ -41,23 +41,20 @@ OPTIONS
     --all
         Stop all registered Creatio environments.
 
-    -q, --quiet
+    --silent
         Skip confirmation prompt and proceed immediately.
 
 EXAMPLE
     clio stop -e production
         stop production environment with confirmation
 
-    clio stop -e production --quiet
+    clio stop -e production --silent
         stop production without confirmation
-
-    clio stop -e production -q
-        same as above (short form)
 
     clio stop --all
         stop all environments with confirmation
 
-    clio stop --all --quiet
+    clio stop --all --silent
         stop all environments without confirmation
 
     Example output (IIS deployment):
@@ -101,7 +98,7 @@ CONFIRMATION PROMPT
 
     Continue? [y/N]: y
 
-    Use --quiet or -q flag to skip confirmation and proceed immediately.
+    Use --silent flag to skip confirmation and proceed immediately.
 
 ENVIRONMENT DETECTION
     An environment is considered active if any of the following are true:


### PR DESCRIPTION
The --quiet and -q options have been removed and replaced with --silent for the clio stop command. All code, tests, and documentation now use IsSilent/--silent to skip the confirmation prompt. Example usage and help text updated accordingly.