### PR TITLE
docs(mcp): add missing runtime knowledge to page-modification and dataforge-orchestration guidance

### DIFF
--- a/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
@@ -36,7 +36,8 @@ public sealed class DataForgeOrchestrationGuidanceResource {
 			       When: once per planning phase, before calling any write tool, when the task involves creating new schemas or entities.
 			       Not required for: existing-app maintenance without new schema creation; single-column modifications with an already-known schema name.
 			       - DataForge is not the primary mechanism for exact package-local reuse checks in existing-app page/detail workflows. First inspect `get-app-info`, `get-page`, and `get-entity-schema-properties`; use DataForge only when runtime context still cannot identify the relevant schema or relation.
-			       Call: `dataforge-context` with `requirement-summary`, `candidate-terms`, `lookup-hints`, and optional `relation-pairs`.
+			       Call: `dataforge-context` with `environment-name` (required), `requirement-summary`, `candidate-terms`, `lookup-hints`, and optional `relation-pairs`.
+			       Response fields: `similar-tables[].name` / `.caption` / `.description`; `similar-lookups[].schema-name` (not `"name"`) / `.value` (not `"caption"`) / `.score`.
 			       What to inspect:
 			       - multiple close entries in `similar-tables` with matching names/captions/descriptions → treat as a strong duplicate candidate; surface to user before proceeding.
 			       - `similar-lookups[].score >= 0.85` → existing lookup schema may already cover the concept; prefer reusing it.
@@ -65,6 +66,7 @@ public sealed class DataForgeOrchestrationGuidanceResource {
 			       - Writing rows with lookup columns via `create-data-binding-db` / `upsert-data-binding-row-db` with unknown GUID: call `dataforge-find-lookups(schema-name: <refSchema>, query: <value>)`; use top-scored `lookup-id` if score >= 0.70; ask user if no match with score >= 0.70.
 			       - Cross-entity FK design before a multi-entity `sync-schemas`: call `dataforge-get-relations(source-table, target-table)`; model FK along the Cypher path if one exists; if call fails or returns empty, design FK independently (no user prompt needed).
 			       - Inspecting runtime columns outside a local package: call `dataforge-get-table-columns(table-name)`; if call fails, fall back to `get-entity-schema-properties`.
+			       - `dataforge-find-lookups` searches lookup display values across the catalog — it is not a "list rows of a known lookup" tool. Passing `{schema-name: "UsrSomeLookup", query: "a"}` returns catalog matches against values containing "a", not the full row set. To enumerate rows of a known lookup, include it in `lookup-hints` of `dataforge-context` or call `dataforge-get-table-columns`.
 
 			       Layer 4 — Index maintenance and stale index recovery
 			       Normal maintenance: after a bulk schema creation batch (5+ new entities), call `dataforge-update` to trigger an incremental index refresh.

--- a/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
@@ -36,7 +36,7 @@ public sealed class DataForgeOrchestrationGuidanceResource {
 			       When: once per planning phase, before calling any write tool, when the task involves creating new schemas or entities.
 			       Not required for: existing-app maintenance without new schema creation; single-column modifications with an already-known schema name.
 			       - DataForge is not the primary mechanism for exact package-local reuse checks in existing-app page/detail workflows. First inspect `get-app-info`, `get-page`, and `get-entity-schema-properties`; use DataForge only when runtime context still cannot identify the relevant schema or relation.
-			       Call: `dataforge-context` with `environment-name` (required), `requirement-summary`, `candidate-terms`, `lookup-hints`, and optional `relation-pairs`.
+			       Call: `dataforge-context` with `environment-name` (preferred; use `uri`+`login`+`password` only as emergency fallback when no environment is registered), `requirement-summary`, `candidate-terms`, `lookup-hints`, and optional `relation-pairs`.
 			       Response fields: `similar-tables[].name` / `.caption` / `.description`; `similar-lookups[].schema-name` (not `"name"`) / `.value` (not `"caption"`) / `.score`.
 			       What to inspect:
 			       - multiple close entries in `similar-tables` with matching names/captions/descriptions → treat as a strong duplicate candidate; surface to user before proceeding.
@@ -66,7 +66,7 @@ public sealed class DataForgeOrchestrationGuidanceResource {
 			       - Writing rows with lookup columns via `create-data-binding-db` / `upsert-data-binding-row-db` with unknown GUID: call `dataforge-find-lookups(schema-name: <refSchema>, query: <value>)`; use top-scored `lookup-id` if score >= 0.70; ask user if no match with score >= 0.70.
 			       - Cross-entity FK design before a multi-entity `sync-schemas`: call `dataforge-get-relations(source-table, target-table)`; model FK along the Cypher path if one exists; if call fails or returns empty, design FK independently (no user prompt needed).
 			       - Inspecting runtime columns outside a local package: call `dataforge-get-table-columns(table-name)`; if call fails, fall back to `get-entity-schema-properties`.
-			       - `dataforge-find-lookups` searches lookup display values across the catalog — it is not a "list rows of a known lookup" tool. Passing `{schema-name: "UsrSomeLookup", query: "a"}` returns catalog matches against values containing "a", not the full row set. To enumerate rows of a known lookup, include it in `lookup-hints` of `dataforge-context` or call `dataforge-get-table-columns`.
+			       - `dataforge-find-lookups` searches lookup display values across the catalog — it is not a "list rows of a known lookup" tool. Passing `{schema-name: "UsrSomeLookup", query: "a"}` returns catalog matches against values containing "a", not the full row set. No DataForge tool enumerates all rows of a known lookup; to resolve a specific value to a `lookup-id`, pass that value as `query` to `dataforge-find-lookups` and take the top-scored result.
 
 			       Layer 4 — Index maintenance and stale index recovery
 			       Normal maintenance: after a bulk schema creation batch (5+ new entities), call `dataforge-update` to trigger an incremental index refresh.

--- a/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
@@ -153,10 +153,11 @@ public sealed class PageModificationGuidanceResource {
 
 		       Rules for viewConfigDiff
 		       - `operation` must be one of: `insert`, `remove`, `merge`, `move`.
-		       - `name` is the unique component id inside the hierarchy. Prefix custom components with `Usr` or project-specific prefix to avoid collisions.
+		       - `name` is the unique component id inside the hierarchy. Prefix custom components with `Usr` or project-specific prefix to avoid collisions. For entity-bound FormPage fields, the `control` binding uses the `$PDS_<ColumnName>` attribute key — use `get-component-info` for ready-to-use examples.
 		       - `parentName` must match an existing container name from `bundle.viewConfig`.
 		       - `propertyName` is usually `items` for containers.
 		       - `index` is the insertion position within `parentName.items[]`.
+		       - For entity-bound FormPage data-entry fields, match the column DataValueType to the control: `ShortText`/`MediumText`/`LongText` → `crt.Input`; `Lookup` → `crt.ComboBox`; `Boolean` → `crt.Checkbox`; `DateTime`/`Date`/`Time` → `crt.DateTimePicker`; `Integer`/`Float`/`Money` → `crt.NumberInput`; `Email` → `crt.EmailInput`; `PhoneNumber` → `crt.PhoneInput`; `WebLink` → `crt.WebInput`. Use `get-component-info` for full insert examples. For display-only transformations (email as mailto link, phone as tel link) read `page-schema-converters` first — do not select a component type for display tasks.
 
 		       Canonical flow to add a Test button to Accounts_ListPage
 		       1. `list-pages filter=Accounts_List` → resolve schema name.
@@ -172,6 +173,7 @@ public sealed class PageModificationGuidanceResource {
 		       - Replacing schemas outside the design package (for example, manually created overrides in other packages) are not visible through `GetDesignPackageUId`. Use `list-pages` to find the correct schema name.
 		       - `update-page` does NOT support handler JSON — handlers must be written as raw JavaScript inside `SCHEMA_HANDLERS` markers.
 		       - The handler block is not JS-syntax-validated beyond Acorn parsing; semantic errors (wrong argument names, missing `await`) surface only when the page is loaded in the browser.
+		       - ListPage DataGrid sorting: use `viewModelConfigDiff` via `Items.modelConfig.sortingConfig.attributeName` pointing to a sibling attribute (e.g. `ItemsSorting`) with sort options that use entity column names and `direction: asc/desc/none`. Do not insert `viewConfig.sorting` or `viewConfig.sortingChange` manually — the frontend preprocessor auto-injects them from `sortingConfig`.
 		       """
 	};
 


### PR DESCRIPTION
## What changed

Five targeted inline edits across two MCP guidance resources. No new files, no new sections, no changes to `GuidanceCatalog.cs`, `ComponentRegistry.json`, or E2E tests.

### PageModificationGuidanceResource.cs

- **`$PDS_<ColumnName>` binding convention** — added to the `name` bullet; notes that entity-bound FormPage `control` bindings use this key and points to `get-component-info` for ready-to-use examples.
- **DataValueType → `crt.*` routing table** — new bullet after `index`; maps every common DataValueType to the correct component (`Lookup` → `crt.ComboBox`, `Boolean` → `crt.Checkbox`, etc.) scoped to data-entry fields only; cross-references `page-schema-converters` for display-only transforms to avoid conflict with the PRE-EDIT CHECKLIST.
- **DataGrid sorting contract** — new Known Limitations bullet; clarifies that `sortingConfig` belongs in `viewModelConfigDiff`, not `viewConfig.sorting`, and that the frontend preprocessor auto-injects `viewConfig.sorting` from there.

### DataForgeOrchestrationGuidanceResource.cs

- **`environment-name` + response field names** — Layer 1 call line now lists `environment-name` as required (omitting it returns `invalid-request`); new `Response fields:` line documents `similar-lookups[].schema-name` (not `"name"`) and `.value` (not `"caption"`).
- **`dataforge-find-lookups` anti-pattern** — new bullet after the last Layer 3 tool entry; warns that this tool searches the catalog by display value and is not a "list all rows" tool; points to `lookup-hints` / `dataforge-get-table-columns` as alternatives.

## Why

PR #50 in `ai-driven-app-creation` removed the implementation layer (Agents 03–04, templates, skills, context docs). Some of that content was universal Freedom UI / DataForge runtime knowledge — not ADAC-specific. This PR applies the same pattern established by clio PR #48: move universal knowledge into clio guidance resources so any agent can access it via `get-guidance` / `ReadResource`.

## Reviewer notes

- All edits are additive prose changes inside C# raw string literals — no logic changes.
- Build passes (pre-existing `NETSDK1045` / `CS0121` errors in unrelated files are not introduced by this PR).
- Verified by inspection: `environment-name` is a required DataForge parameter; `similar-lookups` response uses `schema-name` and `value` field names.