### PR TITLE
fix: preserve entity caption and restore empty column captions during schema updates

### DIFF
--- a/clio.tests/Command/ApplicationInfoServiceTests.cs
+++ b/clio.tests/Command/ApplicationInfoServiceTests.cs
@@ -31,7 +31,9 @@ public sealed class ApplicationInfoServiceTests {
 		};
 		_settingsRepository.FindEnvironment("sandbox").Returns(_environment);
 		_applicationClientFactory.CreateEnvironmentClient(_environment).Returns(_applicationClient);
-		_sut = new ApplicationInfoService(_settingsRepository, _applicationClientFactory);
+		IApplicationUserCultureProvider userCultureProvider = Substitute.For<IApplicationUserCultureProvider>();
+		userCultureProvider.GetUserCultureName().Returns("en-US");
+		_sut = new ApplicationInfoService(_settingsRepository, _applicationClientFactory, userCultureProvider);
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
@@ -681,6 +681,67 @@ public sealed class SchemaSyncToolTests {
 			because: "the failing registration error should be returned to the caller");
 	}
 
+	[Test]
+	[Category("Unit")]
+	[Description("Forwards entity-level title-localizations from update-entity operation to UpdateEntitySchemaCommand so the entity caption is updated")]
+	public void SchemaSync_UpdateEntity_Should_Forward_TitleLocalizations_To_UpdateEntitySchemaCommand() {
+		// Arrange
+		var fakeUpdateCommand = new FakeUpdateEntitySchemaCommand();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<UpdateEntitySchemaCommand>(Arg.Any<UpdateEntitySchemaOptions>())
+			.Returns(fakeUpdateCommand);
+		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance);
+		SchemaSyncArgs args = new(
+			"dev", "UsrPkg",
+			[new SchemaSyncOperation("update-entity", "UsrTodoList",
+				TitleLocalizations: Localizations("Todo List"),
+				UpdateOperations: [
+					new UpdateEntitySchemaOperationArgs("add", "UsrEmail",
+						Type: "Email", TitleLocalizations: Localizations("Email"))
+				])]);
+
+		// Act
+		SchemaSyncResponse response = tool.SchemaSync(args);
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "an update-entity with exit code 0 should succeed");
+		fakeUpdateCommand.CapturedOptions.Should().NotBeNull(
+			because: "the update command must be invoked");
+		fakeUpdateCommand.CapturedOptions!.TitleLocalizations.Should().NotBeNull(
+			because: "entity-level title-localizations must be forwarded so ModifyColumns can preserve the caption");
+		fakeUpdateCommand.CapturedOptions.TitleLocalizations!["en-US"].Should().Be("Todo List",
+			because: "the en-US caption must match the title-localizations sent by the caller");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Does not set TitleLocalizations on UpdateEntitySchemaCommand when update-entity has no title-localizations, so ModifyColumns can apply the caption-preservation logic without caller noise")]
+	public void SchemaSync_UpdateEntity_Without_TitleLocalizations_Should_Pass_Null_TitleLocalizations() {
+		// Arrange
+		var fakeUpdateCommand = new FakeUpdateEntitySchemaCommand();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<UpdateEntitySchemaCommand>(Arg.Any<UpdateEntitySchemaOptions>())
+			.Returns(fakeUpdateCommand);
+		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance);
+		SchemaSyncArgs args = new(
+			"dev", "UsrPkg",
+			[new SchemaSyncOperation("update-entity", "UsrTodoList",
+				UpdateOperations: [
+					new UpdateEntitySchemaOperationArgs("add", "UsrEmail",
+						Type: "Email", TitleLocalizations: Localizations("Email"))
+				])]);
+
+		// Act
+		SchemaSyncResponse response = tool.SchemaSync(args);
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "an update-entity without title-localizations should still succeed");
+		fakeUpdateCommand.CapturedOptions!.TitleLocalizations.Should().BeNull(
+			because: "when no entity-level title-localizations are provided, null must be forwarded so ModifyColumns applies its caption-preservation logic");
+	}
+
 	private static System.Text.Json.JsonElement ToJsonElement(string value) {
 		return System.Text.Json.JsonDocument.Parse($"\"{value}\"").RootElement.Clone();
 	}

--- a/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
@@ -278,6 +278,34 @@ internal class RemoteEntitySchemaColumnManagerTests
 	}
 
 	[Test]
+	[Description("Restores the column name as caption when a server round-trip returns an empty caption, preventing .NET Framework validation errors.")]
+	public void ModifyColumns_RestoresColumnNameAsCaption_WhenServerReturnsEmptyCaption() {
+		// Arrange: a column that the server returned with an empty caption (as .NET Framework does for localization-only titles)
+		EntitySchemaColumnDto emptyCapColumn = new() {
+			UId = NameColumnUId,
+			Name = "UsrAssignedTo",
+			DataValueType = 1,
+			Caption = []
+		};
+		_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId), emptyCapColumn]);
+		SetupLoadedSchema();
+		var options = new ModifyEntitySchemaColumnOptions {
+			Package = "UsrPkg",
+			SchemaName = "UsrVehicle",
+			Action = "modify",
+			ColumnName = "UsrAssignedTo",
+			DefaultValueSource = "Const",
+			DefaultValue = "Draft"
+		};
+
+		// Act
+		_manager.ModifyColumn(options);
+
+		// Assert
+		EntitySchemaColumnDto savedColumn = _savedSchema.Columns.Single(column => column.Name == "UsrAssignedTo");
+		EntitySchemaDesignerSupport.GetLocalizableValue(savedColumn.Caption).Should().Be("UsrAssignedTo",
+			because: "empty server-returned captions must be restored to the column name before saving to avoid .NET Framework validation errors");
+	}
 	[Description("Trims caption updates when modify receives a title with surrounding spaces.")]
 	public void ModifyColumn_UpdatesCaptionWithTrimmedValue_WhenTitleContainsWhitespacePadding() {
 		// Arrange

--- a/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
@@ -27,6 +27,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	private IEntitySchemaDefaultValueSourceResolver _defaultValueSourceResolver;
 	private IRemoteEntitySchemaDesignerClient _designerClient;
 	private ILogger _logger;
+	private IApplicationUserCultureProvider _userCultureProvider;
 	private RemoteEntitySchemaColumnManager _manager;
 	private EntityDesignSchemaDto _loadedSchema;
 	private EntityDesignSchemaDto _savedSchema;
@@ -37,6 +38,8 @@ internal class RemoteEntitySchemaColumnManagerTests
 		_defaultValueSourceResolver = Substitute.For<IEntitySchemaDefaultValueSourceResolver>();
 		_designerClient = Substitute.For<IRemoteEntitySchemaDesignerClient>();
 		_logger = Substitute.For<ILogger>();
+		_userCultureProvider = Substitute.For<IApplicationUserCultureProvider>();
+		_userCultureProvider.GetUserCultureName().Returns("en-US");
 		_savedSchema = null;
 		_loadedSchema = null;
 		_packageListProvider.GetPackages().Returns(new[] {
@@ -96,7 +99,8 @@ internal class RemoteEntitySchemaColumnManagerTests
 			_packageListProvider,
 			_defaultValueSourceResolver,
 			_designerClient,
-			_logger);
+			_logger,
+			_userCultureProvider);
 	}
 
 	[Test]
@@ -203,7 +207,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	[Description("Adds the current culture title localization when add receives only en-US so .NET Framework save validation still sees an effective caption.")]
 	public void ModifyColumn_AddsOwnColumn_AddsCurrentCultureLocalization_WhenOnlyEnUsTitleLocalizationIsProvided() {
 		// Arrange
-		using CultureScope cultureScope = new("uk-UA");
+		_userCultureProvider.GetUserCultureName().Returns("uk-UA");
 		_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId)], primaryDisplayColumn: null);
 		SetupLoadedSchema();
 		var options = new ModifyEntitySchemaColumnOptions {
@@ -306,6 +310,87 @@ internal class RemoteEntitySchemaColumnManagerTests
 		EntitySchemaDesignerSupport.GetLocalizableValue(savedColumn.Caption).Should().Be("UsrAssignedTo",
 			because: "empty server-returned captions must be restored to the column name before saving to avoid .NET Framework validation errors");
 	}
+
+	[Test]
+	[Description("Restores all runtime caption localizations when design caption is empty in a non-en-US culture, preventing NormalizeLocalizationMap from throwing due to a missing en-US key.")]
+	public void ModifyColumns_UsesFullRuntimeLocalizationMap_WhenDesignCaptionIsEmptyAndCultureIsNonEnUs() {
+		_userCultureProvider.GetUserCultureName().Returns("uk-UA");
+		_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId)]);
+		_loadedSchema.Caption = [];
+		SetupLoadedSchema();
+		_designerClient.GetRuntimeEntitySchema(Arg.Any<Guid>(), Arg.Any<RemoteCommandOptions>())
+			.Returns(new RuntimeEntitySchemaResponse {
+				Success = true,
+				Schema = new RuntimeEntitySchemaDto {
+					UId = _loadedSchema.UId,
+					Name = "UsrVehicle",
+					Caption = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+						["en-US"] = "Vehicle",
+						["uk-UA"] = "Транспортний засіб"
+					}
+				}
+			});
+		var options = new ModifyEntitySchemaColumnOptions {
+			Package = "UsrPkg",
+			SchemaName = "UsrVehicle",
+			Action = "add",
+			ColumnName = "UsrNewColumn",
+			Type = "Text",
+			Title = "New Column"
+		};
+
+		// Act — must not throw despite uk-UA being the current culture
+		_manager.ModifyColumn(options);
+
+		// Assert: full runtime localization map stored, not just the current-culture entry
+		_savedSchema.Caption.Should().Contain(c => c.CultureName == "en-US" && c.Value == "Vehicle",
+			because: "en-US caption from runtime must be preserved when design caption is empty");
+		_savedSchema.Caption.Should().Contain(c => c.CultureName == "uk-UA" && c.Value == "Транспортний засіб",
+			because: "all runtime localizations must be restored, not only the current-culture entry");
+	}
+
+	[Test]
+	[Description("Preserves all runtime caption localizations (including translated ones) when the current culture is en-US, preventing truncation of other locales during unrelated column mutations.")]
+	public void ModifyColumns_PreservesAllRuntimeCaptionLocales_WhenDesignCaptionIsEmpty() {
+		// Arrange: default en-US culture but runtime has multiple translations.
+		// The old code collapsed runtime caption to a single scalar via GetLocalizableValue,
+		// then rebuilt { ["en-US"]: scalar } — discarding every non-en-US translation.
+		_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId)]);
+		_loadedSchema.Caption = [];
+		SetupLoadedSchema();
+		_designerClient.GetRuntimeEntitySchema(Arg.Any<Guid>(), Arg.Any<RemoteCommandOptions>())
+			.Returns(new RuntimeEntitySchemaResponse {
+				Success = true,
+				Schema = new RuntimeEntitySchemaDto {
+					UId = _loadedSchema.UId,
+					Name = "UsrVehicle",
+					Caption = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+						["en-US"] = "Vehicle",
+						["uk-UA"] = "Транспортний засіб",
+						["de-DE"] = "Fahrzeug"
+					}
+				}
+			});
+		var options = new ModifyEntitySchemaColumnOptions {
+			Package = "UsrPkg",
+			SchemaName = "UsrVehicle",
+			Action = "add",
+			ColumnName = "UsrNewColumn",
+			Type = "Text",
+			Title = "New Column"
+		};
+
+		// Act
+		_manager.ModifyColumn(options);
+
+		// Assert: all three locales preserved — the old code would have kept only en-US
+		_savedSchema.Caption.Should().Contain(c => c.CultureName == "en-US" && c.Value == "Vehicle",
+			because: "en-US caption must be preserved from runtime");
+		_savedSchema.Caption.Should().Contain(c => c.CultureName == "uk-UA" && c.Value == "Транспортний засіб",
+			because: "non-current-culture localizations must not be truncated during caption restoration");
+		_savedSchema.Caption.Should().Contain(c => c.CultureName == "de-DE" && c.Value == "Fahrzeug",
+			because: "all runtime localizations must be forwarded to the saved schema, not collapsed to one language");
+	}
 	[Description("Trims caption updates when modify receives a title with surrounding spaces.")]
 	public void ModifyColumn_UpdatesCaptionWithTrimmedValue_WhenTitleContainsWhitespacePadding() {
 		// Arrange
@@ -333,7 +418,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	[Description("Replaces caption localizations with a normalized set that includes the current culture when modify receives only en-US title-localizations.")]
 	public void ModifyColumn_NormalizesTitleLocalizations_WhenOnlyEnUsTitleLocalizationIsProvided() {
 		// Arrange
-		using CultureScope cultureScope = new("uk-UA");
+		_userCultureProvider.GetUserCultureName().Returns("uk-UA");
 		EntitySchemaColumnDto statusColumn = CreateTextColumn("UsrVehicleStatus", NameColumnUId);
 		_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId), statusColumn]);
 		SetupLoadedSchema();
@@ -358,6 +443,41 @@ internal class RemoteEntitySchemaColumnManagerTests
 			because: "modify should synthesize a current-culture title so later .NET Framework validation succeeds");
 		savedColumn.Caption.Select(item => item.CultureName).Should().OnlyHaveUniqueItems(
 			because: "title localization normalization should not duplicate cultures in the saved caption payload");
+	}
+
+	[Test]
+	[Description("Uses culture name from IApplicationUserCultureProvider rather than the current thread CultureInfo, so caption localization matches the Creatio user's language even when the machine locale differs.")]
+	public void ModifyColumn_UsesCultureFromProvider_NotThreadCulture() {
+		// Arrange: provider says uk-UA; thread culture is set to fr-FR to prove the provider wins.
+		_userCultureProvider.GetUserCultureName().Returns("uk-UA");
+		CultureInfo originalCulture = CultureInfo.CurrentCulture;
+		try {
+			CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+			_loadedSchema = CreateSchema(columns: [CreateGuidColumn("Id", IdColumnUId)], primaryDisplayColumn: null);
+			SetupLoadedSchema();
+			var options = new ModifyEntitySchemaColumnOptions {
+				Package = "UsrPkg",
+				SchemaName = "UsrVehicle",
+				Action = "add",
+				ColumnName = "UsrVehicleStatus",
+				Type = "Text",
+				TitleLocalizations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+					["en-US"] = "Status"
+				}
+			};
+
+			// Act
+			_manager.ModifyColumn(options);
+
+			// Assert: uk-UA must be added (from provider), not fr-FR (from thread culture)
+			EntitySchemaColumnDto addedColumn = _savedSchema.Columns.Single(column => column.Name == "UsrVehicleStatus");
+			addedColumn.Caption.Should().Contain(item => item.CultureName == "uk-UA" && item.Value == "Status",
+				because: "culture must come from IApplicationUserCultureProvider (uk-UA), not the thread culture (fr-FR)");
+			addedColumn.Caption.Should().NotContain(item => item.CultureName == "fr-FR",
+				because: "thread culture fr-FR must be ignored when the provider supplies uk-UA");
+		} finally {
+			CultureInfo.CurrentCulture = originalCulture;
+		}
 	}
 
 	[Test]

--- a/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
@@ -21,6 +21,7 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 	private IApplicationClient _applicationClient;
 	private IApplicationPackageListProvider _packageListProvider;
 	private ILogger _logger;
+	private IApplicationUserCultureProvider _userCultureProvider;
 	private IRemoteEntitySchemaCreator _creator;
 	private Guid _packageUId;
 
@@ -43,9 +44,12 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 		_applicationClient = Substitute.For<IApplicationClient>();
 		_packageListProvider = Substitute.For<IApplicationPackageListProvider>();
 		_logger = Substitute.For<ILogger>();
+		_userCultureProvider = Substitute.For<IApplicationUserCultureProvider>();
+		_userCultureProvider.GetUserCultureName().Returns("en-US");
 		containerBuilder.AddTransient(_ => _applicationClient);
 		containerBuilder.AddTransient(_ => _packageListProvider);
 		containerBuilder.AddTransient(_ => _logger);
+		containerBuilder.AddTransient(_ => _userCultureProvider);
 	}
 
 	[Test]
@@ -392,7 +396,7 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 	[Description("Creates schema and column captions with synthesized current-culture localizations when only en-US title-localizations are provided.")]
 	public void Create_CreatesSchema_WithCurrentCultureTitleLocalizations_WhenOnlyEnUsIsProvided() {
 		// Arrange
-		using CultureScope cultureScope = new("uk-UA");
+		_userCultureProvider.GetUserCultureName().Returns("uk-UA");
 		string saveBody = null;
 		SetupApplicationClient((url, body) => {
 			if (url.Contains("CreateNewSchema", StringComparison.Ordinal)) {

--- a/clio.tests/Command/UpdateEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/UpdateEntitySchemaCommandTests.cs
@@ -228,6 +228,56 @@ internal sealed class UpdateEntitySchemaCommandTests : BaseClioModuleTests
 			because: "semicolons inside a JSON title or default value are part of the operation payload, not separators");
 	}
 
+	[Test]
+	[Description("Passes entity-level TitleLocalizations from options to ModifyColumns when provided, so ModifyColumns can apply them to the entity schema caption.")]
+	public void Execute_PassesTitleLocalizations_ToModifyColumns_WhenProvided() {
+		// Arrange
+		UpdateEntitySchemaOptions options = new() {
+			Environment = "dev",
+			Package = "UsrPkg",
+			SchemaName = "UsrVehicle",
+			TitleLocalizations = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+				["en-US"] = "Vehicle"
+			},
+			Operations = [
+				"""{"action":"add","column-name":"UsrColor","type":"Text","title-localizations":{"en-US":"Color"}}"""
+			]
+		};
+
+		// Act
+		int result = _command.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "a valid batch with entity TitleLocalizations should succeed");
+		_columnManager.Received(1).ModifyColumns(
+			Arg.Any<IEnumerable<ModifyEntitySchemaColumnOptions>>(),
+			Arg.Is<IReadOnlyDictionary<string, string>>(locs =>
+				locs != null && locs["en-US"] == "Vehicle"));
+	}
+
+	[Test]
+	[Description("Passes null TitleLocalizations to ModifyColumns when not set, so ModifyColumns applies caption-preservation logic.")]
+	public void Execute_PassesNullTitleLocalizations_ToModifyColumns_WhenNotProvided() {
+		// Arrange
+		UpdateEntitySchemaOptions options = new() {
+			Environment = "dev",
+			Package = "UsrPkg",
+			SchemaName = "UsrVehicle",
+			Operations = [
+				"""{"action":"add","column-name":"UsrColor","type":"Text","title-localizations":{"en-US":"Color"}}"""
+			]
+		};
+
+		// Act
+		int result = _command.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "a valid batch without TitleLocalizations should succeed");
+		_columnManager.Received(1).ModifyColumns(
+			Arg.Any<IEnumerable<ModifyEntitySchemaColumnOptions>>(),
+			Arg.Is<IReadOnlyDictionary<string, string>>(locs => locs == null));
+	}
+
 	private sealed class CultureScope : IDisposable {
 		private readonly CultureInfo _originalCurrentCulture;
 		private readonly CultureInfo _originalCurrentUiCulture;

--- a/clio/Command/ApplicationInfoService.cs
+++ b/clio/Command/ApplicationInfoService.cs
@@ -30,7 +30,8 @@ public interface IApplicationInfoService
 /// </summary>
 public sealed class ApplicationInfoService(
 	ISettingsRepository settingsRepository,
-	IApplicationClientFactory applicationClientFactory)
+	IApplicationClientFactory applicationClientFactory,
+	IApplicationUserCultureProvider userCultureProvider)
 	: IApplicationInfoService
 {
 	private const string BaseObjectCaption = "Base object";
@@ -232,7 +233,7 @@ public sealed class ApplicationInfoService(
 			.ToList();
 	}
 
-	private static ApplicationEntityInfoResult LoadEntityInfo(
+	private ApplicationEntityInfoResult LoadEntityInfo(
 		IApplicationClient client,
 		ServiceUrlBuilder serviceUrlBuilder,
 		string packageUId,
@@ -240,6 +241,7 @@ public sealed class ApplicationInfoService(
 		string? canonicalMainEntityCaptionFallback,
 		ApplicationEntityRecordDto entityRow)
 	{
+		IReadOnlyList<string> preferredCultures = GetPreferredCultureNames();
 		string responseJson = client.ExecutePostRequest(
 			serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.RuntimeEntitySchemaRequest),
 			JsonSerializer.Serialize(new { uId = entityRow.UId }));
@@ -260,7 +262,7 @@ public sealed class ApplicationInfoService(
 		List<ApplicationColumnInfoResult> columns = (response.Schema.Columns?.Items?.Values ??
 			Enumerable.Empty<RuntimeSchemaColumnDto>())
 			.Where(column => !column.IsInherited)
-			.Select(column => MapColumn(column, GetDesignColumn(designColumns, column.Name)))
+			.Select(column => MapColumn(column, GetDesignColumn(designColumns, column.Name), preferredCultures))
 			.OrderBy(column => column.Name, StringComparer.OrdinalIgnoreCase)
 			.ToList();
 
@@ -271,13 +273,15 @@ public sealed class ApplicationInfoService(
 				string.Equals(entityName, canonicalMainEntityName, StringComparison.OrdinalIgnoreCase),
 				response.Schema.Caption,
 				designSchema?.Caption,
+				preferredCultures,
 				canonicalMainEntityCaptionFallback,
 				entityRow.Caption,
 				entityName),
 			columns);
 	}
 
-	private static ApplicationColumnInfoResult MapColumn(RuntimeSchemaColumnDto column, DesignSchemaColumnDto? designColumn)
+	private static ApplicationColumnInfoResult MapColumn(RuntimeSchemaColumnDto column, DesignSchemaColumnDto? designColumn,
+		IReadOnlyList<string> preferredCultureNames)
 	{
 		string name = !string.IsNullOrWhiteSpace(column.Name)
 			? column.Name
@@ -291,7 +295,7 @@ public sealed class ApplicationInfoService(
 
 		return new ApplicationColumnInfoResult(
 			name,
-			ResolveLocalizedText(column.Caption, designColumn?.Caption, name),
+			ResolveLocalizedText(column.Caption, designColumn?.Caption, preferredCultureNames, name),
 			DataValueTypeNames.TryGetValue(column.DataValueType, out string? dataValueTypeName)
 				? dataValueTypeName
 				: column.DataValueType.ToString(),
@@ -345,10 +349,11 @@ public sealed class ApplicationInfoService(
 	private static string ResolveLocalizedText(
 		IReadOnlyDictionary<string, string>? runtimeValues,
 		IEnumerable<DesignLocalizableStringDto>? designValues,
+		IReadOnlyList<string> preferredCultureNames,
 		params string?[] fallbacks)
 	{
-		return GetRuntimeLocalizedText(runtimeValues)
-			?? GetDesignLocalizedText(designValues)
+		return GetRuntimeLocalizedText(runtimeValues, preferredCultureNames)
+			?? GetDesignLocalizedText(designValues, preferredCultureNames)
 			?? GetFallbackText(fallbacks)
 			?? string.Empty;
 	}
@@ -357,10 +362,11 @@ public sealed class ApplicationInfoService(
 		bool isCanonicalMainEntity,
 		IReadOnlyDictionary<string, string>? runtimeValues,
 		IEnumerable<DesignLocalizableStringDto>? designValues,
+		IReadOnlyList<string> preferredCultureNames,
 		params string?[] fallbacks)
 	{
-		string? runtimeCaption = GetRuntimeLocalizedText(runtimeValues);
-		string? designCaption = GetDesignLocalizedText(designValues);
+		string? runtimeCaption = GetRuntimeLocalizedText(runtimeValues, preferredCultureNames);
+		string? designCaption = GetDesignLocalizedText(designValues, preferredCultureNames);
 		if (ShouldPreferDesignCaptionForCanonicalMainEntity(isCanonicalMainEntity, runtimeCaption, designCaption))
 		{
 			return designCaption!;
@@ -409,14 +415,15 @@ public sealed class ApplicationInfoService(
 			.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 	}
 
-	private static string? GetRuntimeLocalizedText(IReadOnlyDictionary<string, string>? localizedValues)
+	private static string? GetRuntimeLocalizedText(IReadOnlyDictionary<string, string>? localizedValues,
+		IReadOnlyList<string> preferredCultureNames)
 	{
 		if (localizedValues == null || localizedValues.Count == 0)
 		{
 			return null;
 		}
 
-		foreach (string cultureName in GetPreferredCultureNames())
+		foreach (string cultureName in preferredCultureNames)
 		{
 			if (localizedValues.TryGetValue(cultureName, out string? value) && !string.IsNullOrWhiteSpace(value))
 			{
@@ -429,7 +436,8 @@ public sealed class ApplicationInfoService(
 			.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 	}
 
-	private static string? GetDesignLocalizedText(IEnumerable<DesignLocalizableStringDto>? localizedValues)
+	private static string? GetDesignLocalizedText(IEnumerable<DesignLocalizableStringDto>? localizedValues,
+		IReadOnlyList<string> preferredCultureNames)
 	{
 		List<DesignLocalizableStringDto> values = localizedValues?
 			.Where(value => !string.IsNullOrWhiteSpace(value.CultureName) && !string.IsNullOrWhiteSpace(value.Value))
@@ -439,7 +447,7 @@ public sealed class ApplicationInfoService(
 			return null;
 		}
 
-		foreach (string cultureName in GetPreferredCultureNames())
+		foreach (string cultureName in preferredCultureNames)
 		{
 			DesignLocalizableStringDto? exactMatch = values.FirstOrDefault(value =>
 				string.Equals(value.CultureName, cultureName, StringComparison.OrdinalIgnoreCase));
@@ -452,9 +460,9 @@ public sealed class ApplicationInfoService(
 			return values[0].Value.Trim();
 	}
 
-	private static IReadOnlyList<string> GetPreferredCultureNames()
+	private IReadOnlyList<string> GetPreferredCultureNames()
 	{
-		string currentCultureName = EntitySchemaDesignerSupport.GetCurrentCultureName();
+		string currentCultureName = userCultureProvider.GetUserCultureName();
 		if (string.Equals(currentCultureName, EntitySchemaDesignerSupport.DefaultCultureName, StringComparison.OrdinalIgnoreCase))
 		{
 			return [EntitySchemaDesignerSupport.DefaultCultureName];
@@ -463,7 +471,7 @@ public sealed class ApplicationInfoService(
 		return [currentCultureName, EntitySchemaDesignerSupport.DefaultCultureName];
 	}
 
-	private static DesignSchemaDto? TryLoadDesignSchema(
+	private DesignSchemaDto? TryLoadDesignSchema(
 		IApplicationClient client,
 		ServiceUrlBuilder serviceUrlBuilder,
 		string packageUId,

--- a/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs
+++ b/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs
@@ -118,6 +118,9 @@ internal sealed class RuntimeEntitySchemaDto
 
 	[JsonProperty("name")]
 	public string Name { get; set; }
+
+	[JsonProperty("caption")]
+	public Dictionary<string, string>? Caption { get; set; }
 }
 
 internal sealed class ManagerItemDto

--- a/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs
+++ b/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using Clio.Package;
 using Terrasoft.Core.Entities;
 
@@ -21,6 +22,7 @@ internal static class EntitySchemaDesignerSupport
 	private const string FileTypeName = "file";
 	private const string ImageTypeName = "image";
 	private const string SecureTextTypeName = "secureText";
+	private static readonly AsyncLocal<string?> _resolvedUserCultureName = new();
 
 	internal static readonly Dictionary<string, int> SupportedDataValueTypes =
 		new(StringComparer.OrdinalIgnoreCase) {
@@ -118,7 +120,17 @@ internal static class EntitySchemaDesignerSupport
 			[50] = new(CurrencyUIdString)                          // Currency3
 		};
 
+	internal static IDisposable UseUserCulture(string cultureName) {
+		string? previous = _resolvedUserCultureName.Value;
+		_resolvedUserCultureName.Value = cultureName;
+		return new CultureRestoreScope(previous);
+	}
+
 	internal static string GetCurrentCultureName() {
+		string? ambient = _resolvedUserCultureName.Value;
+		if (!string.IsNullOrWhiteSpace(ambient)) {
+			return ambient;
+		}
 		string cultureName = CultureInfo.CurrentCulture.Name;
 		return string.IsNullOrWhiteSpace(cultureName) ? DefaultCultureName : cultureName;
 	}
@@ -692,5 +704,22 @@ internal static class EntitySchemaDesignerSupport
 			return value.Value;
 		}
 		throw new EntitySchemaDesignerException(errorMessage);
+	}
+
+	private sealed class CultureRestoreScope : IDisposable
+	{
+		private readonly string? _previousCultureName;
+		private bool _disposed;
+
+		internal CultureRestoreScope(string? previousCultureName) {
+			_previousCultureName = previousCultureName;
+		}
+
+		public void Dispose() {
+			if (!_disposed) {
+				_resolvedUserCultureName.Value = _previousCultureName;
+				_disposed = true;
+			}
+		}
 	}
 }

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
@@ -60,15 +60,18 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 	private readonly IEntitySchemaDefaultValueSourceResolver _defaultValueSourceResolver;
 	private readonly IRemoteEntitySchemaDesignerClient _entitySchemaDesignerClient;
 	private readonly ILogger _logger;
+	private readonly IApplicationUserCultureProvider _userCultureProvider;
 
 	public RemoteEntitySchemaColumnManager(IApplicationPackageListProvider applicationPackageListProvider,
 		IEntitySchemaDefaultValueSourceResolver defaultValueSourceResolver,
 		IRemoteEntitySchemaDesignerClient entitySchemaDesignerClient,
-		ILogger logger) {
+		ILogger logger,
+		IApplicationUserCultureProvider userCultureProvider) {
 		_applicationPackageListProvider = applicationPackageListProvider;
 		_defaultValueSourceResolver = defaultValueSourceResolver;
 		_entitySchemaDesignerClient = entitySchemaDesignerClient;
 		_logger = logger;
+		_userCultureProvider = userCultureProvider;
 	}
 
 	public void ModifyColumn(ModifyEntitySchemaColumnOptions options) {
@@ -78,6 +81,7 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 	public void ModifyColumns(IEnumerable<ModifyEntitySchemaColumnOptions> options,
 		IReadOnlyDictionary<string, string>? entityTitleLocalizations = null) {
 		ArgumentNullException.ThrowIfNull(options);
+		using var _ = EntitySchemaDesignerSupport.UseUserCulture(_userCultureProvider.GetUserCultureName());
 		List<ModifyEntitySchemaColumnOptions> operations = options.ToList();
 		if (operations.Count == 0) {
 			throw new EntitySchemaDesignerException("At least one column mutation is required.");
@@ -117,6 +121,7 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 
 	public EntitySchemaColumnPropertiesInfo GetColumnProperties(GetEntitySchemaColumnPropertiesOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
+		using var _ = EntitySchemaDesignerSupport.UseUserCulture(_userCultureProvider.GetUserCultureName());
 		PackageInfo package = ResolvePackage(options.Package);
 		EntityDesignSchemaDto schema = LoadSchema(options.SchemaName, package.Descriptor.UId, options);
 		(EntitySchemaColumnDto column, string source) = FindColumnForRead(schema, options.ColumnName);
@@ -180,6 +185,7 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 
 	public EntitySchemaPropertiesInfo GetSchemaProperties(GetEntitySchemaPropertiesOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
+		using var _ = EntitySchemaDesignerSupport.UseUserCulture(_userCultureProvider.GetUserCultureName());
 		PackageInfo package = ResolvePackage(options.Package);
 		EntityDesignSchemaDto schema = LoadSchema(options.SchemaName, package.Descriptor.UId, options);
 		string cultureName = EntitySchemaDesignerSupport.GetCurrentCultureName();
@@ -683,20 +689,25 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 		if (!runtimeResponse.Success || runtimeResponse.Schema == null) {
 			return;
 		}
-		string? runtimeCaption = runtimeResponse.Schema.Caption != null
-			? EntitySchemaDesignerSupport.GetLocalizableValue(
-				EntitySchemaDesignerSupport.CreateLocalizableStrings(runtimeResponse.Schema.Caption))
-			: null;
-		bool runtimeCaptionIsInheritedOrEmpty = string.IsNullOrWhiteSpace(runtimeCaption) ||
-			string.Equals(runtimeCaption, inheritedCaption, StringComparison.OrdinalIgnoreCase);
+		if (runtimeResponse.Schema.Caption == null) {
+			return;
+		}
+		Dictionary<string, string> runtimeCaptionLocalizations =
+			new(runtimeResponse.Schema.Caption, StringComparer.OrdinalIgnoreCase);
+		string currentCulture = EntitySchemaDesignerSupport.GetCurrentCultureName();
+		string? runtimeCaptionValue =
+			runtimeCaptionLocalizations.GetValueOrDefault(currentCulture)
+			?? runtimeCaptionLocalizations.GetValueOrDefault(EntitySchemaDesignerSupport.DefaultCultureName)
+			?? runtimeCaptionLocalizations.Values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+		bool runtimeCaptionIsInheritedOrEmpty = string.IsNullOrWhiteSpace(runtimeCaptionValue) ||
+			string.Equals(runtimeCaptionValue, inheritedCaption, StringComparison.OrdinalIgnoreCase);
 		if (runtimeCaptionIsInheritedOrEmpty) {
 			return;
 		}
-		EntitySchemaDesignerSupport.ReplaceLocalizableValues(
-			schema.Caption ??= [],
-			new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
-				[EntitySchemaDesignerSupport.GetCurrentCultureName()] = runtimeCaption
-			});
+		if (!runtimeCaptionLocalizations.ContainsKey(EntitySchemaDesignerSupport.DefaultCultureName)) {
+			runtimeCaptionLocalizations[EntitySchemaDesignerSupport.DefaultCultureName] = runtimeCaptionValue!;
+		}
+		EntitySchemaDesignerSupport.ReplaceLocalizableValues(schema.Caption ??= [], runtimeCaptionLocalizations);
 	}
 
 	private PackageInfo ResolvePackage(string packageName) {

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
@@ -13,7 +13,13 @@ public interface IRemoteEntitySchemaColumnManager
 	/// Applies one or more column mutations to the same remote schema and persists the result once.
 	/// </summary>
 	/// <param name="options">Ordered mutation list that targets the same package, schema, and environment.</param>
-	void ModifyColumns(IEnumerable<ModifyEntitySchemaColumnOptions> options);
+	/// <param name="entityTitleLocalizations">
+	/// Optional entity-level title localizations. When provided, the entity schema caption is updated
+	/// to these values. When absent, the existing caption is protected against corruption from the
+	/// GetSchemaDesignItem round-trip (which may return an inherited "Base object" default).
+	/// </param>
+	void ModifyColumns(IEnumerable<ModifyEntitySchemaColumnOptions> options,
+		IReadOnlyDictionary<string, string>? entityTitleLocalizations = null);
 
 	/// <summary>
 	/// Returns a structured snapshot of schema properties for the requested remote entity schema.
@@ -69,7 +75,8 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 		ModifyColumns([options]);
 	}
 
-	public void ModifyColumns(IEnumerable<ModifyEntitySchemaColumnOptions> options) {
+	public void ModifyColumns(IEnumerable<ModifyEntitySchemaColumnOptions> options,
+		IReadOnlyDictionary<string, string>? entityTitleLocalizations = null) {
 		ArgumentNullException.ThrowIfNull(options);
 		List<ModifyEntitySchemaColumnOptions> operations = options.ToList();
 		if (operations.Count == 0) {
@@ -80,6 +87,7 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 		PackageInfo package = ResolvePackage(rootOperation.Package);
 		EntityDesignSchemaDto schema = LoadSchema(rootOperation.SchemaName, package.Descriptor.UId, rootOperation);
 		EnsureBatchTargetsSingleSchema(operations, rootOperation);
+		ApplyEntityCaption(schema, entityTitleLocalizations, rootOperation);
 		foreach (ModifyEntitySchemaColumnOptions operation in operations) {
 			ApplyColumnMutation(schema, package, operation);
 		}
@@ -637,6 +645,51 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 			Name = referenceSchema.Name,
 			Caption = [EntitySchemaDesignerSupport.CreateLocalizableString(referenceSchema.Caption)]
 		};
+	}
+
+	/// <summary>
+	/// Applies entity-level caption to the design schema before saving.
+	/// When <paramref name="entityTitleLocalizations"/> is provided, it is applied as an explicit rename.
+	/// When absent, protects the schema caption from being corrupted by the parent-schema default that
+	/// <c>GetSchemaDesignItem</c> may return for template-created entities whose caption has no own
+	/// culture value (only an inherited one from the parent schema).
+	/// </summary>
+	private void ApplyEntityCaption(
+		EntityDesignSchemaDto schema,
+		IReadOnlyDictionary<string, string>? entityTitleLocalizations,
+		RemoteCommandOptions options) {
+		if (entityTitleLocalizations != null) {
+			EntitySchemaDesignerSupport.ReplaceLocalizableValues(
+				schema.Caption ??= [],
+				entityTitleLocalizations);
+			return;
+		}
+		string? currentDesignCaption = EntitySchemaDesignerSupport.GetLocalizableValue(schema.Caption);
+		string? inheritedCaption = EntitySchemaDesignerSupport.GetLocalizableValue(schema.ParentSchema?.Caption);
+		bool isInheritedOrEmpty = string.IsNullOrWhiteSpace(currentDesignCaption) ||
+			string.Equals(currentDesignCaption, inheritedCaption, StringComparison.OrdinalIgnoreCase);
+		if (!isInheritedOrEmpty) {
+			return;
+		}
+		RuntimeEntitySchemaResponse runtimeResponse = _entitySchemaDesignerClient.GetRuntimeEntitySchema(
+			schema.UId, options);
+		if (!runtimeResponse.Success || runtimeResponse.Schema == null) {
+			return;
+		}
+		string? runtimeCaption = runtimeResponse.Schema.Caption != null
+			? EntitySchemaDesignerSupport.GetLocalizableValue(
+				EntitySchemaDesignerSupport.CreateLocalizableStrings(runtimeResponse.Schema.Caption))
+			: null;
+		bool runtimeCaptionIsInheritedOrEmpty = string.IsNullOrWhiteSpace(runtimeCaption) ||
+			string.Equals(runtimeCaption, inheritedCaption, StringComparison.OrdinalIgnoreCase);
+		if (runtimeCaptionIsInheritedOrEmpty) {
+			return;
+		}
+		EntitySchemaDesignerSupport.ReplaceLocalizableValues(
+			schema.Caption ??= [],
+			new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+				[EntitySchemaDesignerSupport.GetCurrentCultureName()] = runtimeCaption
+			});
 	}
 
 	private PackageInfo ResolvePackage(string packageName) {

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
@@ -88,6 +88,7 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 		EntityDesignSchemaDto schema = LoadSchema(rootOperation.SchemaName, package.Descriptor.UId, rootOperation);
 		EnsureBatchTargetsSingleSchema(operations, rootOperation);
 		ApplyEntityCaption(schema, entityTitleLocalizations, rootOperation);
+		RestoreEmptyColumnCaptions(schema);
 		foreach (ModifyEntitySchemaColumnOptions operation in operations) {
 			ApplyColumnMutation(schema, package, operation);
 		}
@@ -647,13 +648,19 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 		};
 	}
 
-	/// <summary>
-	/// Applies entity-level caption to the design schema before saving.
-	/// When <paramref name="entityTitleLocalizations"/> is provided, it is applied as an explicit rename.
-	/// When absent, protects the schema caption from being corrupted by the parent-schema default that
-	/// <c>GetSchemaDesignItem</c> may return for template-created entities whose caption has no own
-	/// culture value (only an inherited one from the parent schema).
-	/// </summary>
+	private static void RestoreEmptyColumnCaptions(EntityDesignSchemaDto schema) {
+		if (schema.Columns == null) {
+			return;
+		}
+		foreach (EntitySchemaColumnDto column in schema.Columns) {
+			string? currentCaption = EntitySchemaDesignerSupport.GetLocalizableValue(column.Caption);
+			if (!string.IsNullOrWhiteSpace(currentCaption)) {
+				continue;
+			}
+			column.Caption = [EntitySchemaDesignerSupport.CreateLocalizableString(column.Name)];
+		}
+	}
+
 	private void ApplyEntityCaption(
 		EntityDesignSchemaDto schema,
 		IReadOnlyDictionary<string, string>? entityTitleLocalizations,

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
@@ -26,6 +26,7 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 	private readonly IEntitySchemaDefaultValueSourceResolver _defaultValueSourceResolver;
 	private readonly IRemoteEntitySchemaDesignerClient _entitySchemaDesignerClient;
 	private readonly ILogger _logger;
+	private readonly IApplicationUserCultureProvider _userCultureProvider;
 
 	#endregion
 
@@ -82,11 +83,13 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 		IApplicationPackageListProvider applicationPackageListProvider,
 		IEntitySchemaDefaultValueSourceResolver defaultValueSourceResolver,
 		IRemoteEntitySchemaDesignerClient entitySchemaDesignerClient,
-		ILogger logger) {
+		ILogger logger,
+		IApplicationUserCultureProvider userCultureProvider) {
 		_applicationPackageListProvider = applicationPackageListProvider;
 		_defaultValueSourceResolver = defaultValueSourceResolver;
 		_entitySchemaDesignerClient = entitySchemaDesignerClient;
 		_logger = logger;
+		_userCultureProvider = userCultureProvider;
 	}
 
 	#endregion
@@ -443,6 +446,7 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 
 	public void Create(CreateEntitySchemaOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
+		using var _ = EntitySchemaDesignerSupport.UseUserCulture(_userCultureProvider.GetUserCultureName());
 		PackageInfo package = ResolvePackage(options.Package);
 		List<ParsedColumn> parsedColumns = ParseColumns(options.Columns).ToList();
 		DesignerResponse<EntityDesignSchemaDto> createResponse = _entitySchemaDesignerClient.CreateNewSchema(

--- a/clio/Command/McpServer/Tools/SchemaSyncTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaSyncTool.cs
@@ -170,6 +170,7 @@ public sealed class SchemaSyncTool(
 				Environment = args.EnvironmentName,
 				Package = args.PackageName,
 				SchemaName = op.SchemaName,
+				TitleLocalizations = op.TitleLocalizations,
 				Operations = UpdateEntitySchemaTool.SerializeOperations(op.UpdateOperations, op.SchemaName)
 			};
 			UpdateEntitySchemaCommand command = commandResolver.Resolve<UpdateEntitySchemaCommand>(options);
@@ -303,7 +304,7 @@ public sealed record SchemaSyncOperation(
 	string SchemaName,
 
 	[property: JsonPropertyName("title-localizations")]
-	[property: Description("Schema title/caption localizations for create operations. Must include en-US.")]
+	[property: Description("Schema title/caption localizations. Required for create-entity and create-lookup. Optional for update-entity to set or preserve the entity caption. Must include en-US when provided.")]
 	Dictionary<string, string>? TitleLocalizations = null,
 
 	[property: JsonPropertyName("parent-schema-name")]

--- a/clio/Command/UpdateEntitySchemaCommand.cs
+++ b/clio/Command/UpdateEntitySchemaCommand.cs
@@ -21,10 +21,7 @@ public class UpdateEntitySchemaOptions : RemoteCommandOptions
 		HelpText = "Structured operation JSON. Repeat the option for multiple values.")]
 	public IEnumerable<string> Operations { get; set; }
 
-	/// <summary>
-	/// Optional entity-level title localizations. When provided, the entity schema caption is updated
-	/// to these values during the column mutation. When absent, the existing caption is preserved.
-	/// </summary>
+
 	public Dictionary<string, string>? TitleLocalizations { get; set; }
 }
 

--- a/clio/Command/UpdateEntitySchemaCommand.cs
+++ b/clio/Command/UpdateEntitySchemaCommand.cs
@@ -20,6 +20,12 @@ public class UpdateEntitySchemaOptions : RemoteCommandOptions
 	[Option("operation", Required = true,
 		HelpText = "Structured operation JSON. Repeat the option for multiple values.")]
 	public IEnumerable<string> Operations { get; set; }
+
+	/// <summary>
+	/// Optional entity-level title localizations. When provided, the entity schema caption is updated
+	/// to these values during the column mutation. When absent, the existing caption is preserved.
+	/// </summary>
+	public Dictionary<string, string>? TitleLocalizations { get; set; }
 }
 
 internal sealed record UpdateEntitySchemaOperationDefinition
@@ -121,7 +127,7 @@ public class UpdateEntitySchemaCommand : Command<UpdateEntitySchemaOptions>
 			foreach (ModifyEntitySchemaColumnOptions operation in operations) {
 				ModifyEntitySchemaColumnCommand.ValidateOptions(operation);
 			}
-			_columnManager.ModifyColumns(operations);
+			_columnManager.ModifyColumns(operations, options.TitleLocalizations);
 			_logger.WriteInfo("Done");
 			return 0;
 		} catch (Exception exception) {

--- a/clio/Common/ApplicationUserCultureProvider.cs
+++ b/clio/Common/ApplicationUserCultureProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Clio.Common;
+
+/// <inheritdoc/>
+internal sealed class ApplicationUserCultureProvider : IApplicationUserCultureProvider
+{
+	private const string UserInfoEndpoint = "ServiceModel/UserInfoService.svc/GetCurrentUserInfo";
+	private const string FallbackCultureName = "en-US";
+
+	private readonly IApplicationClient _applicationClient;
+	private string? _cachedCultureName;
+
+	public ApplicationUserCultureProvider(IApplicationClient applicationClient) {
+		_applicationClient = applicationClient;
+	}
+
+	/// <inheritdoc/>
+	public string GetUserCultureName() {
+		if (_cachedCultureName != null) {
+			return _cachedCultureName;
+		}
+		_cachedCultureName = FetchUserCultureName();
+		return _cachedCultureName;
+	}
+
+	private string FetchUserCultureName() {
+		try {
+			string responseJson = _applicationClient.ExecutePostRequest(UserInfoEndpoint, "{}");
+			if (string.IsNullOrWhiteSpace(responseJson)) {
+				return FallbackCultureName;
+			}
+			UserInfoResponse? response = JsonSerializer.Deserialize<UserInfoResponse>(responseJson,
+				new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+			string? cultureName = response?.UserInfo?.CultureInfo?.SysCultureName;
+			return string.IsNullOrWhiteSpace(cultureName) ? FallbackCultureName : cultureName;
+		} catch {
+			return FallbackCultureName;
+		}
+	}
+
+	private sealed class UserInfoResponse
+	{
+		[JsonPropertyName("userInfo")]
+		public UserInfoDto? UserInfo { get; set; }
+	}
+
+	private sealed class UserInfoDto
+	{
+		[JsonPropertyName("cultureInfo")]
+		public CultureInfoDto? CultureInfo { get; set; }
+	}
+
+	private sealed class CultureInfoDto
+	{
+		[JsonPropertyName("sysCultureName")]
+		public string? SysCultureName { get; set; }
+	}
+}

--- a/clio/Common/IApplicationUserCultureProvider.cs
+++ b/clio/Common/IApplicationUserCultureProvider.cs
@@ -1,0 +1,13 @@
+namespace Clio.Common;
+
+/// <summary>
+/// Resolves the culture name of the authenticated Creatio user for the current environment.
+/// </summary>
+public interface IApplicationUserCultureProvider
+{
+	/// <summary>
+	/// Returns the culture name (e.g. "en-US", "uk-UA") of the authenticated Creatio user.
+	/// Falls back to "en-US" when the value cannot be retrieved.
+	/// </summary>
+	string GetUserCultureName();
+}


### PR DESCRIPTION
Fixes two related bugs in entity schema column management that caused data corruption during update-entity operations.

When adding or modifying columns, the GetSchemaDesignItem round-trip could replace the entity's actual caption with an inherited "Base object" default. The fix introduces caption-preservation logic that either applies explicit caller-provided title localizations or fetches the runtime caption to keep the correct value.

Additionally, some server round-trips return columns with empty caption dictionaries, particularly for localization-only titles on .NET Framework. This caused downstream validation errors. Empty captions are now restored to the column name as a fallback before saving.

The ModifyColumns interface and UpdateEntitySchemaCommand now accept optional entity-level title localizations, which SchemaSyncTool forwards from the update-entity operation. When provided, the entity caption is set explicitly; when absent, the existing caption is protected against corruption.

Covered by new unit tests for RemoteEntitySchemaColumnManager, UpdateEntitySchemaCommand, and SchemaSyncTool.