### PR TITLE
ENG-88815 fix(entity-schema): default parent schema to BaseEntity when omitted in create-entity-schema

### DIFF
--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -24,7 +24,16 @@ namespace Clio.Mcp.E2E;
 /// End-to-end tests for entity schema MCP tools.
 /// </summary>
 [TestFixture]
-[AllureNUnit]
+// [AllureNUnit] is intentionally omitted.
+// Root cause: [AllureNUnit] installs NUnit lifecycle hooks that interact with
+// NUnit's single-threaded SynchronizationContext in a way that deadlocks tests
+// containing many sequential async operations. Short tests (1-2 awaits) complete
+// fine, but longer flows (6+ sequential async MCP calls) hang indefinitely with
+// no timeout or error — the test process simply never makes progress past the
+// last awaited call. Confirmed by: commenting out [AllureNUnit] alone reduced
+// the hanging test from 30+ minutes to ~50 seconds, with all steps completing
+// normally. Individual [AllureStep] attributes on sync void assert methods are
+// unaffected and remain in place.
 [AllureFeature("entity-schema")]
 [NonParallelizable]
 public sealed class EntitySchemaToolE2ETests {
@@ -1176,6 +1185,8 @@ public sealed class EntitySchemaToolE2ETests {
 			because: "the created schema should be readable through the structured schema properties tool");
 		properties.PackageName.Should().Be(arrangeContext.PackageName,
 			because: "the structured result should report the package that owns the created schema");
+		properties.ParentSchemaName.Should().NotBeNullOrWhiteSpace(
+			because: "create-entity-schema should assign a parent schema so the entity has a valid inheritance chain");
 		properties.Title.Should().Be("Vehicle",
 			because: "the structured result should preserve the schema title from creation");
 		properties.OwnColumnCount.Should().BeGreaterThan(0,

--- a/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
@@ -263,6 +263,36 @@ public class CreateEntitySchemaToolTests {
 	}
 
 	[Test]
+	[Description("When extend-parent is true and no parent-schema-name is supplied, the tool should return exit code 1 because CreateEntitySchemaCommand.Validate rejects extend-parent without an explicit parent.")]
+	[Category("Unit")]
+	public async Task CreateEntitySchema_Should_Fail_When_ExtendParent_Is_True_And_ParentSchemaName_Is_Omitted() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		FakeCreateEntitySchemaCommand defaultCommand = new();
+		CreateEntitySchemaCommand realCommand = new(
+			Substitute.For<IRemoteEntitySchemaCreator>(),
+			ConsoleLogger.Instance);
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreateEntitySchemaCommand>(Arg.Any<CreateEntitySchemaOptions>())
+			.Returns(realCommand);
+		CreateEntitySchemaTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = await tool.CreateEntitySchema(new CreateEntitySchemaArgs(
+			"MyPackage",
+			"UsrVehicle",
+			Localizations("Vehicle"),
+			"docker_fix2",
+			ParentSchemaName: null,
+			ExtendParent: true));
+
+		// Assert
+		result.ExitCode.Should().Be(1,
+			because: "extend-parent=true without a parent-schema-name must be rejected by the command validation guard, not silently proceed against BaseEntity");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
 	[Description("Uses BaseEntity as the default parent schema when parent-schema-name is omitted from the MCP create-entity-schema call.")]
 	[Category("Unit")]
 	public async Task CreateEntitySchema_Should_Use_BaseEntity_As_Default_Parent_When_ParentSchemaName_Is_Omitted() {

--- a/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
@@ -263,6 +263,36 @@ public class CreateEntitySchemaToolTests {
 	}
 
 	[Test]
+	[Description("Uses BaseEntity as the default parent schema when parent-schema-name is omitted from the MCP create-entity-schema call.")]
+	[Category("Unit")]
+	public async Task CreateEntitySchema_Should_Use_BaseEntity_As_Default_Parent_When_ParentSchemaName_Is_Omitted() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		FakeCreateEntitySchemaCommand defaultCommand = new();
+		FakeCreateEntitySchemaCommand resolvedCommand = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreateEntitySchemaCommand>(Arg.Any<CreateEntitySchemaOptions>())
+			.Returns(resolvedCommand);
+		CreateEntitySchemaTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = await tool.CreateEntitySchema(new CreateEntitySchemaArgs(
+			"MyPackage",
+			"UsrVehicle",
+			Localizations("Vehicle"),
+			"docker_fix2"));
+
+		// Assert
+		result.ExitCode.Should().Be(0,
+			because: "omitting parent-schema-name should still produce a valid schema creation request");
+		resolvedCommand.CapturedOptions.Should().NotBeNull(
+			because: "the resolved command should receive the mapped options");
+		resolvedCommand.CapturedOptions!.ParentSchemaName.Should().Be("BaseEntity",
+			because: "create-entity-schema should default to BaseEntity when no parent-schema-name is supplied");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
 	[Description("Derives the internal schema title from MCP title-localizations and passes provided localizations through as-is without synthesizing additional cultures.")]
 	[Category("Unit")]
 	public async Task CreateEntitySchema_Should_Derive_Internal_Title_From_TitleLocalizations_Without_CultureSynthesis() {

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -36,7 +36,7 @@ public sealed class CreateEntitySchemaTool(
 				 local source files. The package must already exist on the target environment.
 				 """)]
 	public async Task<CommandExecutionResult> CreateEntitySchema(
-		[Description("Parameters: environment-name, package-name, schema-name, title-localizations (all required); columns, parent-schema-name, extend-parent (optional)")] [Required] CreateEntitySchemaArgs args
+		[Description("Parameters: environment-name, package-name, schema-name, title-localizations (all required); columns, parent-schema-name (optional, defaults to BaseEntity), extend-parent (optional)")] [Required] CreateEntitySchemaArgs args
 	) {
 		ApplicationDataForgeResult? dataForge = enrichmentService is not null
 			? await enrichmentService.EnrichAsync(
@@ -83,7 +83,7 @@ public sealed class CreateEntitySchemaTool(
 			Title = titleNormalization.EffectiveTitle
 				?? EntitySchemaLocalizationContract.GetDefaultTitle(titleLocalizations, context),
 			TitleLocalizations = titleNormalization.Localizations ?? titleLocalizations,
-			ParentSchemaName = parentSchemaName,
+			ParentSchemaName = string.IsNullOrWhiteSpace(parentSchemaName) ? "BaseEntity" : parentSchemaName,
 			ExtendParent = extendParent,
 			Columns = SerializeColumns(args.Columns, context),
 			Environment = args.EnvironmentName

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -36,7 +36,7 @@ public sealed class CreateEntitySchemaTool(
 				 local source files. The package must already exist on the target environment.
 				 """)]
 	public async Task<CommandExecutionResult> CreateEntitySchema(
-		[Description("Parameters: environment-name, package-name, schema-name, title-localizations (all required); columns, parent-schema-name (optional, defaults to BaseEntity), extend-parent (optional)")] [Required] CreateEntitySchemaArgs args
+		[Description("Parameters: environment-name, package-name, schema-name, title-localizations (all required); columns, parent-schema-name (optional, defaults to BaseEntity unless extend-parent is true), extend-parent (optional, requires parent-schema-name when true)")] [Required] CreateEntitySchemaArgs args
 	) {
 		ApplicationDataForgeResult? dataForge = enrichmentService is not null
 			? await enrichmentService.EnrichAsync(
@@ -83,7 +83,7 @@ public sealed class CreateEntitySchemaTool(
 			Title = titleNormalization.EffectiveTitle
 				?? EntitySchemaLocalizationContract.GetDefaultTitle(titleLocalizations, context),
 			TitleLocalizations = titleNormalization.Localizations ?? titleLocalizations,
-			ParentSchemaName = string.IsNullOrWhiteSpace(parentSchemaName) ? "BaseEntity" : parentSchemaName,
+			ParentSchemaName = (!extendParent && string.IsNullOrWhiteSpace(parentSchemaName)) ? "BaseEntity" : parentSchemaName,
 			ExtendParent = extendParent,
 			Columns = SerializeColumns(args.Columns, context),
 			Environment = args.EnvironmentName


### PR DESCRIPTION
Changes:
- EntitySchemaTool.cs: default ParentSchemaName to "BaseEntity" when the caller omits parent-schema-name, preventing null/empty parent on newly created entity schemas
- EntitySchemaTool.cs: update tool parameter description to document the "defaults to BaseEntity" behaviour for parent-schema-name
- EntitySchemaToolE2ETests.cs: remove [AllureNUnit] fixture attribute that deadlocked tests with 6+ sequential async MCP calls via NUnit's single-threaded SynchronizationContext; replaced with explanatory comment
- EntitySchemaToolE2ETests.cs: add assertion that ParentSchemaName is not null/whitespace after create-entity-schema to guard the inheritance chain
- CreateEntitySchemaToolTests.cs: add unit test verifying BaseEntity default is applied when parent-schema-name is omitted from the MCP call