### PR TITLE
fix(deploy-creatio): handle InvalidCastException in health check on macOS/Linux

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageVersion Include="creatio.client" Version="1.0.33" />
+    <PackageVersion Include="creatio.client" Version="1.0.34" />
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.4" />
     <PackageVersion Include="ErrorOr" Version="2.1.0" />

--- a/clio/Command/HealthCheckCommand.cs
+++ b/clio/Command/HealthCheckCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
 using Clio.Common;
 using CommandLine;
 
@@ -43,12 +44,44 @@ namespace Clio.Command
 				Logger.WriteError($"\tError: {ex.Message}");
 				return 1;
 			}
+			catch (InvalidCastException)
+			{
+				// creatio.client <= 1.0.33 casts WebRequest.Create() to HttpWebRequest, which fails
+				// on macOS/Linux when the runtime returns FileWebRequest for some localhost URLs.
+				return ProbeWithHttpClient(checkName, requestUri);
+			}
 			catch(Exception ex)
 			{
 				Logger.WriteError($"\tUnknown Error: {ex.Message}");
 				return 1;
 			}
 			return 0;
+		}
+
+		private int ProbeWithHttpClient(string checkName, string requestUri) {
+			Logger.WriteWarning(
+				$"\t{checkName} - creatio.client returned a non-HTTP request type; retrying via HttpClient.");
+			try {
+				using HttpClientHandler handler = new() {
+					ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+				};
+				using HttpClient client = new(handler) {
+					Timeout = RequestTimeout > 0
+						? TimeSpan.FromMilliseconds(RequestTimeout)
+						: TimeSpan.FromSeconds(100)
+				};
+				using HttpResponseMessage response = client.GetAsync(requestUri).GetAwaiter().GetResult();
+				if (!response.IsSuccessStatusCode) {
+					Logger.WriteError($"\tError: {(int)response.StatusCode} {response.ReasonPhrase}");
+					return 1;
+				}
+				Logger.WriteInfo($"\t{checkName} - OK");
+				return 0;
+			}
+			catch (Exception ex) {
+				Logger.WriteError($"\tError: {ex.Message}");
+				return 1;
+			}
 		}
 
 		public override int Execute(HealthCheckOptions options) {


### PR DESCRIPTION
## Summary

- Bump `creatio.client` from `1.0.33` to `1.0.34` to pick up the `WebRequest.CreateHttp` fix in [creatioclient#6](https://github.com/Advance-Technologies-Foundation/creatioclient/pull/6).
- Add a defensive `HttpClient` fallback in `HealthCheckCommand.ExecuteGetRequest`. The new `catch (InvalidCastException)` branch retries the same endpoint with `HttpClient.GetAsync`, so `clio deploy-creatio` does not fail with a misleading "Unknown Error" even when callers still resolve an older `creatio.client` from cache.

Fixes #552 — `clio deploy-creatio` on macOS exits 1 with `Unable to cast object of type 'System.Net.FileWebRequest' to type 'System.Net.HttpWebRequest'` despite Creatio being healthy.

## Test plan

- [ ] CI green.
- [ ] On macOS rerun the original repro: `clio deploy-creatio -e my_env --ZipFile … --SitePort 40001 --deployment dotnet --silent --auto-run false` — expect exit code 0 and `Server is ready after N attempt(s).` log.
- [ ] Smoke-check that `healthcheck` command keeps working unchanged on Windows / .NET Framework targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)