### PR TITLE
fix(deploy-creatio): enable Windows Auth and ensure required Windows features on IIS sites (#557)

### DIFF
--- a/clio/Common/DeploymentStrategies/IISDeploymentStrategy.cs
+++ b/clio/Common/DeploymentStrategies/IISDeploymentStrategy.cs
@@ -21,15 +21,21 @@ public class IISDeploymentStrategy : IDeploymentStrategy
 	private readonly IMediator _mediator;
 	private readonly ILogger _logger;
 	private readonly IAbstractionsFileSystem _fileSystem;
+	private readonly IWindowsFeatureManager _windowsFeatureManager;
 
 	/// <summary>
 	/// Initializes a new instance of the IISDeploymentStrategy class.
 	/// </summary>
-	public IISDeploymentStrategy(IMediator mediator, ILogger logger, IAbstractionsFileSystem fileSystem)
+	public IISDeploymentStrategy(
+		IMediator mediator,
+		ILogger logger,
+		IAbstractionsFileSystem fileSystem,
+		IWindowsFeatureManager windowsFeatureManager)
 	{
 		_mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
 		_logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		_fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+		_windowsFeatureManager = windowsFeatureManager ?? throw new ArgumentNullException(nameof(windowsFeatureManager));
 	}
 
 	/// <summary>
@@ -62,6 +68,11 @@ public class IISDeploymentStrategy : IDeploymentStrategy
 		}
 
 		_logger.WriteInfo("[Create IIS Site] - Started");
+
+		// Pre-deploy: best-effort check & install of Windows features required by Creatio.
+		// Runs for every IIS-on-Windows deploy regardless of framework. Failures are logged
+		// as warnings — deployment continues just like before this check existed.
+		EnsureRequiredWindowsFeatures();
 
 		try {
 			InstallerHelper.FrameworkType frameworkType = InstallerHelper.DetectFrameworkByPath(appDirectoryPath);
@@ -126,4 +137,30 @@ public class IISDeploymentStrategy : IDeploymentStrategy
 	/// Gets a human-readable description of this deployment strategy.
 	/// </summary>
 	public string GetDescription() => "Windows IIS (Internet Information Services)";
+
+	private void EnsureRequiredWindowsFeatures()
+	{
+		try {
+			List<WindowsFeature> missed = _windowsFeatureManager.GetMissedComponents();
+			if (missed is null || missed.Count == 0) {
+				_logger.WriteInfo("[Create IIS Site] - All required Windows features are installed.");
+				return;
+			}
+			_logger.WriteInfo($"[Create IIS Site] - Found {missed.Count} missing Windows feature(s) required by Creatio. Attempting to install...");
+			foreach (WindowsFeature feature in missed) {
+				try {
+					_windowsFeatureManager.InstallFeature(feature.Name);
+				}
+				catch (Exception ex) {
+					_logger.WriteWarning(
+						$"Could not install Windows feature '{feature.Name}': {ex.Message}. "
+						+ "Deployment will continue; install it manually if required.");
+				}
+			}
+		}
+		catch (Exception ex) {
+			_logger.WriteWarning(
+				$"Could not check required Windows features: {ex.Message}. Deployment will continue.");
+		}
+	}
 }

--- a/clio/Common/ScenarioHandlers/CreateIISSite.cs
+++ b/clio/Common/ScenarioHandlers/CreateIISSite.cs
@@ -116,6 +116,7 @@ namespace Clio.Common.ScenarioHandlers {
             if(isNetFramework) {
                 sb.Append(CreateWebApplication(siteName, Path.Combine(destinationFolder, "Terrasoft.WebApp")));
             }
+            sb.Append("EnableWindowsAuthentication: ").AppendLine(EnableWindowsAuthentication(siteName));
 
             return new CreateIISSiteResponse {
                 Status = BaseHandlerResponse.CompletionStatus.Success,
@@ -165,6 +166,29 @@ namespace Clio.Common.ScenarioHandlers {
 
             // Return both outputs so caller can see the unlock and enable results
             return "UnlockResult: " + unlockResult + Environment.NewLine + "EnableResult: " + basicResult;
+        }
+
+        private string EnableWindowsAuthentication(string siteName) {
+            // Best-effort: a failure here (missing appcmd, permission denied) must not fail
+            // deploy-creatio. Required IIS modules are ensured upfront by IISDeploymentStrategy.
+            try {
+                string appcmdPath = Path.Combine("C:", "Windows", "System32", "inetsrv", "appcmd.exe");
+                string section = "system.webServer/security/authentication/windowsAuthentication";
+
+                string unlockCmd = $"unlock config -section:{section}";
+                var unlockResult = _processExecutor.Execute(appcmdPath, unlockCmd, true);
+
+                string enableCmd = $"set config \"{siteName}\" -section:{section} /enabled:true /commit:apphost";
+                var enableResult = _processExecutor.Execute(appcmdPath, enableCmd, true);
+
+                return "UnlockResult: " + unlockResult + Environment.NewLine + "EnableResult: " + enableResult;
+            }
+            catch (Exception ex) {
+                _logger.WriteWarning(
+                    $"Could not enable Windows Authentication for site '{siteName}': {ex.Message}. "
+                    + "Deployment will continue; enable it manually if required.");
+                return "Skipped: Windows Authentication step failed (" + ex.Message + "). Deployment continues.";
+            }
         }
 
         private string CreateWebApplication(string siteName, string physicalPath) {


### PR DESCRIPTION
## Summary
- **Pre-deploy**: `IISDeploymentStrategy` now checks the Windows features required by Creatio (list lives in `tpl/windows_features/RequirmentNetFramework.txt` — Static Content, ISAPI, ASP.NET, Basic Auth, **Windows Authentication**, etc.) and best-effort installs missing ones via `DismApi` (`IWindowsFeatureManager.InstallFeature`). Runs only when the IIS strategy is selected on Windows; covers both NetFramework and Net8.
- **Post-site-create**: `CreateIISSite` always enables Windows Authentication on the newly created site via `appcmd set config "<siteName>" -section:.../windowsAuthentication /enabled:true /commit:apphost` — for both NetFramework and Net8.
- **Failure mode**: every new step is wrapped in `try/catch`; any error (no admin, no `appcmd.exe`, WMI/DISM unavailable) is logged via `WriteWarning(...)` and `deploy-creatio` proceeds with the same return code and behaviour as before this PR.

Closes #557.

## Why two layers?
- The OS feature install puts the `WindowsAuthenticationModule` in IIS but defaults to `enabled="false"` for new sites — without the per-site `appcmd set config` step the site still has Windows Auth disabled (exactly what #557 reports).
- Without the OS feature, the per-site `appcmd` would fail because the section is not registered in `applicationHost.config`.

## Test plan
- [ ] On Windows + IIS, with `IIS-WindowsAuthentication` feature **uninstalled**, run `clio deploy-creatio --deployment iis` for a Net8 ZIP and verify (a) DISM installs the missing features, (b) the new site has Windows Authentication enabled.
- [ ] Same on a machine with the feature **already installed** — verify pre-deploy step is a no-op and the per-site enable still flips the site to `enabled="true"`.
- [ ] Repeat for a NetFramework ZIP to confirm both steps run and don't break the existing `Terrasoft.WebApp` flow.
- [ ] On macOS/Linux: `IISDeploymentStrategy.CanDeploy()` already returns false on non-Windows, so no codepath in this PR runs there. Sanity-check that `deploy-creatio --deployment dotnet` still works.
- [ ] Simulate failure modes (revoke admin, remove `appcmd.exe` from PATH) and verify deploy still finishes successfully with warnings in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)