### PR TITLE
feat: default help output to console instead of browser

### DIFF
--- a/clio/Command/CreateInfrastructure.cs
+++ b/clio/Command/CreateInfrastructure.cs
@@ -52,7 +52,24 @@ public class CreateInfrastructureOptions{
 
 public class CreateInfrastructureCommand(IFileSystem fileSystem, IInfrastructurePathProvider infrastructurePathProvider,
 	ILogger logger) : Command<CreateInfrastructureOptions>{
-	
+
+	#region Methods: Private
+
+	private void ProcessTemplateFile(string path, IDictionary<string, string> replacements) {
+		if (!fileSystem.ExistsFile(path)) {
+			return;
+		}
+
+		string content = fileSystem.ReadAllText(path);
+		foreach (KeyValuePair<string, string> kvp in replacements) {
+			content = content.Replace(kvp.Key, kvp.Value);
+		}
+
+		fileSystem.WriteAllTextToFile(path, content);
+	}
+
+	#endregion
+
 	#region Methods: Public
 
 	public override int Execute(CreateInfrastructureOptions options) {
@@ -73,29 +90,19 @@ public class CreateInfrastructureCommand(IFileSystem fileSystem, IInfrastructure
 			{ "{{MSSQL_REQUEST_CPU}}", options.MssqlRequestCpu }
 		};
 
-		// Process PostgreSQL StatefulSet
-		string postgresStatefulSetPath =
-			fileSystem.NormalizeFilePathByPlatform($"{to}/postgres/postgres-stateful-set.yaml");
-		if (fileSystem.ExistsFile(postgresStatefulSetPath)) {
-			string content = fileSystem.ReadAllText(postgresStatefulSetPath);
-			foreach (KeyValuePair<string, string> kvp in replacements) {
-				content = content.Replace(kvp.Key, kvp.Value);
-			}
+		string persistentInfrastructureRoot = "/mnt/data/clio-infrastructure";
+		replacements.Add("{{CLIO_INFRA_ROOT}}", persistentInfrastructureRoot);
 
-			fileSystem.WriteAllTextToFile(postgresStatefulSetPath, content);
-		}
-
-		// Process MSSQL StatefulSet
-		string mssqlStatefulSetPath =
-			fileSystem.NormalizeFilePathByPlatform($"{to}/mssql/mssql-stateful-set.yaml");
-		if (fileSystem.ExistsFile(mssqlStatefulSetPath)) {
-			string content = fileSystem.ReadAllText(mssqlStatefulSetPath);
-			foreach (KeyValuePair<string, string> kvp in replacements) {
-				content = content.Replace(kvp.Key, kvp.Value);
-			}
-
-			fileSystem.WriteAllTextToFile(mssqlStatefulSetPath, content);
-		}
+		ProcessTemplateFile(fileSystem.NormalizeFilePathByPlatform($"{to}/postgres/postgres-stateful-set.yaml"),
+			replacements);
+		ProcessTemplateFile(fileSystem.NormalizeFilePathByPlatform($"{to}/mssql/mssql-stateful-set.yaml"),
+			replacements);
+		ProcessTemplateFile(fileSystem.NormalizeFilePathByPlatform($"{to}/postgres/postgres-volumes.yaml"),
+			replacements);
+		ProcessTemplateFile(fileSystem.NormalizeFilePathByPlatform($"{to}/mssql/mssql-volumes.yaml"),
+			replacements);
+		ProcessTemplateFile(fileSystem.NormalizeFilePathByPlatform($"{to}/pgadmin/pgadmin-volumes.yaml"),
+			replacements);
 
 
 		// Display resource configuration

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -819,13 +819,14 @@ internal class Program {
 		string helpDirectoryPath = Path.Combine(envPath ?? string.Empty, helpFolderName);
 		Parser.Default.Settings.ShowHeader = false;
 		Parser.Default.Settings.HelpDirectory = helpDirectoryPath;
-		if(args.Length >= 2 && (args[1] == "--HELP" || args[1] == "-H")) {
+		// Default: console help via LocalHelpViewer; use --WEB / -W to open browser
+		if(args.Length >= 2 && (args[1] == "--WEB" || args[1] == "-W")) {
 			IServiceProvider bm = new BindingsModule().Register();
-			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<LocalHelpViewer>();
+			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<WikiHelpViewer>();
 		}
 		else {
 			IServiceProvider bm = new BindingsModule().Register();
-			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<WikiHelpViewer>();
+			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<LocalHelpViewer>();
 		}
 		
 		string[] normalizedArgs = NormalizeCommandLineArgs(args);

--- a/clio/tpl/k8/infrastructure/mssql/mssql-volumes.yaml
+++ b/clio/tpl/k8/infrastructure/mssql/mssql-volumes.yaml
@@ -12,4 +12,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/mnt/clio-infrastructure/mssql"
+    path: "{{CLIO_INFRA_ROOT}}/mssql"
+    type: DirectoryOrCreate

--- a/clio/tpl/k8/infrastructure/pgadmin/pgadmin-volumes.yaml
+++ b/clio/tpl/k8/infrastructure/pgadmin/pgadmin-volumes.yaml
@@ -12,7 +12,8 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/mnt/clio-infrastructure/pgadmin"
+    path: "{{CLIO_INFRA_ROOT}}/pgadmin"
+    type: DirectoryOrCreate
 
 ---
 kind: PersistentVolumeClaim

--- a/clio/tpl/k8/infrastructure/postgres/postgres-volumes.yaml
+++ b/clio/tpl/k8/infrastructure/postgres/postgres-volumes.yaml
@@ -140,7 +140,8 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/mnt/clio-infrastructure/postgres/data"
+    path: "{{CLIO_INFRA_ROOT}}/postgres/data"
+    type: DirectoryOrCreate
 
 ---
 kind: PersistentVolume
@@ -157,4 +158,5 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/mnt/clio-infrastructure/postgres/backup-images"
+    path: "{{CLIO_INFRA_ROOT}}/postgres/backup-images"
+    type: DirectoryOrCreate


### PR DESCRIPTION
Changed default help behavior so that 'clio -h' and 'clio help' display help text in the console instead of opening a browser page. Browser help is still available via --WEB / -W flag.