### PR TITLE
feat(mcp): add uid filter to list-pages and uId to list-packages

### DIFF
--- a/clio/Command/McpServer/McpServerInstructions.cs
+++ b/clio/Command/McpServer/McpServerInstructions.cs
@@ -58,6 +58,17 @@ internal static class McpServerInstructions
 		  and `*-by-credentials` (takes raw URL/username/password). Prefer the environment-name variant.
 		- Read the `docs://help/command/{CommandName}` resources for detailed usage of any command.
 
+		### Edit a page from a Creatio designer URL
+		A Freedom UI designer URL is one of:
+		- `#/PageDesigner/<pageUId>` — first edit of a page that lives in a locked package; the backend will create a virtual replacing package automatically on first save.
+		- `#/PageDesigner/<pageUId>?packageUId=<packageUId>` — subsequent edit of an already-replaced page; the URL's packageUId points to the existing substitution.
+
+		Canonical flow in BOTH cases:
+		1. Identify the active environment from the host — use `list-environments` to confirm the matching `environment-name`.
+		2. Call `list-pages uid=<pageUId>` — returns the exact page with its `schema-name` and `packageName` in one call.
+		3. Call `get-page schema-name=<matched schema-name>` to retrieve the editable body and bundle.
+		4. Call `update-page schema-name=<matched schema-name> body=<...>` to save. Do NOT pass `target-package-uid`: the backend's `GetDesignPackageUId` resolves the correct package automatically — it materializes a virtual package on first save (locked-source case) or reuses the existing replacing package (already-substituted case). Each platform package has a deterministic owning app, so there is no ambiguity to override.
+
 		## Error handling
 		- Every tool response includes a `correlation-id` for tracing.
 		- Errors include the full exception chain. Look at inner exceptions for root cause.

--- a/clio/Command/McpServer/Resources/GuidanceCatalog.cs
+++ b/clio/Command/McpServer/Resources/GuidanceCatalog.cs
@@ -43,6 +43,10 @@ internal static class GuidanceCatalog {
 				"page-schema-validators",
 				"Canonical MCP guidance for creating and editing Freedom UI page validators inside raw page schema bodies.",
 				PageSchemaValidatorsGuidanceResource.Guide),
+			["page-modification"] = Create(
+				"page-modification",
+				"Canonical MCP guidance for Freedom UI page modification: replacing-schema concept, bundle.json structure, update-page write modes, multi-app target-package-uid resolution, and container selection.",
+				PageModificationGuidanceResource.Guide),
 			["agent-execution"] = Create(
 				"agent-execution",
 				"Canonical MCP guidance for executing approved plans through clio MCP: transport, execution order, branching, and recovery patterns.",

--- a/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
@@ -53,14 +53,34 @@ public sealed class PageModificationGuidanceResource {
 		       - `page` — metadata of the editable replacing schema: `schemaName`, `schemaUId`, `packageName`, `packageUId`, `parentSchemaName`.
 		       - `raw.body` — full JavaScript body of the replacing schema (with markers). Read-only reference; see the CRITICAL warning below before reusing it as the write payload.
 		       - `bundle` — read-only merged view across the full hierarchy. Do not send `bundle` or `bundle.viewConfig` as the body payload.
-		       - `bundle.containers` — flat list of usable `parentName` values.
 
-		       CRITICAL — multi-app replacements and target-package-uid
-		       - Many platform pages are replaced by MULTIPLE apps (for example `Opportunities_ListPage` is replaced by both `CrtLeadOppMgmt` and `CrtWaterfallPipelineInLeadOppMgmt`). Each replacement lives in a different design package.
-		       - `get-page` returns the most-derived replacement plus `page.designPackageUId` — the package where `update-page` will save by default. If `page.willCreateReplacingInDesignPackage` is `true`, a NEW replacing schema will be materialized in the design package.
-		       - The auto-picked design package comes from the user's currently active app. If the wrong app wins the resolution, the saved button never shows up in the workspace the user is actually viewing.
-		       - When in doubt, pass `target-package-uid` explicitly to `update-page`. Discover the candidate packages via `list-pages` (shows every schema named `Opportunities_ListPage` with its package) and pick the one owned by the workplace where the user expects the change.
-		       - Symptom if the wrong package is picked: `update-page` returns `success: true` but the button is absent at runtime, the designer URL hangs or loads an empty page, and Workspace Explorer shows the page in an unexpected package.
+		       bundle.json shape (top-level keys)
+		       - `name` — string, the page schema name.
+		       - `viewConfig` — ARRAY container that wraps the merged root tree as its single element. By design: in `body.js`, `viewConfigDiff` is an array of operations; in `bundle.json`, `viewConfig` holds the result of applying those diffs, wrapped as `[ rootObject ]`. Walk it as `.viewConfig[0]` for the merged root, or `.viewConfig | .. | objects | ...` for recursive search.
+		       - `containers` — ARRAY of objects `{ name, type, childCount, path }`, NOT a keyed object. Use `.containers[]`, never `.containers | keys[]` or `.containers | to_entries[]`.
+		       - `resources` — nested object (localizable strings); not flat — `to_entries` plus `@tsv` will fail on nested values.
+		       - `handlers`, `converters`, `validators` — plain JavaScript SOURCE STRINGS, not parsed JSON. Read with `jq -r '.handlers'`.
+		       - `viewModelConfig`, `modelConfig`, `optionalProperties`, `parameters` — structured (object/array) merged metadata.
+
+		       jq recipes for bundle.json
+		       - Find a tab or container by name pattern (use `containers`, the index):
+		         `jq '.containers[] | select(.name | test("Sales"; "i"))' .clio-pages/<schema>/bundle.json`
+		       - List all tab containers:
+		         `jq '.containers[] | select(.type == "crt.TabContainer") | {name, path, childCount}' .clio-pages/<schema>/bundle.json`
+		       - Read the merged root object:
+		         `jq '.viewConfig[0]' .clio-pages/<schema>/bundle.json`
+		       - Find a node deep in viewConfig by name (recursive):
+		         `jq '.viewConfig | .. | objects | select(.name? == "SalesTab")' .clio-pages/<schema>/bundle.json`
+		       - Resolve a parent path for a known node:
+		         `jq '.containers[] | select(.name == "SalesTab") | .path' .clio-pages/<schema>/bundle.json`
+		       - Inspect handler source code:
+		         `jq -r '.handlers' .clio-pages/<schema>/bundle.json`
+		       Always use `.containers[]` (array iteration) and `.viewConfig[0]` for the merged root. Casting through `keys`, `to_entries`, or `@csv`/`@tsv` on these structures produces the errors `"object is not valid in a csv row"` or `"number cannot be matched, as it is not a string"`.
+
+		       Design-package resolution (trust the backend)
+		       - `get-page` returns `page.designPackageUId` — the package where `update-page` will save. `page.willCreateReplacingInDesignPackage: true` means a NEW replacing schema will be materialized on save (the package itself is virtual until then; the backend creates it from the cached `AppVirtualPackageInfo` at SaveSchema time).
+		       - The backend resolves the design package deterministically from the locked schema's owning app via `SysPackageInInstalledApp` — there is no per-user "active app" to manage and no ambiguity between installed apps.
+		       - Do NOT pass `target-package-uid` in normal flows. The override exists for niche scenarios where you have already discovered a specific replacing schema (for example via `list-pages` filtered by name) and want to bypass hierarchy resolution; otherwise, omit it and let the backend pick.
 
 		       update-page write modes
 		       - `mode: "replace"` (default): the body you pass replaces the schema body verbatim. Use only when composing the full schema body from scratch. All six marker pairs must be present.

--- a/clio/Command/McpServer/Tools/GetPkgListTool.cs
+++ b/clio/Command/McpServer/Tools/GetPkgListTool.cs
@@ -54,7 +54,8 @@ public sealed class GetPkgListTool(
 			.Select(package => new PackageListItemResult(
 				package.Descriptor.Name,
 				package.Descriptor.PackageVersion,
-				package.Descriptor.Maintainer))
+				package.Descriptor.Maintainer,
+				package.Descriptor.UId.ToString()))
 			.ToList();
 	}
 }
@@ -79,4 +80,5 @@ public sealed record GetPkgListArgs(
 public sealed record PackageListItemResult(
 	[property: JsonPropertyName("name")] string Name,
 	[property: JsonPropertyName("version")] string Version,
-	[property: JsonPropertyName("maintainer")] string Maintainer);
+	[property: JsonPropertyName("maintainer")] string Maintainer,
+	[property: JsonPropertyName("uId")] string UId);

--- a/clio/Command/McpServer/Tools/GuidanceGetTool.cs
+++ b/clio/Command/McpServer/Tools/GuidanceGetTool.cs
@@ -33,7 +33,7 @@ public sealed class GuidanceGetTool {
 	/// Resolves one named guidance article and returns its plain-text content.
 	/// </summary>
 	[McpServerTool(Name = ToolName, ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
-	[Description("Returns a named clio MCP guidance article, or lists all available guide names when the requested name is unknown. Known names include: app-modeling, existing-app-maintenance, dataforge-orchestration, page-schema-handlers, page-schema-creatio-devkit-common, page-schema-validators.")]
+	[Description("Returns a named clio MCP guidance article, or lists all available guide names when the requested name is unknown. Known names include: app-modeling, existing-app-maintenance, dataforge-orchestration, page-modification, page-schema-handlers, page-schema-creatio-devkit-common, page-schema-validators.")]
 	public Task<GuidanceGetResponse> GetGuidance(
 		[Description("Parameters: name (required). Use one of the known guidance names such as page-schema-handlers, page-schema-creatio-devkit-common, page-schema-validators, or existing-app-maintenance.")]
 		[Required] GuidanceGetArgs args,

--- a/clio/Command/McpServer/Tools/PageGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageGetTool.cs
@@ -23,6 +23,7 @@ public sealed class PageGetTool(
 		"Get a Freedom UI page. Writes body.js / bundle.json / meta.json to .clio-pages/{schema-name}/ in the working directory and returns file paths. " +
 		"body.js contains the EDITABLE own-body of the replacing schema in the design package (empty template when no replacing schema exists yet) — this is what update-page should receive. " +
 		"bundle.json contains the full merged view of the entire hierarchy and is the correct source for reading what components are on the page. " +
+		"IMPORTANT: bundle.json is a JSON document. Use a JSON parsing tool (jq, PowerShell ConvertFrom-Json, Python json.load) to navigate it; do NOT rely on grep or line-oriented text search — it is typically minified to a single line. " +
 		"Prefer `environment-name`; keep direct connection args only for bootstrap or emergency fallback flows. " +
 		"Before editing the returned raw.body: " +
 		"if the task involves display-only value transformation (email as mailto link, phone as tel link, text to uppercase, boolean inversion, number formatting, any value that should look different on screen without changing the underlying model) call get-guidance with name `page-schema-converters` first — this determines whether a converter is the right tool before touching any component type; " +

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -53,6 +53,7 @@ public sealed class PageListTool(
 			AppCode = args.Code,
 			SearchPattern = args.SearchPattern,
 			Limit = args.Limit ?? 50,
+			UId = args.UId,
 			Environment = args.EnvironmentName,
 			Uri = args.Uri,
 			Login = args.Login,
@@ -127,7 +128,11 @@ public sealed record PageListArgs(
 	string? Login,
 	[property: JsonPropertyName("password")]
 	[property: Description("Direct Creatio password paired with `uri`. Emergency fallback only.")]
-	string? Password
+	string? Password,
+
+	[property: JsonPropertyName("uid")]
+	[property: Description("Filter by schema UId (exact match). Use to locate a specific page directly from its UId in a Creatio designer URL (#/PageDesigner/<pageUId>).")]
+	string? UId = null
 ) {
 	[JsonExtensionData]
 	public Dictionary<string, JsonElement>? ExtensionData { get; init; }

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -20,6 +20,9 @@ namespace Clio.Command {
 
 		[Option("limit", Required = false, Default = 50, HelpText = "Maximum number of results")]
 		public int Limit { get; set; }
+
+		[Option("uid", Required = false, HelpText = "Filter by schema UId (exact match)")]
+		public string UId { get; set; }
 	}
 
 	public class PageListCommand : Command<PageListOptions> {
@@ -70,6 +73,9 @@ namespace Clio.Command {
 				string nameFilter = options.SearchPattern?.Trim('*', ' ') ?? string.Empty;
 				if (!string.IsNullOrWhiteSpace(nameFilter)) {
 					filters[ItemsKey]["Name"] = BuildComparisonFilter("Name", nameFilter, 1, ContainsComparisonType);
+				}
+				if (!string.IsNullOrWhiteSpace(options.UId)) {
+					filters[ItemsKey]["UId"] = BuildComparisonFilter("UId", options.UId, 1, 3);
 				}
 				var selectQuery = new JObject {
 					["rootSchemaName"] = "SysSchema",

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -75,7 +75,7 @@ namespace Clio.Command {
 					filters[ItemsKey]["Name"] = BuildComparisonFilter("Name", nameFilter, 1, ContainsComparisonType);
 				}
 				if (!string.IsNullOrWhiteSpace(options.UId)) {
-					filters[ItemsKey]["UId"] = BuildComparisonFilter("UId", options.UId, 1, 3);
+					filters[ItemsKey]["UId"] = BuildComparisonFilter("UId", options.UId, 0, 3);
 				}
 				var selectQuery = new JObject {
 					["rootSchemaName"] = "SysSchema",


### PR DESCRIPTION
## Summary
Improves clio MCP so that an AI agent given a Creatio designer URL (`#/PageDesigner/<pageUId>?packageUId=<packageUId>`) can locate and edit the page in **one** call instead of enumerating packages. Also fixes stale guidance that pushed AI to pass `target-package-uid` when the backend already resolves the design package correctly.

## What changed
- **`list-pages`**: new optional `uid` filter — exact-match `SysSchema.UId`. Lets AI resolve the schema directly from the URL's `pageUId`. ([PageListOptions.cs](clio/Command/PageListOptions.cs), [PageListTool.cs](clio/Command/McpServer/Tools/PageListTool.cs))
- **`list-packages`**: response items now expose `uId` from `PackageDescriptor`, enabling `packageUId` → `packageName` lookups when needed. ([GetPkgListTool.cs](clio/Command/McpServer/Tools/GetPkgListTool.cs))
- **`get-page` description**: warns that `bundle.json` is a JSON document — use `jq`/`ConvertFrom-Json`, not grep. ([PageGetTool.cs](clio/Command/McpServer/Tools/PageGetTool.cs))
- **`McpServerInstructions`**: new "Edit a page from a designer URL" workflow with both URL shapes (locked-source, already-substituted). Explicitly says do NOT pass `target-package-uid`; trust backend `GetDesignPackageUId` (deterministic via `SysPackageInInstalledApp`).
- **`page-modification` guidance**: now registered in `GuidanceCatalog` so AI can fetch it via `get-guidance` (previously only an MCP resource — invisible to most clients). ([GuidanceCatalog.cs](clio/Command/McpServer/Resources/GuidanceCatalog.cs), [GuidanceGetTool.cs](clio/Command/McpServer/Tools/GuidanceGetTool.cs))
- **`PageModificationGuidanceResource`**: replaced stale "CRITICAL — multi-app replacements" section (the platform's `FindPackageApp`/`GetOrInitAppCurrentPackage` is deterministic — no ambiguity). Added concrete `bundle.json` shape (containers ARRAY, viewConfig array-wrapped merged root, handlers-as-JS-source) with `jq` recipes that avoid the common `keys`/`to_entries`/`@tsv` pitfalls.

## Why
Real Codex CLI session log of `add text NEW in the Sales tab <designer URL>`:
- **Before**: `list-pages search-pattern="*" limit=200` → `clio list-pages --help` (CLI exec) → `clio list-pages --limit 5000 | rg "<schemaUId>"` → `get-page` → `update-page target-package-uid="<...>"`.
- **After**: `list-pages uid=<pageUId>` → `get-page` → `get-guidance name=page-modification` → `sync-pages` (no `target-package-uid`).

## Test plan
- [x] `dotnet build clio/clio.csproj -p:TargetFrameworks=net8.0 -c Debug` — clean
- [x] Verified end-to-end against `localhost:5001`: `list-pages uid=...` returns the exact substitution row; `get-page` + `sync-pages` updates page in-place when substitution exists in unlocked package
- [x] Codex CLI session after rebuild used the new flow with `uid` filter and `get-guidance name=page-modification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)