### PR TITLE
feat(auto-updater): check for updates on startup and update in background

### DIFF
--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -34,15 +34,16 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 
 	#region Methods: Private
 
-	private async Task<string> GetLatestPackageVersionAsync(string packageName){
+	private async Task<string> GetLatestPackageVersionAsync(string packageName,
+		CancellationToken cancellationToken = default){
 		string searchUrl = $"https://api.nuget.org/v3-flatcontainer/{packageName.ToLower()}/index.json";
 
 		try {
 			using HttpClient client = new();
-			HttpResponseMessage response = await client.GetAsync(searchUrl);
+			HttpResponseMessage response = await client.GetAsync(searchUrl, cancellationToken);
 			response.EnsureSuccessStatusCode();
 
-			string responseBody = await response.Content.ReadAsStringAsync();
+			string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 			JObject data = JObject.Parse(responseBody);
 
 			string latestVersion = data["versions"].Last.ToString();
@@ -226,8 +227,7 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 			}
 
 			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
-			string latestVersion = await Task
-				.Run(() => GetLatestVersionFromNuget(), cts.Token)
+			string latestVersion = await GetLatestPackageVersionAsync("clio", cts.Token)
 				.ConfigureAwait(false);
 
 			if (string.IsNullOrEmpty(latestVersion)) {

--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Clio.Common;
 using Newtonsoft.Json.Linq;
@@ -213,6 +214,43 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 		}
 	}
 
+	/// <inheritdoc/>
+	public async Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder) {
+		try {
+			UpdateCheckCache cache = UpdateCheckCache.Load(cacheFolder);
+			string currentVersion = GetCurrentVersion();
+
+			if (!cache.IsCheckDue() && !string.IsNullOrEmpty(cache.LatestVersion)) {
+				bool available = CompareVersions(currentVersion, cache.LatestVersion) < 0;
+				return (available, cache.LatestVersion);
+			}
+
+			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
+			string latestVersion = await Task
+				.Run(() => GetLatestVersionFromNuget(), cts.Token)
+				.ConfigureAwait(false);
+
+			if (string.IsNullOrEmpty(latestVersion)) {
+				return (false, null);
+			}
+
+			UpdateCheckCache.Save(cacheFolder, new UpdateCheckCache {
+				LastCheckedUtc = DateTime.UtcNow,
+				LatestVersion = latestVersion
+			});
+
+			return (CompareVersions(currentVersion, latestVersion) < 0, latestVersion);
+		} catch {
+			return (false, null);
+		}
+	}
+
+	/// <inheritdoc/>
+	public async Task UpdateInBackgroundAsync() {
+		ProcessExecutionOptions options = new("dotnet", "tool update clio -g");
+		await processExecutor.FireAndForgetAsync(options).ConfigureAwait(false);
+	}
+
 	/// <summary>
 	/// Compares two version strings.
 	/// </summary>
@@ -324,6 +362,18 @@ public interface IAppUpdater {
 	/// </summary>
 	/// <returns>Release notes body or null if not available</returns>
 	Task<string> GetReleaseNotesAsync(string version);
+
+	/// <summary>
+	/// Checks whether an update is available, using a local cache to avoid hitting NuGet more
+	/// than once every 8 hours.
+	/// </summary>
+	Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder);
+
+	/// <summary>
+	/// Launches <c>dotnet tool update clio -g</c> as a detached background process and returns
+	/// immediately.  The update takes effect on the next invocation of clio.
+	/// </summary>
+	Task UpdateInBackgroundAsync();
 
 	#endregion
 

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -293,6 +293,7 @@ public class BindingsModule {
 		services.AddTransient<CheckNugetUpdateCommand>();
 		services.AddHttpClient<INugetPackagesProvider, NugetPackagesProvider>();
 		services.AddTransient<UpdateCliCommand>();
+		services.AddTransient<SetAutoupdateCommand>();
 		services.AddTransient<RegisterCommand>();
 		services.AddTransient<UnregisterCommand>();
 		

--- a/clio/Command/Update/SetAutoupdateCommand.cs
+++ b/clio/Command/Update/SetAutoupdateCommand.cs
@@ -1,0 +1,45 @@
+using Clio.Common;
+using Clio.UserEnvironment;
+using CommandLine;
+
+namespace Clio.Command.Update;
+
+[Verb("autoupdate", HelpText = "Enable or disable automatic updates on startup")]
+public class SetAutoupdateOptions {
+
+	[Option("enable", SetName = "enable", HelpText = "Enable automatic updates on startup (default behavior)")]
+	public bool Enable { get; set; }
+
+	[Option("disable", SetName = "disable", HelpText = "Disable automatic updates on startup")]
+	public bool Disable { get; set; }
+
+}
+
+public class SetAutoupdateCommand : Command<SetAutoupdateOptions> {
+
+	private readonly ISettingsRepository _settingsRepository;
+	private readonly ILogger _logger;
+
+	public SetAutoupdateCommand(ISettingsRepository settingsRepository, ILogger logger) {
+		_settingsRepository = settingsRepository;
+		_logger = logger;
+	}
+
+	public override int Execute(SetAutoupdateOptions options) {
+		if (options.Enable) {
+			_settingsRepository.SetAutoupdate(true);
+			_logger.WriteInfo("Auto-update enabled. clio will update automatically on startup.");
+			return 0;
+		}
+		if (options.Disable) {
+			_settingsRepository.SetAutoupdate(false);
+			_logger.WriteInfo("Auto-update disabled. Run 'clio update' to update manually.");
+			return 0;
+		}
+		bool current = _settingsRepository.GetAutoupdate();
+		_logger.WriteInfo($"Auto-update is currently {(current ? "enabled" : "disabled")}.");
+		_logger.WriteInfo("Use --enable or --disable to change.");
+		return 0;
+	}
+
+}

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -186,6 +186,9 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="unlock-package"></a>
 <a id="up"></a>
 - [`unlock-package`](docs/commands/unlock-package.md) - Unlock a package in Creatio, `up`
+<a id="autoupdate"></a>
+- [`autoupdate`](docs/commands/autoupdate.md) - Enable or disable automatic updates on startup
+
 <a id="update-cli"></a>
 <a id="update"></a>
 - [`update-cli`](docs/commands/update-cli.md) - Update clio, `update`

--- a/clio/Common/UpdateCheckCache.cs
+++ b/clio/Common/UpdateCheckCache.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Clio.Common;
+
+public class UpdateCheckCache {
+
+	public DateTime LastCheckedUtc { get; set; }
+
+	public string LatestVersion { get; set; }
+
+	private const string CacheFileName = "update-check.json";
+
+	private static readonly TimeSpan CheckInterval = TimeSpan.FromHours(8);
+
+	public bool IsCheckDue() => DateTime.UtcNow - LastCheckedUtc > CheckInterval;
+
+	public static UpdateCheckCache Load(string folder) {
+		try {
+			string path = Path.Combine(folder, CacheFileName);
+			if (!File.Exists(path)) {
+				return new UpdateCheckCache();
+			}
+			string json = File.ReadAllText(path);
+			return JsonConvert.DeserializeObject<UpdateCheckCache>(json) ?? new UpdateCheckCache();
+		} catch {
+			return new UpdateCheckCache();
+		}
+	}
+
+	public static void Save(string folder, UpdateCheckCache cache) {
+		try {
+			if (!Directory.Exists(folder)) {
+				Directory.CreateDirectory(folder);
+			}
+			string path = Path.Combine(folder, CacheFileName);
+			string json = JsonConvert.SerializeObject(cache, Formatting.Indented);
+			File.WriteAllText(path, json);
+		} catch {
+			// cache write failure must never break the tool
+		}
+	}
+
+}

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -329,7 +329,7 @@ namespace Clio
 			}
 		}
 
-		public bool Autoupdate {
+		public bool? Autoupdate {
 			get; set;
 		}
 
@@ -586,7 +586,12 @@ namespace Clio
 		}
 
 		public bool GetAutoupdate() {
-			return _settings.Autoupdate;
+			return _settings.Autoupdate ?? true;
+		}
+
+		public void SetAutoupdate(bool value) {
+			_settings.Autoupdate = value;
+			Save();
 		}
 
 		public void ConfigureEnvironment(string name, EnvironmentSettings environment) {

--- a/clio/Environment/ISettingsRepository.cs
+++ b/clio/Environment/ISettingsRepository.cs
@@ -172,9 +172,13 @@ namespace Clio.UserEnvironment
 		string GetActualEnvironmentName(string environmentName);
 
 		/// <summary>
-		/// Gets the AutoUpdate setting.
+		/// Gets the AutoUpdate setting. Returns true when not explicitly configured (opt-out model).
 		/// </summary>
-		/// <returns>true if auto-update is enabled; otherwise false.</returns>
 		bool GetAutoupdate();
+
+		/// <summary>
+		/// Persists the AutoUpdate setting.
+		/// </summary>
+		void SetAutoupdate(bool value);
 	}
 }

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -1071,7 +1071,7 @@ internal class Program {
 			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<LocalHelpViewer>();
 		}
 		
-		RunStartupUpdateCheck(args);
+		RunStartupUpdateCheck(args, bm);
 		string[] normalizedArgs = NormalizeCommandLineArgs(args);
 		ParserResult<object> parserResult = Parser.Default.ParseArguments(normalizedArgs, CommandOption);
 		if (parserResult is Parsed<object> parsed) {
@@ -1095,21 +1095,23 @@ internal class Program {
 			|| string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase));
 	}
 
-	private static void RunStartupUpdateCheck(string[] args) {
+	private static void RunStartupUpdateCheck(string[] args, IServiceProvider serviceProvider) {
 		if (ShouldSkipUpdateCheck(args)) return;
 		try {
+			IAppUpdater appUpdater = serviceProvider.GetRequiredService<IAppUpdater>();
+			ISettingsRepository settingsRepository = serviceProvider.GetRequiredService<ISettingsRepository>();
 			string cacheFolder = SettingsRepository.AppSettingsFolderPath;
-			(bool available, string latestVersion) = AppUpdater
+			(bool available, string latestVersion) = appUpdater
 				.CheckForUpdateWithCacheAsync(cacheFolder)
 				.GetAwaiter().GetResult();
 
 			if (!available || string.IsNullOrEmpty(latestVersion)) return;
 
-			string currentVersion = AppUpdater.GetCurrentVersion();
-			if (AutoUpdate) {
+			string currentVersion = appUpdater.GetCurrentVersion();
+			if (settingsRepository.GetAutoupdate()) {
 				ConsoleLogger.Instance.WriteInfo(
 					$"Updating clio {currentVersion} -> {latestVersion} in background...");
-				AppUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
+				appUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
 			} else {
 				ConsoleLogger.Instance.WriteWarning(
 					$"clio {latestVersion} is available. Run 'clio update' to update.");

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -72,6 +72,7 @@ internal class Program {
 		typeof(GetPackageVersionOptions),
 		typeof(CheckNugetUpdateOptions),
 		typeof(UpdateCliOptions),
+		typeof(SetAutoupdateOptions),
 		typeof(CreateWorkspaceCommandOptions),
 		typeof(RestoreWorkspaceOptions),
 		typeof(PushWorkspaceCommandOptions),
@@ -280,6 +281,7 @@ internal class Program {
 			GetPackageVersionOptions opts => Resolve<GetPackageVersionCommand>().Execute(opts),
 			CheckNugetUpdateOptions opts => Resolve<CheckNugetUpdateCommand>(opts).Execute(opts),
 			UpdateCliOptions opts => Resolve<UpdateCliCommand>(opts).Execute(opts),
+			SetAutoupdateOptions opts => Resolve<SetAutoupdateCommand>().Execute(opts),
 			RestoreWorkspaceOptions opts => Resolve<RestoreWorkspaceCommand>(opts).Execute(opts),
 			CreateWorkspaceCommandOptions opts => Resolve<CreateWorkspaceCommand>(opts).Execute(opts),
 			PushWorkspaceCommandOptions opts => Resolve<PushWorkspaceCommand>(opts).Execute(opts),
@@ -1069,12 +1071,56 @@ internal class Program {
 			Parser.Default.Settings.CustomHelpViewer = bm.GetRequiredService<LocalHelpViewer>();
 		}
 		
+		RunStartupUpdateCheck(args);
 		string[] normalizedArgs = NormalizeCommandLineArgs(args);
 		ParserResult<object> parserResult = Parser.Default.ParseArguments(normalizedArgs, CommandOption);
 		if (parserResult is Parsed<object> parsed) {
 			return ExecuteCommandWithOption(parsed.Value);
 		}
 		return HandleParseError(((NotParsed<object>)parserResult).Errors);
+	}
+
+	private static bool ShouldSkipUpdateCheck(string[] args) {
+		if (IsMcpServerMode) return true;
+		if (args == null || args.Length == 0) return true;
+		string first = args[0];
+		if (string.Equals(first, "update-cli", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "update", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "autoupdate", StringComparison.OrdinalIgnoreCase)) {
+			return true;
+		}
+		foreach (string arg in args) {
+			if (string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static void RunStartupUpdateCheck(string[] args) {
+		if (ShouldSkipUpdateCheck(args)) return;
+		try {
+			string cacheFolder = SettingsRepository.AppSettingsFolderPath;
+			(bool available, string latestVersion) = AppUpdater
+				.CheckForUpdateWithCacheAsync(cacheFolder)
+				.GetAwaiter().GetResult();
+
+			if (!available || string.IsNullOrEmpty(latestVersion)) return;
+
+			string currentVersion = AppUpdater.GetCurrentVersion();
+			if (AutoUpdate) {
+				ConsoleLogger.Instance.WriteInfo(
+					$"Updating clio {currentVersion} -> {latestVersion} in background...");
+				AppUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
+			} else {
+				ConsoleLogger.Instance.WriteWarning(
+					$"clio {latestVersion} is available. Run 'clio update' to update.");
+			}
+		} catch {
+			// startup update check must never crash the tool
+		}
 	}
 
 	private static bool TryHandleBuiltInHelp(string[] args, IServiceProvider serviceProvider, out int exitCode) {

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -1089,14 +1089,10 @@ internal class Program {
 			|| string.Equals(first, "autoupdate", StringComparison.OrdinalIgnoreCase)) {
 			return true;
 		}
-		foreach (string arg in args) {
-			if (string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase)) {
-				return true;
-			}
-		}
-		return false;
+		return args.Any(arg =>
+			string.Equals(arg, "--help", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(arg, "-h", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase));
 	}
 
 	private static void RunStartupUpdateCheck(string[] args) {

--- a/clio/Wiki/WikiAnchors.txt
+++ b/clio/Wiki/WikiAnchors.txt
@@ -7,6 +7,7 @@ add-user-task:add-user-task
 alm-deploy:alm-deploy,deploy
 apply-manifest:apply-manifest,apply-environment-manifest,applym
 assert:assert
+autoupdate:autoupdate
 build-docker-image:build-docker-image
 build-workspace:build-workspace,build,compile,compile-all,rebuild
 call-service:call-service,cs,callservice

--- a/clio/docs/commands/autoupdate.md
+++ b/clio/docs/commands/autoupdate.md
@@ -1,0 +1,70 @@
+# autoupdate
+
+## Command Type
+
+    Application management
+
+## Name
+
+autoupdate - Enable or disable automatic updates on startup
+
+## Synopsis
+
+```bash
+autoupdate [--enable | --disable]
+```
+
+## Description
+
+Controls whether clio automatically checks for and installs newer versions
+in the background each time it starts.
+
+When enabled (the default), clio queries NuGet at most once every 8 hours.
+If a newer version is found, it launches `dotnet tool update clio -g` as a
+background process and immediately continues with the requested command.
+The updated binary becomes active on the next invocation.
+
+When disabled, clio shows a one-line notice that a newer version is
+available and suggests running `clio update` manually.
+
+Running `autoupdate` without arguments displays the current setting.
+
+## Options
+
+```bash
+--enable    Enable automatic updates on startup (default behavior)
+
+--disable   Disable automatic updates on startup
+```
+
+## Examples
+
+```bash
+# Show current autoupdate setting
+autoupdate
+
+# Disable automatic updates
+autoupdate --disable
+
+# Re-enable automatic updates
+autoupdate --enable
+```
+
+## Behavior
+
+- With no flags: prints whether auto-update is currently enabled or disabled
+- --enable: sets Autoupdate = true in appsettings.json and confirms
+- --disable: sets Autoupdate = false in appsettings.json and confirms
+- The update check is cached for 8 hours to avoid hitting NuGet on every run
+- Background update never blocks or delays the current command
+- A network timeout of 3 seconds is applied to the version check
+
+## Exit Codes
+
+    0   Setting applied successfully (or status displayed)
+
+## Reporting Bugs
+
+    https://github.com/Advance-Technologies-Foundation/clio
+
+- [Clio Command Reference](../../Commands.md#autoupdate)


### PR DESCRIPTION
## Summary

- **Startup update check**: on every `clio` invocation clio queries NuGet for a newer version (result cached for 8 h to avoid network overhead on every run)
- **Background auto-update (default ON)**: when a newer version is found and `Autoupdate` is enabled, `dotnet tool update clio -g` is launched as a fire-and-forget process — the current command is **never delayed**; the new binary is active on the next run
- **Opt-out model**: `Settings.Autoupdate` changed to `bool?`; `null` (absent from JSON) resolves to `true`, so existing users get auto-update without touching their config
- **`clio autoupdate` command**: `--enable` / `--disable` to toggle the setting; no flags prints the current state
- Skips the check for `update-cli`, `autoupdate`, `--help`, `--version`, and MCP server mode

## What changed

| File | Change |
|---|---|
| `clio/Common/UpdateCheckCache.cs` | New — persists `LastCheckedUtc` + `LatestVersion` to `update-check.json`; `IsCheckDue()` fires after 8 h |
| `clio/AppUpdater.cs` | `CheckForUpdateWithCacheAsync()` (3 s NuGet timeout, silent on error) + `UpdateInBackgroundAsync()` (FireAndForget) |
| `clio/Environment/ConfigurationOptions.cs` | `Autoupdate`: `bool` → `bool?`; `GetAutoupdate()` returns `?? true`; `SetAutoupdate(bool)` added |
| `clio/Environment/ISettingsRepository.cs` | `SetAutoupdate(bool)` added to interface |
| `clio/Command/Update/SetAutoupdateCommand.cs` | New — verb `autoupdate`, options `--enable` / `--disable` |
| `clio/Program.cs` | `RunStartupUpdateCheck()` wired before command dispatch; `SetAutoupdateOptions` registered |
| `clio/BindingsModule.cs` | `SetAutoupdateCommand` registered as transient |
| `clio/docs/commands/autoupdate.md` | New command documentation |
| `clio/Commands.md`, `clio/Wiki/WikiAnchors.txt` | Entries for `autoupdate` command |

## Test plan

- [ ] `clio push-pkg MyPackage` (or any command) — if NuGet has a newer version, should print `Updating clio X → Y in background...` and proceed normally
- [ ] `clio update` — must not trigger a double-update message
- [ ] `clio autoupdate` — prints current state (enabled by default)
- [ ] `clio autoupdate --disable` → sets `Autoupdate: false` in appsettings.json → next command shows warning instead of background update
- [ ] `clio autoupdate --enable` → restores default behaviour
- [ ] Run twice in quick succession — second run must not hit NuGet (cache hit)
- [ ] All unit tests: `dotnet test --filter "Category=Unit"` → 0 failures

🤖 Generated with [Claude Code](https://claude.ai/claude-code)