### PR TITLE
chore: route creatio.client to nuget.org instead of Terrasoft mirror

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -9,6 +9,9 @@
     <packageSourceMapping>
         <packageSource key="nuget.org">
             <package pattern="*" />
+            <!-- creatio.client is published to nuget.org first; pin it here so the
+                 longer-pattern Creatio.* mapping below does not route it to the mirror. -->
+            <package pattern="creatio.client" />
         </packageSource>
         <packageSource key="Terrasoft">
             <package pattern="Terrasoft.*" />


### PR DESCRIPTION
## Summary

Add an exact `creatio.client` pattern to the `nuget.org` packageSource in `nuget.config`. NuGet picks the most specific pattern, so the existing `Creatio.*` mapping no longer routes this package to the internal Terrasoft mirror. Other `Creatio.*` packages still resolve from Terrasoft as before.

## Why

The Terrasoft Nexus mirror lags behind nuget.org. After publishing `creatio.client 1.0.34` to nuget.org, the mirror still only exposed `1.0.33`, which broke the `release-to-nuget` workflow for clio 8.1.0.6 with `NU1102`. Routing this single package directly to nuget.org avoids the lag.

## Test plan

- [x] Local `dotnet restore` succeeds with the mapping change.
- [ ] After merge, rerun `release-to-nuget` for tag `8.1.0.6` and confirm `clio.8.1.0.6.nupkg` is published to nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)