### PR TITLE
ENG-88550 fix: normalize admin metadata on schema create, add value masking support, fix verified-body-file field name

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -2357,3 +2357,51 @@ Decision: Kept `uri/login/password` compatibility in MCP tools, but changed reso
 Discovery: Wording-only MCP surface changes were enough to steer agent behavior without changing payload shape or execution paths. Existing E2E assertions still matched because they only depended on the preserved leading resolver text.
 Files: clio/Command/McpServer/Tools/ToolCommandResolver.cs, clio/Command/McpServer/Tools/PageGetTool.cs, clio/Command/McpServer/Tools/PageListTool.cs, clio/Command/McpServer/Tools/PageUpdateTool.cs, clio/Command/McpServer/Tools/ApplicationDeleteTool.cs, clio/Command/McpServer/Tools/DataForgeTool.cs, clio/Command/McpServer/Prompts/PagePrompt.cs, clio/Command/McpServer/Prompts/ApplicationPrompt.cs, clio/Command/McpServer/Prompts/RegWebAppPrompt.cs, clio.tests/Command/McpServer/PageToolsTests.cs, clio.tests/Command/McpServer/ApplicationToolTests.cs, .codex/workspace-diary.md
 Impact: Agents should now prefer registering environments and using `environment-name`, while direct credentials stay available only as a documented emergency fallback.
+## 2026-04-17 11:55 – E2E pushed packages need hotfix to become editable
+Context: Debugged MCP E2E failures where tests created a temp workspace/package, used push-workspace to install it on remote stands, then immediately tried package mutations such as create-lookup, create-data-binding-db, and sync-schemas update flows.
+Decision: Keep push-workspace for package deployment but enable `pkg-hotfix <package> true` immediately after push inside mutation-oriented E2E arrange flows so the remote package becomes editable before designer/schema-data writes.
+Discovery: Core computes package read-only state from `InstallType`, not `InstallBehavior`. `push-workspace` installs `CreatioPackages.zip` through archive/package-installer flow, which leaves packages as `InstallType=Repository` and therefore `IsReadOnly=true`. `PackageService.StartPackageHotfix` flips package editability by setting maintainer/install-type to editable state. Verified that EntitySchema, DataBindingDb, and SchemaSync mutation E2Es pass after hotfixing.
+Files: clio.mcp.e2e/EntitySchemaToolE2ETests.cs, clio.mcp.e2e/DataBindingDbToolE2ETests.cs, clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+Impact: Future destructive E2E tests that push a workspace and then mutate remote package contents should hotfix the package after push unless a true SourceControl-mode push flow is introduced.
+
+## 2026-04-17 12:32 – sync-pages contract drifted from verified-body-file wire field
+Context: Investigated the failing `ToolContractGet_Should_Return_Maintenance_Oriented_Canonical_Contracts` E2E after the broader MCP tool run.
+Decision: Keep the existing `PageSyncTool` wire shape and update `ToolContractGetTool.BuildPageSync()` so the advertised `sync-pages` output contract says `verified-body-file`.
+Discovery: `PageSyncTool` serializes `[JsonPropertyName("verified-body-file")]` and unit tests already assert that wire name, but `get-tool-contract` had drifted to `verified-body`, causing only the contract inspection test to fail.
+Files: clio/Command/McpServer/Tools/ToolContractGetTool.cs
+Impact: MCP contract inspection for `sync-pages` now matches the real response payload, avoiding false contract failures when clients rely on `get-tool-contract` for page verify output fields.
+
+## 2026-04-17 12:58 – get-page E2E expected pre-compaction payload
+Context: Investigated the failing `PageGetTool_Should_Return_Stable_Metadata_Contract_For_Real_Page` E2E after restoring an installed application so the test would run instead of skipping.
+Decision: Keep `PageGetTool` behavior unchanged and update the E2E to validate the compact MCP response (`page` + `files`) plus written `body.js`/`bundle.json`/`meta.json` paths on disk.
+Discovery: `PageGetCommand` still builds inline `bundle` and `raw`, but `PageGetTool.WriteFilesAndCompact()` intentionally strips those fields from successful MCP responses after writing them to `.clio-pages/<schema-name>/`. Unit tests in `PageToolsTests` already locked in that contract.
+Files: clio.mcp.e2e/PageGetToolE2ETests.cs
+Impact: The live-environment `get-page` E2E now tracks the real MCP wire contract and verifies the file-based artifacts that update flows actually consume.
+
+## 2026-04-17 13:18 – masked entity-schema creation needs synthetic value-masking settings
+Context: Investigated why `CreateEntitySchema_Should_Apply_Masked_For_Text_Column_Through_Mcp` still failed after normalizing root-schema administration flags.
+Decision: Keep the administration-flag normalization for fresh root schemas, and additionally synthesize `valueMaskingSettings` whenever `masked=true` is requested during create-entity-schema. Use the conventional unmask operation code `<SchemaName>_<ColumnName>_UnmaskedValue` with default masking pattern `.*` and replacement `********`.
+Discovery: Core validator `EntitySchemaValidator.ValidateValueMaskingSettings` rejects any column with `isValueMasked=true` unless `valueMaskingSettings.adminOperationCode`, `pattern`, and `replacement` are all non-empty. The previous clio payload only set `isMasked`/`isValueMasked`, which triggered the server-side error `Operation permission is not selected.`.
+Files: clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs, clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs, clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
+Impact: create-entity-schema now produces core-valid masked Text/SecureText payloads, and the live masked-column E2E passes again.
+
+## 2026-04-17 14:05 – entity-schema positive E2Es need Usr-prefixed custom column codes
+Context: Investigated why `UpdateEntitySchema_Should_Add_BinaryLike_Columns_And_Read_Back_Friendly_Types` failed even after the package-editability and masked-column fixes.
+Decision: Update the positive entity-schema E2E fixture to use `Usr...` codes for every custom column created through `create-entity-schema` and `update-entity-schema`, including the shared arrange defaults and the binary-like test-specific columns.
+Discovery: The failure was not in binary/image/file column handling. The initial create step still seeded a custom column named `Name`, which core rejects because custom entity-schema column codes must start with `Usr`. The binary-like test also used unprefixed custom add names (`Payload`, `Preview`, `Document`), so fixing the shared setup and per-test constants together avoids the next validation failure.
+Files: clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+Impact: The targeted binary-like entity-schema E2E now passes, and other positive entity-schema flows that reuse the shared arrange helper are less likely to fail on the same prefix validation.
+
+## 2026-04-17 14:52 – Allure async step attributes can deadlock NUnit tests
+Context: Investigated MCP E2E hangs where async helper methods were annotated with `[AllureStep]`.
+Decision: Remove `[AllureStep]` from private static async Task helpers and wrap their bodies with `await AllureApi.Step(...)` instead.
+Discovery: `[AllureStep]` blocks the NUnit test thread while async continuations still need `NUnitSynchronizationContext` to resume on that same thread, which causes a deadlock. Non-async step methods are unaffected.
+Files: clio.mcp.e2e/*.cs
+Impact: Async E2E helper steps can report to Allure without blocking test execution on NUnit.
+
+## 2026-04-17 15:12 – Reuse one deterministic sys setting in entity-schema E2Es
+Context: Review of the settings-default entity-schema E2Es found that creating a unique sys setting per run polluted the shared sandbox.
+Decision: Replace per-run generated setting codes with one deterministic reusable code, `UsrEntitySchemaE2EDefaultText`, and keep updating that setting idempotently during arrange.
+Discovery: The tests only need any resolvable `Text` sys setting; they do not depend on special semantics of the original `Maintainer` value or on unique setting names per run.
+Files: clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+Impact: The settings-default E2Es remain self-sufficient without leaking unbounded sys settings into shared environments.

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -135,11 +135,16 @@ public sealed class ApplicationToolE2ETests {
 			because: "list-apps should succeed whether the target environment currently has zero installed apps or many");
 		listResult.Result.Applications.Should().NotBeNull(
 			because: "list-apps should always include the applications collection so MCP clients can handle empty and populated environments uniformly");
-		listResult.Result.Applications.Should().OnlyContain(application =>
-				!string.IsNullOrWhiteSpace(application.Id)
-				&& !string.IsNullOrWhiteSpace(application.Name)
-				&& !string.IsNullOrWhiteSpace(application.Code),
-			because: "every returned application item should expose the selectors that MCP clients need for follow-up targeting");
+		if (listResult.Result.Applications.Count == 0) {
+			listResult.Result.Applications.Should().BeEmpty(
+				because: "empty environments should still return an empty applications collection instead of null");
+		} else {
+			listResult.Result.Applications.Should().OnlyContain(application =>
+					!string.IsNullOrWhiteSpace(application.Id)
+					&& !string.IsNullOrWhiteSpace(application.Name)
+					&& !string.IsNullOrWhiteSpace(application.Code),
+				because: "every returned application item should expose the selectors that MCP clients need for follow-up targeting");
+		}
 		listResult.Result.Error.Should().BeNullOrWhiteSpace(
 			because: "successful list-apps calls should not include an error payload");
 	}

--- a/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
@@ -288,6 +288,11 @@ public sealed class DataBindingDbToolE2ETests {
 				["push-workspace", "-e", environmentName],
 				workingDirectory: workspacePath,
 				cancellationToken: cancellationTokenSource.Token);
+			await ClioCliCommandRunner.RunAndAssertSuccessAsync(
+				settings,
+				["pkg-hotfix", packageName, "true", "-e", environmentName],
+				workingDirectory: workspacePath,
+				cancellationToken: cancellationTokenSource.Token);
 		}
 
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command;
@@ -28,7 +29,7 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class EntitySchemaToolE2ETests {
 	private const string CurrentDateTimeSystemValueUId = "d7c295d3-3146-4ee1-ac49-3a7bd0edc45d";
-	private const string MaintainerSettingCode = "Maintainer";
+	private const string TextDefaultSettingCode = "UsrEntitySchemaE2EDefaultText";
 	private const string CreateToolName = CreateEntitySchemaTool.CreateEntitySchemaToolName;
 	private const string CreateLookupToolName = CreateLookupTool.CreateLookupToolName;
 	private const string UpdateToolName = UpdateEntitySchemaTool.UpdateEntitySchemaToolName;
@@ -190,9 +191,9 @@ public sealed class EntitySchemaToolE2ETests {
 	public async Task UpdateEntitySchema_Should_Add_BinaryLike_Columns_And_Read_Back_Friendly_Types() {
 		// Arrange
 		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSandboxPackageAsync();
-		const string binaryColumnName = "Payload";
-		const string imageColumnName = "Preview";
-		const string fileColumnName = "Document";
+		const string binaryColumnName = "UsrPayload";
+		const string imageColumnName = "UsrPreview";
+		const string fileColumnName = "UsrDocument";
 
 		// Act
 		CommandExecutionEnvelope createResult = await ActCreateEntitySchemaAsync(arrangeContext);
@@ -251,7 +252,12 @@ public sealed class EntitySchemaToolE2ETests {
 			"modify-entity-schema-column should succeed when applying default-value-config after a localized batch add");
 		AssertIncludesInfoMessage(modifyResult,
 			"successful follow-up default-value-config mutations should emit progress output");
-		AssertStructuredSettingsColumnProperties(columnProperties, arrangeContext.SchemaName, localizedColumnName, "Status");
+		AssertStructuredSettingsColumnProperties(
+			columnProperties,
+			arrangeContext.SchemaName,
+			localizedColumnName,
+			"Status",
+			TextDefaultSettingCode);
 	}
 
 	[Test]
@@ -309,7 +315,12 @@ public sealed class EntitySchemaToolE2ETests {
 			"modify-entity-schema-column should succeed when adding a Text column with a settings default");
 		AssertIncludesInfoMessage(addResult,
 			"successful structured settings mutations should emit progress output");
-		AssertStructuredSettingsColumnProperties(columnProperties, arrangeContext.SchemaName, titleColumnName, "Title");
+		AssertStructuredSettingsColumnProperties(
+			columnProperties,
+			arrangeContext.SchemaName,
+			titleColumnName,
+			"Title",
+			TextDefaultSettingCode);
 	}
 
 	[Test]
@@ -600,328 +611,356 @@ public sealed class EntitySchemaToolE2ETests {
 			"unknown environment names should be reported before any schema search is executed");
 	}
 
-	[AllureStep("Arrange sandbox MCP session for non-destructive find-entity-schema checks")]
 	private static async Task<SandboxFindEntitySchemaArrangeContext> ArrangeSandboxFindEntitySchemaAsync() {
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new SandboxFindEntitySchemaArrangeContext(
-			settings.Sandbox.EnvironmentName!,
-			session,
-			cancellationTokenSource);
+		return await AllureApi.Step("Arrange sandbox MCP session for non-destructive find-entity-schema checks", async () => {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			TestConfiguration.EnsureSandboxIsConfigured(settings);
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new SandboxFindEntitySchemaArrangeContext(
+				settings.Sandbox.EnvironmentName!,
+				session,
+				cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Arrange sandbox package and MCP session for entity schema tools")]
 	private static async Task<EntitySchemaArrangeContext> ArrangeSandboxPackageAsync() {
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		if (!settings.AllowDestructiveMcpTests) {
-			Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive entity schema MCP end-to-end tests.");
-		}
+		return await AllureApi.Step("Arrange sandbox package and MCP session for entity schema tools", async () => {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			if (!settings.AllowDestructiveMcpTests) {
+				Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive entity schema MCP end-to-end tests.");
+			}
 
-		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-entity-schema-mcp-e2e-{Guid.NewGuid():N}");
-		Directory.CreateDirectory(rootDirectory);
+			TestConfiguration.EnsureSandboxIsConfigured(settings);
+			string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-entity-schema-mcp-e2e-{Guid.NewGuid():N}");
+			Directory.CreateDirectory(rootDirectory);
 
-		string workspaceName = $"workspace-{Guid.NewGuid():N}";
-		string workspacePath = Path.Combine(rootDirectory, workspaceName);
-		string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
-		string schemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
-		string initialColumnName = "Name";
-		string lookupColumnName = "UsrSortOrder";
-		string addedColumnName = "Code";
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(8));
+			string workspaceName = $"workspace-{Guid.NewGuid():N}";
+			string workspacePath = Path.Combine(rootDirectory, workspaceName);
+			string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
+			string schemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
+			string initialColumnName = "UsrName";
+			string lookupColumnName = "UsrSortOrder";
+			string addedColumnName = "UsrCode";
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(8));
 
-		try {
-			await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
+			try {
+				await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
+					settings,
+					settings.Sandbox.EnvironmentName!,
+					cancellationTokenSource.Token);
+			}
+			catch (Exception ex) {
+				Assert.Ignore(
+					$"Skipping destructive entity schema MCP end-to-end test because cliogate could not be installed or verified for '{settings.Sandbox.EnvironmentName}'. {ex.Message}");
+			}
+			await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationTokenSource.Token);
+			await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
+			await PushWorkspaceAsync(
+				settings,
+				workspacePath,
+				settings.Sandbox.EnvironmentName!,
+				packageName,
+				cancellationTokenSource.Token);
+			await EnsureTextSysSettingAsync(
 				settings,
 				settings.Sandbox.EnvironmentName!,
+				TextDefaultSettingCode,
+				"Entity schema MCP E2E default",
 				cancellationTokenSource.Token);
-		}
-		catch (Exception ex) {
-			Assert.Ignore(
-				$"Skipping destructive entity schema MCP end-to-end test because cliogate could not be installed or verified for '{settings.Sandbox.EnvironmentName}'. {ex.Message}");
-		}
-		await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationTokenSource.Token);
-		await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
-		await PushWorkspaceAsync(settings, workspacePath, settings.Sandbox.EnvironmentName!, cancellationTokenSource.Token);
 
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new EntitySchemaArrangeContext(
-			rootDirectory,
-			settings.Sandbox.EnvironmentName!,
-			packageName,
-			schemaName,
-			initialColumnName,
-			lookupColumnName,
-			addedColumnName,
-			session,
-			cancellationTokenSource);
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new EntitySchemaArrangeContext(
+				rootDirectory,
+				settings.Sandbox.EnvironmentName!,
+				packageName,
+				schemaName,
+				initialColumnName,
+				lookupColumnName,
+				addedColumnName,
+				session,
+				cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Arrange invalid-environment MCP session for entity schema tools")]
 	private static async Task<InvalidEnvironmentArrangeContext> ArrangeInvalidEnvironmentAsync() {
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new InvalidEnvironmentArrangeContext(
-			$"missing-entity-schema-env-{Guid.NewGuid():N}",
-			session,
-			cancellationTokenSource);
+		return await AllureApi.Step("Arrange invalid-environment MCP session for entity schema tools", async () => {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new InvalidEnvironmentArrangeContext(
+				$"missing-entity-schema-env-{Guid.NewGuid():N}",
+				session,
+				cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking create-entity-schema through MCP")]
 	private static async Task<CommandExecutionEnvelope> ActCreateEntitySchemaAsync(EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallCreateEntitySchemaAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token,
-			columns: [
-				new Dictionary<string, object?> {
-					["name"] = arrangeContext.InitialColumnName,
-					["type"] = "Text",
-					["title-localizations"] = BuildLocalizations("Vehicle name")
-				}
-			]);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking create-entity-schema through MCP", async () => {
+			CallToolResult callResult = await CallCreateEntitySchemaAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				columns: [
+					new Dictionary<string, object?> {
+						["name"] = arrangeContext.InitialColumnName,
+						["type"] = "Text",
+						["title-localizations"] = BuildLocalizations("Vehicle name")
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking create-entity-schema through MCP with a masked text column")]
 	private static async Task<CommandExecutionEnvelope> ActCreateEntitySchemaWithMaskedTextColumnAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string columnName) {
-		CallToolResult callResult = await CallCreateEntitySchemaAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token,
-			columns: [
-				new Dictionary<string, object?> {
-					["name"] = columnName,
-					["type"] = "Text",
-					["title-localizations"] = BuildLocalizations("Masked text"),
-					["masked"] = true
-				}
-			]);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking create-entity-schema through MCP with a masked text column", async () => {
+			CallToolResult callResult = await CallCreateEntitySchemaAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				columns: [
+					new Dictionary<string, object?> {
+						["name"] = columnName,
+						["type"] = "Text",
+						["title-localizations"] = BuildLocalizations("Masked text"),
+						["masked"] = true
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking get-entity-schema-properties through MCP")]
 	private static async Task<EntitySchemaPropertiesInfo> ActGetSchemaPropertiesAsync(
 		EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallGetSchemaPropertiesAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token);
-		return EntitySchemaStructuredResultParser.Extract<EntitySchemaPropertiesInfo>(callResult);
+		return await AllureApi.Step("Act by invoking get-entity-schema-properties through MCP", async () => {
+			CallToolResult callResult = await CallGetSchemaPropertiesAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token);
+			return EntitySchemaStructuredResultParser.Extract<EntitySchemaPropertiesInfo>(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP")]
 	private static async Task<CommandExecutionEnvelope> ActAddEntitySchemaColumnAsync(
 		EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"add",
-			arrangeContext.AddedColumnName,
-			arrangeContext.CancellationTokenSource.Token,
-			type: "ShortText",
-			titleLocalizations: BuildLocalizations("Vehicle code"),
-			indexed: true,
-			defaultValueSource: "Const",
-			defaultValue: "Draft");
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"add",
+				arrangeContext.AddedColumnName,
+				arrangeContext.CancellationTokenSource.Token,
+				type: "ShortText",
+				titleLocalizations: BuildLocalizations("Vehicle code"),
+				indexed: true,
+				defaultValueSource: "Const",
+				defaultValue: "Draft");
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking create-lookup through MCP")]
 	private static async Task<CommandExecutionEnvelope> ActCreateLookupAsync(EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallCreateLookupAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token,
-			columns: [
-				new Dictionary<string, object?> {
-					["name"] = arrangeContext.LookupColumnName,
-					["type"] = "Integer",
-					["title-localizations"] = BuildLocalizations("Sort order")
-				}
-			]);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking create-lookup through MCP", async () => {
+			CallToolResult callResult = await CallCreateLookupAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				columns: [
+					new Dictionary<string, object?> {
+						["name"] = arrangeContext.LookupColumnName,
+						["type"] = "Integer",
+						["title-localizations"] = BuildLocalizations("Sort order")
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking create-lookup through MCP without custom columns")]
 	private static async Task<CommandExecutionEnvelope> ActCreateLookupWithoutCustomColumnsAsync(EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallCreateLookupAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking create-lookup through MCP without custom columns", async () => {
+			CallToolResult callResult = await CallCreateLookupAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP for modify")]
 	private static async Task<CommandExecutionEnvelope> ActModifyEntitySchemaColumnAsync(
 		EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"modify",
-			arrangeContext.AddedColumnName,
-			arrangeContext.CancellationTokenSource.Token,
-			titleLocalizations: BuildLocalizations("Vehicle code updated"),
-			defaultValueSource: "None");
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP for modify", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"modify",
+				arrangeContext.AddedColumnName,
+				arrangeContext.CancellationTokenSource.Token,
+				titleLocalizations: BuildLocalizations("Vehicle code updated"),
+				defaultValueSource: "None");
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP for remove")]
 	private static async Task<CommandExecutionEnvelope> ActRemoveEntitySchemaColumnAsync(
 		EntitySchemaArrangeContext arrangeContext) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"remove",
-			arrangeContext.AddedColumnName,
-			arrangeContext.CancellationTokenSource.Token);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP for remove", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"remove",
+				arrangeContext.AddedColumnName,
+				arrangeContext.CancellationTokenSource.Token);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP for a structured system-value default")]
 	private static async Task<CommandExecutionEnvelope> ActAddDateTimeColumnWithStructuredDefaultAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string columnName) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"add",
-			columnName,
-			arrangeContext.CancellationTokenSource.Token,
-			type: "DateTime",
-			titleLocalizations: BuildLocalizations("Start date"),
-			defaultValueConfig: BuildSystemValueDefaultValueConfig("Current Time and Date"));
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP for a structured system-value default", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"add",
+				columnName,
+				arrangeContext.CancellationTokenSource.Token,
+				type: "DateTime",
+				titleLocalizations: BuildLocalizations("Start date"),
+				defaultValueConfig: BuildSystemValueDefaultValueConfig("Current Time and Date"));
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP for a structured settings default")]
 	private static async Task<CommandExecutionEnvelope> ActAddTextColumnWithStructuredSettingsDefaultAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string columnName) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"add",
-			columnName,
-			arrangeContext.CancellationTokenSource.Token,
-			type: "Text",
-			titleLocalizations: BuildLocalizations("Title"),
-			defaultValueConfig: BuildSettingsDefaultValueConfig(MaintainerSettingCode));
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP for a structured settings default", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"add",
+				columnName,
+				arrangeContext.CancellationTokenSource.Token,
+				type: "Text",
+				titleLocalizations: BuildLocalizations("Title"),
+				defaultValueConfig: BuildSettingsDefaultValueConfig(TextDefaultSettingCode));
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking get-entity-schema-column-properties through MCP")]
 	private static async Task<EntitySchemaColumnPropertiesInfo> ActGetColumnPropertiesAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string? columnName = null) {
-		CallToolResult callResult = await CallGetColumnPropertiesAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			columnName ?? arrangeContext.AddedColumnName,
-			arrangeContext.CancellationTokenSource.Token);
-		return EntitySchemaStructuredResultParser.Extract<EntitySchemaColumnPropertiesInfo>(callResult);
+		return await AllureApi.Step("Act by invoking get-entity-schema-column-properties through MCP", async () => {
+			CallToolResult callResult = await CallGetColumnPropertiesAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				columnName ?? arrangeContext.AddedColumnName,
+				arrangeContext.CancellationTokenSource.Token);
+			return EntitySchemaStructuredResultParser.Extract<EntitySchemaColumnPropertiesInfo>(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking update-entity-schema through MCP for binary-like columns")]
 	private static async Task<CommandExecutionEnvelope> ActBatchAddBinaryLikeColumnsAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string binaryColumnName,
 		string imageColumnName,
 		string fileColumnName) {
-		CallToolResult callResult = await CallUpdateEntitySchemaAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token,
-			[
-				new Dictionary<string, object?> {
-					["action"] = "add",
-					["column-name"] = binaryColumnName,
-					["type"] = "Binary",
-					["title-localizations"] = BuildLocalizations("Payload")
-				},
-				new Dictionary<string, object?> {
-					["action"] = "add",
-					["column-name"] = imageColumnName,
-					["type"] = "Image",
-					["title-localizations"] = BuildLocalizations("Preview")
-				},
-				new Dictionary<string, object?> {
-					["action"] = "add",
-					["column-name"] = fileColumnName,
-					["type"] = "File",
-					["title-localizations"] = BuildLocalizations("Document")
-				}
-			]);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for binary-like columns", async () => {
+			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				[
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = binaryColumnName,
+						["type"] = "Binary",
+						["title-localizations"] = BuildLocalizations("Payload")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = imageColumnName,
+						["type"] = "Image",
+						["title-localizations"] = BuildLocalizations("Preview")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = fileColumnName,
+						["type"] = "File",
+						["title-localizations"] = BuildLocalizations("Document")
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking update-entity-schema through MCP for a localized text column")]
 	private static async Task<CommandExecutionEnvelope> ActBatchAddLocalizedTextColumnAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string columnName) {
-		CallToolResult callResult = await CallUpdateEntitySchemaAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			arrangeContext.CancellationTokenSource.Token,
-			[
-				new Dictionary<string, object?> {
-					["action"] = "add",
-					["column-name"] = columnName,
-					["type"] = "Text",
-					["title-localizations"] = BuildLocalizations("Status")
-				}
-			]);
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for a localized text column", async () => {
+			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				[
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = columnName,
+						["type"] = "Text",
+						["title-localizations"] = BuildLocalizations("Status")
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
-	[AllureStep("Act by invoking modify-entity-schema-column through MCP for a localized column follow-up default")]
 	private static async Task<CommandExecutionEnvelope> ActModifyLocalizedTextColumnWithStructuredSettingsDefaultAsync(
 		EntitySchemaArrangeContext arrangeContext,
 		string columnName) {
-		CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
-			arrangeContext.Session,
-			arrangeContext.EnvironmentName,
-			arrangeContext.PackageName,
-			arrangeContext.SchemaName,
-			"modify",
-			columnName,
-			arrangeContext.CancellationTokenSource.Token,
-			defaultValueConfig: BuildSettingsDefaultValueConfig(MaintainerSettingCode));
-		return McpCommandExecutionParser.Extract(callResult);
+		return await AllureApi.Step("Act by invoking modify-entity-schema-column through MCP for a localized column follow-up default", async () => {
+			CallToolResult callResult = await CallModifyEntitySchemaColumnAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				"modify",
+				columnName,
+				arrangeContext.CancellationTokenSource.Token,
+				defaultValueConfig: BuildSettingsDefaultValueConfig(TextDefaultSettingCode));
+			return McpCommandExecutionParser.Extract(callResult);
+		});
 	}
 
 	private static async Task<CallToolResult> CallCreateEntitySchemaAsync(
@@ -1269,7 +1308,8 @@ public sealed class EntitySchemaToolE2ETests {
 		EntitySchemaColumnPropertiesInfo properties,
 		string schemaName,
 		string columnName,
-		string title) {
+		string title,
+		string expectedSettingCode) {
 		properties.SchemaName.Should().Be(schemaName,
 			because: "the structured result should identify the schema that received the settings default");
 		properties.ColumnName.Should().Be(columnName,
@@ -1282,15 +1322,15 @@ public sealed class EntitySchemaToolE2ETests {
 			because: "the structured result should preserve the added Text column title");
 		properties.DefaultValueSource.Should().Be("Settings",
 			because: "legacy summary fields should surface the resolved settings source");
-		properties.DefaultValue.Should().Be(MaintainerSettingCode,
+		properties.DefaultValue.Should().Be(expectedSettingCode,
 			because: "legacy summary fields should expose canonical setting code values");
 		properties.DefaultValueConfig.Should().NotBeNull(
 			because: "structured column readback should expose default-value-config metadata for settings defaults");
 		properties.DefaultValueConfig!.Source.Should().Be("Settings",
 			because: "the structured default value config should preserve the resolved settings source");
-		properties.DefaultValueConfig.ValueSource.Should().Be(MaintainerSettingCode,
+		properties.DefaultValueConfig.ValueSource.Should().Be(expectedSettingCode,
 			because: "the structured default value config should preserve canonical setting code values");
-		properties.DefaultValueConfig.ResolvedValueSource.Should().Be(MaintainerSettingCode,
+		properties.DefaultValueConfig.ResolvedValueSource.Should().Be(expectedSettingCode,
 			because: "structured default value readback should include additive resolved-value-source metadata");
 	}
 
@@ -1374,11 +1414,29 @@ public sealed class EntitySchemaToolE2ETests {
 		McpE2ESettings settings,
 		string workspacePath,
 		string environmentName,
+		string packageName,
 		CancellationToken cancellationToken) {
 		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
 			settings,
 			["push-workspace", "-e", environmentName],
 			workingDirectory: workspacePath,
+			cancellationToken: cancellationToken);
+		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
+			settings,
+			["pkg-hotfix", packageName, "true", "-e", environmentName],
+			workingDirectory: workspacePath,
+			cancellationToken: cancellationToken);
+	}
+
+	private static async Task EnsureTextSysSettingAsync(
+		McpE2ESettings settings,
+		string environmentName,
+		string code,
+		string value,
+		CancellationToken cancellationToken) {
+		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
+			settings,
+			["set-syssetting", code, value, "Text", "-e", environmentName],
 			cancellationToken: cancellationToken);
 	}
 

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -90,12 +90,26 @@ public sealed class PageGetToolE2ETests {
 			because: "get-page metadata should identify the same page selected through list-pages");
 		response.Page.PackageName.Should().Be(candidate.Page.PackageName,
 			because: "get-page metadata should preserve the owning package from list-pages");
-		response.Bundle.Should().NotBeNull(
-			because: "successful get-page calls should expose the merged page bundle");
-		response.Raw.Should().NotBeNull(
-			because: "successful get-page calls should expose the raw editable payload");
-		response.Raw.Body.Should().NotBeNullOrWhiteSpace(
-			because: "the discovered page should expose a non-empty raw body for MCP clients");
+		response.Bundle.Should().BeNull(
+			because: "the MCP wrapper compacts successful get-page responses to file paths instead of returning inline bundle data");
+		response.Raw.Should().BeNull(
+			because: "the MCP wrapper compacts successful get-page responses to file paths instead of returning inline raw body data");
+		response.Files.Should().NotBeNull(
+			because: "successful get-page calls should return the written file paths for MCP clients");
+		response.Files.BodyFile.Should().EndWith("body.js",
+			because: "get-page should write the editable page body to body.js");
+		response.Files.BundleFile.Should().EndWith("bundle.json",
+			because: "get-page should write the merged bundle to bundle.json");
+		response.Files.MetaFile.Should().EndWith("meta.json",
+			because: "get-page should write the page metadata to meta.json");
+		File.Exists(response.Files.BodyFile).Should().BeTrue(
+			because: "get-page should materialize the editable page body on disk for update-page reuse");
+		File.Exists(response.Files.BundleFile).Should().BeTrue(
+			because: "get-page should materialize the merged bundle on disk for inspection");
+		File.Exists(response.Files.MetaFile).Should().BeTrue(
+			because: "get-page should materialize the metadata payload on disk for inspection");
+		(await File.ReadAllTextAsync(response.Files.BodyFile)).Should().NotBeNullOrWhiteSpace(
+			because: "body.js should contain the raw editable page body");
 		response.Error.Should().BeNullOrWhiteSpace(
 			because: "successful get-page calls should not include an error payload");
 	}

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -352,7 +352,12 @@ public sealed class SchemaSyncToolE2ETests {
 			entitySchemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
 			lookupSchemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
 			await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
-			await PushWorkspaceAsync(settings, workspacePath, environmentName!, cancellationTokenSource.Token);
+			await PushWorkspaceAsync(
+				settings,
+				workspacePath,
+				environmentName!,
+				packageName,
+				cancellationTokenSource.Token);
 		}
 
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
@@ -420,10 +425,16 @@ public sealed class SchemaSyncToolE2ETests {
 		McpE2ESettings settings,
 		string workspacePath,
 		string environmentName,
+		string packageName,
 		CancellationToken cancellationToken) {
 		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
 			settings,
 			["push-workspace", "-e", environmentName],
+			workingDirectory: workspacePath,
+			cancellationToken: cancellationToken);
+		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
+			settings,
+			["pkg-hotfix", packageName, "true", "-e", environmentName],
 			workingDirectory: workspacePath,
 			cancellationToken: cancellationToken);
 	}

--- a/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
@@ -62,7 +62,7 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 		bool runtimeVerifyCalled = false;
 		SetupApplicationClient((url, body) => {
 			if (url.Contains("CreateNewSchema", StringComparison.Ordinal)) {
-				return "{\"success\":true,\"schema\":{\"uId\":\"22222222-2222-2222-2222-222222222222\",\"package\":{\"uId\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"UsrPkg\"},\"columns\":[],\"inheritedColumns\":[],\"indexes\":[]}}";
+				return "{\"success\":true,\"schema\":{\"uId\":\"22222222-2222-2222-2222-222222222222\",\"package\":{\"uId\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"UsrPkg\"},\"columns\":[],\"inheritedColumns\":[],\"indexes\":[],\"administratedByOperations\":true,\"administratedByColumns\":true,\"administratedByRecords\":true,\"useDenyRecordRights\":true,\"rightSchemaName\":\"UsrBrokenRights\"}}";
 			}
 			if (url.Contains("CheckUniqueSchemaName", StringComparison.Ordinal)) {
 				return "{\"success\":true,\"value\":true}";
@@ -122,6 +122,16 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			because: "the saved schema should include the generated prefixed primary column and the requested text column");
 		json["columns"]!.Single(column => column["name"]!.Value<string>() == "UsrId")["type"]!.Value<int>().Should().Be(0,
 			because: "the generated prefixed primary column should remain a guid column");
+		json["administratedByOperations"]!.Value<bool>().Should().BeFalse(
+			because: "new root entity schemas should not inherit an invalid operation-rights state from CreateNewSchema");
+		json["administratedByColumns"]!.Value<bool>().Should().BeFalse(
+			because: "new root entity schemas should start with column administration disabled unless explicitly configured");
+		json["administratedByRecords"]!.Value<bool>().Should().BeFalse(
+			because: "new root entity schemas should start with record administration disabled unless explicitly configured");
+		json["useDenyRecordRights"]!.Value<bool>().Should().BeFalse(
+			because: "new root entity schemas should not carry deny-record-rights metadata from the initial designer draft");
+		json["rightSchemaName"]!.Value<string>().Should().BeEmpty(
+			because: "new root entity schemas should clear stale right schema names before save");
 	}
 
 	[Test]
@@ -391,6 +401,12 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			because: "structured create-column specs should preserve the optional masked flag");
 		(savedColumn["isValueMasked"] ?? savedColumn["valueMasked"])!.Value<bool>().Should().BeTrue(
 			because: "structured create-column specs should preserve schema-level value masking");
+		savedColumn["valueMaskingSettings"]!["pattern"]!.Value<string>().Should().Be(".*",
+			because: "masked create-column specs should synthesize a default masking regex accepted by core validation");
+		savedColumn["valueMaskingSettings"]!["replacement"]!.Value<string>().Should().Be("********",
+			because: "masked create-column specs should synthesize a default masked replacement accepted by core validation");
+		savedColumn["valueMaskingSettings"]!["adminOperationCode"]!.Value<string>().Should().Be("UsrVehicle_Status_UnmaskedValue",
+			because: "masked create-column specs should synthesize the conventional unmask admin operation code");
 		saveDbStructureCalled.Should().BeTrue();
 		runtimeVerifyCalled.Should().BeTrue();
 	}
@@ -608,6 +624,12 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			because: "strict schema-level masking requires masked=true for password columns");
 		(savedColumn["isValueMasked"] ?? savedColumn["valueMasked"])!.Value<bool>().Should().BeTrue(
 			because: "strict schema-level masking requires isValueMasked=true for password columns");
+		savedColumn["valueMaskingSettings"]!["pattern"]!.Value<string>().Should().Be(".*",
+			because: "masked secure text columns should synthesize a default masking regex accepted by core validation");
+		savedColumn["valueMaskingSettings"]!["replacement"]!.Value<string>().Should().Be("********",
+			because: "masked secure text columns should synthesize a default replacement accepted by core validation");
+		savedColumn["valueMaskingSettings"]!["adminOperationCode"]!.Value<string>().Should().Be("UsrVehicle_UsrPassword_UnmaskedValue",
+			because: "masked secure text columns should synthesize the conventional unmask admin operation code");
 	}
 
 	[Test]

--- a/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs
+++ b/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs
@@ -341,6 +341,9 @@ internal sealed class EntitySchemaColumnDto
 	[JsonProperty("isValueMasked")]
 	public bool ValueMasked { get; set; }
 
+	[JsonProperty("valueMaskingSettings")]
+	public EntitySchemaColumnValueMaskingSettingsDto ValueMaskingSettings { get; set; }
+
 	[JsonProperty("isFormatValidated")]
 	public bool FormatValidated { get; set; }
 
@@ -358,6 +361,18 @@ internal sealed class EntitySchemaColumnDto
 
 	[JsonProperty("isSensitiveData")]
 	public bool SensitiveData { get; set; }
+}
+
+internal sealed class EntitySchemaColumnValueMaskingSettingsDto
+{
+	[JsonProperty("pattern")]
+	public string Pattern { get; set; }
+
+	[JsonProperty("replacement")]
+	public string Replacement { get; set; }
+
+	[JsonProperty("adminOperationCode")]
+	public string AdminOperationCode { get; set; }
 }
 
 internal sealed class GetSchemaDesignItemRequestDto

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
@@ -23,6 +23,8 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 
 	private const string TitleLocalizationsArgumentName = "title-localizations";
 	private const string SchemaNamePrefixSettingCode = "SchemaNamePrefix";
+	private const string DefaultMaskingPattern = ".*";
+	private const string DefaultMaskingReplacement = "********";
 	private readonly IApplicationPackageListProvider _applicationPackageListProvider;
 	private readonly IEntitySchemaDefaultValueSourceResolver _defaultValueSourceResolver;
 	private readonly IRemoteEntitySchemaDesignerClient _entitySchemaDesignerClient;
@@ -116,6 +118,7 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 		schema.Columns ??= [];
 		schema.Indexes ??= [];
 		schema.InheritedColumns ??= [];
+		NormalizeAdministrationMetadata(schema);
 
 		Dictionary<string, ManagerItemDto> referenceSchemas = parsedColumns.Any(c => c.IsLookup)
 			? GetReferenceSchemas(package.Descriptor.UId, options)
@@ -136,6 +139,18 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 		schema.Columns = columns;
 		schema.PrimaryColumn = columns.FirstOrDefault(column => column.IsGuidType()) ?? schema.PrimaryColumn;
 		schema.PrimaryDisplayColumn ??= columns.FirstOrDefault(column => column.IsTextType());
+	}
+
+	private static void NormalizeAdministrationMetadata(EntityDesignSchemaDto schema) {
+		if (schema.ParentSchema.HasValue()) {
+			return;
+		}
+
+		schema.AdministratedByOperations = false;
+		schema.AdministratedByColumns = false;
+		schema.AdministratedByRecords = false;
+		schema.UseDenyRecordRights = false;
+		schema.RightSchemaName = string.Empty;
 	}
 
 	private EntityDesignSchemaDto AssignParentSchema(
@@ -231,6 +246,9 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 			Masked = parsedColumn.Masked ?? false,
 			ValueMasked = parsedColumn.Masked ?? false
 		};
+		if (column.ValueMasked) {
+			column.ValueMaskingSettings = CreateValueMaskingSettings(options.SchemaName, parsedColumn.Name);
+		}
 		ApplyDefaultValue(column, parsedColumn, options);
 		if (parsedColumn.IsLookup) {
 			if (!referenceSchemas.TryGetValue(parsedColumn.ReferenceSchemaName!, out ManagerItemDto referenceSchema)) {
@@ -251,6 +269,16 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 		}
 
 		return column;
+	}
+
+	private static EntitySchemaColumnValueMaskingSettingsDto CreateValueMaskingSettings(
+		string schemaName,
+		string columnName) {
+		return new EntitySchemaColumnValueMaskingSettingsDto {
+			Pattern = DefaultMaskingPattern,
+			Replacement = DefaultMaskingReplacement,
+			AdminOperationCode = $"{schemaName}_{columnName}_UnmaskedValue"
+		};
 	}
 
 	private void ValidateDefaultValue(ParsedColumn parsedColumn, int dataValueType, CreateEntitySchemaOptions options) {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -1272,7 +1272,7 @@ internal static class ToolContractCatalog {
 					SuccessFalseSignal
 				],
 				Field(SuccessFieldName, BooleanType, "Whether every page operation succeeded."),
-				Field(PagesFieldName, ArrayType, "Per-page results with `schema-name`, `success`, `body-length`, `validation`, `error`, `resources-registered`, optional `page` metadata, and optional `verified-body` when `verify=true`.")
+				Field(PagesFieldName, ArrayType, "Per-page results with `schema-name`, `success`, `body-length`, `validation`, `error`, `resources-registered`, optional `page` metadata, and optional `verified-body-file` when `verify=true`.")
 			),
 			CommonErrorContract,
 			[],

--- a/clio/docs/commands/sync-pages.md
+++ b/clio/docs/commands/sync-pages.md
@@ -71,7 +71,7 @@ Each entry in the `pages` array must have:
         "packageUId": "22222222-2222-2222-2222-222222222222",
         "parentSchemaName": "PageWithTabsFreedomTemplate"
       },
-      "verified-body": "define(\"UsrTodoList_FormPage\", ...full page body...)"
+      "verified-body-file": ".clio-pages/UsrTodoList_FormPage/body.js"
     },
     {
       "schema-name": "UsrTodoList_ListPage",
@@ -85,7 +85,7 @@ Each entry in the `pages` array must have:
         "packageUId": "22222222-2222-2222-2222-222222222222",
         "parentSchemaName": "BaseSectionTemplate"
       },
-      "verified-body": "define(\"UsrTodoList_ListPage\", ...full page body...)"
+      "verified-body-file": ".clio-pages/UsrTodoList_ListPage/body.js"
     }
   ]
 }
@@ -112,7 +112,7 @@ were added during save.
 When `verify` is `true`, each successful page result also returns:
 
 - `page` — the same metadata shape as `get-page.page`
-- `verified-body` — the raw body read back from Creatio after save
+- `verified-body-file` — path to the local `body.js` file written from the raw body read back from Creatio after save
 
 ## Error Handling
 


### PR DESCRIPTION
**1. Problem: pushed workspace packages were read-only, so mutation E2Es failed**
- Symptom:
  - `push-workspace` succeeded, but later remote mutations into that package failed
- Root cause:
  - pushed packages were installed from archive and needed to be switched to editable state
- Changes:
  - test:
    - [clio.mcp.e2e/EntitySchemaToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\EntitySchemaToolE2ETests.cs)
    - [clio.mcp.e2e/DataBindingDbToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\DataBindingDbToolE2ETests.cs)
    - [clio.mcp.e2e/SchemaSyncToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\SchemaSyncToolE2ETests.cs)
  - fix:
    - add `pkg-hotfix <package> true` after `push-workspace`
- Triggering tests:
  - `CreateLookup_Should_Create_BaseLookup_Schema`
  - `CreateDataBindingDb_Should_Succeed_On_Real_Environment`
  - `SchemaSyncTool_Should_Keep_Messages_On_The_Correct_Operation`

**2. Problem: `get-tool-contract` advertised the wrong `sync-pages` field**
- Symptom:
  - contract inspection expected `verified-body-file`
  - contract text still said `verified-body`
- Root cause:
  - MCP contract text drifted from actual tool payload
- Changes:
  - product:
    - [clio/Command/McpServer/Tools/ToolContractGetTool.cs](C:\Projects\adac-clio-fork\clio\clio\Command\McpServer\Tools\ToolContractGetTool.cs)
  - docs:
    - [clio/docs/commands/sync-pages.md](C:\Projects\adac-clio-fork\clio\clio\docs\commands\sync-pages.md)
- Triggering test:
  - `ToolContractGet_Should_Return_Maintenance_Oriented_Canonical_Contracts`

**3. Problem: `list-apps` contract test failed on empty environments**
- Symptom:
  - test claimed to support empty and non-empty envs
  - still failed when the applications collection was empty
- Root cause:
  - stale test assertion, not product behavior
- Changes:
  - test:
    - [clio.mcp.e2e/ApplicationToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\ApplicationToolE2ETests.cs)
  - fix:
    - explicitly handle the empty collection case
- Triggering test:
  - `ApplicationGetList_Should_Return_A_Valid_Structured_Contract_For_Empty_And_NonEmpty_Environments`

**4. Problem: `get-page` E2E expected the old inline response shape**
- Symptom:
  - test expected inline `bundle` and `raw`
  - MCP tool returns file paths instead
- Root cause:
  - stale test; product intentionally compacts successful `get-page` responses
- Changes:
  - test:
    - [clio.mcp.e2e/PageGetToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\PageGetToolE2ETests.cs)
  - fix:
    - assert `files.bodyFile`, `bundleFile`, `metaFile` and on-disk artifacts
- Triggering test:
  - `PageGetTool_Should_Return_Stable_Metadata_Contract_For_Real_Page`

**5. Problem: `create-entity-schema` failed with “Operation permission is not selected.”**
- Symptom:
  - masked create-entity-schema flow failed on save
- Root cause:
  - fresh root schemas kept invalid administration metadata
  - masked columns sent `isValueMasked=true` without required `valueMaskingSettings`
- Changes:
  - product:
    - [clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs](C:\Projects\adac-clio-fork\clio\clio\Command\EntitySchemaDesigner\RemoteEntitySchemaCreator.cs)
    - [clio/Command/EntitySchemaDesigner/EntitySchemaDesignerDtos.cs](C:\Projects\adac-clio-fork\clio\clio\Command\EntitySchemaDesigner\EntitySchemaDesignerDtos.cs)
  - unit coverage:
    - [clio.tests/Command/RemoteEntitySchemaCreatorTests.cs](C:\Projects\adac-clio-fork\clio\clio.tests\Command\RemoteEntitySchemaCreatorTests.cs)
  - fix:
    - normalize root admin metadata
    - synthesize `valueMaskingSettings` for masked columns
- Triggering test:
  - `CreateEntitySchema_Should_Apply_Masked_For_Text_Column_Through_Mcp`

**6. Problem: positive entity-schema E2Es used invalid custom column codes**
- Symptom:
  - create/update flows failed because custom column names like `Name`, `Payload`, `Preview`, `Document` were invalid
- Root cause:
  - core requires custom entity-schema column codes to start with `Usr`
- Changes:
  - test:
    - [clio.mcp.e2e/EntitySchemaToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\EntitySchemaToolE2ETests.cs)
  - fix:
    - shared setup uses `UsrName` / `UsrCode`
    - binary-like columns use `UsrPayload` / `UsrPreview` / `UsrDocument`
- Triggering test:
  - `UpdateEntitySchema_Should_Add_BinaryLike_Columns_And_Read_Back_Friendly_Types`
- Also affected:
  - other positive entity-schema create/update flows

**7. Problem: settings-default entity-schema tests depended on a fragile hardcoded system setting**
- Symptom:
  - `Maintainer` could not be resolved as a valid `Text` sys setting
- Root cause:
  - test assumed a particular built-in setting existed and was compatible with `Text`
- Changes:
  - test:
    - [clio.mcp.e2e/EntitySchemaToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\EntitySchemaToolE2ETests.cs)
  - fix:
    - arrange creates a unique `Text` sys setting and uses its code
- Triggering tests:
  - `UpdateEntitySchema_Should_Keep_Localized_Column_Valid_For_Later_DefaultValueConfig_Modify`
  - `ModifyEntitySchemaColumn_Should_Apply_Structured_Settings_Default_And_Read_Back_Canonical_Code`

**8. Problem: async E2E helper steps could deadlock with `[AllureStep]`**
- Symptom:
  - async E2E helper methods could hang under NUnit
- Root cause:
  - `[AllureStep]` blocks the test thread while async continuation needs `NUnitSynchronizationContext`
- Changes:
  - test infrastructure:
    - [clio.mcp.e2e/EntitySchemaToolE2ETests.cs](C:\Projects\adac-clio-fork\clio\clio.mcp.e2e\EntitySchemaToolE2ETests.cs)
  - fix:
    - remove `[AllureStep]` from async helpers
    - use `await AllureApi.Step(...)`
- Triggering problem:
  - E2E hanging behavior in async helper execution