### PR TITLE
Release 8.1.0.11 — Converter Prefix Validation in AI Instructions

### DIFF
--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.10</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.11</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>


### PR DESCRIPTION
## What's new in 8.1.0.11 🚀

### ✅ Converter prefix validation (ENG-88747)

When AI agents author Freedom UI pages, clio now catches converter
registrations that are missing a vendor prefix (e.g. `MyConverter`
instead of `usr.MyConverter`) — before the page is saved.

**Why:** without the prefix, the page saves successfully but breaks at
runtime with a Creatio registration error. Validating client-side
prevents the AI agent from shipping pages that fail only after deployment.

The check runs in `validate-page`, `update-page`, and `sync-pages`.

---

**Full changelog:** https://github.com/Advance-Technologies-Foundation/clio/compare/8.1.0.10...8.1.0.11