### PR TITLE
fix(page-bundle): apply merge diffs targeting the bundle root

### DIFF
--- a/clio.tests/Command/PageJsonPathDiffApplierTests.cs
+++ b/clio.tests/Command/PageJsonPathDiffApplierTests.cs
@@ -56,4 +56,29 @@ public sealed class PageJsonPathDiffApplierTests {
 		items[1]!["_id"]!.ToString().Should().Be("Field2",
 			because: "insert should resolve the aliased parent container before appending the new item");
 	}
+
+	[Test]
+	[Description("Apply merges into the root object when the operation path is empty")]
+	public void Apply_WhenMergeOperationHasEmptyPath_MergesValuesIntoRoot() {
+		IPageJsonPathDiffApplier applier = new PageJsonPathDiffApplier();
+		JObject source = new();
+		JArray operations = [
+			new JObject {
+				["operation"] = "merge",
+				["path"] = new JArray(),
+				["values"] = new JObject {
+					["attributes"] = new JObject {
+						["UsrName"] = new JObject {
+							["modelConfig"] = new JObject {
+								["path"] = "PDS.UsrName"
+							}
+						}
+					}
+				}
+			}
+		];
+		JObject result = applier.Apply(source, operations);
+		result["attributes"]!["UsrName"]!["modelConfig"]!["path"]!.ToString().Should().Be("PDS.UsrName",
+			because: "a merge with an empty path must apply values to the root, otherwise viewModelConfig and modelConfig stay empty in the bundle");
+	}
 }

--- a/clio/Command/PageBundleMergeHelpers.cs
+++ b/clio/Command/PageBundleMergeHelpers.cs
@@ -20,6 +20,14 @@ internal static class PageBundleMergeHelpers {
 		return result;
 	}
 
+	public static void MergeInPlace(JObject target, JObject next) {
+		if (target is null || next is null) {
+			return;
+		}
+
+		target.Merge(next, MergeSettings);
+	}
+
 	public static JsonObject ToJsonObject(JObject token) {
 		return ToJsonNode(token) as JsonObject ?? [];
 	}

--- a/clio/Command/PageJsonPathDiffApplier.cs
+++ b/clio/Command/PageJsonPathDiffApplier.cs
@@ -39,8 +39,7 @@ internal sealed class PageJsonPathDiffApplier : IPageJsonPathDiffApplier {
 	private static void Merge(JObject root, JObject operation) {
 		PageJsonPathTarget target = ResolveTarget(root, operation);
 		if (target.Token is JObject targetObject && operation[ValuesPropertyName] is JObject values) {
-			JObject merged = PageBundleMergeHelpers.DeepMerge(targetObject, values);
-			ReplaceToken(target, merged);
+			PageBundleMergeHelpers.MergeInPlace(targetObject, values);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `clio get-page` returned bundles where `viewModelConfig` and `modelConfig` were always `{}` even when `ownBodySummary` reported diff operations — blocker for page-business-rules tooling that needs those fields to discover attributes and validate `dataValueType`.
- Root cause: `PageJsonPathDiffApplier.Merge` computed the merged `JObject` via `DeepMerge` and tried to splice it back via `ReplaceToken`. `ReplaceToken` only handles a target with a non-null parent, so for diff entries with `path: []` (where the target is the root itself) the merged result was silently dropped. `PageBundleBuilder.BuildConfig` feeds `viewModelConfigDiff` / `modelConfigDiff` into an empty root, and those diffs start with such an empty-path merge — so every call lost the merged content.
- Fix: switched `Merge` to mutate the target object in place via a new `PageBundleMergeHelpers.MergeInPlace` helper. The target is always a reference inside the cloned root, so in-place merging is correct for both the root case and nested paths, and the failed `ReplaceToken` round-trip is gone.
- Added a regression test that applies a `{operation: "merge", path: []}` to an empty root and asserts the values land on the result.

## Test plan
- [x] `dotnet test clio.tests/clio.tests.csproj --filter FullyQualifiedName~PageJsonPathDiffApplier` (2/2 pass)
- [x] `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~PageBundle|FullyQualifiedName~PageJson|FullyQualifiedName~GetPage"` (18/18 pass)
- [x] Full Command-suite regression: `dotnet test clio.tests/clio.tests.csproj --filter FullyQualifiedName~Clio.Tests.Command` (1761 pass / 26 skipped / 0 fail)
- [x] End-to-end on a live Creatio stand: `clio get-page --schema-name UsrTodo0504100003_FormPage` now returns `bundle.viewModelConfig` populated with `attributes` and `bundle.modelConfig` populated with `dataSources` + `primaryDataSourceName` (previously both were `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)