### PR TITLE
feat(mcp): add unlock-for-hotfix and finish-hotfix MCP tools

### DIFF
--- a/clio.mcp.e2e/PackageHotfixToolE2ETests.cs
+++ b/clio.mcp.e2e/PackageHotfixToolE2ETests.cs
@@ -1,0 +1,171 @@
+using System.Text.RegularExpressions;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>
+/// End-to-end tests for the unlock-for-hotfix and finish-hotfix MCP tools.
+/// </summary>
+[TestFixture]
+[AllureNUnit]
+[AllureFeature("pkg-hotfix")]
+public sealed class PackageHotfixToolE2ETests {
+
+	private const string UnlockToolName = PackageHotfixTool.UnlockForHotfixToolName;
+	private const string FinishToolName = PackageHotfixTool.FinishHotfixToolName;
+
+	[Test]
+	[AllureTag(UnlockToolName)]
+	[AllureDescription("Starts the real clio MCP server and verifies that unlock-for-hotfix is advertised in the tool list.")]
+	[AllureName("unlock-for-hotfix tool is advertised by the MCP server")]
+	[Description("Verifies that unlock-for-hotfix appears in the MCP tool advertisement from the real clio mcp-server process.")]
+	public async Task UnlockForHotfix_Should_Be_Advertised_By_McpServer() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		await using PackageHotfixArrangeContext arrangeContext = await ArrangeAsync(settings);
+
+		// Act
+		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+
+		// Assert
+		AssertToolIsAdvertised(tools, UnlockToolName);
+	}
+
+	[Test]
+	[AllureTag(FinishToolName)]
+	[AllureDescription("Starts the real clio MCP server and verifies that finish-hotfix is advertised in the tool list.")]
+	[AllureName("finish-hotfix tool is advertised by the MCP server")]
+	[Description("Verifies that finish-hotfix appears in the MCP tool advertisement from the real clio mcp-server process.")]
+	public async Task FinishHotfix_Should_Be_Advertised_By_McpServer() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		await using PackageHotfixArrangeContext arrangeContext = await ArrangeAsync(settings);
+
+		// Act
+		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+
+		// Assert
+		AssertToolIsAdvertised(tools, FinishToolName);
+	}
+
+	[Test]
+	[AllureTag(UnlockToolName)]
+	[AllureDescription("Invokes unlock-for-hotfix with an invalid environment name and verifies that the MCP result reports a failure with human-readable diagnostics.")]
+	[AllureName("unlock-for-hotfix reports invalid environment name failures")]
+	[Description("Reports invalid environment failures for unlock-for-hotfix through the real MCP server.")]
+	public async Task UnlockForHotfix_Should_Report_Invalid_Environment_Failure() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		await using PackageHotfixArrangeContext arrangeContext = await ArrangeAsync(settings);
+		string invalidEnvironmentName = $"missing-hotfix-env-{Guid.NewGuid():N}";
+
+		// Act
+		CommandExecutionActResult actResult = await ActAsync(arrangeContext, UnlockToolName, "SomePackage", invalidEnvironmentName);
+
+		// Assert
+		AssertCommandToolFailed(actResult);
+		AssertFailureIncludesErrorMessage(actResult);
+		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
+	}
+
+	[Test]
+	[AllureTag(FinishToolName)]
+	[AllureDescription("Invokes finish-hotfix with an invalid environment name and verifies that the MCP result reports a failure with human-readable diagnostics.")]
+	[AllureName("finish-hotfix reports invalid environment name failures")]
+	[Description("Reports invalid environment failures for finish-hotfix through the real MCP server.")]
+	public async Task FinishHotfix_Should_Report_Invalid_Environment_Failure() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		await using PackageHotfixArrangeContext arrangeContext = await ArrangeAsync(settings);
+		string invalidEnvironmentName = $"missing-hotfix-env-{Guid.NewGuid():N}";
+
+		// Act
+		CommandExecutionActResult actResult = await ActAsync(arrangeContext, FinishToolName, "SomePackage", invalidEnvironmentName);
+
+		// Assert
+		AssertCommandToolFailed(actResult);
+		AssertFailureIncludesErrorMessage(actResult);
+		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
+	}
+
+	[AllureStep("Arrange MCP server session")]
+	private static async Task<PackageHotfixArrangeContext> ArrangeAsync(McpE2ESettings settings) {
+		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		return new PackageHotfixArrangeContext(session, cancellationTokenSource);
+	}
+
+	[AllureStep("Act by invoking hotfix tool through MCP")]
+	private static async Task<CommandExecutionActResult> ActAsync(
+		PackageHotfixArrangeContext arrangeContext,
+		string toolName,
+		string packageName,
+		string environmentName) {
+		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			toolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["package-name"] = packageName,
+					["environment-name"] = environmentName
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+		return new CommandExecutionActResult(callResult, execution);
+	}
+
+	[AllureStep("Assert tool is advertised by MCP server")]
+	private static void AssertToolIsAdvertised(IList<McpClientTool> tools, string toolName) {
+		tools.Select(t => t.Name).Should().Contain(toolName,
+			because: $"the {toolName} MCP tool must be advertised by the clio mcp-server process");
+	}
+
+	[AllureStep("Assert command-oriented MCP tool failed")]
+	private static void AssertCommandToolFailed(CommandExecutionActResult actResult) {
+		(actResult.CallResult.IsError == true || actResult.Execution.ExitCode != 0).Should().BeTrue(
+			because: "hotfix tool should fail when the requested environment is not registered");
+	}
+
+	[AllureStep("Assert failure output contains Error message")]
+	private static void AssertFailureIncludesErrorMessage(CommandExecutionActResult actResult) {
+		actResult.Execution.Output.Should().NotBeNullOrEmpty(
+			because: "failed MCP command execution should emit human-readable diagnostics");
+		actResult.Execution.Output!.Should().Contain(
+			message => message.MessageType == Clio.Common.LogDecoratorType.Error,
+			because: "failed hotfix execution should report its diagnostics as error-level log output");
+	}
+
+	[AllureStep("Assert failure diagnostics mention the invalid environment")]
+	private static void AssertFailureMentionsEnvironment(CommandExecutionActResult actResult, string environmentName) {
+		string combinedOutput = string.Join(
+			Environment.NewLine,
+			(actResult.Execution.Output ?? []).Select(message => $"{message.MessageType}: {message.Value}"));
+
+		combinedOutput.Should().NotBeNullOrWhiteSpace(
+			because: "failed hotfix execution should provide diagnostics that explain the failure");
+		combinedOutput.Should().MatchRegex(
+			$"(?is)({Regex.Escape(environmentName)}|environment.*not.*found|not found|error occurred invoking)",
+			because: "the failure log should identify that the requested environment is not registered");
+	}
+
+	private sealed record PackageHotfixArrangeContext(
+		McpServerSession Session,
+		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
+		public async ValueTask DisposeAsync() {
+			await Session.DisposeAsync();
+			CancellationTokenSource.Dispose();
+		}
+	}
+
+	private sealed record CommandExecutionActResult(
+		CallToolResult CallResult,
+		CommandExecutionEnvelope Execution);
+}

--- a/clio.tests/Command/McpServer/PackageHotfixToolTests.cs
+++ b/clio.tests/Command/McpServer/PackageHotfixToolTests.cs
@@ -63,9 +63,9 @@ public class PackageHotfixToolTests {
 	}
 
 	[Test]
-	[Description("UnlockForHotfix preserves the package name and environment from args.")]
+	[Description("FinishHotfix preserves the package name and environment from args.")]
 	[Category("Unit")]
-	public void UnlockForHotfix_Should_Forward_PackageName_And_Environment() {
+	public void FinishHotfix_Should_Forward_PackageName_And_Environment() {
 		ConsoleLogger.Instance.ClearMessages();
 		FakePackageHotFixCommand defaultCommand = new();
 		FakePackageHotFixCommand resolvedCommand = new();
@@ -73,7 +73,7 @@ public class PackageHotfixToolTests {
 		commandResolver.Resolve<PackageHotFixCommand>(Arg.Any<PackageHotFixCommandOptions>()).Returns(resolvedCommand);
 		PackageHotfixTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		tool.UnlockForHotfix(new PackageHotfixArgs("MyPackage", "production"));
+		tool.FinishHotfix(new PackageHotfixArgs("MyPackage", "production"));
 
 		resolvedCommand.CapturedOptions!.Environment.Should().Be("production",
 			because: "environment name must be forwarded from args");
@@ -82,16 +82,35 @@ public class PackageHotfixToolTests {
 		ConsoleLogger.Instance.ClearMessages();
 	}
 
+	[Test]
+	[Description("UnlockForHotfix returns non-zero ExitCode when the command fails.")]
+	[Category("Unit")]
+	public void UnlockForHotfix_Should_Return_NonZero_ExitCode_When_Command_Fails() {
+		ConsoleLogger.Instance.ClearMessages();
+		FakePackageHotFixCommand defaultCommand = new();
+		FakePackageHotFixCommand resolvedCommand = new(exitCode: 1);
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<PackageHotFixCommand>(Arg.Any<PackageHotFixCommandOptions>()).Returns(resolvedCommand);
+		PackageHotfixTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		CommandExecutionResult result = tool.UnlockForHotfix(new PackageHotfixArgs("CrtNUI", "dev"));
+
+		result.ExitCode.Should().NotBe(0, because: "failed command must propagate non-zero exit code");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
 	private sealed class FakePackageHotFixCommand : PackageHotFixCommand {
+		private readonly int _exitCode;
 		public PackageHotFixCommandOptions? CapturedOptions { get; private set; }
 
-		public FakePackageHotFixCommand()
+		public FakePackageHotFixCommand(int exitCode = 0)
 			: base(Substitute.For<IPackageEditableMutator>(), new EnvironmentSettings()) {
+			_exitCode = exitCode;
 		}
 
 		public override int Execute(PackageHotFixCommandOptions options) {
 			CapturedOptions = options;
-			return 0;
+			return _exitCode;
 		}
 	}
 }

--- a/clio.tests/Command/McpServer/PackageHotfixToolTests.cs
+++ b/clio.tests/Command/McpServer/PackageHotfixToolTests.cs
@@ -1,0 +1,97 @@
+using Clio.Command;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using Clio.Package;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Property("Module", "McpServer")]
+public class PackageHotfixToolTests {
+
+	[Test]
+	[Description("UnlockForHotfix resolves command for requested environment and sets Enable=true.")]
+	[Category("Unit")]
+	public void UnlockForHotfix_Should_Resolve_Command_And_Set_Enable_True() {
+		ConsoleLogger.Instance.ClearMessages();
+		FakePackageHotFixCommand defaultCommand = new();
+		FakePackageHotFixCommand resolvedCommand = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<PackageHotFixCommand>(Arg.Any<PackageHotFixCommandOptions>()).Returns(resolvedCommand);
+		PackageHotfixTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		CommandExecutionResult result = tool.UnlockForHotfix(new PackageHotfixArgs("CrtNUI", "dev"));
+
+		result.ExitCode.Should().Be(0, because: "UnlockForHotfix should succeed");
+		commandResolver.Received(1).Resolve<PackageHotFixCommand>(Arg.Is<PackageHotFixCommandOptions>(o =>
+			o.PackageName == "CrtNUI" &&
+			o.Enable == true &&
+			o.Environment == "dev"));
+		defaultCommand.CapturedOptions.Should().BeNull(because: "resolved command instance must be used");
+		resolvedCommand.CapturedOptions.Should().NotBeNull();
+		resolvedCommand.CapturedOptions!.PackageName.Should().Be("CrtNUI");
+		resolvedCommand.CapturedOptions!.Enable.Should().BeTrue();
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
+	[Description("FinishHotfix resolves command for requested environment and sets Enable=false.")]
+	[Category("Unit")]
+	public void FinishHotfix_Should_Resolve_Command_And_Set_Enable_False() {
+		ConsoleLogger.Instance.ClearMessages();
+		FakePackageHotFixCommand defaultCommand = new();
+		FakePackageHotFixCommand resolvedCommand = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<PackageHotFixCommand>(Arg.Any<PackageHotFixCommandOptions>()).Returns(resolvedCommand);
+		PackageHotfixTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		CommandExecutionResult result = tool.FinishHotfix(new PackageHotfixArgs("CrtNUI", "dev"));
+
+		result.ExitCode.Should().Be(0, because: "FinishHotfix should succeed");
+		commandResolver.Received(1).Resolve<PackageHotFixCommand>(Arg.Is<PackageHotFixCommandOptions>(o =>
+			o.PackageName == "CrtNUI" &&
+			o.Enable == false &&
+			o.Environment == "dev"));
+		defaultCommand.CapturedOptions.Should().BeNull(because: "resolved command instance must be used");
+		resolvedCommand.CapturedOptions.Should().NotBeNull();
+		resolvedCommand.CapturedOptions!.PackageName.Should().Be("CrtNUI");
+		resolvedCommand.CapturedOptions!.Enable.Should().BeFalse();
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
+	[Description("UnlockForHotfix preserves the package name and environment from args.")]
+	[Category("Unit")]
+	public void UnlockForHotfix_Should_Forward_PackageName_And_Environment() {
+		ConsoleLogger.Instance.ClearMessages();
+		FakePackageHotFixCommand defaultCommand = new();
+		FakePackageHotFixCommand resolvedCommand = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<PackageHotFixCommand>(Arg.Any<PackageHotFixCommandOptions>()).Returns(resolvedCommand);
+		PackageHotfixTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
+
+		tool.UnlockForHotfix(new PackageHotfixArgs("MyPackage", "production"));
+
+		resolvedCommand.CapturedOptions!.Environment.Should().Be("production",
+			because: "environment name must be forwarded from args");
+		resolvedCommand.CapturedOptions!.PackageName.Should().Be("MyPackage",
+			because: "package name must be forwarded from args");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	private sealed class FakePackageHotFixCommand : PackageHotFixCommand {
+		public PackageHotFixCommandOptions? CapturedOptions { get; private set; }
+
+		public FakePackageHotFixCommand()
+			: base(Substitute.For<IPackageEditableMutator>(), new EnvironmentSettings()) {
+		}
+
+		public override int Execute(PackageHotFixCommandOptions options) {
+			CapturedOptions = options;
+			return 0;
+		}
+	}
+}

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -260,6 +260,7 @@ public class BindingsModule {
 		services.AddTransient<PageSyncTool>();
 		services.AddTransient<GuidanceGetTool>();
 		services.AddTransient<ComponentInfoTool>();
+		services.AddTransient<PackageHotfixTool>();
 		services.AddTransient<DataForgeTool>();
 		services.AddTransient<IDataForgeEnrichmentBuilder, DataForgeEnrichmentBuilder>();
 		services.AddTransient<IApplicationCreateEnrichmentService, ApplicationCreateEnrichmentService>();

--- a/clio/Command/McpServer/Resources/GetHelpResources.cs
+++ b/clio/Command/McpServer/Resources/GetHelpResources.cs
@@ -30,7 +30,9 @@ public class GetHelpResources(IFileSystem fileSystem){
 			["start-creatio"] = "start",
 			["stop-creatio"] = "stop",
 			["stop-all-creatio"] = "stop",
-			["StopAllCreatio"] = "stop"
+			["StopAllCreatio"] = "stop",
+			["unlock-for-hotfix"] = "pkg-hotfix",
+			["finish-hotfix"] = "pkg-hotfix"
 		};
 	
 	[McpServerResource(UriTemplate = "docs://help/command/{commandName}", Name = "Help Article")]

--- a/clio/Command/McpServer/Tools/PackageHotfixTool.cs
+++ b/clio/Command/McpServer/Tools/PackageHotfixTool.cs
@@ -12,7 +12,10 @@ public class PackageHotfixTool(
 	IToolCommandResolver commandResolver)
 	: BaseTool<PackageHotFixCommandOptions>(packageHotFixCommand, logger, commandResolver) {
 
-	[McpServerTool(Name = "unlock-for-hotfix", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false)]
+	internal const string UnlockForHotfixToolName = "unlock-for-hotfix";
+	internal const string FinishHotfixToolName = "finish-hotfix";
+
+	[McpServerTool(Name = UnlockForHotfixToolName, ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false)]
 	[Description("Unlocks a Creatio package for hotfix editing by starting hotfix state on the remote environment.")]
 	public CommandExecutionResult UnlockForHotfix(
 		[Description("unlock-for-hotfix parameters")] [Required] PackageHotfixArgs args
@@ -25,7 +28,7 @@ public class PackageHotfixTool(
 		return InternalExecute<PackageHotFixCommand>(options);
 	}
 
-	[McpServerTool(Name = "finish-hotfix", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[McpServerTool(Name = FinishHotfixToolName, ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
 	[Description("Finishes hotfix state for a Creatio package, locking it back after hotfix editing.")]
 	public CommandExecutionResult FinishHotfix(
 		[Description("finish-hotfix parameters")] [Required] PackageHotfixArgs args

--- a/clio/Command/McpServer/Tools/PackageHotfixTool.cs
+++ b/clio/Command/McpServer/Tools/PackageHotfixTool.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Clio.Common;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Tools;
+
+public class PackageHotfixTool(
+	PackageHotFixCommand packageHotFixCommand,
+	ILogger logger,
+	IToolCommandResolver commandResolver)
+	: BaseTool<PackageHotFixCommandOptions>(packageHotFixCommand, logger, commandResolver) {
+
+	[McpServerTool(Name = "unlock-for-hotfix", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[Description("Unlocks a Creatio package for hotfix editing by starting hotfix state on the remote environment.")]
+	public CommandExecutionResult UnlockForHotfix(
+		[Description("unlock-for-hotfix parameters")] [Required] PackageHotfixArgs args
+	) {
+		PackageHotFixCommandOptions options = new() {
+			PackageName = args.PackageName,
+			Enable = true,
+			Environment = args.EnvironmentName
+		};
+		return InternalExecute<PackageHotFixCommand>(options);
+	}
+
+	[McpServerTool(Name = "finish-hotfix", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[Description("Finishes hotfix state for a Creatio package, locking it back after hotfix editing.")]
+	public CommandExecutionResult FinishHotfix(
+		[Description("finish-hotfix parameters")] [Required] PackageHotfixArgs args
+	) {
+		PackageHotFixCommandOptions options = new() {
+			PackageName = args.PackageName,
+			Enable = false,
+			Environment = args.EnvironmentName
+		};
+		return InternalExecute<PackageHotFixCommand>(options);
+	}
+}
+
+public record PackageHotfixArgs(
+	[property: JsonPropertyName("package-name")]
+	[Description("Package name")]
+	[Required]
+	string PackageName,
+
+	[property: JsonPropertyName("environment-name")]
+	[Description("Target Creatio environment name")]
+	[Required]
+	string EnvironmentName
+);

--- a/clio/Command/McpServer/Tools/PackageHotfixTool.cs
+++ b/clio/Command/McpServer/Tools/PackageHotfixTool.cs
@@ -12,7 +12,7 @@ public class PackageHotfixTool(
 	IToolCommandResolver commandResolver)
 	: BaseTool<PackageHotFixCommandOptions>(packageHotFixCommand, logger, commandResolver) {
 
-	[McpServerTool(Name = "unlock-for-hotfix", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[McpServerTool(Name = "unlock-for-hotfix", ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false)]
 	[Description("Unlocks a Creatio package for hotfix editing by starting hotfix state on the remote environment.")]
 	public CommandExecutionResult UnlockForHotfix(
 		[Description("unlock-for-hotfix parameters")] [Required] PackageHotfixArgs args

--- a/clio/Command/PackageHotFixCommand.cs
+++ b/clio/Command/PackageHotFixCommand.cs
@@ -13,7 +13,7 @@ public class PackageHotFixCommandOptions : RemoteCommandOptions
 	public string PackageName { get; set; }
 	
 	[Value(1, MetaName = "HotFixState", Required = true, HelpText = "HotFix state")]
-	public bool Enable { get; internal set; }
+	public bool Enable { get; set; }
 
 	#endregion
 


### PR DESCRIPTION
## Summary

- Exposes existing `pkg-hotfix` CLI command as two MCP server tools so AI agents can unlock and re-lock Creatio packages for hotfix editing without falling back to the CLI
- Adds `unlock-for-hotfix` tool (`Idempotent=true` — safe to retry)
- Adds `finish-hotfix` tool
- Changes `Enable` property in `PackageHotFixCommandOptions` from `internal set` to `set` to support programmatic usage
- Registers `PackageHotfixTool` in DI (`BindingsModule.cs`)

## Test plan

- [x] `UnlockForHotfix` resolves correct command with `Enable=true`
- [x] `FinishHotfix` resolves correct command with `Enable=false`
- [x] `FinishHotfix` forwards package name and environment from args
- [x] `UnlockForHotfix` propagates non-zero exit code on failure
- [x] Manually tested on `localhost:5001` — `CrtNUI` package unlocked successfully via `pkg-hotfix CrtNUI true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)