### PR TITLE
fix(ENG-89241): send group field in SaveSchema payload so pages open in correct designer

### DIFF
--- a/clio.tests/Command/PageCreateCommandTests.cs
+++ b/clio.tests/Command/PageCreateCommandTests.cs
@@ -159,6 +159,7 @@ public sealed class PageCreateCommandTests {
 		response.TemplateName.Should().Be(TemplateName);
 		response.PackageUId.Should().Be(PackageUId);
 		response.Caption.Should().Be("Demo page");
+		response.SchemaType.Should().Be(9);
 		_applicationClient.Received(1).ExecutePostRequest(SaveSchemaUrl, Arg.Is<string>(s => s.Contains(TemplateUId)));
 	}
 

--- a/clio.tests/Command/PageCreateCommandTests.cs
+++ b/clio.tests/Command/PageCreateCommandTests.cs
@@ -160,7 +160,8 @@ public sealed class PageCreateCommandTests {
 		response.PackageUId.Should().Be(PackageUId);
 		response.Caption.Should().Be("Demo page");
 		response.SchemaType.Should().Be(9);
-		_applicationClient.Received(1).ExecutePostRequest(SaveSchemaUrl, Arg.Is<string>(s => s.Contains(TemplateUId)));
+		_applicationClient.Received(1).ExecutePostRequest(SaveSchemaUrl,
+			Arg.Is<string>(s => s.Contains(TemplateUId) && s.Contains("\"extendParent\":true")));
 	}
 
 	[Test]

--- a/clio.tests/Command/PageCreateCommandTests.cs
+++ b/clio.tests/Command/PageCreateCommandTests.cs
@@ -161,7 +161,9 @@ public sealed class PageCreateCommandTests {
 		response.Caption.Should().Be("Demo page");
 		response.SchemaType.Should().Be(9);
 		_applicationClient.Received(1).ExecutePostRequest(SaveSchemaUrl,
-			Arg.Is<string>(s => s.Contains(TemplateUId) && s.Contains("\"extendParent\":true")));
+			Arg.Is<string>(s => s.Contains(TemplateUId)
+				&& s.Contains("\"extendParent\":false")
+				&& s.Contains("\"group\":\"Page\"")));
 	}
 
 	[Test]

--- a/clio/Command/McpServer/Resources/PageCreationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageCreationGuidanceResource.cs
@@ -66,10 +66,21 @@ public sealed class PageCreationGuidanceResource {
 			       - Missing entity: if `entity-schema-name` is supplied but the entity schema does not exist, the call is rejected before the page is created.
 			       - Post-create verification: `create-page` does not run AI sampling. Use `get-page` after success to confirm the schema loads.
 
+			       create-page response fields
+			       - `schemaType` — integer schema type from the template used: 9 = Freedom UI web page, 10 = mobile page.
+			       - `templateName` — name of the template (e.g. `BlankPageTemplate`, `BaseHomePage`).
+
+			       Designer type mapping
+			       - `BaseHomePage` (schemaType=9): opens in the **Homepage designer**. Do NOT use the standard Freedom UI page designer URL for this template.
+			       - All other schemaType=9 templates (BlankPageTemplate, PageWithTabsFreedomTemplate, BaseMiniPageTemplate, ListPageV3Template, etc.): open in the **Freedom UI page designer**.
+			       - schemaType=10 mobile templates: open in the **Mobile page designer**.
+			       - IMPORTANT: Do NOT guess or construct a browser designer URL based only on `schemaUId`. Use `templateName` and `schemaType` from the response to determine the correct designer. If unsure, call `get-page` to verify the created page loaded correctly — that is sufficient; the user can open the designer themselves from Workspace Explorer.
+
 			       Do NOT
 			       - Do not create `__FormPage`-style clone names when a matching page already exists. Prefer editing the existing page via `sync-pages`.
 			       - Do not bypass `list-page-templates`; the catalog reflects the active environment feature flags and may change.
 			       - Do not assume `create-page` creates an app section. Use `create-app-section` when the requested outcome is "add a new section" rather than "add a standalone Freedom UI page".
+			       - Do not construct a browser designer URL after `create-page` without checking `templateName` in the response. Using the Homepage designer URL for non-homepage pages (or vice versa) opens the wrong designer.
 			       """
 		};
 }

--- a/clio/Command/PageCreateOptions.cs
+++ b/clio/Command/PageCreateOptions.cs
@@ -222,7 +222,7 @@ namespace Clio.Command {
 					["uId"] = template.UId,
 					["name"] = template.Name
 				},
-				["extendParent"] = false,
+				["extendParent"] = true,
 				["body"] = string.Empty,
 				["localizableStrings"] = new JArray(),
 				["parameters"] = new JArray(),

--- a/clio/Command/PageCreateOptions.cs
+++ b/clio/Command/PageCreateOptions.cs
@@ -135,6 +135,7 @@ namespace Clio.Command {
 					PackageUId = packageUId,
 					TemplateName = template.Name,
 					TemplateUId = template.UId,
+					SchemaType = template.SchemaType,
 					Caption = caption,
 					EntitySchemaName = options.EntitySchemaName,
 					EntitySchemaUId = entitySchemaUId

--- a/clio/Command/PageCreateOptions.cs
+++ b/clio/Command/PageCreateOptions.cs
@@ -208,26 +208,34 @@ namespace Clio.Command {
 			var schema = new JObject {
 				["uId"] = newSchemaUId,
 				["name"] = schemaName,
+				["isReadOnly"] = false,
+				["useFullHierarchy"] = false,
+				["userLevelSchema"] = false,
+				["addonTypes"] = new JArray("AppearanceSettings", "Sidebar", "BusinessRule"),
+				["package"] = new JObject {
+					["uId"] = packageUId,
+					["name"] = packageName
+				},
+				["body"] = string.Empty,
+				["extendParent"] = false,
 				["caption"] = new JArray { localizableCaption },
 				["description"] = string.IsNullOrWhiteSpace(description) ? new JArray() : new JArray(new JObject {
 					["cultureName"] = "en-US",
 					["value"] = description
 				}),
-				["package"] = new JObject {
-					["uId"] = packageUId,
-					["name"] = packageName
-				},
-				["managerName"] = ClientUnitManagerName,
+				["localizableStrings"] = new JArray(),
+				["parameters"] = new JArray(),
+				["messages"] = new JArray(),
+				["images"] = new JArray(),
+				["optionalProperties"] = new JArray(),
+				["group"] = template.GroupName,
+				["schemaType"] = template.SchemaType,
+				["schemaVersion"] = 1,
 				["parent"] = new JObject {
 					["uId"] = template.UId,
 					["name"] = template.Name
 				},
-				["extendParent"] = true,
-				["body"] = string.Empty,
-				["localizableStrings"] = new JArray(),
-				["parameters"] = new JArray(),
-				["messages"] = new JArray(),
-				["images"] = new JArray()
+				["less"] = string.Empty
 			};
 			if (!string.IsNullOrWhiteSpace(entitySchemaUId)) {
 				schema["dependsOn"] = new JArray(new JObject {

--- a/clio/Command/PageModels.cs
+++ b/clio/Command/PageModels.cs
@@ -789,6 +789,17 @@ public sealed class PageCreateResponse {
 	[System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string EntitySchemaUId { get; set; }
 
+	/// <summary>
+	/// Schema type of the template used to create this page.
+	/// 9 = Freedom UI web page (use the Freedom UI page designer).
+	/// 10 = mobile page (use the mobile page designer).
+	/// Note: <c>BaseHomePage</c>-based pages have schemaType=9 but require the Homepage designer, not the standard page designer.
+	/// </summary>
+	[DataMember(Name = "schemaType")]
+	[JsonProperty("schemaType")]
+	[JsonPropertyName("schemaType")]
+	public int SchemaType { get; set; }
+
 	[DataMember(Name = "error")]
 	[JsonProperty("error")]
 	[JsonPropertyName("error")]

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.8</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.9</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>


### PR DESCRIPTION
## Summary

- **Root cause**: `BuildSaveSchemaPayload` in `PageCreateCommand` was missing the `group` field (and several other fields like `schemaType`, `schemaVersion`, `addonTypes`, `isReadOnly`, `useFullHierarchy`, `userLevelSchema`, `optionalProperties`, `less`) that real browser payloads always include. Without `group`, the platform stored the schema with `group=None` and fell back to the **Homepage designer** for every newly created page regardless of template.
- **Fix**: Rewrote `BuildSaveSchemaPayload` to include all fields from a real browser `SaveSchema` request. The key field is `["group"] = template.GroupName`, which correctly routes the page to Freedom UI page designer (`Page`, `MiniPage`, `Sidebar`), Homepage designer (`Dashboard`), or Mobile designer (`MobilePage`).
- **`extendParent`**: Kept as `false` for new pages created from templates (correct). `extendParent=true` is only for replacing schemas in `update-page`.
- **Response enrichment**: Added `schemaType` to `PageCreateResponse` so callers can determine the correct designer without a follow-up lookup.
- **Guidance update**: `PageCreationGuidanceResource` now documents the `schemaType`/`templateName` response fields and the designer-type mapping.

Fixes [ENG-89241](https://creatio.atlassian.net/browse/ENG-89241) (sub-bug of ENG-88189).

## Test plan

- [x] All existing `PageCreateCommandTests` pass (11/11)
- [x] `TryCreatePage_Happy_Path_Posts_SaveSchema_And_Returns_SchemaUId` asserts `"extendParent":false` and `"group":"Page"` in SaveSchema payload, verifies `response.SchemaType == 9`
- [x] Manual: created 5 pages via new clio on `localhost:5001`, verified `group` field via `GetSchema`:
  - `UsrDemo_BlankPage` → `group=Page` ✅
  - `UsrDemo_MiniPage` → `group=MiniPage` ✅
  - `UsrDemo_HomePage` → `group=Dashboard` ✅
  - `UsrDemo_SidebarPage` → `group=Sidebar` ✅
  - `UsrDemo_MobilePage` → `group=MobilePage` ✅
- [x] Old clio v8.1.0.8 on same environment: all pages created with `group=None` ❌ (confirmed bug)
- [x] `update-page` (replacing schema): verified 3 cases — `group` inherited correctly, `extendParent=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)