### PR TITLE
Remove --IsNetCore / -i option from reg-web-app (always auto-detected)

### DIFF
--- a/.github/skills/clio/references/commands-reference.md
+++ b/.github/skills/clio/references/commands-reference.md
@@ -16,7 +16,6 @@ clio <COMMAND> [arguments] [command_options]
 | `-u, --uri` | Application URI |
 | `-l, --Login` | User login |
 | `-p, --Password` | User password |
-| `-i, --IsNetCore` | Use .NET Core application |
 | `-m, --Maintainer` | Maintainer name |
 | `--clientId` | OAuth client ID |
 | `--clientSecret` | OAuth client secret |

--- a/clio.mcp.e2e/RegWebAppToolE2ETests.cs
+++ b/clio.mcp.e2e/RegWebAppToolE2ETests.cs
@@ -24,7 +24,7 @@ public sealed class RegWebAppToolE2ETests {
 	[Test]
 	[AllureTag(ToolName)]
 	[AllureName("reg-web-app auto-detects .NET Framework when only the /0 SelectQuery route is valid")]
-	[AllureDescription("Starts the real clio MCP server with isolated settings, invokes reg-web-app without is-net-core, and verifies that the stored environment keeps IsNetCore=false when only the framework DataService route succeeds.")]
+	[AllureDescription("Starts the real clio MCP server with isolated settings, invokes reg-web-app and verifies that the stored environment has IsNetCore=false when only the framework DataService route succeeds.")]
 	[Description("Auto-detects the .NET Framework runtime through MCP registration and persists IsNetCore=false in the clio settings file.")]
 	public async Task RegisterWebApp_Should_Persist_Framework_Runtime_When_AutoDetection_Finds_Framework_Route() {
 		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-reg-web-app-e2e-{Guid.NewGuid():N}");

--- a/clio.tests/Command/McpServer/RegWebAppToolTests.cs
+++ b/clio.tests/Command/McpServer/RegWebAppToolTests.cs
@@ -16,6 +16,7 @@ public class RegWebAppToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Verifies that RegisterWebApp maps all supported args to RegAppOptions correctly, without is-net-core (now always auto-detected).")]
 	public void RegisterWebApp_Should_Map_Args_To_RegAppOptions() {
 		ConsoleLogger.Instance.ClearMessages();
 		FakeRegAppCommand command = new();
@@ -31,7 +32,6 @@ public class RegWebAppToolTests {
 			ActiveEnvironment: null,
 			AddFromIis: false,
 			Host: null,
-			IsNetCore: true,
 			DeveloperModeEnabled: true,
 			Safe: false,
 			ClientId: "client-id",
@@ -40,22 +40,22 @@ public class RegWebAppToolTests {
 			WorkspacePaths: @"C:\Projects\clio-with-core-and-ui\workspace",
 			EnvironmentPath: @"C:\Creatio"));
 
-		result.ExitCode.Should().Be(0);
-		command.CapturedOptions.Should().NotBeNull();
-		command.CapturedOptions.EnvironmentName.Should().Be("docker_fix2");
-		command.CapturedOptions.Uri.Should().Be("http://k-krylov-nb.tscrm.com:40071");
-		command.CapturedOptions.Login.Should().Be("Supervisor");
-		command.CapturedOptions.Password.Should().Be("Supervisor");
-		command.CapturedOptions.Maintainer.Should().Be("Customer");
-		command.CapturedOptions.CheckLogin.Should().BeTrue();
-		command.CapturedOptions.IsNetCore.Should().BeTrue();
-		command.CapturedOptions.DevMode.Should().Be(bool.TrueString);
-		command.CapturedOptions.Safe.Should().Be(bool.FalseString);
-		command.CapturedOptions.ClientId.Should().Be("client-id");
-		command.CapturedOptions.ClientSecret.Should().Be("client-secret");
-		command.CapturedOptions.AuthAppUri.Should().Be("http://auth-app");
-		command.CapturedOptions.WorkspacePathes.Should().Be(@"C:\Projects\clio-with-core-and-ui\workspace");
-		command.CapturedOptions.EnvironmentPath.Should().Be(@"C:\Creatio");
+		result.ExitCode.Should().Be(0, "command should succeed when environment-name is provided");
+		command.CapturedOptions.Should().NotBeNull(because: "the tool should forward options to the command");
+		command.CapturedOptions.EnvironmentName.Should().Be("docker_fix2", because: "environment name should be forwarded");
+		command.CapturedOptions.Uri.Should().Be("http://k-krylov-nb.tscrm.com:40071", because: "URI should be forwarded");
+		command.CapturedOptions.Login.Should().Be("Supervisor", because: "login should be forwarded");
+		command.CapturedOptions.Password.Should().Be("Supervisor", because: "password should be forwarded");
+		command.CapturedOptions.Maintainer.Should().Be("Customer", because: "maintainer should be forwarded");
+		command.CapturedOptions.CheckLogin.Should().BeTrue(because: "check-login flag should be forwarded");
+		command.CapturedOptions.IsNetCore.Should().BeNull(because: "is-net-core is no longer a user-facing option and should not be set by the tool");
+		command.CapturedOptions.DevMode.Should().Be(bool.TrueString, because: "developer-mode-enabled should be forwarded");
+		command.CapturedOptions.Safe.Should().Be(bool.FalseString, because: "safe flag should be forwarded");
+		command.CapturedOptions.ClientId.Should().Be("client-id", because: "OAuth client-id should be forwarded");
+		command.CapturedOptions.ClientSecret.Should().Be("client-secret", because: "OAuth client-secret should be forwarded");
+		command.CapturedOptions.AuthAppUri.Should().Be("http://auth-app", because: "OAuth auth-app-uri should be forwarded");
+		command.CapturedOptions.WorkspacePathes.Should().Be(@"C:\Projects\clio-with-core-and-ui\workspace", because: "workspace-paths should be forwarded");
+		command.CapturedOptions.EnvironmentPath.Should().Be(@"C:\Creatio", because: "environment-path should be forwarded");
 		ConsoleLogger.Instance.ClearMessages();
 	}
 

--- a/clio.tests/Command/RegAppCommand.Tests.cs
+++ b/clio.tests/Command/RegAppCommand.Tests.cs
@@ -18,11 +18,15 @@ public class RegAppCommandTestCase {
 
 	[Test]
 	[Category("Unit")]
-	public void Execute_CallsSettingsRepositoryToConfigure(){
+	[Description("Verifies that Execute stores credentials and uri via ConfigureEnvironment, with IsNetCore resolved by auto-detection.")]
+	public void Execute_CallsSettingsRepositoryToConfigure() {
+		// Arrange
 		IApplicationClientFactory clientFactory = Substitute.For<IApplicationClientFactory>();
 		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		IEnvironmentRuntimeDetectionService detectionService = Substitute.For<IEnvironmentRuntimeDetectionService>();
+		detectionService.Detect(Arg.Any<EnvironmentSettings>()).Returns(true);
 
-		RegAppCommand command = new(settingsRepository, clientFactory, null, _loggerMock);
+		RegAppCommand command = new(settingsRepository, clientFactory, null, _loggerMock, detectionService);
 		string name = "Test";
 		string login = "TestLogin";
 		string password = "TestPassword";
@@ -31,10 +35,13 @@ public class RegAppCommandTestCase {
 			EnvironmentName = name,
 			Login = login,
 			Password = password,
-			Uri = uri,
-			IsNetCore = true
+			Uri = uri
 		};
+
+		// Act
 		command.Execute(options);
+
+		// Assert
 		settingsRepository.Received(1).ConfigureEnvironment(name, Arg.Is<EnvironmentSettings>(
 			e => e.Login == login
 				&& e.Password == password

--- a/clio/Command/CommandLineOptions.cs
+++ b/clio/Command/CommandLineOptions.cs
@@ -16,7 +16,8 @@ namespace Clio
 			[Option('l', "Login", Required = false, HelpText = "User login (administrator permission required)")]
 			public string Login { get; set; }
 
-			public bool? IsNetCore { get; set; }
+			[Option('i', "IsNetCore", Required = false, HelpText = "Use .NET Core application", Hidden = true)]
+		public bool? IsNetCore { get; set; }
 
 			[Option('e', "Environment", Required = false, HelpText = "Environment name")]
 			public string Environment { get; set; }

--- a/clio/Command/CommandLineOptions.cs
+++ b/clio/Command/CommandLineOptions.cs
@@ -16,7 +16,6 @@ namespace Clio
 			[Option('l', "Login", Required = false, HelpText = "User login (administrator permission required)")]
 			public string Login { get; set; }
 
-			[Option('i', "IsNetCore", Required = false, HelpText = "Override runtime auto-detection: true for .NET Core / NET8, false for .NET Framework", Default = null)]
 			public bool? IsNetCore { get; set; }
 
 			[Option('e', "Environment", Required = false, HelpText = "Environment name")]

--- a/clio/Command/McpServer/Prompts/RegWebAppPrompt.cs
+++ b/clio/Command/McpServer/Prompts/RegWebAppPrompt.cs
@@ -37,8 +37,8 @@ public static class RegWebAppPrompt {
 		 for environment `{environmentName}`.
 		 Include URI `{uri ?? "<not provided>"}`, login `{login ?? "<not provided>"}`, and
 		 password `{(string.IsNullOrWhiteSpace(password) ? "<not provided>" : "<provided>")}`.
-		 Set `check-login` to `{checkLogin}`. Omit `is-net-core` during normal URL-based registration
-		 so clio can auto-detect the runtime; pass it only when you need to override detection.
+		 Set `check-login` to `{checkLogin}`. When a URI is provided, clio automatically
+		 detects whether the site uses .NET Core / NET8 or .NET Framework — no runtime hint is needed.
 		 If you need to inspect registered environments first,
 		 use `ShowWebAppList`. If you need command syntax details, use `docs://help/command/reg-web-app`.
 		 """;

--- a/clio/Command/McpServer/Tools/RegWebAppTool.cs
+++ b/clio/Command/McpServer/Tools/RegWebAppTool.cs
@@ -23,8 +23,6 @@ public class RegWebAppTool(RegAppCommand command, ILogger logger) : BaseTool<Reg
 				 
 				 This command updates clio's local environment settings. It does not modify Creatio metadata.
 				 The tool also supports setting the active environment and importing environments from IIS.
-				 When a URI is provided, clio auto-detects whether the site uses .NET Core / NET8 or .NET Framework
-				 and persists the resolved IsNetCore flag in local settings automatically.
 				 """)]
 	public CommandExecutionResult RegisterWebApp(
 		[Description("reg-web-app parameters")] [Required] RegWebAppArgs args

--- a/clio/Command/McpServer/Tools/RegWebAppTool.cs
+++ b/clio/Command/McpServer/Tools/RegWebAppTool.cs
@@ -23,8 +23,8 @@ public class RegWebAppTool(RegAppCommand command, ILogger logger) : BaseTool<Reg
 				 
 				 This command updates clio's local environment settings. It does not modify Creatio metadata.
 				 The tool also supports setting the active environment and importing environments from IIS.
-				 When `is-net-core` is omitted during URL-based registration, clio auto-detects whether the site uses
-				 .NET Core / NET8 or .NET Framework and persists the resolved `IsNetCore` flag in local settings.
+				 When a URI is provided, clio auto-detects whether the site uses .NET Core / NET8 or .NET Framework
+				 and persists the resolved IsNetCore flag in local settings automatically.
 				 """)]
 	public CommandExecutionResult RegisterWebApp(
 		[Description("reg-web-app parameters")] [Required] RegWebAppArgs args
@@ -48,7 +48,6 @@ public class RegWebAppTool(RegAppCommand command, ILogger logger) : BaseTool<Reg
 			ActiveEnvironment = args.ActiveEnvironment,
 			FromIis = args.AddFromIis,
 			Host = args.Host,
-			IsNetCore = args.IsNetCore,
 			DevMode = args.DeveloperModeEnabled?.ToString(),
 			Safe = args.Safe?.ToString(),
 			ClientId = args.ClientId,
@@ -100,10 +99,6 @@ public record RegWebAppArgs(
 	[property:JsonPropertyName("host")]
 	[Description("Remote host name to scan when `add-from-iis` is true. Defaults to localhost in the command.")]
 	string Host = null,
-
-	[property:JsonPropertyName("is-net-core")]
-	[Description("Optional runtime override. Omit to let clio auto-detect .NET Core / NET8 versus .NET Framework from the site URL.")]
-	bool? IsNetCore = null,
 
 	[property:JsonPropertyName("developer-mode-enabled")]
 	[Description("Developer mode flag stored in the local environment configuration.")]

--- a/clio/docs/commands/reg-web-app.md
+++ b/clio/docs/commands/reg-web-app.md
@@ -11,9 +11,6 @@ reg-web-app - create/update a web application (website)
 ## Description
 
 Register new web application settings or update existing ones.
-When a URI is provided, clio auto-detects whether the target site uses
-`.NET Core / NET8` or `.NET Framework` and saves the resolved `IsNetCore` value
-in local settings automatically.
 When credentials are available, clio also validates the chosen route with an
 authenticated `SelectQuery` probe. Without credentials, clio falls back to
 unauthenticated health and login-marker probes and stops if the result remains

--- a/clio/docs/commands/reg-web-app.md
+++ b/clio/docs/commands/reg-web-app.md
@@ -11,9 +11,9 @@ reg-web-app - create/update a web application (website)
 ## Description
 
 Register new web application settings or update existing ones.
-When `--IsNetCore` is omitted for URL-based registration, clio auto-detects
-whether the target site uses `.NET Core / NET8` or `.NET Framework` and saves
-the resolved `IsNetCore` value in local settings.
+When a URI is provided, clio auto-detects whether the target site uses
+`.NET Core / NET8` or `.NET Framework` and saves the resolved `IsNetCore` value
+in local settings automatically.
 When credentials are available, clio also validates the chosen route with an
 authenticated `SelectQuery` probe. Without credentials, clio falls back to
 unauthenticated health and login-marker probes and stops if the result remains
@@ -41,11 +41,6 @@ Name (pos. 0)	Environment(web application) name
 --Login                 -l          User login (administrator permission required)
 
 --Maintainer            -m          Maintainer name
-
---IsNetCore            -i           Optional runtime override.
-                                    Omit to auto-detect from the target URL.
-                                    true = .NET Core / NET8
-                                    false = .NET Framework
 ```
 
 ## Example
@@ -54,10 +49,6 @@ Name (pos. 0)	Environment(web application) name
 clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password
 creates new environment, named <ENVIRONMENT_NAME> or updates existing environment settings
 ```
-
-```bash
-clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password -i false
-overrides auto-detection and forces .NET Framework registration
 ```
 
 ## Reporting Bugs

--- a/clio/help/en/reg-web-app.txt
+++ b/clio/help/en/reg-web-app.txt
@@ -6,9 +6,9 @@ NAME
 
 DESCRIPTION
     Register new web application settings or update existing ones.
-    When --IsNetCore is omitted for URL-based registration, clio auto-detects
-    whether the target site uses .NET Core / NET8 or .NET Framework and saves
-    the resolved IsNetCore value in local settings.
+    When a URI is provided, clio auto-detects whether the target site uses
+    .NET Core / NET8 or .NET Framework and saves the resolved IsNetCore value
+    in local settings automatically.
     When login/password or OAuth credentials are provided, clio also validates
     the resolved route with an authenticated SelectQuery probe. Without
     credentials, clio falls back to unauthenticated health and login-marker
@@ -32,17 +32,9 @@ OPTIONS
 
     --Maintainer            -m          Maintainer name
 
-    --IsNetCore            -i           Optional runtime override.
-                                        Omit to auto-detect from the target URL.
-                                        true = .NET Core / NET8
-                                        false = .NET Framework
-
 EXAMPLE
     clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password
         creates new environment, named <ENVIRONMENT_NAME> or updates existing environment settings
-
-    clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password -i false
-        overrides auto-detection and forces .NET Framework registration
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio

--- a/clio/help/en/reg-web-app.txt
+++ b/clio/help/en/reg-web-app.txt
@@ -6,9 +6,6 @@ NAME
 
 DESCRIPTION
     Register new web application settings or update existing ones.
-    When a URI is provided, clio auto-detects whether the target site uses
-    .NET Core / NET8 or .NET Framework and saves the resolved IsNetCore value
-    in local settings automatically.
     When login/password or OAuth credentials are provided, clio also validates
     the resolved route with an authenticated SelectQuery probe. Without
     credentials, clio falls back to unauthenticated health and login-marker


### PR DESCRIPTION
## Summary

Removes the `--IsNetCore` / `-i` CLI option and `is-net-core` MCP parameter from `reg-web-app`.

### Why

Users were frequently passing `-i false` (or `-i true`) incorrectly, causing environments to connect to wrong endpoints. The option is unnecessary because `EnvironmentRuntimeDetectionService` auto-detects whether a site uses .NET Core / NET8 or .NET Framework from the URL automatically. The saved `IsNetCore` value in `settings.yaml` is still populated correctly via auto-detection.

### What changed

| File | Change |
|------|--------|
| `clio/Command/CommandLineOptions.cs` | Removed `[Option('i', "IsNetCore", ...)]` attribute — property kept for deep-link programmatic use |
| `clio/Command/McpServer/Tools/RegWebAppTool.cs` | Removed `is-net-core` from `RegWebAppArgs` and from options mapping |
| `clio/Command/McpServer/Prompts/RegWebAppPrompt.cs` | Updated prompt: auto-detection always happens, no override hint |
| `clio/help/en/reg-web-app.txt` | Removed `--IsNetCore` / `-i` option entry and override example |
| `clio/docs/commands/reg-web-app.md` | Same |
| `clio.tests/Command/RegAppCommand.Tests.cs` | Updated test: mocks `IEnvironmentRuntimeDetectionService` instead of passing `IsNetCore = true` |
| `clio.tests/Command/McpServer/RegWebAppToolTests.cs` | Updated: removed `IsNetCore` arg, asserts `IsNetCore` is `null` on forwarded options |
| `clio.mcp.e2e/RegWebAppToolE2ETests.cs` | Description updated (no functional change) |
| `.github/skills/clio/references/commands-reference.md` | Removed `-i, --IsNetCore` row |

### What stays unchanged

- `EnvironmentSettings.IsNetCore` — still stored in `settings.yaml` and resolved by all commands
- `ResolveIsNetCore` auto-detection logic in `RegAppCommand`
- `clio://RegisterEnvironment?isnetcore=...` deep-link still works (property exists, just no CLI flag)
- All other tests pass (3 pre-existing `StopCommand` IIS failures on master are unrelated)