### PR TITLE
feat(mcp): enforce Freedom UI palette for create-app icon-background

### DIFF
--- a/clio.tests/Command/ApplicationCreateServiceTests.cs
+++ b/clio.tests/Command/ApplicationCreateServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Clio.Command;
 using Clio.Common;
@@ -44,7 +45,7 @@ public sealed class ApplicationCreateServiceTests {
 			Description: "Created by tests",
 			TemplateCode: "AppFreedomUI",
 			IconId: "11111111-1111-1111-1111-111111111111",
-			IconBackground: "#FFFFFF",
+			IconBackground: "#0058EF",
 			ClientTypeId: "22222222-2222-2222-2222-222222222222",
 			OptionalTemplateData: new ApplicationOptionalTemplateData(
 				EntitySchemaName: "UsrCodexEntity",
@@ -89,7 +90,7 @@ public sealed class ApplicationCreateServiceTests {
 		ApplicationCreateRequest request = _fullRequest with {
 			Code = null,
 			IconId = "11111111-1111-1111-1111-111111111111",
-			IconBackground = "#FFFFFF"
+			IconBackground = "#0058EF"
 		};
 		ConfigureCreateSuccessForCode("UsrCodexApp");
 		_applicationInfoService.GetApplicationInfo("sandbox", "33333333-3333-3333-3333-333333333333", "UsrCodexApp")
@@ -112,7 +113,7 @@ public sealed class ApplicationCreateServiceTests {
 			Name = null,
 			Code = "UsrCodexApplication",
 			IconId = "11111111-1111-1111-1111-111111111111",
-			IconBackground = "#FFFFFF"
+			IconBackground = "#0058EF"
 		};
 		ConfigureCreateSuccessForCode("UsrCodexApplication");
 		_applicationInfoService.GetApplicationInfo("sandbox", "33333333-3333-3333-3333-333333333333", "UsrCodexApplication")
@@ -173,7 +174,7 @@ public sealed class ApplicationCreateServiceTests {
 			Name = "Explicit App",
 			Code = "UsrExplicitApp",
 			IconId = "11111111-1111-1111-1111-111111111111",
-			IconBackground = "#123456"
+			IconBackground = "#0058EF"
 		};
 
 		// Act
@@ -188,8 +189,8 @@ public sealed class ApplicationCreateServiceTests {
 	}
 
 	[Test]
-	[Description("Generates an icon background color when the caller omits it.")]
-	public void CreateApplication_Should_Generate_Icon_Background_When_Omitted() {
+	[Description("Assigns a random Freedom UI palette color when the caller omits icon-background.")]
+	public void CreateApplication_Should_Assign_Palette_Color_When_IconBackground_Omitted() {
 		// Arrange
 		ApplicationCreateRequest request = _fullRequest with {
 			IconBackground = null,
@@ -205,7 +206,24 @@ public sealed class ApplicationCreateServiceTests {
 		// Assert
 		_applicationClient.Received(1).ExecutePostRequest(
 			Arg.Is<string>(url => url.EndsWith("CreateApp", StringComparison.Ordinal)),
-			Arg.Is<string>(body => Regex.IsMatch(body, "\"iconBackground\":\"#[0-9A-F]{6}\"")));
+			Arg.Is<string>(body => ApplicationSectionColorPalette.Colors.Any(c =>
+				body.Contains($"\"iconBackground\":\"{c}\"", StringComparison.Ordinal))));
+	}
+
+	[Test]
+	[Description("Rejects icon-background values that are not in the Freedom UI palette.")]
+	public void CreateApplication_Should_Reject_IconBackground_Outside_Palette() {
+		// Arrange
+		ApplicationCreateRequest request = _fullRequest with { IconBackground = "#1F5F8B" };
+
+		// Act
+		Action action = () => _sut.CreateApplication("sandbox", request);
+
+		// Assert
+		action.Should().Throw<ArgumentException>()
+			.WithMessage("*not a Freedom UI palette color*",
+				because: "only the 16 Freedom UI palette swatches are accepted as icon background colors");
+		_applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(default!, default!);
 	}
 
 	[Test]
@@ -222,7 +240,7 @@ public sealed class ApplicationCreateServiceTests {
 		// Assert
 		_applicationClient.Received(1).ExecutePostRequest(
 			Arg.Is<string>(url => url.EndsWith("CreateApp", StringComparison.Ordinal)),
-			Arg.Is<string>(body => body.Contains("\"iconBackground\":\"#FFFFFF\"", StringComparison.Ordinal)));
+			Arg.Is<string>(body => body.Contains("\"iconBackground\":\"#0058EF\"", StringComparison.Ordinal)));
 	}
 
 	[Test]
@@ -231,7 +249,7 @@ public sealed class ApplicationCreateServiceTests {
 		// Arrange
 		ApplicationCreateRequest request = _fullRequest with {
 			IconId = null,
-			IconBackground = "#FFFFFF"
+			IconBackground = "#0058EF"
 		};
 		ConfigureIconQuery("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 		ConfigureCreateSuccessForCode("UsrCodexApp");
@@ -256,7 +274,7 @@ public sealed class ApplicationCreateServiceTests {
 		// Arrange
 		ApplicationCreateRequest request = _fullRequest with {
 			IconId = "auto",
-			IconBackground = "#FFFFFF"
+			IconBackground = "#0058EF"
 		};
 		ConfigureIconQuery("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 		ConfigureCreateSuccessForCode("UsrCodexApp");
@@ -298,7 +316,7 @@ public sealed class ApplicationCreateServiceTests {
 		// Arrange
 		ApplicationCreateRequest request = _fullRequest with {
 			IconId = null,
-			IconBackground = "#FFFFFF"
+			IconBackground = "#0058EF"
 		};
 		_applicationClient.ExecutePostRequest(
 				Arg.Is<string>(url => url.EndsWith("SelectQuery", StringComparison.Ordinal)),

--- a/clio.tests/Command/McpServer/ApplicationToolTests.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTests.cs
@@ -704,7 +704,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: "AppFreedomUI",
 			IconId: "auto",
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: "22222222-2222-2222-2222-222222222222",
 			OptionalTemplateDataJson: """
 				{"entitySchemaName":"UsrCodexEntity","useExistingEntitySchema":true,"useAIContentGeneration":false,"appSectionDescription":"Section description"}
@@ -719,7 +719,7 @@ public sealed class ApplicationToolTests {
 				request.Description == null &&
 				request.TemplateCode == "AppFreedomUI" &&
 				request.IconId == "auto" &&
-				request.IconBackground == "#112233" &&
+				request.IconBackground == "#0058EF" &&
 				request.ClientTypeId == "22222222-2222-2222-2222-222222222222" &&
 				request.OptionalTemplateData != null &&
 				request.OptionalTemplateData.EntitySchemaName == "UsrCodexEntity" &&
@@ -928,7 +928,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: "AppFreedomUI",
 			IconId: null,
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: null,
 			OptionalTemplateDataJson: "{not-json"));
 
@@ -958,7 +958,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: "AppFreedomUI",
 			IconId: null,
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: null,
 			OptionalTemplateDataJson: null,
 			TitleLocalizations: new Dictionary<string, string> {
@@ -991,7 +991,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: "AppFreedomUI",
 			IconId: null,
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: null,
 			OptionalTemplateDataJson: JsonSerializer.Serialize(new {
 				useAIContentGeneration = true
@@ -1033,7 +1033,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: "AppFreedomUI",
 			IconId: null,
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: null,
 			OptionalTemplateDataJson: null));
 
@@ -1386,7 +1386,7 @@ public sealed class ApplicationToolTests {
 			name: "Codex App",
 			code: "UsrCodexApp",
 			templateCode: "AppFreedomUI",
-			iconBackground: "#112233",
+			iconBackground: "#0058EF",
 			description: null,
 			iconId: "11111111-1111-1111-1111-111111111111",
 			clientTypeId: "22222222-2222-2222-2222-222222222222",
@@ -1537,7 +1537,7 @@ public sealed class ApplicationToolTests {
 			Description: null,
 			TemplateCode: string.Empty,
 			IconId: null,
-			IconBackground: "#112233",
+			IconBackground: "#0058EF",
 			ClientTypeId: null,
 			OptionalTemplateDataJson: null));
 

--- a/clio.tests/Command/McpServer/ApplicationToolTests.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTests.cs
@@ -881,11 +881,11 @@ public sealed class ApplicationToolTests {
 		string[] requiredProperties = [
 			nameof(ApplicationCreateArgs.EnvironmentName),
 			nameof(ApplicationCreateArgs.Name),
-			nameof(ApplicationCreateArgs.Code),
-			nameof(ApplicationCreateArgs.IconBackground)
+			nameof(ApplicationCreateArgs.Code)
 		];
 		string[] optionalProperties = [
 			nameof(ApplicationCreateArgs.TemplateCode),
+			nameof(ApplicationCreateArgs.IconBackground),
 			nameof(ApplicationCreateArgs.IconId),
 			nameof(ApplicationCreateArgs.ClientTypeId),
 			nameof(ApplicationCreateArgs.Description),
@@ -1446,8 +1446,8 @@ public sealed class ApplicationToolTests {
 			because: "the create prompt should reference the exact production tool name");
 		createPrompt.Should().Contain(ToolContractGetTool.ToolName,
 			because: "the create prompt should bootstrap app-modeling workflows from the authoritative MCP contract");
-		createPrompt.Should().Contain("Provide `name`, `code`, `template-code`, and `icon-background`",
-			because: "the create prompt should explain the new required input contract");
+		createPrompt.Should().Contain("Provide `name`, `code`, and `template-code`",
+			because: "the create prompt should explain the required input contract");
 		createPrompt.Should().Contain("do not nest them under `args`",
 			because: "the create prompt should explicitly reject the wrapper shape that caused the analyzed session failure");
 		createPrompt.Should().Contain("`optional-template-data-json`",
@@ -1551,11 +1551,16 @@ public sealed class ApplicationToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Returns a structured error envelope when icon-background is missing from the minimal create-app shell.")]
-	public async Task ApplicationCreate_Should_Return_Error_When_IconBackground_Is_Missing() {
+	[Description("Accepts a missing icon-background and forwards the request to the service, which assigns a random palette color.")]
+	public async Task ApplicationCreate_Should_Accept_Missing_IconBackground_And_Forward_To_Service() {
 		// Arrange
 		IApplicationCreateService applicationCreateService = Substitute.For<IApplicationCreateService>();
 		IApplicationCreateEnrichmentService enrichmentService = Substitute.For<IApplicationCreateEnrichmentService>();
+		applicationCreateService.CreateApplication(Arg.Any<string>(), Arg.Any<ApplicationCreateRequest>())
+			.Returns(new ApplicationInfoResult("pkg-uid", "PrimaryPkg", []));
+		enrichmentService.EnrichAsync(Arg.Any<ApplicationCreateArgs>(), Arg.Any<ApplicationOptionalTemplateData?>(), Arg.Any<CancellationToken>())
+			.Returns(new ApplicationDataForgeResult(Used: false, Health: null, Status: null, Coverage: null,
+				Warnings: Array.Empty<string>(), ContextSummary: null));
 		ApplicationCreateTool tool = new(applicationCreateService, enrichmentService);
 
 		// Act
@@ -1563,22 +1568,12 @@ public sealed class ApplicationToolTests {
 			EnvironmentName: "sandbox",
 			Name: "Codex App",
 			Code: "UsrCodexApp",
-			Description: null,
-			TemplateCode: "AppFreedomUI",
-			IconId: null,
-			IconBackground: string.Empty,
-			ClientTypeId: null,
-			OptionalTemplateDataJson: null));
+			IconBackground: null));
 
 		// Assert
-		result.Success.Should().BeFalse(
-			because: "missing required shell fields should fail before the backend create flow starts");
-		result.Error.Should().Contain("icon-background is required",
-			because: "the validation message should identify the missing contract field");
-		result.Error.Should().Contain("#1F5F8B",
-			because: "the validation message should point callers to a valid color example");
-		applicationCreateService.DidNotReceiveWithAnyArgs().CreateApplication(default!, default!);
-		await enrichmentService.DidNotReceiveWithAnyArgs().EnrichAsync(default!, default!, default);
+		result.Success.Should().BeTrue(
+			because: "omitting icon-background is valid — the service assigns a random Freedom UI palette color");
+		applicationCreateService.ReceivedWithAnyArgs().CreateApplication(default!, default!);
 	}
 
 	[Test]

--- a/clio/Command/ApplicationCreateService.cs
+++ b/clio/Command/ApplicationCreateService.cs
@@ -171,8 +171,11 @@ public sealed class ApplicationCreateService(
 			: request.Name.Trim();
 
 		resolvedCode ??= GenerateCodeFromName(resolvedName);
+		if (!string.IsNullOrWhiteSpace(request.IconBackground)) {
+			ApplicationSectionColorPalette.ValidateOrThrow(request.IconBackground.Trim());
+		}
 		string resolvedIconBackground = string.IsNullOrWhiteSpace(request.IconBackground)
-			? GenerateRandomHexColor()
+			? ApplicationSectionColorPalette.PickRandom()
 			: request.IconBackground.Trim();
 		bool needsIconResolution = string.IsNullOrWhiteSpace(request.IconId) ||
 			string.Equals(request.IconId, "auto", StringComparison.OrdinalIgnoreCase);
@@ -343,19 +346,6 @@ public sealed class ApplicationCreateService(
 		return char.ToUpperInvariant(sanitizedWord[0]) + sanitizedWord[1..];
 	}
 
-	private static string GenerateRandomHexColor()
-	{
-		int red = Random.Shared.Next(50, 200);
-		int green = Random.Shared.Next(50, 200);
-		int blue = Random.Shared.Next(50, 200);
-		return string.Create(7, (red, green, blue), static (span, value) =>
-		{
-			span[0] = '#';
-			value.red.TryFormat(span.Slice(1, 2), out _, "X2");
-			value.green.TryFormat(span.Slice(3, 2), out _, "X2");
-			value.blue.TryFormat(span.Slice(5, 2), out _, "X2");
-		});
-	}
 
 	private static string ResolveRandomIconId(
 		IApplicationClient client,

--- a/clio/Command/McpServer/Prompts/ApplicationPrompt.cs
+++ b/clio/Command/McpServer/Prompts/ApplicationPrompt.cs
@@ -83,8 +83,9 @@ public static class ApplicationPrompt {
 		 Use clio mcp server `{ApplicationCreateTool.ApplicationCreateToolName}` to create a Creatio application and return its primary package and entity metadata.
 		 Before the first app-modeling tool call in a workflow, call `{ToolContractGetTool.ToolName}` with `tool-names` such as `create-app`, `sync-schemas`, and `sync-pages` so the client starts from the authoritative contract and follow-up flow.
 		 Pass `environment-name` `{environmentName}` exactly as provided.
-		 Provide `name`, `code`, `template-code`, and `icon-background`.
+		 Provide `name`, `code`, and `template-code`.
 		 Pass those fields at the top level of the MCP request; do not nest them under `args`.
+		 Pass `icon-background` only when the user explicitly specified a color; omit it otherwise — a random Freedom UI palette color is assigned automatically.
 		 For end-to-end app modeling guardrails, call `{GuidanceGetTool.ToolName}` with `name` set to `app-modeling`.
 		 `create-app` already performs an internal Data Forge enrichment step and returns optional `dataforge` diagnostics with health, coverage, warnings, and a compact context summary.
 		 Do not add a separate mandatory Data Forge preflight outside the canonical `create-app` flow unless the workflow explicitly needs standalone Data Forge inspection or remediation.

--- a/clio/Command/McpServer/Tools/ApplicationTool.cs
+++ b/clio/Command/McpServer/Tools/ApplicationTool.cs
@@ -154,6 +154,10 @@ public sealed class ApplicationCreateTool(
 				$"Known templates: {available}. Omit template-code to use the default AppFreedomUI.");
 		}
 
+		if (!string.IsNullOrWhiteSpace(args.IconBackground)) {
+			ApplicationSectionColorPalette.ValidateOrThrow(args.IconBackground.Trim());
+		}
+
 		if (args.TitleLocalizations is not null ||
 			args.DescriptionLocalizations is not null ||
 			args.CaptionLocalizations is not null ||

--- a/clio/Command/McpServer/Tools/ApplicationTool.cs
+++ b/clio/Command/McpServer/Tools/ApplicationTool.cs
@@ -102,7 +102,7 @@ public sealed class ApplicationCreateTool(
 		OpenWorld = false)]
 	[Description("Creates a new application in Creatio through backend MCP and returns installed application identity plus the created package and entity context.")]
 	public async Task<ApplicationContextResponse> ApplicationCreate(
-		[Description("Parameters: environment-name, name, code, icon-background (required); template-code (optional, defaults to AppFreedomUI — the stable recommended template); description, icon-id, client-type-id (optional)")]
+		[Description("Parameters: environment-name, name, code (required); template-code (optional, defaults to AppFreedomUI — the stable recommended template); description, icon-background, icon-id, client-type-id (optional)")]
 		[Required]
 		ApplicationCreateArgs args) {
 		try {
@@ -152,12 +152,6 @@ public sealed class ApplicationCreateTool(
 				$"Unknown template-code '{args.TemplateCode}'. " +
 				$"Use the technical template name, not the display name. " +
 				$"Known templates: {available}. Omit template-code to use the default AppFreedomUI.");
-		}
-
-		if (string.IsNullOrWhiteSpace(args.IconBackground)) {
-			throw new ArgumentException(
-				"icon-background is required. " +
-				"Provide a top-level #RRGGBB value such as #1F5F8B.");
 		}
 
 		if (args.TitleLocalizations is not null ||

--- a/clio/Command/McpServer/Tools/ApplicationToolArgs.cs
+++ b/clio/Command/McpServer/Tools/ApplicationToolArgs.cs
@@ -52,11 +52,6 @@ public sealed record ApplicationCreateArgs(
 	[property: Required]
 	string Code,
 
-	[property: JsonPropertyName("icon-background")]
-	[property: Description("Application icon background color in #RRGGBB format, e.g. '#1F5F8B'")]
-	[property: Required]
-	string IconBackground,
-
 	[property: JsonPropertyName("template-code")]
 	[property: Description("Technical template name (NOT display name). Known values: AppFreedomUI, AppFreedomUIv2, AppWithHomePage, EmptyApp. Defaults to AppFreedomUI when omitted — use this default unless you have a specific reason to change it.")]
 	string? TemplateCode = "AppFreedomUI",
@@ -64,6 +59,10 @@ public sealed record ApplicationCreateArgs(
 	[property: JsonPropertyName("description")]
 	[property: Description("Application description")]
 	string? Description = null,
+
+	[property: JsonPropertyName("icon-background")]
+	[property: Description("Optional Freedom UI palette color in #RRGGBB format. Must be one of: #A6DE00, #20A959, #22AC14, #FFAC07, #FF8800, #F9307F, #FF602E, #FF4013, #B87CCF, #7848EE, #247EE5, #0058EF, #009DE3, #4F43C2, #08857E, #00BFA5. Omit unless the user explicitly requested a specific color — a random palette color is assigned automatically when absent.")]
+	string? IconBackground = null,
 
 	[property: JsonPropertyName("icon-id")]
 	[property: Description("Optional application icon GUID (e.g. '00000000-0000-0000-0000-000000000000'), or 'auto' to resolve a random icon.")]

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.0.2.72</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.4</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>

--- a/clio/docs/commands/create-app.md
+++ b/clio/docs/commands/create-app.md
@@ -20,8 +20,10 @@ with the Usr prefix with --code.
 Choose the application template with --template-code. Known values are:
 AppFreedomUIv2, AppFreedomUI, AppWithHomePage, EmptyApp.
 
-Optionally supply --icon-background in #RRGGBB format and --icon-id as a GUID
-or the special value 'auto' to let Creatio choose a random icon.
+Optionally supply --icon-background as one of the Freedom UI palette colors and
+--icon-id as a GUID or the special value 'auto' to let Creatio choose a random
+icon. When --icon-background is omitted a random palette color is assigned
+automatically.
 
 ## Synopsis
 
@@ -41,7 +43,9 @@ clio create-app [options]
                                  Known values: AppFreedomUIv2, AppFreedomUI,
                                  AppWithHomePage, EmptyApp
 
---icon-background                Icon background color in #RRGGBB format
+--icon-background                Freedom UI palette color in #RRGGBB format.
+                                 Optional; a random palette color is used
+                                 when omitted.
 
 --description                    Application description
 
@@ -62,14 +66,15 @@ of the primary package that was created together with the application.
 clio create-app --name "My Orders App" --code UsrOrdersApp --template-code AppFreedomUIv2 -e dev
 # create a Freedom UI v2 application in the dev environment
 
-clio create-app --name "Sales" --code UsrSalesApp --template-code EmptyApp --icon-background "#1F5F8B" -e dev
-# create an empty application with a custom icon background color
+clio create-app --name "Sales" --code UsrSalesApp --template-code EmptyApp --icon-background "#0058EF" -e dev
+# create an empty application with a specific Freedom UI palette color
 ```
 
 ## Notes
 
 - --name, --code, and --template-code are required.
 - The application code must start with the Usr prefix.
+- --icon-background must be one of the Freedom UI palette colors when provided; a random palette color is assigned when omitted.
 - When --icon-id is omitted the command does not assign an icon automatically.
 
 ## Reporting Bugs

--- a/clio/help/en/create-app.txt
+++ b/clio/help/en/create-app.txt
@@ -15,8 +15,10 @@ DESCRIPTION
     Choose the application template with --template-code. Known values are:
     AppFreedomUIv2, AppFreedomUI, AppWithHomePage, EmptyApp.
 
-    Optionally supply --icon-background in #RRGGBB format and --icon-id as
-    a GUID or the special value 'auto' to let Creatio choose a random icon.
+    Optionally supply --icon-background as one of the Freedom UI palette colors
+    and --icon-id as a GUID or the special value 'auto' to let Creatio choose
+    a random icon. When --icon-background is omitted a random palette color is
+    assigned automatically.
 
 SYNOPSIS
     clio create-app [options]
@@ -31,7 +33,9 @@ OPTIONS
                                      Known values: AppFreedomUIv2, AppFreedomUI,
                                      AppWithHomePage, EmptyApp
 
-    --icon-background                Icon background color in #RRGGBB format
+    --icon-background                Freedom UI palette color in #RRGGBB format.
+                                     Optional; a random palette color is used
+                                     when omitted.
 
     --description                    Application description
 
@@ -44,8 +48,8 @@ EXAMPLE
     clio create-app --name "My Orders App" --code UsrOrdersApp --template-code AppFreedomUIv2 -e dev
         create a Freedom UI v2 application in the dev environment
 
-    clio create-app --name "Sales" --code UsrSalesApp --template-code EmptyApp --icon-background "#1F5F8B" -e dev
-        create an empty application with a custom icon background color
+    clio create-app --name "Sales" --code UsrSalesApp --template-code EmptyApp --icon-background "#0058EF" -e dev
+        create an empty application with a specific Freedom UI palette color
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio


### PR DESCRIPTION
ENG-88806

Previously create-app accepted any #RRGGBB color while create-app-section already enforced the 16-color Freedom UI palette. This change aligns both tools: validates the provided color against the palette, assigns a random palette color when omitted, and makes icon-background optional in the MCP contract so AI does not fill it unless the user explicitly requests a color.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

AI agents: none