### PR TITLE
feat: add support for selecting container image CLI in build-docker-image

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -868,3 +868,10 @@ Discovery: `Link4RepoCommand.TryResolveDirectoryPath` already normalized relativ
 Files: C:\Projects\clio\clio.tests\Command\Link4RepoCommand.Tests.cs, C:\Projects\clio\.codex\workspace-diary.md
 Impact: The Link4Repo path-resolution tests now pass consistently on Windows, macOS, and Linux without changing production command behavior.
 
+## 2026-03-24 11:45 – Add docker vs nerdctl selection for build-docker-image
+Context: User needed `build-docker-image` to honor a default container image CLI from clio appsettings and allow per-run override flags for `docker` and `nerdctl`, with `nerdctl` always using namespace `k8s.io`.
+Decision: Added appsettings key `container-image-cli` with default `docker`, exposed it through `ISettingsRepository`, added `--use-docker` and `--use-nerdctl` command flags, and changed `BuildDockerImageService` to resolve the effective CLI from flags first and settings second. Also serialized all nerdctl invocations as `nerdctl --namespace k8s.io ...`.
+Discovery: The existing implementation had drifted to a hardcoded `nerdctl` executable even though tests and docs still described Docker. Full-suite testing also exposed a pre-existing race in `SettingsRepository.SaveSchema()`, so schema generation now short-circuits under a static lock when the shared testhost schema file already exists.
+Files: C:\Projects\clio\clio\Command\BuildDockerImageCommand.cs, C:\Projects\clio\clio\Command\BuildDockerImageService.cs, C:\Projects\clio\clio\Environment\ConfigurationOptions.cs, C:\Projects\clio\clio\Environment\ISettingsRepository.cs, C:\Projects\clio\clio\tpl\jsonschema\schema.json.tpl, C:\Projects\clio\clio.tests\Command\BuildDockerImageServiceTests.cs, C:\Projects\clio\clio\help\en\build-docker-image.txt, C:\Projects\clio\clio\docs\commands\build-docker-image.md, C:\Projects\clio\clio\Commands.md, C:\Projects\clio\.codex\workspace-diary.md
+Impact: Future image-build work can switch between Docker and containerd-backed nerdctl without patching the service again, appsettings/schema/docs now describe the same contract, and the full test suite can initialize shared settings in parallel without schema.json file-lock failures.
+

--- a/clio.tests/Command/BuildDockerImageServiceTests.cs
+++ b/clio.tests/Command/BuildDockerImageServiceTests.cs
@@ -3,6 +3,7 @@ using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Clio.Command;
 using Clio.Common;
+using Clio.UserEnvironment;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -15,6 +16,7 @@ public class BuildDockerImageServiceTests {
 	private Clio.Common.IFileSystem _fileSystem = null!;
 	private ILogger _logger = null!;
 	private IProcessExecutor _processExecutor = null!;
+	private ISettingsRepository _settingsRepository = null!;
 	private IDockerTemplatePathProvider _templatePathProvider = null!;
 	private IZipFile _zipFile = null!;
 	private BuildDockerImageService _service = null!;
@@ -26,9 +28,11 @@ public class BuildDockerImageServiceTests {
 		_fileSystem = new Clio.Common.FileSystem(_msFileSystem);
 		_logger = Substitute.For<ILogger>();
 		_processExecutor = Substitute.For<IProcessExecutor>();
+		_settingsRepository = Substitute.For<ISettingsRepository>();
+		_settingsRepository.GetContainerImageCli().Returns("docker");
 		_templatePathProvider = Substitute.For<IDockerTemplatePathProvider>();
 		_zipFile = Substitute.For<IZipFile>();
-		_service = new BuildDockerImageService(_processExecutor, _logger, _fileSystem, _msFileSystem, _zipFile,
+		_service = new BuildDockerImageService(_processExecutor, _logger, _settingsRepository, _fileSystem, _msFileSystem, _zipFile,
 			_templatePathProvider);
 		_tempRoot = _msFileSystem.Path.Combine(_msFileSystem.Path.GetTempPath(), "clio-build-docker-image-tests",
 			Guid.NewGuid().ToString("N"));
@@ -78,6 +82,69 @@ public class BuildDockerImageServiceTests {
 			o.Arguments.Contains("save --output")));
 		_processExecutor.DidNotReceive().ExecuteWithRealtimeOutputAsync(Arg.Is<ProcessExecutionOptions>(o =>
 			o.Arguments.Contains("push \"")));
+	}
+
+	[Test]
+	[Description("Execute should use nerdctl with the k8s.io namespace when appsettings selects nerdctl.")]
+	public void Execute_ShouldUseNerdctlWithK8sNamespace_WhenConfiguredInSettings() {
+		// Arrange
+		string sourceDirectory = CreateDotNetSourceDirectory("Nerdctl Source");
+		string templateDirectory = CreateTemplateDirectory("dev-template");
+		_settingsRepository.GetContainerImageCli().Returns("nerdctl");
+		_templatePathProvider.ResolveTemplate("dev")
+			.Returns(new DockerTemplateResolution("dev", templateDirectory, true));
+		_processExecutor.ExecuteWithRealtimeOutputAsync(Arg.Any<ProcessExecutionOptions>())
+			.Returns(Task.FromResult(new ProcessExecutionResult {
+				Started = true,
+				ExitCode = 0
+			}));
+
+		BuildDockerImageOptions options = new() {
+			SourcePath = sourceDirectory,
+			Template = "dev"
+		};
+
+		// Act
+		int result = _service.Execute(options);
+
+		// Assert
+		result.Should().Be(0, "because nerdctl was selected from appsettings and all commands succeeded");
+		_processExecutor.Received().ExecuteWithRealtimeOutputAsync(Arg.Is<ProcessExecutionOptions>(o =>
+			o.Program == "nerdctl" && o.Arguments == "--namespace k8s.io --version"));
+		_processExecutor.Received().ExecuteWithRealtimeOutputAsync(Arg.Is<ProcessExecutionOptions>(o =>
+			o.Program == "nerdctl" && o.Arguments.Contains("--namespace k8s.io build")));
+	}
+
+	[Test]
+	[Description("Execute should let the CLI override a nerdctl appsettings default and force docker instead.")]
+	public void Execute_ShouldPreferUseDockerOverSettingsDefault() {
+		// Arrange
+		string sourceDirectory = CreateDotNetSourceDirectory("Override Source");
+		string templateDirectory = CreateTemplateDirectory("prod-template");
+		_settingsRepository.GetContainerImageCli().Returns("nerdctl");
+		_templatePathProvider.ResolveTemplate("prod")
+			.Returns(new DockerTemplateResolution("prod", templateDirectory, true));
+		_processExecutor.ExecuteWithRealtimeOutputAsync(Arg.Any<ProcessExecutionOptions>())
+			.Returns(Task.FromResult(new ProcessExecutionResult {
+				Started = true,
+				ExitCode = 0
+			}));
+
+		BuildDockerImageOptions options = new() {
+			SourcePath = sourceDirectory,
+			Template = "prod",
+			UseDocker = true
+		};
+
+		// Act
+		int result = _service.Execute(options);
+
+		// Assert
+		result.Should().Be(0, "because the explicit --use-docker flag should override appsettings");
+		_processExecutor.Received().ExecuteWithRealtimeOutputAsync(Arg.Is<ProcessExecutionOptions>(o =>
+			o.Program == "docker" && o.Arguments == "--version"));
+		_processExecutor.DidNotReceive().ExecuteWithRealtimeOutputAsync(Arg.Is<ProcessExecutionOptions>(o =>
+			o.Program == "nerdctl"));
 	}
 
 	[Test]
@@ -212,7 +279,34 @@ public class BuildDockerImageServiceTests {
 
 		// Assert
 		result.Should().Be(1, "because docker is required to build container images");
-		_logger.Received().WriteError(Arg.Is<string>(s => s.Contains("Docker is not installed", StringComparison.Ordinal)));
+		_logger.Received().WriteError(Arg.Is<string>(s =>
+			s.Contains("Container image CLI 'docker' is not installed", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Execute should reject mutually exclusive CLI engine overrides before starting the build.")]
+	public void Execute_ShouldRejectConflictingCliOverrides() {
+		// Arrange
+		string sourceDirectory = CreateDotNetSourceDirectory("Conflicting Overrides");
+		string templateDirectory = CreateTemplateDirectory("dev-template");
+		_templatePathProvider.ResolveTemplate("dev")
+			.Returns(new DockerTemplateResolution("dev", templateDirectory, true));
+
+		BuildDockerImageOptions options = new() {
+			SourcePath = sourceDirectory,
+			Template = "dev",
+			UseDocker = true,
+			UseNerdctl = true
+		};
+
+		// Act
+		int result = _service.Execute(options);
+
+		// Assert
+		result.Should().Be(1, "because both engine override flags cannot be used together");
+		_logger.Received().WriteError(Arg.Is<string>(s =>
+			s.Contains("Use either --use-docker or --use-nerdctl", StringComparison.Ordinal)));
+		_processExecutor.DidNotReceive().ExecuteWithRealtimeOutputAsync(Arg.Any<ProcessExecutionOptions>());
 	}
 
 	private string CreateDotNetSourceDirectory(string leafName) {

--- a/clio/Command/BuildDockerImageCommand.cs
+++ b/clio/Command/BuildDockerImageCommand.cs
@@ -31,6 +31,18 @@ public class BuildDockerImageOptions {
 	/// </summary>
 	[Option("registry", Required = false, HelpText = "Optional registry or repository prefix used when pushing the image")]
 	public string Registry { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether to force use of the Docker CLI for this invocation.
+	/// </summary>
+	[Option("use-docker", Required = false, HelpText = "Use the docker CLI for this invocation, overriding appsettings.json")]
+	public bool UseDocker { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether to force use of the nerdctl CLI for this invocation.
+	/// </summary>
+	[Option("use-nerdctl", Required = false, HelpText = "Use the nerdctl CLI for this invocation, overriding appsettings.json")]
+	public bool UseNerdctl { get; set; }
 }
 
 /// <summary>

--- a/clio/Command/BuildDockerImageService.cs
+++ b/clio/Command/BuildDockerImageService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Clio.Common;
+using Clio.UserEnvironment;
 
 namespace Clio.Command;
 
@@ -26,13 +27,16 @@ public interface IBuildDockerImageService {
 public sealed class BuildDockerImageService(
 	IProcessExecutor processExecutor,
 	ILogger logger,
+	ISettingsRepository settingsRepository,
 	Clio.Common.IFileSystem fileSystem,
 	System.IO.Abstractions.IFileSystem msFileSystem,
 	IZipFile zipFile,
 	IDockerTemplatePathProvider dockerTemplatePathProvider)
 	: IBuildDockerImageService {
-	private const string DockerProgramName = "docker";
 	private const string DatabaseSourceLabelName = "org.creatio.database-source";
+	private const string DockerCli = "docker";
+	private const string NerdctlCli = "nerdctl";
+	private const string NerdctlNamespace = "k8s.io";
 	private const string SourceFolderName = "source";
 	private const string TerrasoftWebHostDll = "Terrasoft.WebHost.dll";
 	private const string TerrasoftWebHostConfig = "Terrasoft.WebHost.dll.config";
@@ -45,6 +49,8 @@ public sealed class BuildDockerImageService(
 	private readonly System.IO.Abstractions.IFileSystem _msFileSystem =
 		msFileSystem ?? throw new ArgumentNullException(nameof(msFileSystem));
 	private readonly IProcessExecutor _processExecutor = processExecutor ?? throw new ArgumentNullException(nameof(processExecutor));
+	private readonly ISettingsRepository _settingsRepository =
+		settingsRepository ?? throw new ArgumentNullException(nameof(settingsRepository));
 	private readonly IZipFile _zipFile = zipFile ?? throw new ArgumentNullException(nameof(zipFile));
 
 	/// <inheritdoc />
@@ -64,6 +70,7 @@ public sealed class BuildDockerImageService(
 			string localImageReference = $"{imageRepository}:{imageTag}";
 			string registryImageReference = BuildRegistryImageReference(options.Registry, imageRepository, imageTag);
 			string outputTarPath = NormalizeOptionalOutputPath(options.OutputPath);
+			ContainerImageCliKind containerImageCli = ResolveContainerImageCli(options);
 
 			stagingRoot = CreateTemporaryDirectory("build-docker-image");
 			string preparedSourceRoot = PrepareSourceRoot(sourcePath, stagingRoot);
@@ -71,20 +78,24 @@ public sealed class BuildDockerImageService(
 
 			_logger.WriteInfo($"Resolved source: {preparedSourceRoot}");
 			_logger.WriteInfo($"Resolved template: {templateResolution.TemplatePath}");
+			_logger.WriteInfo($"Container image CLI: {containerImageCli.ToCliName()}");
 			_logger.WriteInfo($"Local image reference: {localImageReference}");
 
-			ProcessExecutionResult versionResult = ExecuteDocker("--version", null);
+			ProcessExecutionResult versionResult = ExecuteContainerCli(containerImageCli, "--version", null);
 			if (!WasSuccessful(versionResult)) {
-				return LogAndReturnFailure(versionResult, "Docker is not installed or not available in PATH.");
+				return LogAndReturnFailure(versionResult,
+					$"Container image CLI '{containerImageCli.ToCliName()}' is not installed or not available in PATH.");
 			}
 
 			string databaseSourceLabel = BuildDockerLabel(DatabaseSourceLabelName, sourceLeafName);
 			ProcessExecutionResult buildResult =
-				ExecuteDocker(
+				ExecuteContainerCli(
+					containerImageCli,
 					$"build --label \"{databaseSourceLabel}\" -t \"{localImageReference}\" \"{buildContextPath}\"",
 					buildContextPath);
 			if (!WasSuccessful(buildResult)) {
-				return LogAndReturnFailure(buildResult, $"Docker build failed for image '{localImageReference}'.");
+				return LogAndReturnFailure(buildResult,
+					$"Container image build failed for image '{localImageReference}' using '{containerImageCli.ToCliName()}'.");
 			}
 
 			_logger.WriteInfo($"Built Docker image: {localImageReference}");
@@ -92,10 +103,11 @@ public sealed class BuildDockerImageService(
 			if (!string.IsNullOrWhiteSpace(outputTarPath)) {
 				EnsureOutputDirectoryExists(outputTarPath);
 				ProcessExecutionResult saveResult =
-					ExecuteDocker($"save --output \"{outputTarPath}\" \"{localImageReference}\"", buildContextPath);
+					ExecuteContainerCli(containerImageCli,
+						$"save --output \"{outputTarPath}\" \"{localImageReference}\"", buildContextPath);
 				if (!WasSuccessful(saveResult)) {
 					return LogAndReturnFailure(saveResult,
-						$"Docker save failed for image '{localImageReference}' to '{outputTarPath}'.");
+						$"Container image save failed for image '{localImageReference}' to '{outputTarPath}'.");
 				}
 
 				_logger.WriteInfo($"Saved Docker image tar: {outputTarPath}");
@@ -103,17 +115,18 @@ public sealed class BuildDockerImageService(
 
 			if (!string.IsNullOrWhiteSpace(registryImageReference)) {
 				ProcessExecutionResult tagResult =
-					ExecuteDocker($"tag \"{localImageReference}\" \"{registryImageReference}\"", buildContextPath);
+					ExecuteContainerCli(containerImageCli,
+						$"tag \"{localImageReference}\" \"{registryImageReference}\"", buildContextPath);
 				if (!WasSuccessful(tagResult)) {
 					return LogAndReturnFailure(tagResult,
-						$"Docker tag failed for '{localImageReference}' to '{registryImageReference}'.");
+						$"Container image tag failed for '{localImageReference}' to '{registryImageReference}'.");
 				}
 
 				ProcessExecutionResult pushResult =
-					ExecuteDocker($"push \"{registryImageReference}\"", buildContextPath);
+					ExecuteContainerCli(containerImageCli, $"push \"{registryImageReference}\"", buildContextPath);
 				if (!WasSuccessful(pushResult)) {
 					return LogAndReturnFailure(pushResult,
-						$"Docker push failed for image '{registryImageReference}'.");
+						$"Container image push failed for image '{registryImageReference}'.");
 				}
 
 				_logger.WriteInfo($"Pushed Docker image: {registryImageReference}");
@@ -173,14 +186,46 @@ public sealed class BuildDockerImageService(
 		_fileSystem.CreateDirectoryIfNotExists(outputDirectory);
 	}
 
-	private ProcessExecutionResult ExecuteDocker(string arguments, string workingDirectory) {
-		ProcessExecutionOptions executionOptions = new(DockerProgramName, arguments) {
+	private ProcessExecutionResult ExecuteContainerCli(
+		ContainerImageCliKind containerImageCli,
+		string arguments,
+		string workingDirectory) {
+		string effectiveArguments = containerImageCli == ContainerImageCliKind.Nerdctl
+			? $"--namespace {NerdctlNamespace} {arguments}"
+			: arguments;
+		ProcessExecutionOptions executionOptions = new(containerImageCli.ToCliName(), effectiveArguments) {
 			WorkingDirectory = workingDirectory,
 			MirrorOutputToLogger = false,
 			OnOutput = (line, _) => _logger.WriteLine(line)
 		};
 
 		return _processExecutor.ExecuteWithRealtimeOutputAsync(executionOptions).GetAwaiter().GetResult();
+	}
+
+	private ContainerImageCliKind ResolveContainerImageCli(BuildDockerImageOptions options) {
+		if (options.UseDocker && options.UseNerdctl) {
+			throw new InvalidOperationException("Use either --use-docker or --use-nerdctl, but not both.");
+		}
+
+		if (options.UseDocker) {
+			return ContainerImageCliKind.Docker;
+		}
+
+		if (options.UseNerdctl) {
+			return ContainerImageCliKind.Nerdctl;
+		}
+
+		string configuredCli = _settingsRepository.GetContainerImageCli();
+		if (string.Equals(configuredCli, DockerCli, StringComparison.OrdinalIgnoreCase)) {
+			return ContainerImageCliKind.Docker;
+		}
+
+		if (string.Equals(configuredCli, NerdctlCli, StringComparison.OrdinalIgnoreCase)) {
+			return ContainerImageCliKind.Nerdctl;
+		}
+
+		throw new InvalidOperationException(
+			$"Unsupported container-image-cli setting '{configuredCli}'. Allowed values are '{DockerCli}' and '{NerdctlCli}'.");
 	}
 
 	private string GetSourceLeafName(string sourcePath) {
@@ -301,6 +346,27 @@ public sealed class BuildDockerImageService(
 
 	private bool WasSuccessful(ProcessExecutionResult result) {
 		return result.Started && result.ExitCode.GetValueOrDefault(-1) == 0;
+	}
+}
+
+/// <summary>
+/// Identifies the container image CLI used by build-docker-image.
+/// </summary>
+public enum ContainerImageCliKind {
+	/// <summary>
+	/// Use Docker.
+	/// </summary>
+	Docker,
+
+	/// <summary>
+	/// Use nerdctl with the Kubernetes namespace.
+	/// </summary>
+	Nerdctl
+}
+
+internal static class ContainerImageCliKindExtensions {
+	public static string ToCliName(this ContainerImageCliKind containerImageCli) {
+		return containerImageCli == ContainerImageCliKind.Nerdctl ? "nerdctl" : "docker";
 	}
 }
 

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -4019,11 +4019,15 @@ clio build-docker-image --from <zip-or-folder> --template <name-or-path> [option
 - `--template <NameOrPath>` - Required. Bundled template name (`dev`, `prod`) or custom template directory path
 - `--output-path <Path>` - Optional. Save the built image to a tar file with `docker save`
 - `--registry <Prefix>` - Optional. Tag and push the image to `<Prefix>/creatio-<template>:<tag>`
+- `--use-docker` - Optional. Force `docker` for this invocation
+- `--use-nerdctl` - Optional. Force `nerdctl` for this invocation; clio adds `--namespace k8s.io`
 
 ### Behavior
 
 - Accepts only `.NET 8+` Creatio payloads
 - Rejects `.NET Framework` distributions before Docker execution
+- Uses appsettings.json key `container-image-cli` to choose `docker` or `nerdctl` by default
+- Lets CLI flags override the configured container image CLI per invocation
 - Copies bundled templates to the local clio settings folder under `docker-templates`
 - Creates a temporary Docker build context and cleans it up after execution
 - Adds OCI label `org.creatio.database-source` with the original source payload name
@@ -4046,6 +4050,10 @@ clio build-docker-image \
   --template prod \
   --output-path "/tmp/creatio-prod.tar" \
   --registry "ghcr.io/acme"
+```
+
+```bash
+clio build-docker-image --from "/opt/builds/creatio-net8" --template prod --use-nerdctl
 ```
 
 ## deploy-creatio

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -238,6 +238,14 @@ namespace Clio
 
 	public class Settings
 	{
+		/// <summary>
+		/// Supported container image CLIs for build-docker-image.
+		/// </summary>
+		/// <summary>
+		/// Default container image CLI used by build-docker-image.
+		/// </summary>
+		public const string DefaultContainerImageCli = "docker";
+
 		public Settings() {
 			Environments = new Dictionary<string, EnvironmentSettings>();
 		}
@@ -278,6 +286,17 @@ namespace Clio
 		public string WorkspacesRoot {
 			get;
 			set;
+		}
+
+		private string _containerImageCli;
+
+		/// <summary>
+		/// Gets or sets the default container image CLI used by build-docker-image.
+		/// </summary>
+		[JsonProperty("container-image-cli")]
+		public string ContainerImageCli {
+			get => string.IsNullOrWhiteSpace(_containerImageCli) ? DefaultContainerImageCli : _containerImageCli;
+			set => _containerImageCli = value;
 		}
 
 		[JsonProperty("$schema")]
@@ -328,6 +347,7 @@ namespace Clio
 	{
 		private const string FileName = "appsettings.json";
 		private const string SchemaFileName = "schema.json";
+		private static readonly object SchemaFileLock = new ();
 
 		private Settings _settings = new ();
 		public static string AppSettingsFolderPath {
@@ -414,10 +434,15 @@ namespace Clio
 		/// This file is used by intelisence in vs code and other json editors.
 		/// </summary>
 		private void SaveSchema() {
-			var baseDir = AppDomain.CurrentDomain.BaseDirectory;
-			var tplPath = Path.Combine(baseDir, "tpl", "jsonschema", "schema.json.tpl");
-			var tplContect = File.ReadAllText(tplPath);
-			File.WriteAllText(SchemaFilePath, tplContect);
+			lock (SchemaFileLock) {
+				if (FileSystem.File.Exists(SchemaFilePath)) {
+					return;
+				}
+				var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+				var tplPath = Path.Combine(baseDir, "tpl", "jsonschema", "schema.json.tpl");
+				var tplContect = File.ReadAllText(tplPath);
+				File.WriteAllText(SchemaFilePath, tplContect);
+			}
 		}
 
 		private void Save() {
@@ -577,6 +602,14 @@ namespace Clio
 
 		public string GetWorkspacesRoot() {
 			return _settings.WorkspacesRoot;
+		}
+
+		/// <summary>
+		/// Gets the configured container image CLI used by build-docker-image.
+		/// </summary>
+		/// <returns>The configured container image CLI name.</returns>
+		public string GetContainerImageCli() {
+			return _settings.ContainerImageCli;
 		}
 
 		public LocalDbServerConfiguration GetLocalDbServer(string name) {

--- a/clio/Environment/ISettingsRepository.cs
+++ b/clio/Environment/ISettingsRepository.cs
@@ -115,6 +115,12 @@ namespace Clio.UserEnvironment
 		string GetWorkspacesRoot();
 
 		/// <summary>
+		/// Gets the configured container image CLI used by build-docker-image.
+		/// </summary>
+		/// <returns>The configured container image CLI name.</returns>
+		string GetContainerImageCli();
+
+		/// <summary>
 		/// Gets a named local database server configuration.
 		/// </summary>
 		/// <param name="name">The configured local database server name.</param>

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Default version for local development. Will be overridden during release from tag -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.0.2.37</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.0.2.38</AssemblyVersion>
 		<FileVersion>$(AssemblyVersion)</FileVersion>
 		<Version>$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>

--- a/clio/docs/commands/build-docker-image.md
+++ b/clio/docs/commands/build-docker-image.md
@@ -4,6 +4,8 @@
 
 `build-docker-image` builds a Docker image for a Creatio `.NET 8+` distribution from either a ZIP archive or an already extracted application directory. It supports bundled `dev` and `prod` templates, or a custom template directory, and can optionally save the image to a tar file and push it to a registry.
 
+The command can run through either `docker` or `nerdctl`. The default container image CLI comes from clio `appsettings.json`, and you can override it per invocation with `--use-docker` or `--use-nerdctl`.
+
 `.NET Framework` distributions are permanently unsupported for this command.
 
 ## Usage
@@ -20,6 +22,35 @@ clio build-docker-image --from <zip-or-folder> --template <name-or-path> [option
 | `--template` | Yes | Bundled template name (`dev`, `prod`) or custom template directory path |
 | `--output-path` | No | Optional tar file path used by `docker save` |
 | `--registry` | No | Optional registry or repository prefix used by `docker push` |
+| `--use-docker` | No | Force the command to use `docker` for this invocation |
+| `--use-nerdctl` | No | Force the command to use `nerdctl` for this invocation; clio adds `--namespace k8s.io` automatically |
+
+## Container Image CLI Selection
+
+Clio resolves the effective container image CLI in this order:
+
+1. `--use-docker`
+2. `--use-nerdctl`
+3. `appsettings.json` key `container-image-cli`
+4. default `docker`
+
+Supported `appsettings.json` values:
+
+```json
+{
+  "container-image-cli": "docker"
+}
+```
+
+Allowed values:
+- `docker`
+- `nerdctl`
+
+When `nerdctl` is used, clio runs every image command with:
+
+```text
+--namespace k8s.io
+```
 
 ## Supported Sources
 
@@ -94,11 +125,12 @@ The command performs these steps:
 1. Validate the source path
 2. Resolve the bundled or custom template
 3. Build a temporary Docker context
-4. Run `docker --version`
-5. Run `docker build`
-6. Optionally run `docker save`
-7. Optionally run `docker tag` and `docker push`
-8. Clean up temporary files
+4. Resolve the effective container image CLI
+5. Run the CLI version check
+6. Run image build
+7. Optionally run image save
+8. Optionally run image tag and image push
+9. Clean up temporary files
 
 ## Examples
 
@@ -112,6 +144,18 @@ clio build-docker-image --from "C:\Creatio\8.3.3_StudioNet8.zip" --template dev
 
 ```bash
 clio build-docker-image --from "/opt/builds/creatio-net8" --template prod
+```
+
+### Force nerdctl for one build
+
+```bash
+clio build-docker-image --from "/opt/builds/creatio-net8" --template prod --use-nerdctl
+```
+
+### Force docker for one build
+
+```bash
+clio build-docker-image --from "/opt/builds/creatio-net8" --template prod --use-docker
 ```
 
 ### Build and export a tar file
@@ -159,9 +203,9 @@ org.creatio.database-source=8.3.4.1671_StudioNet8_Softkey_PostgreSQL_ENU
 
 ## Common Errors
 
-### Docker is not installed
+### Container image CLI is not installed
 
-If clio reports that Docker is not installed or not available in `PATH`, install Docker and verify that the `docker` executable can be started from the same shell.
+If clio reports that the selected container image CLI is not installed or not available in `PATH`, install that CLI and verify that the executable can be started from the same shell.
 
 ### Unknown bundled template
 

--- a/clio/help/en/build-docker-image.txt
+++ b/clio/help/en/build-docker-image.txt
@@ -8,7 +8,14 @@ DESCRIPTION
     Builds a Docker image from either a Creatio ZIP archive or an already extracted
     application directory. The command resolves a bundled template (`dev`, `prod`)
     or a custom template directory, stages the application into a temporary Docker
-    build context, and invokes the local docker CLI.
+    build context, and invokes the configured container image CLI.
+
+    Container image CLI selection:
+    - Default is controlled by appsettings.json key `container-image-cli`
+    - Allowed values: `docker`, `nerdctl`
+    - Default value: `docker`
+    - `--use-docker` and `--use-nerdctl` override appsettings.json for a single run
+    - When `nerdctl` is used, clio adds `--namespace k8s.io` to each CLI invocation
 
     The command supports only Creatio .NET 8+ distributions. .NET Framework
     distributions are rejected before any docker command is executed.
@@ -37,10 +44,18 @@ OPTIONS
         Useful for air-gapped environments or offline transport.
 
     --registry PREFIX
-        Optional. Registry or repository prefix used for docker push.
+        Optional. Registry or repository prefix used for image push.
         The command tags the built image as:
             <PREFIX>/creatio-<template-name>:<tag>
         and then pushes that tagged image.
+
+    --use-docker
+        Optional. Force docker for this invocation even if appsettings.json selects
+        nerdctl.
+
+    --use-nerdctl
+        Optional. Force nerdctl for this invocation even if appsettings.json selects
+        docker. clio always adds `--namespace k8s.io` when nerdctl is used.
 
 SUPPORTED INPUTS
     ZIP archive:
@@ -71,11 +86,12 @@ BEHAVIOR
     1. Resolve and validate source path
     2. Resolve and validate template
     3. Prepare a temporary Docker build context
-    4. Run docker --version
-    5. Run docker build
-    6. Optionally run docker save
-    7. Optionally run docker tag + docker push
-    8. Clean up temporary files
+    4. Resolve the effective container image CLI from appsettings.json or CLI flags
+    5. Run the CLI version check
+    6. Run image build
+    7. Optionally run image save
+    8. Optionally run image tag + image push
+    9. Clean up temporary files
 
 EXAMPLES
     Build a local development image from a ZIP archive:
@@ -97,6 +113,12 @@ EXAMPLES
           --output-path "C:\Images\creatio-prod.tar" \
           --registry "ghcr.io/acme"
 
+    Force nerdctl for a single run:
+        clio build-docker-image --from "/opt/builds/creatio-net8" --template prod --use-nerdctl
+
+    Force docker for a single run:
+        clio build-docker-image --from "/opt/builds/creatio-net8" --template prod --use-docker
+
     Use a custom template directory:
         clio build-docker-image \
           --from "/opt/builds/creatio-net8" \
@@ -114,8 +136,8 @@ OUTPUT
     - OCI label `org.creatio.database-source` with the original source payload name
 
 TROUBLESHOOTING
-    "Docker is not installed or not available in PATH"
-        Install Docker and make sure the `docker` executable is available on PATH.
+    "Container image CLI 'X' is not installed or not available in PATH"
+        Install the selected CLI and make sure its executable is available on PATH.
 
     "Bundled Docker template 'X' was not found"
         Use one of the bundled templates (`dev`, `prod`) or pass a valid template directory.

--- a/clio/tpl/jsonschema/schema.json.tpl
+++ b/clio/tpl/jsonschema/schema.json.tpl
@@ -9,6 +9,12 @@
 			"type": "string",
 			"description": "Default absolute base directory for create-workspace --empty when --directory is omitted"
 		},
+		"container-image-cli": {
+			"type": "string",
+			"description": "Default container image CLI used by build-docker-image",
+			"enum": ["docker", "nerdctl"],
+			"default": "docker"
+		},
 		"RemoteArtefactServerPath": {
 			"type": "string",
 			"description": "Path to remote artefact server"


### PR DESCRIPTION

- Introduced `--use-docker` and `--use-nerdctl` flags to override the default container image CLI.
- Added `container-image-cli` key in appsettings to specify the default CLI.
- Updated `BuildDockerImageService` to resolve the effective CLI based on flags and settings.
- Modified documentation to reflect new CLI selection behavior.
- Enhanced tests to cover new CLI selection logic and conflict handling.