### PR TITLE
ENG-88550 stop GitHub MCP E2E for future TeamCity ownership

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -2405,3 +2405,10 @@ Decision: Replace per-run generated setting codes with one deterministic reusabl
 Discovery: The tests only need any resolvable `Text` sys setting; they do not depend on special semantics of the original `Maintainer` value or on unique setting names per run.
 Files: clio.mcp.e2e/EntitySchemaToolE2ETests.cs
 Impact: The settings-default E2Es remain self-sufficient without leaking unbounded sys settings into shared environments.
+
+## 2026-04-20 15:40 – Stop MCP E2E from running in GitHub Actions
+Context: MCP end-to-end coverage is being moved off GitHub Actions so the repo should stop scheduling that suite there for now.
+Decision: Remove the dedicated `mcp-e2e-tests` workflow job and the now-unused `mcp` change-detection output/filter from `.github/workflows/build.yml`; keep the `clio.mcp.e2e` project in the repo for future TeamCity ownership.
+Discovery: GitHub Actions invoked MCP E2E only from the dedicated workflow job, so no project or test code changes were required for the stopgap.
+Files: .github/workflows/build.yml, .codex/workspace-diary.md
+Impact: PRs and branch builds on GitHub no longer queue MCP E2E, reducing CI time while preserving the suite for a later TeamCity migration.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
     outputs:
       clio-src:    ${{ steps.filter.outputs.clio-src }}
       tests:       ${{ steps.filter.outputs.tests }}
-      mcp:         ${{ steps.filter.outputs.mcp }}
       analyzers:   ${{ steps.filter.outputs.analyzers }}
       cliogate:    ${{ steps.filter.outputs.cliogate }}
     steps:
@@ -33,9 +32,6 @@ jobs:
               - 'Directory.Packages.props'
             tests:
               - 'clio.tests/**'
-            mcp:
-              - 'clio/Command/McpServer/**'
-              - 'clio.mcp.e2e/**'
             analyzers:
               - 'Clio.Analyzers/**'
               - 'Clio.Analyzers.Tests/**'
@@ -121,23 +117,3 @@ jobs:
           $ErrorActionPreference = 'Stop';
           dotnet test .\Clio.Analyzers.Tests\Clio.Analyzers.Tests.csproj -p:RunAnalyzers=false;
 
-  # ── MCP E2E tests (only when MCP code changes, on PRs with label) ────
-  mcp-e2e-tests:
-    name: MCP E2E Tests
-    needs: [changes, unit-tests]
-    timeout-minutes: 30
-    if: >-
-      needs.changes.outputs.mcp == 'true' &&
-      (github.event_name == 'pull_request' ||
-       github.ref == 'refs/heads/master')
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-
-      - name: Run MCP E2E tests
-        shell: powershell
-        run: |
-          $ErrorActionPreference = 'Stop';
-          dotnet test .\clio.mcp.e2e\clio.mcp.e2e.csproj -p:RunAnalyzers=false;


### PR DESCRIPTION
Remove the dedicated `mcp-e2e-tests` workflow job and the now-unused `mcp` change-detection output/filter from `.github/workflows/build.yml`; keep the `clio.mcp.e2e` project in the repo for future TeamCity ownership.