### PR TITLE
ENG-88782 Fix create-app-section readback failure for platform entity sections

### DIFF
--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -20,6 +20,7 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ApplicationSectionToolE2ETests {
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
+	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 
 	[Test]
 	[Description("Advertises create-app-section in the MCP tool list so callers can discover the existing-app section creation tool.")]
@@ -193,13 +194,141 @@ public sealed class ApplicationSectionToolE2ETests {
 	}
 
 	[Test]
-	[Description("Deferred positive coverage for create-app-section when the E2E environment has a known installed application.")]
-	[AllureFeature(SectionCreateToolName)]
-	[AllureTag(SectionCreateToolName)]
-	[AllureName("Application section create returns structured readback data")]
-	[AllureDescription("Placeholder for a future seeded-data E2E that creates a section in a known installed application and verifies persisted read-back data.")]
-	public void ApplicationSectionCreate_Should_Return_Structured_Readback_Data() {
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment, then restore this positive create-app-section read-back scenario.");
+	[Description("Creates a section with a brand-new custom entity in a known installed application and verifies the structured read-back data including the created section metadata.")]
+	public async Task ApplicationSectionCreate_WithCustomEntity_Should_Return_Structured_Readback_Data() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		string? environmentName = settings.Sandbox.EnvironmentName;
+		string? applicationCode = settings.Sandbox.ApplicationCode;
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
+		}
+
+		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
+			Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment — Sandbox.EnvironmentName or Sandbox.ApplicationCode is not configured.");
+		}
+
+		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		string? createdSectionCode = null;
+		try {
+			// Act
+			CallToolResult callResult = await session.CallToolAsync(
+				SectionCreateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["caption"] = caption
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
+
+			// Assert
+			callResult.IsError.Should().NotBeTrue(
+				because: $"create-app-section with a custom entity should not throw an MCP-level error. Actual: {DescribeCallResult(callResult)}");
+			response.Success.Should().BeTrue(
+				because: $"create-app-section without entity-schema-name must succeed and auto-create the entity schema. Error: {response.Error}");
+			response.Section.Should().NotBeNull(
+				because: "a successful create-app-section must include the created section metadata in the readback");
+			response.Section!.Code.Should().NotBeNullOrWhiteSpace(
+				because: "the readback must expose the generated section code");
+			response.Section.EntitySchemaName.Should().NotBeNullOrWhiteSpace(
+				because: "the readback must expose the auto-created entity schema name");
+
+			createdSectionCode = response.Section.Code;
+		} finally {
+			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
+				try {
+					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+					await session.CallToolAsync(
+						SectionDeleteToolName,
+						new Dictionary<string, object?> {
+							["args"] = new Dictionary<string, object?> {
+								["environment-name"] = environmentName,
+								["application-code"] = applicationCode,
+								["section-code"] = createdSectionCode
+							}
+						},
+						cleanupCts.Token);
+				} catch (Exception ex) {
+					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+				}
+			}
+		}
+	}
+
+	[Test]
+	[Description("Creates a section reusing the platform Case entity in a known installed application and verifies the structured read-back data. Covers ENG-88782: Creatio stores Code = EntitySchemaName for platform entity sections; the readback must match by entity schema name, not the caption-derived code sent in the INSERT.")]
+	public async Task ApplicationSectionCreate_WithPlatformEntity_Should_Return_Structured_Readback_Data() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		string? environmentName = settings.Sandbox.EnvironmentName;
+		string? applicationCode = settings.Sandbox.ApplicationCode;
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
+		}
+
+		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
+			Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment — Sandbox.EnvironmentName or Sandbox.ApplicationCode is not configured.");
+		}
+
+		const string platformEntitySchemaName = "Case";
+		string caption = $"E2E Case {Guid.NewGuid():N}"[..23];
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		string? createdSectionCode = null;
+		try {
+			// Act
+			CallToolResult callResult = await session.CallToolAsync(
+				SectionCreateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["caption"] = caption,
+						["entity-schema-name"] = platformEntitySchemaName
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
+
+			// Assert
+			callResult.IsError.Should().NotBeTrue(
+				because: $"create-app-section with a platform entity should not throw an MCP-level error. Actual: {DescribeCallResult(callResult)}");
+			response.Success.Should().BeTrue(
+				because: $"create-app-section with entity-schema-name:{platformEntitySchemaName} must return success:true. " +
+					"Creatio stores Code = EntitySchemaName for platform entity sections, so the readback poll must match " +
+					$"by entity schema name, not the caption-derived code sent in the INSERT. Error: {response.Error}");
+			response.Section.Should().NotBeNull(
+				because: "a successful create-app-section must include the created section metadata in the readback");
+			response.Section!.EntitySchemaName.Should().Be(platformEntitySchemaName,
+				because: "the readback must preserve the platform entity schema name provided in the create request");
+
+			createdSectionCode = response.Section.Code;
+		} finally {
+			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
+				try {
+					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+					await session.CallToolAsync(
+						SectionDeleteToolName,
+						new Dictionary<string, object?> {
+							["args"] = new Dictionary<string, object?> {
+								["environment-name"] = environmentName,
+								["application-code"] = applicationCode,
+								["section-code"] = createdSectionCode
+							}
+						},
+						cleanupCts.Token);
+				} catch (Exception ex) {
+					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+				}
+			}
+		}
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {

--- a/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
+++ b/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
@@ -27,5 +27,7 @@ internal sealed class SandboxSettings {
 
 	public string? PackageName { get; set; }
 
+	public string? ApplicationCode { get; set; }
+
 	public string SeedKeyPrefix { get; set; } = "clio-mcp-e2e";
 }

--- a/clio.tests/Command/ApplicationSectionCreateServiceTests.cs
+++ b/clio.tests/Command/ApplicationSectionCreateServiceTests.cs
@@ -254,6 +254,58 @@ public sealed class ApplicationSectionCreateServiceTests {
 	}
 
 	[Test]
+	[Description("When EntitySchemaName is provided, Creatio stores Code = EntitySchemaName on the section " +
+		"instead of the caption-derived code sent in the INSERT. The readback must match by EntitySchemaName " +
+		"so that the polling loop finds the section and returns success.")]
+	public void CreateSection_WithPlatformEntity_Should_Match_Section_By_EntitySchemaName_As_Code() {
+		// Arrange
+		ApplicationEntityInfoResult entity = new("entity-uid", "Case", "Cases", []);
+		ApplicationInfoResult appInfo = new(
+			"pkg-uid", "UsrTaskApp", [entity], [], "app-id", "Task App", "UsrTaskApp", "8.3.0");
+		_applicationInfoService.GetApplicationInfo("sandbox", null, "UsrTaskApp")
+			.Returns(appInfo);
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"SysAppIcons\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true,"rows":[{"Id":"11111111-1111-1111-1111-111111111111"}]}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"columnValues\"", StringComparison.Ordinal) &&
+				body.Contains("\"Code\"", StringComparison.Ordinal) &&
+				!body.Contains("\"filters\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"SectionSchemaUId\"", StringComparison.Ordinal) &&
+				body.Contains("\"filters\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true,"rows":[{"Id":"section-id","ApplicationId":"app-id","Caption":"My Case Section","Code":"Case","Description":null,"EntitySchemaName":"Case","PackageId":"pkg-uid","SectionSchemaUId":"section-schema-uid","LogoId":"icon-id","IconBackground":null,"ClientTypeId":null}]}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"columnValues\"", StringComparison.Ordinal) &&
+				body.Contains("\"IconBackground\"", StringComparison.Ordinal) &&
+				body.Contains("\"filters\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true}""");
+
+		// Act
+		ApplicationSectionCreateResult result = _sut.CreateSection(
+			"sandbox",
+			new ApplicationSectionCreateRequest(
+				ApplicationCode: "UsrTaskApp",
+				Caption: "My Case Section",
+				EntitySchemaName: "Case"));
+
+		// Assert
+		result.Section.Code.Should().Be("Case",
+			because: "Creatio stores Code = EntitySchemaName for platform entity sections; " +
+				"the readback must match this server-assigned code, not the caption-derived code sent in the INSERT");
+		result.Section.EntitySchemaName.Should().Be("Case",
+			because: "the entity schema name from the request should be reflected in the section result");
+	}
+
+	[Test]
 	[Description("Rejects requests that omit application-code before any remote calls are made.")]
 	public void CreateSection_Should_Reject_Missing_ApplicationCode() {
 		// Arrange

--- a/clio/Command/ApplicationSectionCreateCommand.cs
+++ b/clio/Command/ApplicationSectionCreateCommand.cs
@@ -229,7 +229,8 @@ public sealed class ApplicationSectionCreateService(
 					client,
 					environmentSettings,
 					request.ApplicationId,
-					request.SectionCode);
+					request.SectionCode,
+					entitySchemaName: request.EntitySchemaName);
 				SetIconBackground(client, environmentSettings, createdSection, request.IconBackground);
 				string? entitySchemaName = string.IsNullOrWhiteSpace(createdSection.EntitySchemaName)
 					? request.EntitySchemaName
@@ -333,7 +334,8 @@ public sealed class ApplicationSectionCreateService(
 		IApplicationClient client,
 		EnvironmentSettings environmentSettings,
 		string applicationId,
-		string sectionCode) {
+		string sectionCode,
+		string? entitySchemaName = null) {
 		ApplicationSectionSelectQueryResponseDto response = SelectQueryHelper.ExecuteSelectQuery<ApplicationSectionSelectQueryResponseDto>(
 			client,
 			serviceUrlBuilderFactory.Create(environmentSettings),
@@ -358,10 +360,16 @@ public sealed class ApplicationSectionCreateService(
 						applicationId,
 						SelectQueryHelper.GuidDataValueType)
 				]));
+		string searchDescription = string.IsNullOrWhiteSpace(entitySchemaName)
+			? $"'{sectionCode}'"
+			: $"'{sectionCode}' or entity schema name '{entitySchemaName}'";
 		return response.Rows
-				.FirstOrDefault(row => string.Equals(row.Code, sectionCode, StringComparison.OrdinalIgnoreCase))
+				.FirstOrDefault(row =>
+					string.Equals(row.Code, sectionCode, StringComparison.OrdinalIgnoreCase)
+					|| (!string.IsNullOrWhiteSpace(entitySchemaName)
+						&& string.Equals(row.Code, entitySchemaName, StringComparison.OrdinalIgnoreCase)))
 			?? throw new InvalidOperationException(
-				$"Section '{sectionCode}' was not found in application '{applicationId}'.");
+				$"Section {searchDescription} was not found in application '{applicationId}'.");
 	}
 
 	private static ApplicationEntityInfoResult? ResolveEntity(

--- a/clio/Command/ApplicationSectionCreateCommand.cs
+++ b/clio/Command/ApplicationSectionCreateCommand.cs
@@ -367,7 +367,7 @@ public sealed class ApplicationSectionCreateService(
 				.FirstOrDefault(row =>
 					string.Equals(row.Code, sectionCode, StringComparison.OrdinalIgnoreCase)
 					|| (!string.IsNullOrWhiteSpace(entitySchemaName)
-						&& string.Equals(row.Code, entitySchemaName, StringComparison.OrdinalIgnoreCase)))
+						&& string.Equals(row.EntitySchemaName, entitySchemaName, StringComparison.OrdinalIgnoreCase)))
 			?? throw new InvalidOperationException(
 				$"Section {searchDescription} was not found in application '{applicationId}'.");
 	}


### PR DESCRIPTION
When a section is created with an existing platform entity (e.g. Case, Activity), Creatio stores Code = EntitySchemaName on the ApplicationSection record instead of the caption-derived code sent in the INSERT. The readback polling loop in GetSectionRecord was matching only by the caption-derived code, so it never found the section and exhausted all 15 attempts, returning success: false even though the section was created successfully.

Fix: extend GetSectionRecord to match by EntitySchemaName when provided, in addition to the caption-derived code. This covers both custom entities (where Code equals the generated code) and platform entities (where Code equals the entity schema name).

Changes:
- clio/Command/ApplicationSectionCreateCommand.cs: add dual-match predicate in GetSectionRecord — matches by sectionCode OR entitySchemaName; improve the not-found error message to include both search terms
- clio.tests/Command/ApplicationSectionCreateServiceTests.cs: add unit test CreateSection_WithPlatformEntity_Should_Match_Section_By_EntitySchemaName_As_Code that mocks the server returning Code = EntitySchemaName and verifies the readback finds the section correctly
- clio.mcp.e2e/ApplicationSectionToolE2ETests.cs: replace placeholder test with two live E2E tests — one for custom entity (baseline) and one for platform entity (ENG-88782 scenario); both include cleanup with graceful error handling so cleanup failures do not mask the create assertion
- clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs: add ApplicationCode property to SandboxSettings to allow E2E tests to target a specific installed application