### PR TITLE
ENG-88648 normalize proxy bindings in get-page before writing body.js

### DIFF
--- a/clio.tests/Command/McpServer/PageBodyNormalizerTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyNormalizerTests.cs
@@ -1,0 +1,210 @@
+using Clio.Command;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public class PageBodyNormalizerTests {
+
+	private static string CreatePageBody(
+		string viewConfigDiff = "[]",
+		string viewModelConfigDiff = "[]",
+		string viewModelConfig = "{}") {
+		return $$"""
+			define("TestPage", /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, function/**SCHEMA_ARGS*/()/**SCHEMA_ARGS*/ {
+				return {
+					viewConfigDiff: /**SCHEMA_VIEW_CONFIG_DIFF*/{{viewConfigDiff}}/**SCHEMA_VIEW_CONFIG_DIFF*/,
+					viewModelConfig: /**SCHEMA_VIEW_MODEL_CONFIG*/{{viewModelConfig}}/**SCHEMA_VIEW_MODEL_CONFIG*/,
+					viewModelConfigDiff: /**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/{{viewModelConfigDiff}}/**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/,
+					modelConfig: /**SCHEMA_MODEL_CONFIG*/{}/**SCHEMA_MODEL_CONFIG*/,
+					modelConfigDiff: /**SCHEMA_MODEL_CONFIG_DIFF*/[]/**SCHEMA_MODEL_CONFIG_DIFF*/,
+					handlers: /**SCHEMA_HANDLERS*/[]/**SCHEMA_HANDLERS*/,
+					converters: /**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/,
+					validators: /**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/
+				};
+			});
+			""";
+	}
+
+	[Test]
+	[Description("Proxy binding on a standard field is rewritten to $PDS_* form.")]
+	public void NormalizeProxyBindings_ProxyField_RewritesToPdsBinding() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrStatus","values":{"type":"crt.ComboBox","label":"$Resources.Strings.PDS_UsrStatus","control":"$UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrStatus",
+			because: "proxy binding $UsrStatus pointing to PDS.UsrStatus should be rewritten to $PDS_UsrStatus");
+		result.Should().NotContain("\"$UsrStatus\"",
+			because: "the proxy binding must be replaced");
+	}
+
+	[Test]
+	[Description("Proxy binding for the primary Name field is rewritten to $Name (special case).")]
+	public void NormalizeProxyBindings_NameField_RewritesToDollarName() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrName","values":{"type":"crt.Input","label":"$Resources.Strings.PDS_Name","control":"$UsrName"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrName":{"modelConfig":{"path":"PDS.Name"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("\"$Name\"",
+			because: "PDS.Name has the special-case expected binding $Name, not $PDS_Name");
+		result.Should().NotContain("\"$UsrName\"",
+			because: "the proxy binding must be replaced");
+	}
+
+	[Test]
+	[Description("A binding already in canonical $PDS_* form is left unchanged.")]
+	public void NormalizeProxyBindings_CanonicalBinding_Unchanged() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrStatus","values":{"type":"crt.ComboBox","control":"$PDS_UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"PDS_UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrStatus",
+			because: "canonical binding should not be touched");
+	}
+
+	[Test]
+	[Description("A component type not in the standard set is not normalized.")]
+	public void NormalizeProxyBindings_NonStandardComponentType_Unchanged() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrStatus","values":{"type":"crt.Button","control":"$UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("\"$UsrStatus\"",
+			because: "normalization only applies to standard field component types");
+	}
+
+	[Test]
+	[Description("A binding whose attribute has no entry in viewModelConfigDiff is left unchanged even when other attributes are present.")]
+	public void NormalizeProxyBindings_OrphanAttribute_Unchanged() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrOrphan","values":{"type":"crt.Input","control":"$UsrOrphan"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"OtherField":{"modelConfig":{"path":"PDS.OtherField"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("\"$UsrOrphan\"",
+			because: "an attribute absent from modelConfig cannot be resolved to a PDS path and must stay unchanged");
+	}
+
+	[Test]
+	[Description("Malformed JSON in SCHEMA_VIEW_CONFIG_DIFF returns the original body without throwing.")]
+	public void NormalizeProxyBindings_MalformedViewConfigDiff_ReturnsOriginalBody() {
+		// Arrange
+		string body = CreatePageBody(viewConfigDiff: "{[invalid json");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Be(body,
+			because: "normalization must be a no-op when the body cannot be parsed");
+	}
+
+	[Test]
+	[Description("Null or empty body returns without throwing.")]
+	[TestCase(null)]
+	[TestCase("")]
+	public void NormalizeProxyBindings_NullOrEmpty_ReturnsUnchanged(string body) {
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Be(body,
+			because: "null/empty input must pass through unchanged");
+	}
+
+	[Test]
+	[Description("Multiple proxy fields in one body are all rewritten in a single call.")]
+	public void NormalizeProxyBindings_MultipleProxyFields_AllRewritten() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """
+				[
+					{"operation":"insert","name":"UsrStatus","values":{"type":"crt.ComboBox","control":"$UsrStatus"}},
+					{"operation":"insert","name":"UsrDueDate","values":{"type":"crt.DateTimePicker","control":"$UsrDueDate"}},
+					{"operation":"insert","name":"UsrName","values":{"type":"crt.Input","control":"$UsrName"}}
+				]
+				""",
+			viewModelConfigDiff: """
+				[{"operation":"merge","values":{
+					"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}},
+					"UsrDueDate":{"modelConfig":{"path":"PDS.UsrDueDate"}},
+					"UsrName":{"modelConfig":{"path":"PDS.Name"}}
+				}}]
+				""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrStatus",
+			because: "UsrStatus proxy binding must be rewritten");
+		result.Should().Contain("$PDS_UsrDueDate",
+			because: "UsrDueDate proxy binding must be rewritten");
+		result.Should().Contain("\"$Name\"",
+			because: "UsrName pointing to PDS.Name must use the special-case $Name binding");
+		result.Should().NotMatchRegex("\"\\$Usr[A-Za-z]",
+			because: "no proxy bindings should remain after normalization");
+	}
+
+	[Test]
+	[Description("A proxy binding expressed via 'value' property (not 'control') is also rewritten.")]
+	public void NormalizeProxyBindings_ValueProperty_Rewritten() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrPhoto","values":{"type":"crt.ImageInput","value":"$UsrPhoto"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrPhoto":{"modelConfig":{"path":"PDS.UsrPhoto"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrPhoto",
+			because: "'value' bindings are also checked for proxy patterns");
+		result.Should().NotContain("\"$UsrPhoto\"",
+			because: "the proxy 'value' binding must be replaced");
+	}
+
+	[Test]
+	[Description("A component at the top level of the viewConfigDiff array (flat shape, no 'values' wrapper) is normalized.")]
+	public void NormalizeProxyBindings_FlatShapeComponent_Rewritten() {
+		// Arrange
+		string body = CreatePageBody(
+			viewConfigDiff: """[{"type":"crt.Input","control":"$UsrStatus"}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrStatus",
+			because: "flat-shape components without a 'values' wrapper must also be normalized");
+	}
+}

--- a/clio.tests/Command/McpServer/PageBodyNormalizerTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyNormalizerTests.cs
@@ -29,6 +29,19 @@ public class PageBodyNormalizerTests {
 			""";
 	}
 
+	private static string CreatePageBodyWithSchemaDiffMarker(
+		string viewConfigDiff = "[]",
+		string viewModelConfigDiff = "[]") {
+		return $$"""
+			define("TestPage", /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, function/**SCHEMA_ARGS*/()/**SCHEMA_ARGS*/ {
+				return {
+					viewConfigDiff: /**SCHEMA_DIFF*/{{viewConfigDiff}}/**SCHEMA_DIFF*/,
+					viewModelConfigDiff: /**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/{{viewModelConfigDiff}}/**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/
+				};
+			});
+			""";
+	}
+
 	[Test]
 	[Description("Proxy binding on a standard field is rewritten to $PDS_* form.")]
 	public void NormalizeProxyBindings_ProxyField_RewritesToPdsBinding() {
@@ -206,5 +219,23 @@ public class PageBodyNormalizerTests {
 		// Assert
 		result.Should().Contain("$PDS_UsrStatus",
 			because: "flat-shape components without a 'values' wrapper must also be normalized");
+	}
+
+	[Test]
+	[Description("A body that uses the SCHEMA_DIFF alias instead of SCHEMA_VIEW_CONFIG_DIFF is also normalized.")]
+	public void NormalizeProxyBindings_SchemaDiffAlias_RewritesProxyBinding() {
+		// Arrange
+		string body = CreatePageBodyWithSchemaDiffMarker(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrStatus","values":{"type":"crt.ComboBox","control":"$UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+
+		// Act
+		string result = PageBodyNormalizer.NormalizeProxyBindings(body);
+
+		// Assert
+		result.Should().Contain("$PDS_UsrStatus",
+			because: "SCHEMA_DIFF is a supported alias for SCHEMA_VIEW_CONFIG_DIFF and must trigger proxy binding rewrite");
+		result.Should().NotContain("\"$UsrStatus\"",
+			because: "the proxy binding must be replaced even when the body uses the SCHEMA_DIFF marker");
 	}
 }

--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -1215,6 +1215,29 @@ public class PageToolsTests {
 			new PageBundleBuilder(new PageJsonDiffApplier(), new PageJsonPathDiffApplier()));
 	}
 
+	private static (PageGetTool tool, MockFileSystem mockFs) CreatePageGetToolWithBody(string body) {
+		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		ILogger logger = Substitute.For<ILogger>();
+		serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery")
+			.Returns("http://test/DataService/json/SyncReply/SelectQuery");
+		applicationClient.ExecutePostRequest(
+				Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(CreateMetadataResponse("UsrMcp_FormPage", "uid-1", "pkg-1", "UsrMcp", "BasePage").ToString());
+		IPageDesignerHierarchyClient hierarchyClient = Substitute.For<IPageDesignerHierarchyClient>();
+		hierarchyClient.GetParentSchemas("uid-1", "pkg-1")
+			.Returns([new PageDesignerHierarchySchema {
+				UId = "uid-1", Name = "UsrMcp_FormPage",
+				PackageUId = "pkg-1", PackageName = "UsrMcp",
+				SchemaVersion = 1, Body = body
+			}]);
+		PageGetCommand command = CreatePageGetCommand(applicationClient, serviceUrlBuilder, logger, hierarchyClient);
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<PageGetCommand>(Arg.Any<PageGetOptions>()).Returns(command);
+		MockFileSystem mockFs = new();
+		return (new PageGetTool(command, logger, commandResolver, mockFs), mockFs);
+	}
+
 	private static JObject CreateMetadataResponse(
 		string schemaName,
 		string schemaUId,
@@ -1345,6 +1368,48 @@ public class PageToolsTests {
 			because: "files must be written under .clio-pages directory");
 		response.Files.BodyFile.Should().Contain("UsrMcp_FormPage",
 			because: "files must be grouped under the schema name subdirectory");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("get-page normalizes proxy bindings before writing body.js so the file passes sync-pages validation.")]
+	public void PageGetTool_WhenBodyHasProxyBindings_WritesNormalizedBodyFile() {
+		// Arrange
+		string proxyBody = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"UsrStatus","values":{"type":"crt.ComboBox","label":"$Resources.Strings.PDS_UsrStatus","control":"$UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+		(PageGetTool tool, MockFileSystem mockFs) = CreatePageGetToolWithBody(proxyBody);
+
+		// Act
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+
+		// Assert
+		response.Success.Should().BeTrue(because: "get-page should succeed even when the source body has proxy bindings");
+		string writtenBody = mockFs.File.ReadAllText(response.Files.BodyFile);
+		writtenBody.Should().Contain("$PDS_UsrStatus",
+			because: "get-page must normalize proxy binding $UsrStatus to $PDS_UsrStatus before writing body.js");
+		writtenBody.Should().NotContain("\"$UsrStatus\"",
+			because: "the proxy binding must not remain in the written body.js");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("get-page leaves body.js unchanged when it already uses canonical $PDS_* bindings.")]
+	public void PageGetTool_WhenBodyHasNoProxyBindings_WritesBodyUnchanged() {
+		// Arrange
+		string canonicalBody = CreatePageBody(
+			viewConfigDiff: """[{"operation":"insert","name":"PDS_UsrStatus","values":{"type":"crt.ComboBox","control":"$PDS_UsrStatus"}}]""",
+			viewModelConfigDiff: """[{"operation":"merge","values":{"PDS_UsrStatus":{"modelConfig":{"path":"PDS.UsrStatus"}}}}]""");
+		(PageGetTool tool, MockFileSystem mockFs) = CreatePageGetToolWithBody(canonicalBody);
+
+		// Act
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+
+		// Assert
+		response.Success.Should().BeTrue(because: "get-page should succeed for a body with canonical bindings");
+		string writtenBody = mockFs.File.ReadAllText(response.Files.BodyFile);
+		writtenBody.Should().Contain("$PDS_UsrStatus",
+			because: "canonical binding must be preserved unchanged in body.js");
 	}
 
 	[Test]

--- a/clio/Command/McpServer/Tools/PageGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageGetTool.cs
@@ -57,7 +57,7 @@ public sealed class PageGetTool(
 		string bundleFile = fileSystem.Path.Combine(schemaDir, "bundle.json");
 		string metaFile   = fileSystem.Path.Combine(schemaDir, "meta.json");
 		try {
-			fileSystem.File.WriteAllText(bodyFile,   response.Raw.Body);
+			fileSystem.File.WriteAllText(bodyFile,   PageBodyNormalizer.NormalizeProxyBindings(response.Raw.Body));
 			fileSystem.File.WriteAllText(bundleFile, System.Text.Json.JsonSerializer.Serialize(response.Bundle));
 			fileSystem.File.WriteAllText(metaFile,   System.Text.Json.JsonSerializer.Serialize(response.Page));
 		} catch (Exception ex) {

--- a/clio/Command/PageBodyEditor.cs
+++ b/clio/Command/PageBodyEditor.cs
@@ -174,7 +174,7 @@ internal static class PageBodyEditor {
 		return true;
 	}
 
-	private static string ReplaceMarkerContent(string body, string marker, string newContent) {
+	internal static string ReplaceMarkerContent(string body, string marker, string newContent) {
 		if (!TryFindMarkerSpan(body, marker, out int start, out int end))
 			throw new InvalidOperationException($"Marker {marker} not found in body");
 		return body[..start] + newContent + body[end..];
@@ -197,7 +197,7 @@ internal static class PageBodyEditor {
 			?? throw new InvalidOperationException($"Marker {marker} content parsed as null");
 	}
 
-	private static string SerializeJson(JsonNode node) {
+	internal static string SerializeJson(JsonNode node) {
 		string raw = node.ToJsonString(IndentedOptions);
 		const string prefix = "\t\t";
 		string[] lines = raw.Split('\n');

--- a/clio/Command/PageBodyNormalizer.cs
+++ b/clio/Command/PageBodyNormalizer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using JsonhCs;
 
 namespace Clio.Command;
 
@@ -27,17 +28,18 @@ internal static class PageBodyNormalizer {
 			if (modelPaths.Count == 0) {
 				return body;
 			}
-			if (!PageSchemaSectionReader.TryRead(body, out string content, "SCHEMA_VIEW_CONFIG_DIFF")) {
+			string marker = ResolveViewConfigMarker(body, out string content);
+			if (marker is null) {
 				return body;
 			}
-			if (JsonNode.Parse(SchemaValidationService.NormalizeJson(content)) is not JsonArray viewConfigDiff) {
+			if (JsonNode.Parse(JsonhReader.ParseElement(content).Value.GetRawText()) is not JsonArray viewConfigDiff) {
 				return body;
 			}
 			if (!NormalizeElements(viewConfigDiff, modelPaths)) {
 				return body;
 			}
 			string serialized = PageBodyEditor.SerializeJson(viewConfigDiff);
-			return PageBodyEditor.ReplaceMarkerContent(body, "SCHEMA_VIEW_CONFIG_DIFF", serialized);
+			return PageBodyEditor.ReplaceMarkerContent(body, marker, serialized);
 		} catch (JsonException) {
 			return body;
 		} catch (InvalidOperationException) {
@@ -45,6 +47,16 @@ internal static class PageBodyNormalizer {
 		} catch (RegexMatchTimeoutException) {
 			return body;
 		}
+	}
+
+	private static string ResolveViewConfigMarker(string body, out string content) {
+		foreach (string candidate in new[] { "SCHEMA_VIEW_CONFIG_DIFF", "SCHEMA_DIFF" }) {
+			if (PageSchemaSectionReader.TryRead(body, out content, candidate)) {
+				return candidate;
+			}
+		}
+		content = null;
+		return null;
 	}
 
 	private static bool NormalizeElements(JsonArray viewConfigDiff, IReadOnlyDictionary<string, string> modelPaths) {

--- a/clio/Command/PageBodyNormalizer.cs
+++ b/clio/Command/PageBodyNormalizer.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Clio.Command;
+
+internal static class PageBodyNormalizer {
+
+	private static readonly string[] BindingProperties = { "control", "value" };
+
+	/// <summary>
+	/// Rewrites proxy-style bindings (e.g. <c>"control": "$UsrStatus"</c>) in
+	/// <c>SCHEMA_VIEW_CONFIG_DIFF</c> to their canonical <c>$PDS_*</c> / <c>$Name</c> form
+	/// so the body passes <see cref="SchemaValidationService.ValidateStandardFieldBindings"/>
+	/// without a manual rewrite loop.
+	/// Returns the original body unchanged on any parse or write failure.
+	/// </summary>
+	internal static string NormalizeProxyBindings(string body) {
+		if (string.IsNullOrEmpty(body)) {
+			return body;
+		}
+		try {
+			Dictionary<string, string> modelPaths = SchemaValidationService.CollectViewModelPaths(body);
+			if (modelPaths.Count == 0) {
+				return body;
+			}
+			if (!PageSchemaSectionReader.TryRead(body, out string content, "SCHEMA_VIEW_CONFIG_DIFF")) {
+				return body;
+			}
+			if (JsonNode.Parse(SchemaValidationService.NormalizeJson(content)) is not JsonArray viewConfigDiff) {
+				return body;
+			}
+			if (!NormalizeElements(viewConfigDiff, modelPaths)) {
+				return body;
+			}
+			string serialized = PageBodyEditor.SerializeJson(viewConfigDiff);
+			return PageBodyEditor.ReplaceMarkerContent(body, "SCHEMA_VIEW_CONFIG_DIFF", serialized);
+		} catch (JsonException) {
+			return body;
+		} catch (InvalidOperationException) {
+			return body;
+		} catch (RegexMatchTimeoutException) {
+			return body;
+		}
+	}
+
+	private static bool NormalizeElements(JsonArray viewConfigDiff, IReadOnlyDictionary<string, string> modelPaths) {
+		bool changed = false;
+		foreach (JsonObject item in viewConfigDiff.OfType<JsonObject>())
+			changed |= TryNormalizeElement(item, modelPaths);
+		return changed;
+	}
+
+	private static bool TryNormalizeElement(JsonObject item, IReadOnlyDictionary<string, string> modelPaths) {
+		JsonObject values = item["values"] as JsonObject ?? item;
+		if (!TryGetString(values, "type", out string type) ||
+		    !SchemaValidationService.StandardFieldComponentTypes.Contains(type)) {
+			return false;
+		}
+		return BindingProperties.Any(bindingProp => TryRewriteBinding(values, bindingProp, modelPaths));
+	}
+
+	private static bool TryRewriteBinding(JsonObject values, string bindingProp,
+		IReadOnlyDictionary<string, string> modelPaths) {
+		if (!TryGetString(values, bindingProp, out string expression) ||
+		    !expression.StartsWith("$", StringComparison.Ordinal) ||
+		    expression.Length < 2) {
+			return false;
+		}
+		string attr = expression[1..];
+		if (SchemaValidationService.IsAllowedDirectFieldBinding(attr)) {
+			return false;
+		}
+		if (!modelPaths.TryGetValue(attr, out string? modelPath) ||
+		    !modelPath.StartsWith("PDS.", StringComparison.OrdinalIgnoreCase)) {
+			return false;
+		}
+		values[bindingProp] = SchemaValidationService.BuildExpectedBinding(modelPath);
+		return true;
+	}
+
+	private static bool TryGetString(JsonObject obj, string key, out string value) {
+		value = string.Empty;
+		if (obj[key] is not JsonValue jsonValue) {
+			return false;
+		}
+		try {
+			string? candidate = jsonValue.GetValue<string>();
+			if (string.IsNullOrWhiteSpace(candidate)) {
+				return false;
+			}
+			value = candidate;
+			return true;
+		} catch (InvalidOperationException) {
+			return false;
+		}
+	}
+}

--- a/clio/Command/SchemaValidationService.cs
+++ b/clio/Command/SchemaValidationService.cs
@@ -35,7 +35,7 @@ public static class SchemaValidationService
 		@"^Usr[A-Za-z0-9_]*_(label|caption)$",
 		RegexOptions.Compiled | RegexOptions.IgnoreCase,
 		RegexTimeout);
-	private static readonly HashSet<string> StandardFieldComponentTypes = new(StringComparer.OrdinalIgnoreCase) {
+	internal static readonly HashSet<string> StandardFieldComponentTypes = new(StringComparer.OrdinalIgnoreCase) {
 		"crt.Input",
 		"crt.NumberInput",
 		"crt.Checkbox",
@@ -250,7 +250,7 @@ public static class SchemaValidationService
 		}
 	}
 
-	private static Dictionary<string, string> CollectViewModelPaths(string jsBody) {
+	internal static Dictionary<string, string> CollectViewModelPaths(string jsBody) {
 		var modelPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		CollectViewModelPathsFromMarker(jsBody, modelPaths, "SCHEMA_VIEW_MODEL_CONFIG_DIFF");
 		CollectViewModelPathsFromMarker(jsBody, modelPaths, "SCHEMA_VIEW_MODEL_CONFIG");
@@ -489,12 +489,12 @@ public static class SchemaValidationService
 		return !string.IsNullOrWhiteSpace(resourceKey);
 	}
 
-	private static bool IsAllowedDirectFieldBinding(string bindingAttribute) {
+	internal static bool IsAllowedDirectFieldBinding(string bindingAttribute) {
 		return string.Equals(bindingAttribute, "Name", StringComparison.OrdinalIgnoreCase)
 			|| bindingAttribute.StartsWith("PDS_", StringComparison.OrdinalIgnoreCase);
 	}
 
-	private static string BuildExpectedBinding(string modelPath) {
+	internal static string BuildExpectedBinding(string modelPath) {
 		if (string.Equals(modelPath, "PDS.Name", StringComparison.OrdinalIgnoreCase)) {
 			return "$Name";
 		}
@@ -543,7 +543,7 @@ public static class SchemaValidationService
 		}
 	}
 
-	private static string NormalizeJson(string content) {
+	internal static string NormalizeJson(string content) {
 		return Regex.Replace(content, @",(\s*[\]\}])", "$1", RegexOptions.None, RegexTimeout);
 	}
 


### PR DESCRIPTION
- Add PageBodyNormalizer.NormalizeProxyBindings: rewrites proxy-style control bindings ($UsrField) to canonical $PDS_* / $Name form by cross-referencing viewModelConfigDiff paths; no-op on parse failure
- Call NormalizeProxyBindings in PageGetTool.WriteFilesAndCompact before writing body.js so MCP clients always receive a sync-pages-ready body
- Promote 5 members in SchemaValidationService and 2 in PageBodyEditor from private to internal to support the normalizer
- Add PageBodyNormalizerTests (10 unit tests) covering proxy rewrite, PDS.Name special case, canonical no-op, non-standard types, orphan attributes, malformed JSON, and multi-field batch rewrites
- Add PageGetTool integration tests: WhenBodyHasProxyBindings_WritesNormalizedBodyFile and WhenBodyHasNoProxyBindings_WritesBodyUnchanged via shared helper

E2E: existing contract test (file exists, non-empty) still holds; normalization requires seeded proxy-binding data not available in E2E env.

ADAC: page_body_edit.py already emits canonical $PDS_* via _derive_attr_key; this fix is a safety net for legacy proxy bindings stored on the server.