### PR TITLE
fix(dataforge): fix SecureText SysSettings reading

### DIFF
--- a/clio.tests/Command/McpServer/DataForgeEnrichmentBuilderTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeEnrichmentBuilderTests.cs
@@ -61,7 +61,6 @@ public sealed class DataForgeEnrichmentBuilderTests {
 		// Assert
 		commandResolver.Received(1).Resolve<IDataForgeContextService>(Arg.Is<DataForgeTargetOptions>(options =>
 			options.Environment == "sandbox" &&
-			options.AllowSysSettingsAuthFallback &&
 			options.Scope == "use_enrichment"));
 		capturedRequest.Should().NotBeNull(
 			because: "the builder should call the Data Forge context service with one normalized aggregation request");
@@ -75,8 +74,6 @@ public sealed class DataForgeEnrichmentBuilderTests {
 			because: "lookup hints should be forwarded verbatim to the Data Forge context service");
 		capturedConfig.Should().NotBeNull(
 			because: "the builder should forward explicit Data Forge auth defaults to the context layer");
-		capturedConfig!.AllowSysSettingsAuthFallback.Should().BeTrue(
-			because: "MCP enrichment should keep the Data Forge syssettings auth fallback enabled by default");
 		capturedConfig.Scope.Should().Be("use_enrichment",
 			because: "MCP enrichment should use the standard Data Forge OAuth scope");
 		result.Used.Should().BeTrue(

--- a/clio.tests/Command/McpServer/DataForgeToolTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeToolTests.cs
@@ -173,9 +173,7 @@ public sealed class DataForgeToolTests {
 		response.Success.Should().BeTrue(because: "health requests should succeed when the underlying client succeeds");
 		capturedRequest.Should().NotBeNull(
 			because: "the tool should forward a Data Forge config request to the client");
-		capturedRequest!.AllowSysSettingsAuthFallback.Should().BeTrue(
-			because: "MCP Data Forge calls default to syssettings auth fallback for environments that only store OAuth credentials in Creatio");
-		capturedRequest.Scope.Should().Be("use_enrichment",
+		capturedRequest!.Scope.Should().Be("use_enrichment",
 			because: "MCP Data Forge calls should default to the service scope expected by the current environments");
 	}
 

--- a/clio.tests/Command/McpServer/DataForgeToolTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeToolTests.cs
@@ -188,17 +188,15 @@ public sealed class DataForgeToolTests {
 		Environment.SetEnvironmentVariable("HTTPS_PROXY", "http://127.0.0.1:9");
 		Environment.SetEnvironmentVariable("ALL_PROXY", "http://127.0.0.1:9");
 
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl")
-			.Returns(_ => throw new InvalidOperationException("cliogate endpoint is unavailable"));
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
 		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
+		directReader.ReadValue(Arg.Any<string>())
+			.Returns(new DataForgeSysSettingReadResult(false, null, null));
+		directReader.ReadValue("DataForgeServiceUrl")
 			.Returns(new DataForgeSysSettingReadResult(true, "https://data-forge-stage.bpmonline.com/", null));
 		ObservingHttpMessageHandler handler = new();
 		IDataForgeClient resolvedClient = new DataForgeClient(
 			new HttpClient(handler),
-			new DataForgeConfigResolver(new EnvironmentSettings(), sysSettingsManager, directReader),
+			new DataForgeConfigResolver(directReader, Substitute.For<ISysSettingsManager>()),
 			Substitute.For<ILogger>());
 		IDataForgeClient fallbackClient = Substitute.For<IDataForgeClient>();
 		IDataForgeMaintenanceClient maintenanceClient = Substitute.For<IDataForgeMaintenanceClient>();
@@ -223,7 +221,7 @@ public sealed class DataForgeToolTests {
 			because: "poisoned proxy env vars should be cleared for the whole Data Forge call scope");
 		handler.RequestUris.Should().Contain(uri => uri.ToString() == "https://data-forge-stage.bpmonline.com/liveness",
 			because: "the resolved service URL should come from the direct SysSettings fallback");
-		directReader.Received(1).ReadTextValue("DataForgeServiceUrl");
+		directReader.Received(1).ReadValue("DataForgeServiceUrl");
 		Environment.GetEnvironmentVariable("HTTP_PROXY").Should().Be("http://127.0.0.1:9",
 			because: "proxy env vars should be restored after the Data Forge call finishes");
 	}
@@ -233,15 +231,12 @@ public sealed class DataForgeToolTests {
 	[Description("Health tool should return a meaningful config-resolution error instead of masking the real failure as a generic DataForgeServiceUrl is required message.")]
 	public async Task DataForgeHealth_Should_Return_Meaningful_Error_On_Config_Failure() {
 		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns("<html>cliogate outdated</html>");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
 		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
+		directReader.ReadValue("DataForgeServiceUrl")
 			.Returns(new DataForgeSysSettingReadResult(false, null, "direct SysSettings OData read failed with 401 Unauthorized"));
 		IDataForgeClient resolvedClient = new DataForgeClient(
 			new HttpClient(new ObservingHttpMessageHandler()),
-			new DataForgeConfigResolver(new EnvironmentSettings(), sysSettingsManager, directReader),
+			new DataForgeConfigResolver(directReader, Substitute.For<ISysSettingsManager>()),
 			Substitute.For<ILogger>());
 		IDataForgeClient fallbackClient = Substitute.For<IDataForgeClient>();
 		IDataForgeMaintenanceClient maintenanceClient = Substitute.For<IDataForgeMaintenanceClient>();
@@ -342,20 +337,16 @@ public sealed class DataForgeToolTests {
 		IRuntimeEntitySchemaReader runtimeEntitySchemaReader,
 		IDataForgeContextService contextService,
 		IToolCommandResolver commandResolver) {
+		var clioGateEnsurer = Substitute.For<IClioGateEnsurer>();
+		clioGateEnsurer.EnsureInstalled().Returns(ClioGateEnsureResult.Present());
 		return new(
 			dataForgeClient,
 			maintenanceClient,
 			runtimeEntitySchemaReader,
 			contextService,
 			commandResolver,
-			new DataForgeProxySafeExecutor());
-	}
-
-	private static void ConfigureDefaultNumericSysSettings(ISysSettingsManager sysSettingsManager) {
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeServiceQueryTimeout").Returns(30_000);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeSimilarTablesResultLimit").Returns(50);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeLookupResultLimit").Returns(5);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeTableRelationshipsCountLimit").Returns(5);
+			new DataForgeProxySafeExecutor(),
+			clioGateEnsurer);
 	}
 
 	private sealed class ObservingHttpMessageHandler : HttpMessageHandler {

--- a/clio.tests/Command/McpServer/DataForgeToolTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeToolTests.cs
@@ -339,6 +339,7 @@ public sealed class DataForgeToolTests {
 		IToolCommandResolver commandResolver) {
 		var clioGateEnsurer = Substitute.For<IClioGateEnsurer>();
 		clioGateEnsurer.EnsureInstalled().Returns(ClioGateEnsureResult.Present());
+		commandResolver.Resolve<IClioGateEnsurer>(Arg.Any<EnvironmentOptions>()).Returns(clioGateEnsurer);
 		return new(
 			dataForgeClient,
 			maintenanceClient,

--- a/clio.tests/Common/ClioGateEnsurerTests.cs
+++ b/clio.tests/Common/ClioGateEnsurerTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Clio.Common;
+using Clio.Package;
+using Clio.Project.NuGet;
+using Clio.WebApplication;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Common")]
+public sealed class ClioGateEnsurerTests {
+
+	// Each test gets a unique URI so the static ConfirmedEnvironments cache cannot leak
+	// between tests (the cache is keyed by normalized URI).
+	private static (ClioGateEnsurer Ensurer, IClioGateway Gateway, IPackageInstaller Installer,
+		IApplication App, EnvironmentSettings Env)
+		Create(bool isNetCore = false) {
+		EnvironmentSettings env = new() {
+			Uri = $"http://test-host/{Guid.NewGuid():N}",
+			Login = "Supervisor",
+			Password = "Supervisor",
+			IsNetCore = isNetCore
+		};
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		IPackageInstaller installer = Substitute.For<IPackageInstaller>();
+		IApplication app = Substitute.For<IApplication>();
+		IWorkingDirectoriesProvider dirs = Substitute.For<IWorkingDirectoriesProvider>();
+		dirs.ExecutingDirectory.Returns(@"C:\fake");
+		return (new ClioGateEnsurer(env, gateway, installer, app, dirs), gateway, installer, app, env);
+	}
+
+	[Test]
+	[Description("After the first confirmed call, subsequent calls must return Present() without re-querying the gateway.")]
+	public void EnsureInstalled_Should_Return_Present_On_Cache_Hit_Without_Querying_Gateway() {
+		var (ensurer, gateway, _, _, _) = Create();
+		gateway.GetInstalledVersion().Returns(new PackageVersion(new Version(1, 0, 0), string.Empty));
+
+		ClioGateEnsureResult first = ensurer.EnsureInstalled();
+		ClioGateEnsureResult second = ensurer.EnsureInstalled();
+
+		first.AlreadyInstalled.Should().BeTrue("ClioGate was already present on first call");
+		second.AlreadyInstalled.Should().BeTrue("cache hit must report Present");
+		second.Warning.Should().BeNull();
+		gateway.Received(1).GetInstalledVersion();
+	}
+
+	[Test]
+	[Description("On .NET Framework, a successful install must call Restart() because PackageInstaller does not restart for framework targets.")]
+	public void EnsureInstalled_Should_Install_And_Restart_On_NetFramework_When_Missing() {
+		var (ensurer, gateway, installer, app, _) = Create(isNetCore: false);
+		gateway.GetInstalledVersion().Returns(default(PackageVersion));
+		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true).Returns(true);
+
+		ClioGateEnsureResult result = ensurer.EnsureInstalled();
+
+		result.JustInstalled.Should().BeTrue();
+		result.Warning.Should().Contain("installed automatically");
+		installer.Received(1).Install(
+			Arg.Is<string>(p => p.Contains("cliogate.gz")),
+			Arg.Any<EnvironmentSettings>(), null, null, true);
+		app.Received(1).Restart();
+	}
+
+	[Test]
+	[Description("On NetCore, a successful install must NOT call Restart() because PackageInstaller already restarts the app during install for NetCore targets.")]
+	public void EnsureInstalled_Should_Install_Without_Restart_On_NetCore_When_Missing() {
+		var (ensurer, gateway, installer, app, _) = Create(isNetCore: true);
+		gateway.GetInstalledVersion().Returns(default(PackageVersion));
+		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true).Returns(true);
+
+		ClioGateEnsureResult result = ensurer.EnsureInstalled();
+
+		result.JustInstalled.Should().BeTrue();
+		installer.Received(1).Install(
+			Arg.Is<string>(p => p.Contains("cliogate_netcore.gz")),
+			Arg.Any<EnvironmentSettings>(), null, null, true);
+		app.DidNotReceive().Restart();
+	}
+
+	[Test]
+	[Description("When GetInstalledVersion throws (e.g. network error), EnsureInstalled should swallow the exception and proceed to install rather than surfacing it.")]
+	public void EnsureInstalled_Should_Attempt_Install_When_GetInstalledVersion_Throws() {
+		var (ensurer, gateway, installer, _, _) = Create(isNetCore: true);
+		gateway.GetInstalledVersion().Throws(new Exception("Network error"));
+		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true).Returns(true);
+
+		ClioGateEnsureResult result = ensurer.EnsureInstalled();
+
+		result.JustInstalled.Should().BeTrue();
+		installer.Received(1).Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true);
+	}
+
+	[Test]
+	[Description("When the package installer returns false, EnsureInstalled should return a Failed result with a descriptive warning and must not add the env to the cache.")]
+	public void EnsureInstalled_Should_Return_Failed_When_Installer_Returns_False() {
+		var (ensurer, gateway, installer, _, _) = Create();
+		gateway.GetInstalledVersion().Returns(default(PackageVersion));
+		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true).Returns(false);
+
+		ClioGateEnsureResult result = ensurer.EnsureInstalled();
+
+		result.AlreadyInstalled.Should().BeFalse();
+		result.JustInstalled.Should().BeFalse();
+		result.Warning.Should().Contain("auto-install failed");
+	}
+
+	[Test]
+	[Description("When two concurrent calls race for the same uncached environment, Install must be executed exactly once — the double-check inside the lock prevents a duplicate install.")]
+	public void EnsureInstalled_Should_Install_Only_Once_Under_Concurrent_Access() {
+		// Use a shared EnvironmentSettings so both ensurers map to the same cache key.
+		EnvironmentSettings env = new() {
+			Uri = $"http://test-host/{Guid.NewGuid():N}",
+			Login = "Supervisor",
+			Password = "Supervisor",
+			IsNetCore = true
+		};
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		IPackageInstaller installer = Substitute.For<IPackageInstaller>();
+		IApplication app = Substitute.For<IApplication>();
+		IWorkingDirectoriesProvider dirs = Substitute.For<IWorkingDirectoriesProvider>();
+		dirs.ExecutingDirectory.Returns(@"C:\fake");
+
+		ManualResetEventSlim installStarted = new(false);
+		ManualResetEventSlim releaseInstall = new(false);
+
+		gateway.GetInstalledVersion().Returns(default(PackageVersion));
+		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true)
+			.Returns(_ => {
+				installStarted.Set();
+				releaseInstall.Wait();
+				return true;
+			});
+
+		ClioGateEnsurer ensurer1 = new(env, gateway, installer, app, dirs);
+		ClioGateEnsurer ensurer2 = new(env, gateway, installer, app, dirs);
+
+		ClioGateEnsureResult? result1 = null;
+		ClioGateEnsureResult? result2 = null;
+
+		Task t1 = Task.Run(() => result1 = ensurer1.EnsureInstalled());
+		// Wait until t1 is inside Install, then launch t2 which will block on the semaphore.
+		installStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("t1 should reach Install() within 5 s");
+		Task t2 = Task.Run(() => result2 = ensurer2.EnsureInstalled());
+
+		// Give t2 time to reach gate.Wait() before releasing the install.
+		Thread.Sleep(100);
+		releaseInstall.Set();
+		Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(10)).Should().BeTrue("both tasks must finish");
+
+		installer.Received(1).Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true);
+		result1!.JustInstalled.Should().BeTrue("t1 performed the install");
+		result2!.AlreadyInstalled.Should().BeTrue("t2 must hit the cache after waiting for the lock");
+	}
+}

--- a/clio.tests/Common/ClioGateEnsurerTests.cs
+++ b/clio.tests/Common/ClioGateEnsurerTests.cs
@@ -129,6 +129,7 @@ public sealed class ClioGateEnsurerTests {
 
 		ManualResetEventSlim installStarted = new(false);
 		ManualResetEventSlim releaseInstall = new(false);
+		ManualResetEventSlim t2Waiting = new(false);
 
 		gateway.GetInstalledVersion().Returns(default(PackageVersion));
 		installer.Install(Arg.Any<string>(), Arg.Any<EnvironmentSettings>(), null, null, true)
@@ -145,12 +146,15 @@ public sealed class ClioGateEnsurerTests {
 		ClioGateEnsureResult? result2 = null;
 
 		Task t1 = Task.Run(() => result1 = ensurer1.EnsureInstalled());
-		// Wait until t1 is inside Install, then launch t2 which will block on the semaphore.
+		// Wait until t1 is inside Install (holding the semaphore), then start t2.
 		installStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("t1 should reach Install() within 5 s");
-		Task t2 = Task.Run(() => result2 = ensurer2.EnsureInstalled());
-
-		// Give t2 time to reach gate.Wait() before releasing the install.
-		Thread.Sleep(100);
+		// t2 will immediately block on gate.Wait() because t1 still holds the semaphore.
+		Task t2 = Task.Run(() => {
+			t2Waiting.Set();
+			result2 = ensurer2.EnsureInstalled();
+		});
+		// Wait for t2 to start (so it is past the fast-path check and heading to gate.Wait()).
+		t2Waiting.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue("t2 should start within 5 s");
 		releaseInstall.Set();
 		Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(10)).Should().BeTrue("both tasks must finish");
 

--- a/clio.tests/Common/DataForgeConfigResolverTests.cs
+++ b/clio.tests/Common/DataForgeConfigResolverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Clio.Common;
 using Clio.Common.DataForge;
 using FluentAssertions;
@@ -12,232 +13,202 @@ namespace Clio.Tests.Common;
 public sealed class DataForgeConfigResolverTests {
 	[Test]
 	[Category("Unit")]
-	[Description("Resolve should prefer OAuth credentials from the clio environment settings over IdentityServer syssettings when both are present.")]
-	public void Resolve_Should_Prefer_Environment_OAuth_Settings() {
-		// Arrange
-		EnvironmentSettings settings = new() {
-			AuthAppUri = "https://identity.example/connect/token",
-			ClientId = "clio-client",
-			ClientSecret = "clio-secret"
-		};
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns("https://dataforge.example/");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerUrl").Returns("https://syssettings.identity/connect/token");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientId").Returns("sys-client");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientSecret").Returns("sys-secret");
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		DataForgeConfigResolver resolver = CreateResolver(settings, sysSettingsManager, directReader);
+	[Description("Resolve should use canonical DataForge and IdentityServer syssettings from the direct reader instead of any persisted local OAuth state.")]
+	public void Resolve_Should_Use_Canonical_SysSettings_For_DataForge_Config() {
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("https://dataforge.example/"),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Found("https://syssettings.identity/connect/token"),
+			["IdentityServerClientId"] = Found("sys-client"),
+			["IdentityServerClientSecret"] = Found("sys-secret")
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Act
 		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
 
-		// Assert
-		result.ServiceUrl.Should().Be("https://dataforge.example/",
-			because: "the configured Data Forge service URL should be preserved when the gateway returns a valid URL");
-		result.AuthMode.Should().Be(DataForgeAuthMode.OAuthClientCredentials,
-			because: "environment OAuth credentials should win over syssettings fallback");
-		result.TokenUrl.Should().Be("https://identity.example/connect/token",
-			because: "the environment identity endpoint should be used when present");
-		result.ClientId.Should().Be("clio-client",
-			because: "the environment client id should win over syssettings fallback");
-		result.ClientSecret.Should().Be("clio-secret",
-			because: "the environment client secret should win over syssettings fallback");
-		result.Scope.Should().Be("use_enrichment",
-			because: "the default Data Forge scope should stay stable");
+		result.ServiceUrl.Should().Be("https://dataforge.example/");
+		result.AuthMode.Should().Be(DataForgeAuthMode.OAuthClientCredentials);
+		result.TokenUrl.Should().Be("https://syssettings.identity/connect/token");
+		result.ClientId.Should().Be("sys-client");
+		result.ClientSecret.Should().Be("sys-secret");
+		result.Scope.Should().Be("use_enrichment");
 	}
 
 	[Test]
 	[Category("Unit")]
-	[Description("Resolve should use IdentityServer syssettings only when the caller explicitly allows the fallback and the clio environment does not already contain OAuth credentials.")]
-	public void Resolve_Should_Use_SysSettings_OAuth_Fallback_Only_When_Enabled() {
-		// Arrange
-		EnvironmentSettings settings = new();
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns("https://dataforge.example/");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerUrl").Returns("https://identity-from-syssettings/connect/token");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientId").Returns("sys-client");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientSecret").Returns("sys-secret");
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		DataForgeConfigResolver resolver = CreateResolver(settings, sysSettingsManager, directReader);
+	[Description("Resolve should not require the legacy syssettings auth fallback flag because DataForge now treats Creatio syssettings as the canonical source.")]
+	public void Resolve_Should_Ignore_Legacy_Fallback_Flag_When_SysSettings_Are_Available() {
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("https://dataforge.example/"),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Found("https://identity-from-syssettings/connect/token"),
+			["IdentityServerClientId"] = Found("sys-client"),
+			["IdentityServerClientSecret"] = Found("sys-secret")
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Act
-		DataForgeResolvedConfig disabledFallbackResult = resolver.Resolve(new DataForgeConfigRequest());
-		DataForgeResolvedConfig enabledFallbackResult = resolver.Resolve(new DataForgeConfigRequest {
-			AllowSysSettingsAuthFallback = true
+		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest {
+			AllowSysSettingsAuthFallback = false
 		});
 
-		// Assert
-		disabledFallbackResult.AuthMode.Should().Be(DataForgeAuthMode.None,
-			because: "syssettings fallback must remain opt-in to keep auth primarily managed by clio");
-		enabledFallbackResult.AuthMode.Should().Be(DataForgeAuthMode.OAuthClientCredentials,
-			because: "the explicit opt-in should enable IdentityServer syssettings fallback");
-		enabledFallbackResult.TokenUrl.Should().Be("https://identity-from-syssettings/connect/token",
-			because: "the syssettings token endpoint should be used when fallback is enabled");
-		enabledFallbackResult.ClientId.Should().Be("sys-client",
-			because: "the syssettings client id should be used when fallback is enabled");
-		enabledFallbackResult.ClientSecret.Should().Be("sys-secret",
-			because: "the syssettings client secret should be used when fallback is enabled");
-		enabledFallbackResult.Scope.Should().Be("use_enrichment",
-			because: "the default Data Forge scope should stay stable");
+		result.AuthMode.Should().Be(DataForgeAuthMode.OAuthClientCredentials);
+		result.TokenUrl.Should().Be("https://identity-from-syssettings/connect/token");
+		result.ClientId.Should().Be("sys-client");
+		result.ClientSecret.Should().Be("sys-secret");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Resolve should keep explicit request OAuth credentials as the highest-priority emergency override.")]
+	public void Resolve_Should_Prefer_Explicit_Request_OAuth_Override() {
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("https://dataforge.example/"),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Found("https://identity-from-syssettings/connect/token"),
+			["IdentityServerClientId"] = Found("sys-client"),
+			["IdentityServerClientSecret"] = Found("sys-secret")
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
+
+		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest {
+			AuthAppUri = "https://request.identity/connect/token",
+			ClientId = "request-client",
+			ClientSecret = "request-secret"
+		});
+
+		result.TokenUrl.Should().Be("https://request.identity/connect/token");
+		result.ClientId.Should().Be("request-client");
+		result.ClientSecret.Should().Be("request-secret");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Resolve should return auth mode none when IdentityServer syssettings are not available and no explicit request credentials were supplied.")]
+	public void Resolve_Should_Not_Fall_Back_To_Persisted_Environment_OAuth_When_SysSettings_Are_Missing() {
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("https://dataforge.example/"),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Missing(),
+			["IdentityServerClientId"] = Missing(),
+			["IdentityServerClientSecret"] = Missing()
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
+
+		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
+
+		result.AuthMode.Should().Be(DataForgeAuthMode.None);
+		result.TokenUrl.Should().BeNull();
+		result.ClientId.Should().BeNull();
+		result.ClientSecret.Should().BeNull();
 	}
 
 	[Test]
 	[Category("Unit")]
 	[Description("Resolve should reject missing DataForgeServiceUrl because direct DataForge calls cannot be constructed without the server-owned endpoint.")]
 	public void Resolve_Should_Reject_Missing_Service_Url() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns(string.Empty);
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
-			.Returns(new DataForgeSysSettingReadResult(false, null, null));
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Missing()
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Act
 		Action act = () => resolver.Resolve(new DataForgeConfigRequest());
 
-		// Assert
 		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*DataForgeServiceUrl*not configured*");
 	}
 
 	[Test]
 	[Category("Unit")]
-	[Description("Resolve should normalize string syssettings returned as JSON string literals so quoted URLs and client ids remain valid for outbound DataForge calls.")]
+	[Description("Resolve should normalize syssettings returned as JSON string literals so quoted URLs and client ids remain valid for outbound DataForge calls.")]
 	public void Resolve_Should_Unquote_Json_String_SysSettings() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns("\"https://dataforge.example/\"");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerUrl").Returns("\"https://identity.example/connect/token\"");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientId").Returns("\"sys-client\"");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientSecret").Returns("\"sys-secret\"");
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
-
-		// Act
-		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest {
-			AllowSysSettingsAuthFallback = true
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("\"https://dataforge.example/\""),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Found("\"https://identity.example/connect/token\""),
+			["IdentityServerClientId"] = Found("\"sys-client\""),
+			["IdentityServerClientSecret"] = Found("\"sys-secret\"")
 		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Assert
-		result.ServiceUrl.Should().Be("https://dataforge.example/",
-			because: "gateway syssettings can return JSON-quoted strings that must be normalized before use");
-		result.TokenUrl.Should().Be("https://identity.example/connect/token",
-			because: "quoted identity URLs must be normalized before OAuth token calls");
-		result.ClientId.Should().Be("sys-client",
-			because: "quoted client ids must be normalized before OAuth token calls");
-		result.ClientSecret.Should().Be("sys-secret",
-			because: "quoted client secrets must be normalized before OAuth token calls");
+		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
+
+		result.ServiceUrl.Should().Be("https://dataforge.example/");
+		result.TokenUrl.Should().Be("https://identity.example/connect/token");
+		result.ClientId.Should().Be("sys-client");
+		result.ClientSecret.Should().Be("sys-secret");
 	}
 
 	[Test]
 	[Category("Unit")]
 	[Description("Resolve should normalize IdentityServer syssettings into a concrete token endpoint when the syssetting contains only the identity service base URL.")]
 	public void Resolve_Should_Append_ConnectToken_To_IdentityServerUrl_Fallback() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns("https://dataforge.example/");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerUrl").Returns("https://identity.example:31390");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientId").Returns("sys-client");
-		sysSettingsManager.GetSysSettingValueByCode("IdentityServerClientSecret").Returns("sys-secret");
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
-
-		// Act
-		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest {
-			AllowSysSettingsAuthFallback = true
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("https://dataforge.example/"),
+			["DataForgeServiceQueryTimeout"] = Found("30000"),
+			["DataForgeSimilarTablesResultLimit"] = Found("50"),
+			["DataForgeLookupResultLimit"] = Found("5"),
+			["DataForgeTableRelationshipsCountLimit"] = Found("5"),
+			["IdentityServerUrl"] = Found("https://identity.example:31390"),
+			["IdentityServerClientId"] = Found("sys-client"),
+			["IdentityServerClientSecret"] = Found("sys-secret")
 		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Assert
-		result.TokenUrl.Should().Be("https://identity.example:31390/connect/token",
-			because: "identity base URLs should be normalized to the concrete token endpoint");
-		result.Scope.Should().Be("use_enrichment",
-			because: "the default Data Forge scope should remain stable");
-	}
-
-	[Test]
-	[Category("Unit")]
-	[Description("Resolve should fall back to the direct SysSettings reader when the cliogate path returns HTML instead of a valid DataForgeServiceUrl value.")]
-	public void Resolve_Should_Fall_Back_To_Direct_Read_When_Gateway_Returns_Html() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl")
-			.Returns("<!DOCTYPE html><html><body>404 gateway not found</body></html>");
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
-			.Returns(new DataForgeSysSettingReadResult(true, "https://data-forge-stage.bpmonline.com/", null));
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
-
-		// Act
 		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
 
-		// Assert
-		result.ServiceUrl.Should().Be("https://data-forge-stage.bpmonline.com/",
-			because: "HTML gateway responses should be rejected and retried through direct site reads");
-		directReader.Received(1).ReadTextValue("DataForgeServiceUrl");
+		result.TokenUrl.Should().Be("https://identity.example:31390/connect/token");
+		result.Scope.Should().Be("use_enrichment");
 	}
 
 	[Test]
 	[Category("Unit")]
-	[Description("Resolve should fall back to the direct SysSettings reader when the cliogate path throws while reading DataForgeServiceUrl.")]
-	public void Resolve_Should_Fall_Back_To_Direct_Read_When_Gateway_Throws() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl")
-			.Returns(_ => throw new InvalidOperationException("cliogate endpoint is unavailable"));
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
-			.Returns(new DataForgeSysSettingReadResult(true, "https://data-forge-stage.bpmonline.com/", null));
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
-
-		// Act
-		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
-
-		// Assert
-		result.ServiceUrl.Should().Be("https://data-forge-stage.bpmonline.com/",
-			because: "Data Forge should remain functional even when cliogate is missing or outdated");
-		directReader.Received(1).ReadTextValue("DataForgeServiceUrl");
-	}
-
-	[Test]
-	[Category("Unit")]
-	[Description("Resolve should reject service URLs that are found but are not absolute http/https URIs, even after falling back to the direct SysSettings reader.")]
+	[Description("Resolve should reject service URLs that are found in SysSettings but are not absolute http/https URIs.")]
 	public void Resolve_Should_Reject_Invalid_Service_Url_Returned_By_Direct_Read() {
-		// Arrange
-		ISysSettingsManager sysSettingsManager = Substitute.For<ISysSettingsManager>();
-		sysSettingsManager.GetSysSettingValueByCode("DataForgeServiceUrl").Returns(string.Empty);
-		ConfigureDefaultNumericSysSettings(sysSettingsManager);
-		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
-		directReader.ReadTextValue("DataForgeServiceUrl")
-			.Returns(new DataForgeSysSettingReadResult(true, "not-a-valid-url", null));
-		DataForgeConfigResolver resolver = CreateResolver(new EnvironmentSettings(), sysSettingsManager, directReader);
+		IDataForgeSysSettingDirectReader directReader = CreateDirectReader(new Dictionary<string, DataForgeSysSettingReadResult> {
+			["DataForgeServiceUrl"] = Found("not-a-valid-url")
+		});
+		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		// Act
 		Action act = () => resolver.Resolve(new DataForgeConfigRequest());
 
-		// Assert
 		act.Should().Throw<InvalidOperationException>()
 			.WithMessage("*not a valid absolute http/https URL*");
 	}
 
-	private static DataForgeConfigResolver CreateResolver(
-		EnvironmentSettings settings,
-		ISysSettingsManager sysSettingsManager,
-		IDataForgeSysSettingDirectReader directReader) {
-		return new(settings, sysSettingsManager, directReader);
+	private static DataForgeConfigResolver CreateResolver(IDataForgeSysSettingDirectReader directReader) {
+		return new(directReader, Substitute.For<ISysSettingsManager>());
 	}
 
-	private static void ConfigureDefaultNumericSysSettings(ISysSettingsManager sysSettingsManager) {
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeServiceQueryTimeout").Returns(30_000);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeSimilarTablesResultLimit").Returns(50);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeLookupResultLimit").Returns(5);
-		sysSettingsManager.GetSysSettingValueByCode<int>("DataForgeTableRelationshipsCountLimit").Returns(5);
+	private static IDataForgeSysSettingDirectReader CreateDirectReader(
+		IReadOnlyDictionary<string, DataForgeSysSettingReadResult> valuesByCode) {
+		IDataForgeSysSettingDirectReader directReader = Substitute.For<IDataForgeSysSettingDirectReader>();
+		directReader.ReadValue(Arg.Any<string>())
+			.Returns(callInfo => valuesByCode.TryGetValue(callInfo.Arg<string>(), out DataForgeSysSettingReadResult result)
+				? result
+				: Missing());
+		directReader.ReadTextValue(Arg.Any<string>())
+			.Returns(callInfo => valuesByCode.TryGetValue(callInfo.Arg<string>(), out DataForgeSysSettingReadResult result)
+				? result
+				: Missing());
+		return directReader;
 	}
+
+	private static DataForgeSysSettingReadResult Found(string value) => new(true, value, null);
+
+	private static DataForgeSysSettingReadResult Missing() => new(false, null, null);
 }

--- a/clio.tests/Common/DataForgeConfigResolverTests.cs
+++ b/clio.tests/Common/DataForgeConfigResolverTests.cs
@@ -53,9 +53,7 @@ public sealed class DataForgeConfigResolverTests {
 		});
 		DataForgeConfigResolver resolver = CreateResolver(directReader);
 
-		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest {
-			AllowSysSettingsAuthFallback = false
-		});
+		DataForgeResolvedConfig result = resolver.Resolve(new DataForgeConfigRequest());
 
 		result.AuthMode.Should().Be(DataForgeAuthMode.OAuthClientCredentials);
 		result.TokenUrl.Should().Be("https://identity-from-syssettings/connect/token");

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -482,6 +482,8 @@ public class BindingsModule {
 				? new Common.IIS.WindowsIISAppPoolManager(sp.GetRequiredService<IProcessExecutor>())
 				: new Common.IIS.StubIISAppPoolManager());
 		services.AddTransient<ClioGateway>();
+		services.AddTransient<IClioGateway, ClioGateway>();
+		services.AddTransient<IClioGateEnsurer, ClioGateEnsurer>();
 		services.AddTransient<CompileConfigurationCommand>();
 		services.AddTransient<CompileWorkspaceCommand>();
 		services.AddTransient<IMssql, Mssql>();

--- a/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
+++ b/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
@@ -52,7 +52,6 @@ public sealed class DataForgeEnrichmentBuilder(IToolCommandResolver commandResol
 		try {
 			DataForgeTargetOptions options = new() {
 				Environment = request.EnvironmentName,
-				AllowSysSettingsAuthFallback = true,
 				Scope = DefaultScope
 			};
 			IDataForgeContextService contextService = commandResolver.Resolve<IDataForgeContextService>(options);
@@ -63,7 +62,6 @@ public sealed class DataForgeEnrichmentBuilder(IToolCommandResolver commandResol
 					request.LookupHints ?? [],
 					[]),
 				new DataForgeConfigRequest {
-					AllowSysSettingsAuthFallback = true,
 					Scope = DefaultScope
 				},
 				cancellationToken);

--- a/clio/Command/McpServer/Tools/DataForgeTool.cs
+++ b/clio/Command/McpServer/Tools/DataForgeTool.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Clio.Common;
 using Clio.Common.DataForge;
 using Clio.Common.EntitySchema;
 using ModelContextProtocol.Server;
@@ -18,7 +19,8 @@ public sealed class DataForgeTool(
 	IRuntimeEntitySchemaReader runtimeEntitySchemaReader,
 	IDataForgeContextService contextService,
 	IToolCommandResolver commandResolver,
-	IDataForgeProxySafeExecutor proxySafeExecutor) {
+	IDataForgeProxySafeExecutor proxySafeExecutor,
+	IClioGateEnsurer clioGateEnsurer) {
 	internal const string DataForgeHealthToolName = "dataforge-health";
 	internal const string DataForgeStatusToolName = "dataforge-status";
 	internal const string DataForgeFindTablesToolName = "dataforge-find-tables";
@@ -40,11 +42,13 @@ public sealed class DataForgeTool(
 		[Required]
 		DataForgeHealthArgs args) {
 		try {
-			DataForgeHealthResult health = await ExecuteAsync(args, async options => {
-				IDataForgeClient client = ResolveService(options, dataForgeClient);
-				return await client.CheckHealthAsync(BuildConfigRequest(options));
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			DataForgeHealthResult health = await ExecuteWithOptions(options, async o => {
+				IDataForgeClient client = ResolveService(o, dataForgeClient);
+				return await client.CheckHealthAsync(BuildConfigRequest(o));
 			});
-			return new DataForgeHealthResponse(true, SourceName, health.CorrelationId, [], null, health);
+			return new DataForgeHealthResponse(true, SourceName, health.CorrelationId, warnings, null, health);
 		} catch (Exception ex) {
 			return new DataForgeHealthResponse(
 				false,
@@ -64,14 +68,16 @@ public sealed class DataForgeTool(
 		[Required]
 		DataForgeStatusArgs args) {
 		try {
-			(DataForgeHealthResult health, DataForgeMaintenanceStatusResult status) = await ExecuteAsync(args, async options => {
-				IDataForgeClient client = ResolveService(options, dataForgeClient);
-				IDataForgeMaintenanceClient maintenance = ResolveService(options, maintenanceClient);
-				DataForgeHealthResult resolvedHealth = await client.CheckHealthAsync(BuildConfigRequest(options));
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			(DataForgeHealthResult health, DataForgeMaintenanceStatusResult status) = await ExecuteWithOptions(options, async o => {
+				IDataForgeClient client = ResolveService(o, dataForgeClient);
+				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
+				DataForgeHealthResult resolvedHealth = await client.CheckHealthAsync(BuildConfigRequest(o));
 				DataForgeMaintenanceStatusResult resolvedStatus = maintenance.GetStatus();
 				return (resolvedHealth, resolvedStatus);
 			});
-			return new DataForgeStatusResponse(true, SourceName, health.CorrelationId, [], null, health, status);
+			return new DataForgeStatusResponse(true, SourceName, health.CorrelationId, warnings, null, health, status);
 		} catch (Exception ex) {
 			return new DataForgeStatusResponse(
 				false,
@@ -93,14 +99,13 @@ public sealed class DataForgeTool(
 		DataForgeFindTablesArgs args) {
 		try {
 			EnsureRequired(args.Query, "query");
-			IReadOnlyList<SimilarTableResult> results = await ExecuteAsync(args, async options => {
-				IDataForgeClient client = ResolveService(options, dataForgeClient);
-				return await client.FindSimilarTablesAsync(
-					args.Query!,
-					args.Limit,
-					BuildConfigRequest(options));
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			IReadOnlyList<SimilarTableResult> results = await ExecuteWithOptions(options, async o => {
+				IDataForgeClient client = ResolveService(o, dataForgeClient);
+				return await client.FindSimilarTablesAsync(args.Query!, args.Limit, BuildConfigRequest(o));
 			});
-			return new DataForgeFindTablesResponse(true, SourceName, string.Empty, [], null, results);
+			return new DataForgeFindTablesResponse(true, SourceName, string.Empty, warnings, null, results);
 		} catch (Exception ex) {
 			return new DataForgeFindTablesResponse(
 				false,
@@ -121,15 +126,13 @@ public sealed class DataForgeTool(
 		DataForgeFindLookupsArgs args) {
 		try {
 			EnsureRequired(args.Query, "query");
-			IReadOnlyList<SimilarLookupResult> results = await ExecuteAsync(args, async options => {
-				IDataForgeClient client = ResolveService(options, dataForgeClient);
-				return await client.FindSimilarLookupsAsync(
-					args.Query!,
-					args.SchemaName,
-					args.Limit,
-					BuildConfigRequest(options));
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			IReadOnlyList<SimilarLookupResult> results = await ExecuteWithOptions(options, async o => {
+				IDataForgeClient client = ResolveService(o, dataForgeClient);
+				return await client.FindSimilarLookupsAsync(args.Query!, args.SchemaName, args.Limit, BuildConfigRequest(o));
 			});
-			return new DataForgeFindLookupsResponse(true, SourceName, string.Empty, [], null, results);
+			return new DataForgeFindLookupsResponse(true, SourceName, string.Empty, warnings, null, results);
 		} catch (Exception ex) {
 			return new DataForgeFindLookupsResponse(
 				false,
@@ -151,15 +154,13 @@ public sealed class DataForgeTool(
 		try {
 			EnsureRequired(args.SourceTable, "source-table");
 			EnsureRequired(args.TargetTable, "target-table");
-			IReadOnlyList<string> results = await ExecuteAsync(args, async options => {
-				IDataForgeClient client = ResolveService(options, dataForgeClient);
-				return await client.GetTableRelationshipsAsync(
-					args.SourceTable!,
-					args.TargetTable!,
-					args.Limit,
-					BuildConfigRequest(options));
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			IReadOnlyList<string> results = await ExecuteWithOptions(options, async o => {
+				IDataForgeClient client = ResolveService(o, dataForgeClient);
+				return await client.GetTableRelationshipsAsync(args.SourceTable!, args.TargetTable!, args.Limit, BuildConfigRequest(o));
 			});
-			return new DataForgeRelationsResponse(true, SourceName, string.Empty, [], null, results);
+			return new DataForgeRelationsResponse(true, SourceName, string.Empty, warnings, null, results);
 		} catch (Exception ex) {
 			return new DataForgeRelationsResponse(
 				false,
@@ -180,12 +181,14 @@ public sealed class DataForgeTool(
 		DataForgeGetTableColumnsArgs args) {
 		try {
 			EnsureRequired(args.TableName, "table-name");
-			RuntimeEntitySchemaResult runtimeSchema = Execute(args, options => {
-				IRuntimeEntitySchemaReader reader = ResolveService(options, runtimeEntitySchemaReader);
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			RuntimeEntitySchemaResult runtimeSchema = ExecuteWithOptions(options, o => {
+				IRuntimeEntitySchemaReader reader = ResolveService(o, runtimeEntitySchemaReader);
 				return reader.GetByName(args.TableName!);
 			});
 			IReadOnlyList<DataForgeColumnResult> results = DataForgeRuntimeSchemaMapper.MapColumns(runtimeSchema);
-			return new DataForgeColumnsResponse(true, SourceName, string.Empty, [], null, results);
+			return new DataForgeColumnsResponse(true, SourceName, string.Empty, warnings, null, results);
 		} catch (Exception ex) {
 			return new DataForgeColumnsResponse(
 				false,
@@ -205,21 +208,24 @@ public sealed class DataForgeTool(
 		[Required]
 		DataForgeContextArgs args) {
 		try {
-			DataForgeContextAggregationResult contextResult = await ExecuteAsync(args, async options => {
-				IDataForgeContextService resolvedContextService = ResolveService(options, contextService);
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> gateWarnings = EnsureGateAndCollectWarnings(options);
+			DataForgeContextAggregationResult contextResult = await ExecuteWithOptions(options, async o => {
+				IDataForgeContextService resolvedContextService = ResolveService(o, contextService);
 				return await resolvedContextService.GetContextAsync(
 					new DataForgeContextRequest(
 						args.RequirementSummary,
 						args.CandidateTerms,
 						args.LookupHints,
 						args.RelationPairs?.Select(pair => new DataForgeRelationPair(pair.SourceTable, pair.TargetTable)).ToList()),
-					BuildConfigRequest(options));
+					BuildConfigRequest(o));
 			});
+			IReadOnlyList<string> allWarnings = [..gateWarnings, ..contextResult.Warnings];
 			return new DataForgeContextResponse(
 				true,
 				SourceName,
 				contextResult.CorrelationId,
-				contextResult.Warnings,
+				allWarnings,
 				null,
 				contextResult.Health,
 				contextResult.Status,
@@ -253,11 +259,13 @@ public sealed class DataForgeTool(
 		[Required]
 		DataForgeMaintenanceArgs args) {
 		try {
-			DataForgeMaintenanceStatusResult result = Execute(args, options => {
-				IDataForgeMaintenanceClient maintenance = ResolveService(options, maintenanceClient);
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			DataForgeMaintenanceStatusResult result = ExecuteWithOptions(options, o => {
+				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
 				return maintenance.Initialize();
 			});
-			return new DataForgeMaintenanceResponse(true, SourceName, string.Empty, [], null, result);
+			return new DataForgeMaintenanceResponse(true, SourceName, string.Empty, warnings, null, result);
 		} catch (Exception ex) {
 			return new DataForgeMaintenanceResponse(
 				false,
@@ -277,11 +285,13 @@ public sealed class DataForgeTool(
 		[Required]
 		DataForgeMaintenanceArgs args) {
 		try {
-			DataForgeMaintenanceStatusResult result = Execute(args, options => {
-				IDataForgeMaintenanceClient maintenance = ResolveService(options, maintenanceClient);
+			DataForgeTargetOptions options = CreateTargetOptions(args);
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			DataForgeMaintenanceStatusResult result = ExecuteWithOptions(options, o => {
+				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
 				return maintenance.Update();
 			});
-			return new DataForgeMaintenanceResponse(true, SourceName, string.Empty, [], null, result);
+			return new DataForgeMaintenanceResponse(true, SourceName, string.Empty, warnings, null, result);
 		} catch (Exception ex) {
 			return new DataForgeMaintenanceResponse(
 				false,
@@ -293,16 +303,19 @@ public sealed class DataForgeTool(
 		}
 	}
 
-	private T Execute<T>(DataForgeConnectionArgsBase args, Func<DataForgeTargetOptions, T> action) {
-		DataForgeTargetOptions options = CreateTargetOptions(args);
+	private T ExecuteWithOptions<T>(DataForgeTargetOptions options, Func<DataForgeTargetOptions, T> action) {
 		string? targetHost = GetTargetHost(options);
 		return proxySafeExecutor.Execute(() => action(options), targetHost);
 	}
 
-	private Task<T> ExecuteAsync<T>(DataForgeConnectionArgsBase args, Func<DataForgeTargetOptions, Task<T>> action) {
-		DataForgeTargetOptions options = CreateTargetOptions(args);
+	private Task<T> ExecuteWithOptions<T>(DataForgeTargetOptions options, Func<DataForgeTargetOptions, Task<T>> action) {
 		string? targetHost = GetTargetHost(options);
 		return proxySafeExecutor.ExecuteAsync(() => action(options), targetHost);
+	}
+
+	private IReadOnlyList<string> EnsureGateAndCollectWarnings(DataForgeTargetOptions options) {
+		ClioGateEnsureResult gateResult = ResolveService(options, clioGateEnsurer).EnsureInstalled();
+		return gateResult.Warning is not null ? [gateResult.Warning] : [];
 	}
 
 	private static void EnsureRequired(string? value, string parameterName) {

--- a/clio/Command/McpServer/Tools/DataForgeTool.cs
+++ b/clio/Command/McpServer/Tools/DataForgeTool.cs
@@ -182,13 +182,12 @@ public sealed class DataForgeTool(
 		try {
 			EnsureRequired(args.TableName, "table-name");
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
 			RuntimeEntitySchemaResult runtimeSchema = ExecuteWithOptions(options, o => {
 				IRuntimeEntitySchemaReader reader = ResolveService(o, runtimeEntitySchemaReader);
 				return reader.GetByName(args.TableName!);
 			});
 			IReadOnlyList<DataForgeColumnResult> results = DataForgeRuntimeSchemaMapper.MapColumns(runtimeSchema);
-			return new DataForgeColumnsResponse(true, SourceName, string.Empty, warnings, null, results);
+			return new DataForgeColumnsResponse(true, SourceName, string.Empty, [], null, results);
 		} catch (Exception ex) {
 			return new DataForgeColumnsResponse(
 				false,

--- a/clio/Command/McpServer/Tools/DataForgeTool.cs
+++ b/clio/Command/McpServer/Tools/DataForgeTool.cs
@@ -357,7 +357,6 @@ public sealed class DataForgeTool(
 			AuthAppUri = options.AuthAppUri,
 			ClientId = options.ClientId,
 			ClientSecret = options.ClientSecret,
-			AllowSysSettingsAuthFallback = options.AllowSysSettingsAuthFallback,
 			Scope = options.Scope
 		};
 	}
@@ -371,7 +370,6 @@ public sealed class DataForgeTool(
 			ClientId = args.ClientId,
 			ClientSecret = args.ClientSecret,
 			AuthAppUri = args.AuthAppUri,
-			AllowSysSettingsAuthFallback = args.AllowSysSettingsAuthFallback,
 			Scope = string.IsNullOrWhiteSpace(args.Scope) ? DefaultDataForgeScope : args.Scope.Trim()
 		};
 	}
@@ -421,9 +419,6 @@ public abstract record DataForgeConnectionArgsBase {
 	[JsonPropertyName("auth-app-uri")]
 	[Description("OAuth application URI for direct connection mode. Emergency fallback only.")]
 	public string? AuthAppUri { get; init; }
-
-	[JsonPropertyName("allow-syssettings-auth-fallback")]
-	public bool AllowSysSettingsAuthFallback { get; init; } = true;
 
 	[JsonPropertyName("scope")]
 	public string? Scope { get; init; }

--- a/clio/Command/McpServer/Tools/DataForgeTool.cs
+++ b/clio/Command/McpServer/Tools/DataForgeTool.cs
@@ -43,8 +43,7 @@ public sealed class DataForgeTool(
 		DataForgeHealthArgs args) {
 		try {
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			DataForgeHealthResult health = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> warnings, DataForgeHealthResult health) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeClient client = ResolveService(o, dataForgeClient);
 				return await client.CheckHealthAsync(BuildConfigRequest(o));
 			});
@@ -69,8 +68,7 @@ public sealed class DataForgeTool(
 		DataForgeStatusArgs args) {
 		try {
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			(DataForgeHealthResult health, DataForgeMaintenanceStatusResult status) = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> warnings, (DataForgeHealthResult health, DataForgeMaintenanceStatusResult status)) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeClient client = ResolveService(o, dataForgeClient);
 				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
 				DataForgeHealthResult resolvedHealth = await client.CheckHealthAsync(BuildConfigRequest(o));
@@ -100,8 +98,7 @@ public sealed class DataForgeTool(
 		try {
 			EnsureRequired(args.Query, "query");
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			IReadOnlyList<SimilarTableResult> results = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> warnings, IReadOnlyList<SimilarTableResult> results) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeClient client = ResolveService(o, dataForgeClient);
 				return await client.FindSimilarTablesAsync(args.Query!, args.Limit, BuildConfigRequest(o));
 			});
@@ -127,8 +124,7 @@ public sealed class DataForgeTool(
 		try {
 			EnsureRequired(args.Query, "query");
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			IReadOnlyList<SimilarLookupResult> results = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> warnings, IReadOnlyList<SimilarLookupResult> results) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeClient client = ResolveService(o, dataForgeClient);
 				return await client.FindSimilarLookupsAsync(args.Query!, args.SchemaName, args.Limit, BuildConfigRequest(o));
 			});
@@ -155,8 +151,7 @@ public sealed class DataForgeTool(
 			EnsureRequired(args.SourceTable, "source-table");
 			EnsureRequired(args.TargetTable, "target-table");
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			IReadOnlyList<string> results = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> warnings, IReadOnlyList<string> results) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeClient client = ResolveService(o, dataForgeClient);
 				return await client.GetTableRelationshipsAsync(args.SourceTable!, args.TargetTable!, args.Limit, BuildConfigRequest(o));
 			});
@@ -208,8 +203,7 @@ public sealed class DataForgeTool(
 		DataForgeContextArgs args) {
 		try {
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> gateWarnings = EnsureGateAndCollectWarnings(options);
-			DataForgeContextAggregationResult contextResult = await ExecuteWithOptions(options, async o => {
+			(IReadOnlyList<string> gateWarnings, DataForgeContextAggregationResult contextResult) = await ExecuteWithGateAsync(options, async o => {
 				IDataForgeContextService resolvedContextService = ResolveService(o, contextService);
 				return await resolvedContextService.GetContextAsync(
 					new DataForgeContextRequest(
@@ -259,8 +253,7 @@ public sealed class DataForgeTool(
 		DataForgeMaintenanceArgs args) {
 		try {
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			DataForgeMaintenanceStatusResult result = ExecuteWithOptions(options, o => {
+			(IReadOnlyList<string> warnings, DataForgeMaintenanceStatusResult result) = ExecuteWithGate(options, o => {
 				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
 				return maintenance.Initialize();
 			});
@@ -285,8 +278,7 @@ public sealed class DataForgeTool(
 		DataForgeMaintenanceArgs args) {
 		try {
 			DataForgeTargetOptions options = CreateTargetOptions(args);
-			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
-			DataForgeMaintenanceStatusResult result = ExecuteWithOptions(options, o => {
+			(IReadOnlyList<string> warnings, DataForgeMaintenanceStatusResult result) = ExecuteWithGate(options, o => {
 				IDataForgeMaintenanceClient maintenance = ResolveService(o, maintenanceClient);
 				return maintenance.Update();
 			});
@@ -310,6 +302,24 @@ public sealed class DataForgeTool(
 	private Task<T> ExecuteWithOptions<T>(DataForgeTargetOptions options, Func<DataForgeTargetOptions, Task<T>> action) {
 		string? targetHost = GetTargetHost(options);
 		return proxySafeExecutor.ExecuteAsync(() => action(options), targetHost);
+	}
+
+	private (IReadOnlyList<string> warnings, T result) ExecuteWithGate<T>(
+		DataForgeTargetOptions options, Func<DataForgeTargetOptions, T> action) {
+		string? targetHost = GetTargetHost(options);
+		return proxySafeExecutor.Execute(() => {
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			return (warnings, action(options));
+		}, targetHost);
+	}
+
+	private Task<(IReadOnlyList<string> warnings, T result)> ExecuteWithGateAsync<T>(
+		DataForgeTargetOptions options, Func<DataForgeTargetOptions, Task<T>> action) {
+		string? targetHost = GetTargetHost(options);
+		return proxySafeExecutor.ExecuteAsync(async () => {
+			IReadOnlyList<string> warnings = EnsureGateAndCollectWarnings(options);
+			return (warnings, await action(options));
+		}, targetHost);
 	}
 
 	private IReadOnlyList<string> EnsureGateAndCollectWarnings(DataForgeTargetOptions options) {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -2505,11 +2505,6 @@ internal static class ToolContractCatalog {
 			"Use 'auth-app-uri' instead of 'authAppUri'.");
 	}
 
-	private static ToolContractAlias AllowSysSettingsAuthFallbackParameterAlias() {
-		return Alias(ParameterScope, "allow-syssettings-auth-fallback", "allowSysSettingsAuthFallback", RejectedStatus,
-			"Use 'allow-syssettings-auth-fallback' instead of 'allowSysSettingsAuthFallback'.");
-	}
-
 	private static ToolContractAlias TitleParameterAlias() {
 		return Alias(ParameterScope, TitleLocalizationsFieldName, "title", RejectedStatus,
 			$"Use '{TitleLocalizationsFieldName}' instead of legacy scalar 'title'.");
@@ -2547,7 +2542,6 @@ internal static class ToolContractCatalog {
 			ClientIdParameterAlias(),
 			ClientSecretParameterAlias(),
 			AuthAppUriParameterAlias(),
-			AllowSysSettingsAuthFallbackParameterAlias(),
 			..extraAliases
 		];
 	}

--- a/clio/Common/ClioGateEnsurer.cs
+++ b/clio/Common/ClioGateEnsurer.cs
@@ -118,7 +118,11 @@ public sealed class ClioGateEnsurer : IClioGateEnsurer {
 				return ClioGateEnsureResult.Failed(uri, "package installer returned failure");
 			}
 
-			_application.Restart();
+			// NetCore: PackageInstaller already restarts during install (BasePackageInstaller.InstallPackedPackage).
+			// .NET Framework: installer does not restart, so an explicit restart is required.
+			if (!(_environmentSettings?.IsNetCore ?? false)) {
+				_application.Restart();
+			}
 			ConfirmedEnvironments.TryAdd(cacheKey, true);
 			return ClioGateEnsureResult.Installed(uri);
 		} catch (Exception ex) {

--- a/clio/Common/ClioGateEnsurer.cs
+++ b/clio/Common/ClioGateEnsurer.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using Clio.Package;
+using Clio.WebApplication;
+
+namespace Clio.Common;
+
+/// <summary>
+/// Result of a ClioGate ensure operation.
+/// </summary>
+/// <param name="AlreadyInstalled">True when ClioGate was already present — no action taken.</param>
+/// <param name="JustInstalled">True when ClioGate was absent and was installed during this call.</param>
+/// <param name="Warning">Non-null when something noteworthy happened (auto-install or failure).</param>
+public record ClioGateEnsureResult(bool AlreadyInstalled, bool JustInstalled, string? Warning) {
+	public static ClioGateEnsureResult Present() =>
+		new(AlreadyInstalled: true, JustInstalled: false, Warning: null);
+
+	public static ClioGateEnsureResult Installed(string envUri) =>
+		new(AlreadyInstalled: false, JustInstalled: true,
+			Warning: $"ClioGate was not installed on '{envUri}'. It was installed automatically and Creatio was restarted.");
+
+	public static ClioGateEnsureResult Failed(string envUri, string reason) =>
+		new(AlreadyInstalled: false, JustInstalled: false,
+			Warning: $"ClioGate is not installed on '{envUri}' and auto-install failed: {reason}. OAuth SecureText settings (e.g. IdentityServerClientSecret) may not be readable.");
+}
+
+/// <summary>
+/// Ensures ClioGate is installed on the active Creatio environment.
+/// Silently installs when absent and caches confirmed environments to avoid repeated checks.
+/// </summary>
+public interface IClioGateEnsurer {
+	/// <summary>
+	/// Checks whether ClioGate is installed. Installs it automatically if absent.
+	/// Uses the <see cref="EnvironmentSettings"/> injected for the current DI container scope.
+	/// </summary>
+	ClioGateEnsureResult EnsureInstalled();
+}
+
+/// <inheritdoc/>
+public sealed class ClioGateEnsurer : IClioGateEnsurer {
+
+	// Shared across all container instances — keyed by normalized URI.
+	private static readonly ConcurrentDictionary<string, bool> ConfirmedEnvironments =
+		new(StringComparer.OrdinalIgnoreCase);
+
+	private readonly EnvironmentSettings _environmentSettings;
+	private readonly IClioGateway _clioGateway;
+	private readonly IPackageInstaller _packageInstaller;
+	private readonly IApplication _application;
+	private readonly IWorkingDirectoriesProvider _workingDirectoriesProvider;
+
+	public ClioGateEnsurer(
+		EnvironmentSettings environmentSettings,
+		IClioGateway clioGateway,
+		IPackageInstaller packageInstaller,
+		IApplication application,
+		IWorkingDirectoriesProvider workingDirectoriesProvider) {
+		_environmentSettings = environmentSettings;
+		_clioGateway = clioGateway;
+		_packageInstaller = packageInstaller;
+		_application = application;
+		_workingDirectoriesProvider = workingDirectoriesProvider;
+	}
+
+	/// <inheritdoc/>
+	public ClioGateEnsureResult EnsureInstalled() {
+		string cacheKey = NormalizeUri(_environmentSettings?.Uri);
+
+		if (ConfirmedEnvironments.ContainsKey(cacheKey)) {
+			return ClioGateEnsureResult.Present();
+		}
+
+		try {
+			if (_clioGateway.GetInstalledVersion() != null) {
+				ConfirmedEnvironments.TryAdd(cacheKey, true);
+				return ClioGateEnsureResult.Present();
+			}
+		} catch {
+			// Cannot check — proceed to install attempt.
+		}
+
+		return TryInstall(cacheKey);
+	}
+
+	private ClioGateEnsureResult TryInstall(string cacheKey) {
+		string uri = _environmentSettings?.Uri ?? "(unknown)";
+		try {
+			string packagePath = GetPackagePath();
+			EnvironmentSettings installSettings = BuildInstallSettings();
+
+			bool success = _packageInstaller.Install(
+				packagePath,
+				installSettings,
+				packageInstallOptions: null,
+				reportPath: null,
+				createBackup: true);
+
+			if (!success) {
+				return ClioGateEnsureResult.Failed(uri, "package installer returned failure");
+			}
+
+			_application.Restart();
+			ConfirmedEnvironments.TryAdd(cacheKey, true);
+			return ClioGateEnsureResult.Installed(uri);
+		} catch (Exception ex) {
+			return ClioGateEnsureResult.Failed(uri, ex.Message);
+		}
+	}
+
+	private string GetPackagePath() {
+		string packageName = (_environmentSettings?.IsNetCore ?? false) ? "cliogate_netcore" : "cliogate";
+		return Path.Combine(_workingDirectoriesProvider.ExecutingDirectory, "cliogate", $"{packageName}.gz");
+	}
+
+	private EnvironmentSettings BuildInstallSettings() {
+		EnvironmentSettings settings = new();
+		settings.Merge(_environmentSettings);
+		settings.DeveloperModeEnabled = false;
+		return settings;
+	}
+
+	private static string NormalizeUri(string? uri) {
+		if (string.IsNullOrWhiteSpace(uri)) {
+			return string.Empty;
+		}
+		return uri.Trim().TrimEnd('/').ToLowerInvariant();
+	}
+}
+

--- a/clio/Common/ClioGateEnsurer.cs
+++ b/clio/Common/ClioGateEnsurer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Threading;
 using Clio.Package;
 using Clio.WebApplication;
 
@@ -44,6 +45,10 @@ public sealed class ClioGateEnsurer : IClioGateEnsurer {
 	private static readonly ConcurrentDictionary<string, bool> ConfirmedEnvironments =
 		new(StringComparer.OrdinalIgnoreCase);
 
+	// Per-environment install lock — prevents concurrent installs for the same URI.
+	private static readonly ConcurrentDictionary<string, SemaphoreSlim> InstallLocks =
+		new(StringComparer.OrdinalIgnoreCase);
+
 	private readonly EnvironmentSettings _environmentSettings;
 	private readonly IClioGateway _clioGateway;
 	private readonly IPackageInstaller _packageInstaller;
@@ -67,20 +72,33 @@ public sealed class ClioGateEnsurer : IClioGateEnsurer {
 	public ClioGateEnsureResult EnsureInstalled() {
 		string cacheKey = NormalizeUri(_environmentSettings?.Uri);
 
+		// Fast path — lock-free read.
 		if (ConfirmedEnvironments.ContainsKey(cacheKey)) {
 			return ClioGateEnsureResult.Present();
 		}
 
+		// Slow path — serialize per environment to prevent duplicate installs.
+		SemaphoreSlim gate = InstallLocks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+		gate.Wait();
 		try {
-			if (_clioGateway.GetInstalledVersion() != null) {
-				ConfirmedEnvironments.TryAdd(cacheKey, true);
+			// Double-check: another thread may have installed while we were waiting.
+			if (ConfirmedEnvironments.ContainsKey(cacheKey)) {
 				return ClioGateEnsureResult.Present();
 			}
-		} catch {
-			// Cannot check — proceed to install attempt.
-		}
 
-		return TryInstall(cacheKey);
+			try {
+				if (_clioGateway.GetInstalledVersion() != null) {
+					ConfirmedEnvironments.TryAdd(cacheKey, true);
+					return ClioGateEnsureResult.Present();
+				}
+			} catch {
+				// Cannot check — proceed to install attempt.
+			}
+
+			return TryInstall(cacheKey);
+		} finally {
+			gate.Release();
+		}
 	}
 
 	private ClioGateEnsureResult TryInstall(string cacheKey) {

--- a/clio/Common/DataForge/DataForgeConfigResolver.cs
+++ b/clio/Common/DataForge/DataForgeConfigResolver.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
+using Clio.Common;
 
 namespace Clio.Common.DataForge;
 
@@ -9,10 +11,8 @@ public interface IDataForgeConfigResolver {
 }
 
 public sealed class DataForgeConfigResolver(
-	EnvironmentSettings environmentSettings,
-	ISysSettingsManager sysSettingsManager,
-	IDataForgeSysSettingDirectReader directReader)
-	: IDataForgeConfigResolver {
+	IDataForgeSysSettingDirectReader directReader,
+	ISysSettingsManager sysSettingsManager) : IDataForgeConfigResolver {
 	private const string DataForgeServiceUrlCode = "DataForgeServiceUrl";
 	private const string DefaultOAuthScope = "use_enrichment";
 	private const int DefaultTimeoutMs = 30_000;
@@ -34,9 +34,15 @@ public sealed class DataForgeConfigResolver(
 			GetIntSysSetting("DataForgeTableRelationshipsCountLimit", DefaultRelationshipsLimit);
 		string scope = string.IsNullOrWhiteSpace(request.Scope) ? DefaultOAuthScope : request.Scope.Trim();
 
-		string? tokenUrl = NormalizeTokenUrl(FirstNonEmpty(request.AuthAppUri, environmentSettings.AuthAppUri));
-		string? clientId = FirstNonEmpty(request.ClientId, environmentSettings.ClientId);
-		string? clientSecret = FirstNonEmpty(request.ClientSecret, environmentSettings.ClientSecret);
+		string? tokenUrl = NormalizeTokenUrl(request.AuthAppUri);
+		string? clientId = FirstNonEmpty(request.ClientId);
+		string? clientSecret = FirstNonEmpty(request.ClientSecret);
+
+		if (!HasOAuthSettings(tokenUrl, clientId, clientSecret)) {
+			tokenUrl = NormalizeTokenUrl(GetStringSysSetting("IdentityServerUrl"));
+			clientId = GetStringSysSetting("IdentityServerClientId");
+			clientSecret = GetStringSysSetting("IdentityServerClientSecret");
+		}
 
 		if (HasOAuthSettings(tokenUrl, clientId, clientSecret)) {
 			return new DataForgeResolvedConfig(
@@ -50,25 +56,6 @@ public sealed class DataForgeConfigResolver(
 				clientId,
 				clientSecret,
 				scope);
-		}
-
-		if (request.AllowSysSettingsAuthFallback) {
-			tokenUrl = NormalizeTokenUrl(GetStringSysSetting("IdentityServerUrl"));
-			clientId = GetStringSysSetting("IdentityServerClientId");
-			clientSecret = GetStringSysSetting("IdentityServerClientSecret");
-			if (HasOAuthSettings(tokenUrl, clientId, clientSecret)) {
-				return new DataForgeResolvedConfig(
-					serviceUrl,
-					timeoutMs,
-					similarTablesLimit,
-					lookupLimit,
-					relationshipsLimit,
-					DataForgeAuthMode.OAuthClientCredentials,
-					tokenUrl,
-					clientId,
-					clientSecret,
-					scope);
-			}
 		}
 
 		return new DataForgeResolvedConfig(
@@ -97,41 +84,27 @@ public sealed class DataForgeConfigResolver(
 			throw new InvalidOperationException(explicitCandidate.ErrorMessage);
 		}
 
-		ServiceUrlCandidate gatewayCandidate = GetGatewayServiceUrlCandidate();
-		if (gatewayCandidate.IsSuccess) {
-			return gatewayCandidate.Value!;
-		}
-
 		ServiceUrlCandidate directCandidate = GetDirectServiceUrlCandidate();
 		if (directCandidate.IsSuccess) {
 			return directCandidate.Value!;
 		}
 
-		throw new InvalidOperationException(BuildMissingServiceUrlError(gatewayCandidate, directCandidate));
+		throw new InvalidOperationException(BuildMissingServiceUrlError(directCandidate));
 	}
 
 	private int GetIntSysSetting(string code, int defaultValue) {
-		try {
-			return sysSettingsManager.GetSysSettingValueByCode<int>(code);
-		} catch {
+		DataForgeSysSettingReadResult readResult = directReader.ReadValue(code);
+		if (!readResult.Found || !string.IsNullOrWhiteSpace(readResult.FailureReason)) {
 			return defaultValue;
 		}
-	}
 
-	private ServiceUrlCandidate GetGatewayServiceUrlCandidate() {
-		try {
-			return ValidateServiceUrlCandidate(
-				sysSettingsManager.GetSysSettingValueByCode(DataForgeServiceUrlCode),
-				"cliogate GetSysSettingValueByCode(DataForgeServiceUrl)",
-				treatInvalidAsUnavailable: true);
-		} catch (Exception ex) {
-			return ServiceUrlCandidate.Unavailable(
-				$"cliogate GetSysSettingValueByCode(DataForgeServiceUrl) failed: {ex.Message}");
-		}
+		return int.TryParse(readResult.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value)
+			? value
+			: defaultValue;
 	}
 
 	private ServiceUrlCandidate GetDirectServiceUrlCandidate() {
-		DataForgeSysSettingReadResult readResult = directReader.ReadTextValue(DataForgeServiceUrlCode);
+		DataForgeSysSettingReadResult readResult = directReader.ReadValue(DataForgeServiceUrlCode);
 		if (!string.IsNullOrWhiteSpace(readResult.FailureReason)) {
 			return ServiceUrlCandidate.Unavailable(
 				$"direct SysSettings read failed: {readResult.FailureReason}");
@@ -146,21 +119,30 @@ public sealed class DataForgeConfigResolver(
 	}
 
 	private string? GetStringSysSetting(string code) {
+		// Use GetSecureSysSettingValueByCode — calls ClioGate HTTP which decrypts SecureText.
+		// Falls back to ATF.Repository OData when ClioGate is unavailable.
 		try {
-			return NormalizeRawStringValue(sysSettingsManager.GetSysSettingValueByCode(code));
+			string clioGateValue = sysSettingsManager.GetSecureSysSettingValueByCode(code);
+			if (!string.IsNullOrWhiteSpace(clioGateValue)) {
+				return NormalizeRawStringValue(clioGateValue);
+			}
 		} catch {
-			return null;
+			// ClioGate unavailable or failed — fall through to direct OData reader.
 		}
+
+		// Fallback: direct OData reader (works for non-SecureText types).
+		DataForgeSysSettingReadResult readResult = directReader.ReadValue(code);
+		return readResult.Found && string.IsNullOrWhiteSpace(readResult.FailureReason)
+			? NormalizeRawStringValue(readResult.Value)
+			: null;
 	}
 
-	private static string BuildMissingServiceUrlError(
-		ServiceUrlCandidate gatewayCandidate,
-		ServiceUrlCandidate directCandidate) {
-		if (gatewayCandidate.IsMissing && directCandidate.IsMissing) {
+	private static string BuildMissingServiceUrlError(ServiceUrlCandidate directCandidate) {
+		if (directCandidate.IsMissing) {
 			return "DataForgeServiceUrl is not configured in Creatio SysSettings.";
 		}
 
-		return $"Failed to resolve DataForgeServiceUrl. Gateway path: {gatewayCandidate.ErrorMessage} Direct read: {directCandidate.ErrorMessage}";
+		return $"Failed to resolve DataForgeServiceUrl from Creatio SysSettings. {directCandidate.ErrorMessage}";
 	}
 
 	private static bool HasOAuthSettings(string? tokenUrl, string? clientId, string? clientSecret) {

--- a/clio/Common/DataForge/DataForgeModels.cs
+++ b/clio/Common/DataForge/DataForgeModels.cs
@@ -19,7 +19,6 @@ public sealed record DataForgeConfigRequest {
 	public string? ClientId { get; init; }
 	public string? ClientSecret { get; init; }
 	public string? Scope { get; init; }
-	public bool AllowSysSettingsAuthFallback { get; init; }
 }
 
 public sealed record DataForgeResolvedConfig(
@@ -36,8 +35,6 @@ public sealed record DataForgeResolvedConfig(
 );
 
 public sealed class DataForgeTargetOptions : EnvironmentOptions {
-	public bool AllowSysSettingsAuthFallback { get; set; }
-
 	[Description("OAuth scope for dataforge-service token requests. Defaults to use_enrichment.")]
 	public string? Scope { get; set; }
 }

--- a/clio/Common/DataForge/DataForgeSysSettingDirectReader.cs
+++ b/clio/Common/DataForge/DataForgeSysSettingDirectReader.cs
@@ -57,7 +57,7 @@ public sealed class DataForgeSysSettingDirectReader(IDataProvider dataProvider) 
 			string? normalizedValue = context
 				.Models<SysSettingsValue>()
 				.Where(v => v.SysSettingsId == sysSetting.Id)
-				.ToList()
+				.AsEnumerable()
 				.OrderByDescending(v => v.SysAdminUnitId == AllUsersId)
 				.Select(v => MapValue(sysSetting.ValueTypeName, v))
 				.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
@@ -92,7 +92,7 @@ public sealed class DataForgeSysSettingDirectReader(IDataProvider dataProvider) 
 			SysSettingsValue? sysSettingValue = context
 				.Models<SysSettingsValue>()
 				.Where(v => v.SysSettingsId == sysSetting.Id)
-				.ToList()
+				.AsEnumerable()
 				.OrderByDescending(v => v.SysAdminUnitId == AllUsersId)
 				.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v.TextValue));
 

--- a/clio/Common/DataForge/DataForgeSysSettingDirectReader.cs
+++ b/clio/Common/DataForge/DataForgeSysSettingDirectReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using ATF.Repository;
 using ATF.Repository.Providers;
@@ -11,6 +12,13 @@ namespace Clio.Common.DataForge;
 /// Used as a fallback when <see cref="ISysSettingsManager.GetSysSettingValueByCode"/> fails.
 /// </summary>
 public interface IDataForgeSysSettingDirectReader {
+	/// <summary>
+	/// Attempts to read the value of a system setting by its code using direct OData access.
+	/// </summary>
+	/// <param name="code">The SysSetting code (e.g. "DataForgeServiceUrl").</param>
+	/// <returns>The direct-read result describing whether a value was found and whether the lookup failed.</returns>
+	DataForgeSysSettingReadResult ReadValue(string code);
+
 	/// <summary>
 	/// Attempts to read the text value of a system setting by its code using direct OData access.
 	/// </summary>
@@ -34,6 +42,34 @@ public sealed record DataForgeSysSettingReadResult(
 public sealed class DataForgeSysSettingDirectReader(IDataProvider dataProvider) : IDataForgeSysSettingDirectReader {
 	private static readonly Guid AllUsersId = new("a29a3ba5-4b0d-de11-9a51-005056c00008");
 
+	public DataForgeSysSettingReadResult ReadValue(string code) {
+		try {
+			var context = AppDataContextFactory.GetAppDataContext(dataProvider);
+			SysSettings? sysSetting = context
+				.Models<SysSettings>()
+				.Where(s => s.Code == code)
+				.FirstOrDefault();
+
+			if (sysSetting is null) {
+				return new DataForgeSysSettingReadResult(false, null, null);
+			}
+
+			string? normalizedValue = context
+				.Models<SysSettingsValue>()
+				.Where(v => v.SysSettingsId == sysSetting.Id)
+				.ToList()
+				.OrderByDescending(v => v.SysAdminUnitId == AllUsersId)
+				.Select(v => MapValue(sysSetting.ValueTypeName, v))
+				.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+			return string.IsNullOrWhiteSpace(normalizedValue)
+				? new DataForgeSysSettingReadResult(false, null, null)
+				: new DataForgeSysSettingReadResult(true, normalizedValue.Trim(), null);
+		} catch (Exception ex) {
+			return new DataForgeSysSettingReadResult(false, null, ex.Message);
+		}
+	}
+
 	public DataForgeSysSettingReadResult ReadTextValue(string code) {
 		try {
 			var context = AppDataContextFactory.GetAppDataContext(dataProvider);
@@ -56,6 +92,7 @@ public sealed class DataForgeSysSettingDirectReader(IDataProvider dataProvider) 
 			SysSettingsValue? sysSettingValue = context
 				.Models<SysSettingsValue>()
 				.Where(v => v.SysSettingsId == sysSetting.Id)
+				.ToList()
 				.OrderByDescending(v => v.SysAdminUnitId == AllUsersId)
 				.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v.TextValue));
 
@@ -69,7 +106,24 @@ public sealed class DataForgeSysSettingDirectReader(IDataProvider dataProvider) 
 		}
 	}
 
+	private static string? MapValue(string? valueTypeName, SysSettingsValue sysSettingValue) {
+		return valueTypeName switch {
+			"Boolean" => sysSettingValue.BooleanValue.ToString().ToLowerInvariant(),
+			// SecureText is intentionally excluded: the raw TextValue is an encrypted blob and
+			// must not be treated as plain text. Return null so callers see it as "not found".
+			"MediumText" or "ShortText" or "LongText" or "Text" or "MaxSizeText" => sysSettingValue.TextValue,
+			"Integer" => sysSettingValue.IntegerValue.ToString(CultureInfo.InvariantCulture),
+			"Date" => sysSettingValue.DateTimeValue.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+			"Time" => sysSettingValue.DateTimeValue.ToString("HH:mm:ss", CultureInfo.InvariantCulture),
+			"DateTime" => sysSettingValue.DateTimeValue.ToString("o", CultureInfo.InvariantCulture),
+			"Float" or "Decimal" or "Currency" => sysSettingValue.FloatValue.ToString(CultureInfo.InvariantCulture),
+			"Lookup" => sysSettingValue.GuidValue.ToString(),
+			_ => null
+		};
+	}
+
 	private static bool IsTextValueType(string? valueTypeName) {
-		return valueTypeName is "Text" or "ShortText" or "MediumText" or "LongText" or "MaxSizeText" or "SecureText";
+		return valueTypeName is "Text" or "ShortText" or "MediumText" or "LongText" or "MaxSizeText";
 	}
 }
+

--- a/clio/Common/ISysSettingsManager.cs
+++ b/clio/Common/ISysSettingsManager.cs
@@ -31,13 +31,6 @@ public interface ISysSettingsManager
 	string GetSysSettingValueByCode(string code);
 
 	/// <summary>
-	///     Retrieves the value of a system setting by its code via the ClioGate HTTP endpoint,
-	///     which correctly decrypts SecureText settings on the server side.
-	///     Falls back to ATF.Repository OData when ClioGate is unavailable.
-	/// </summary>
-	string GetSecureSysSettingValueByCode(string code);
-
-	/// <summary>
 	///     Retrieves the value of a system setting by its code and converts it to the specified type.
 	/// </summary>
 	/// <typeparam name="T">The type to which the system setting value should be converted.</typeparam>
@@ -52,6 +45,13 @@ public interface ISysSettingsManager
 	///     If the value cannot be converted to the specified type, an InvalidCastException will be thrown.
 	/// </remarks>
 	T GetSysSettingValueByCode<T>(string code);
+
+	/// <summary>
+	///     Retrieves the value of a system setting by its code via the ClioGate HTTP endpoint,
+	///     which correctly decrypts SecureText settings on the server side.
+	///     Falls back to ATF.Repository OData when ClioGate is unavailable.
+	/// </summary>
+	string GetSecureSysSettingValueByCode(string code);
 
 	SysSettingsManager.InsertSysSettingResponse InsertSysSetting(string name, string code, string valueTypeName,
 		bool cached = true, string description = "", bool valueForCurrentUser = false);
@@ -194,6 +194,19 @@ public class SysSettingsManager : ISysSettingsManager
 		return _dataProvider.GetSysSettingValue<string>(code) ?? string.Empty;
 	}
 
+	public T GetSysSettingValueByCode<T>(string code){
+		string val = GetSysSettingValueByCode(code);
+		return typeof(T) switch {
+			_ when typeof(T) == typeof(string) => (T)(object)val,
+			_ when typeof(T) == typeof(int) => (T)ConvertToInt(val),
+			_ when typeof(T) == typeof(decimal) => (T)ConvertToDecimal(val),
+			_ when typeof(T) == typeof(bool) => (T)ConvertToBool(val),
+			_ when typeof(T) == typeof(DateTime) => (T)ConvertToDateTime(val),
+			_ when typeof(T) == typeof(Guid) => (T)ConvertToGuid(val),
+			_ => throw new ArgumentOutOfRangeException()
+		};
+	}
+
 	public string GetSecureSysSettingValueByCode(string code){
 		// Uses ClioGate HTTP endpoint which decrypts SecureText on the server side.
 		// Falls back to ATF.Repository OData when ClioGate is unavailable (returns
@@ -213,19 +226,6 @@ public class SysSettingsManager : ISysSettingsManager
 			// ClioGate not installed or unavailable — fall through to ATF.Repository.
 		}
 		return _dataProvider.GetSysSettingValue<string>(code) ?? string.Empty;
-	}
-
-	public T GetSysSettingValueByCode<T>(string code){
-		string val = GetSysSettingValueByCode(code);
-		return typeof(T) switch {
-			_ when typeof(T) == typeof(string) => (T)(object)val,
-			_ when typeof(T) == typeof(int) => (T)ConvertToInt(val),
-			_ when typeof(T) == typeof(decimal) => (T)ConvertToDecimal(val),
-			_ when typeof(T) == typeof(bool) => (T)ConvertToBool(val),
-			_ when typeof(T) == typeof(DateTime) => (T)ConvertToDateTime(val),
-			_ when typeof(T) == typeof(Guid) => (T)ConvertToGuid(val),
-			_ => throw new ArgumentOutOfRangeException()
-		};
 	}
 
 	public InsertSysSettingResponse InsertSysSetting(string name, string code, string valueTypeName,

--- a/clio/Common/ISysSettingsManager.cs
+++ b/clio/Common/ISysSettingsManager.cs
@@ -31,6 +31,13 @@ public interface ISysSettingsManager
 	string GetSysSettingValueByCode(string code);
 
 	/// <summary>
+	///     Retrieves the value of a system setting by its code via the ClioGate HTTP endpoint,
+	///     which correctly decrypts SecureText settings on the server side.
+	///     Falls back to ATF.Repository OData when ClioGate is unavailable.
+	/// </summary>
+	string GetSecureSysSettingValueByCode(string code);
+
+	/// <summary>
 	///     Retrieves the value of a system setting by its code and converts it to the specified type.
 	/// </summary>
 	/// <typeparam name="T">The type to which the system setting value should be converted.</typeparam>
@@ -184,6 +191,27 @@ public class SysSettingsManager : ISysSettingsManager
 	#region Methods: Public
 
 	public string GetSysSettingValueByCode(string code){
+		return _dataProvider.GetSysSettingValue<string>(code) ?? string.Empty;
+	}
+
+	public string GetSecureSysSettingValueByCode(string code){
+		// Uses ClioGate HTTP endpoint which decrypts SecureText on the server side.
+		// Falls back to ATF.Repository OData when ClioGate is unavailable (returns
+		// an encrypted blob for SecureText in that case — callers must be aware).
+		try {
+			string json = JsonSerializer.Serialize(new GetSettingRequestData(code), _jsonSerializerOptions);
+			string url = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.GetSysSettingValueByCode);
+			string result = _creatioClient.ExecutePostRequest(url, json);
+			if (!string.IsNullOrWhiteSpace(result)) {
+				try {
+					return JsonSerializer.Deserialize<string>(result, _jsonSerializerOptions) ?? string.Empty;
+				} catch {
+					return result.Trim('"');
+				}
+			}
+		} catch {
+			// ClioGate not installed or unavailable — fall through to ATF.Repository.
+		}
 		return _dataProvider.GetSysSettingValue<string>(code) ?? string.Empty;
 	}
 

--- a/clio/Common/ISysSettingsManager.cs
+++ b/clio/Common/ISysSettingsManager.cs
@@ -219,7 +219,10 @@ public class SysSettingsManager : ISysSettingsManager
 				try {
 					return JsonSerializer.Deserialize<string>(result, _jsonSerializerOptions) ?? string.Empty;
 				} catch {
-					return result.Trim('"');
+					// Response is not a valid JSON string — strip exactly one surrounding quote pair if present.
+					return result.Length >= 2 && result[0] == '"' && result[^1] == '"'
+						? result[1..^1]
+						: result;
 				}
 			}
 		} catch {

--- a/clio/Common/ServiceUrlBuilder.cs
+++ b/clio/Common/ServiceUrlBuilder.cs
@@ -91,7 +91,12 @@ public class ServiceUrlBuilder : IServiceUrlBuilder
 		/// <summary>
 		///     Retrieves bound schema data rows from the remote DB.
 		/// </summary>
-		GetBoundSchemaData = 35
+		GetBoundSchemaData = 35,
+
+		/// <summary>
+		///     Retrieves the value of a system setting by its code via ClioGate.
+		/// </summary>
+		GetSysSettingValueByCode = 36
 
 	}
 
@@ -140,6 +145,7 @@ public class ServiceUrlBuilder : IServiceUrlBuilder
 		{KnownRoute.SaveSchemaData, "ServiceModel/SchemaDataDesignerService.svc/SaveSchema"},
 		{KnownRoute.DeletePackageSchemaData, "DataService/json/SyncReply/DeletePackageSchemaDataRequest"},
 		{KnownRoute.GetBoundSchemaData, "ServiceModel/SchemaDataDesignerService.svc/GetBoundSchemaData"},
+		{KnownRoute.GetSysSettingValueByCode, "/rest/CreatioApiGateway/GetSysSettingValueByCode"},
 	};
 
 	private EnvironmentSettings _environmentSettings;

--- a/cliogate/Files/cs/CreatioApiGateway.cs
+++ b/cliogate/Files/cs/CreatioApiGateway.cs
@@ -180,7 +180,7 @@ namespace cliogate.Files.cs
 		public string GetSysSettingValueByCode(string code){
 			CheckCanManageSysSettings();
 			bool isValue = SysSettings.TryGetValue(_userConnection, code, out object value);
-			
+
 			if(value == null || !isValue) {
 				var v  = SysSettings.GetDefValue(_userConnection, code);
 				if(v != null) {
@@ -188,16 +188,15 @@ namespace cliogate.Files.cs
 					isValue = true;
 				}
 			}
-			
+
 			if(value == null || !isValue) {
 				return string.Empty;
 			}
-			
-			
+
 			const string schemaName = "SysSettings";
 			Entity sysSettingsEntity = _userConnection.EntitySchemaManager
 				.FindInstanceByName(schemaName).CreateEntity(_userConnection);
-			
+
 			bool isFetched = sysSettingsEntity.FetchFromDB("Code", code, false);
 			string valueTypeName = sysSettingsEntity.GetTypedColumnValue<string>("ValueTypeName");
 
@@ -214,6 +213,11 @@ namespace cliogate.Files.cs
 				case "Time":
 					DateTime dt3 = DateTime.Parse(value.ToString());
 					returnValue = dt3.ToString(@"HH:mm:ss");
+					break;
+				case "SecureText":
+					// TryGetValue returns ProtectedString for SecureText; .ToString() returns empty
+					// by design (to prevent accidental leaks). Use GetValue<string> to decrypt.
+					returnValue = SysSettings.GetValue<string>(_userConnection, code, string.Empty);
 					break;
 				default:
 					returnValue = value.ToString();


### PR DESCRIPTION
 Changes

  Bug #1 — OData boolean OrderBy crash (.NET Framework)

  DataForgeSysSettingDirectReader used .OrderByDescending(v => v.SysAdminUnitId == AllUsersId) directly in an OData query. .NET Framework OData provider
  does not support boolean expressions in $orderby and throws NotSupportedException.
  Fix: materialize with .ToList() before ordering in memory.

  Bug #2 — SecureText returns encrypted blob via OData

  SysSettingsValue.TextValue for SecureText type columns contains an encrypted blob when read via OData. Using that blob as a plain string silently
  corrupts downstream values (e.g. IdentityServerClientSecret).
  Fix: exclude SecureText from MapValue() and IsTextValueType() — callers receive a "not found" result and fall back to ClioGate HTTP.

  Bug #3 — OAuth settings gated behind AllowSysSettingsAuthFallback

  A prior commit gated IdentityServer* SysSetting reads behind AllowSysSettingsAuthFallback, a flag that is never set in practice. This silently disabled
  OAuth config resolution.
  Fix: always read OAuth settings when no explicit OAuth credentials are supplied in the request.

  Bug #4 — GetSysSettingValueByCode regressed to plain OData

  A "DI cleanup" commit replaced the ClioGate HTTP call with an ATF.Repository OData call, which returns the encrypted blob for SecureText — same problem
  as Bug #2 but in a different code path.
  Fix: add GetSecureSysSettingValueByCode that calls ClioGate HTTP first and falls back to OData; leave the original GetSysSettingValueByCode unchanged.

  Bug #5 — ProtectedString.ToString() returns empty string

  SysSettings.TryGetValue() returns a ProtectedString for SecureText. ProtectedString.ToString() intentionally returns "" as a security feature.
  Fix: use SysSettings.GetValue<string>() which decrypts the value properly.

  Feature — Auto-install ClioGate at DataForge tool entry point

  When ClioGate is absent, all DataForge tools that depend on SecureText OAuth settings fail with a confusing error. There is no standard decryption
  endpoint on .NET Framework Creatio without ClioGate.

  Fix: introduce IClioGateEnsurer / ClioGateEnsurer:

   - Called at the entry point of every tool method that requires OAuth (health, status, find-lookups, context, etc.).
   - Checks GetInstalledVersion() first; only installs if absent.
   - Installs via IPackageInstaller + restarts via IApplication.
   - Surfaces a warning in the tool response warnings[] so the caller knows a restart happened.
   - Uses a static ConcurrentDictionary cache keyed by normalized URI — no repeated checks across calls.
   - Cache misses are serialized per environment via a SemaphoreSlim (double-checked locking) to prevent concurrent installs and duplicate restarts under 
  parallel MCP tool calls.