### PR TITLE
feat(mcp): page business rules: make required, optional, readonly, editable actions

### DIFF
--- a/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
@@ -49,7 +49,7 @@ public sealed class EntityBusinessRuleToolE2ETests {
 		anyOf.GetArrayLength().Should().Be(5,
 			because: "the real MCP tools/list schema should describe each supported business-rule action subtype");
 		anyOf.EnumerateArray().Select(GetActionType).Should().NotContain(["hide-element", "show-element"],
-			because: "page-only show/hide actions should not appear in the entity business-rule runtime schema");
+			because: "page-only actions should not appear in the entity business-rule runtime schema");
 		anyOf.EnumerateArray().Should().Contain(branch =>
 				branch.GetProperty("properties").GetProperty("type").GetProperty("const").GetString() == "make-required"
 				&& branch.GetProperty("properties").GetProperty("items").GetProperty("items").GetProperty("type").GetString() == "string",

--- a/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
@@ -62,15 +62,11 @@ public sealed class PageBusinessRuleToolE2ETests {
 	}
 
 	[Test]
-	[Description("Binds a new page field-state action payload through the real MCP server and reports an invalid environment failure from command execution.")]
-	[TestCase("make-editable")]
-	[TestCase("make-read-only")]
-	[TestCase("make-required")]
-	[TestCase("make-optional")]
+	[Description("Binds a show-element page business-rule payload through the real MCP server and reports an invalid environment failure from command execution.")]
 	[AllureTag(ToolName)]
-	[AllureName("Page business-rule MCP tool binds field-state payloads")]
-	[AllureDescription("Starts the real clio MCP server, calls create-page-business-rule with a field-state payload and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
-	public async Task BusinessRuleCreate_Should_Bind_Field_State_Payload_And_Report_Invalid_Environment(string actionType) {
+	[AllureName("Page business-rule MCP tool binds show/hide payloads")]
+	[AllureDescription("Starts the real clio MCP server, calls create-page-business-rule with a show-element payload and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
+	public async Task BusinessRuleCreate_Should_Bind_ShowElement_Payload_And_Report_Invalid_Environment() {
 		// Arrange
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
 		string invalidEnvironmentName = $"missing-page-business-rule-env-{Guid.NewGuid():N}";
@@ -82,18 +78,16 @@ public sealed class PageBusinessRuleToolE2ETests {
 				["environmentName"] = invalidEnvironmentName,
 				["packageName"] = "UsrPkg",
 				["pageSchemaName"] = "UsrCase_FormPage",
-				["rule"] = CreateFieldStateRule(actionType)
+				["rule"] = CreateShowElementRule()
 			},
 			arrangeContext.CancellationTokenSource.Token);
 		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
 
 		// Assert
 		callResult.IsError.Should().NotBeTrue(
-			because: $"valid {actionType} payloads should bind and return the standard command execution envelope");
+			because: "valid show-element payloads should bind and return the standard command execution envelope");
 		execution.ExitCode.Should().NotBe(0,
 			because: "the intentionally missing environment should fail during command execution");
-		execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
-			because: "missing environments should be reported as command execution errors after payload binding succeeds");
 		execution.Output.Should().Contain(message =>
 				ContainsText(message.Value, invalidEnvironmentName),
 			because: "the failure should come from resolving the requested environment, not from deserializing the page action payload");
@@ -103,7 +97,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 	[Description("Creates a page business rule for Contact_FormPage in the Custom package through the real MCP server and Creatio environment.")]
 	[AllureTag(ToolName)]
 	[AllureName("Page business-rule MCP tool creates a Contact page rule")]
-	[AllureDescription("Requires a reachable sandbox environment and destructive opt-in. Reads Contact_FormPage, builds a valid page field-state rule from its bundle, and verifies that Creatio command execution succeeds.")]
+	[AllureDescription("Requires a reachable sandbox environment and destructive opt-in. Reads Contact_FormPage, builds a valid page show/hide rule from its bundle, and verifies that Creatio command execution succeeds.")]
 	public async Task BusinessRuleCreate_Should_Create_Contact_Page_Rule_In_Creatio() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -136,7 +130,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 
 		// Assert
 		callResult.IsError.Should().NotBeTrue(
-			because: "a valid Contact page field-state rule should return the standard command execution envelope");
+			because: "a valid Contact page show/hide rule should return the standard command execution envelope");
 		execution.ExitCode.Should().Be(0,
 			because: "the Contact page rule should be created in the configured Creatio sandbox");
 		execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Info,
@@ -149,7 +143,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 			packageName,
 			target.RootSchemaUId,
 			caption,
-			"Terrasoft.Core.BusinessRules.Models.Actions.BusinessRuleActionReadonlyElement",
+			"Terrasoft.Core.BusinessRules.Models.Actions.BusinessRuleActionHideElement",
 			[target.ElementName],
 			target.AttributeName,
 			arrangeContext.CancellationTokenSource.Token);
@@ -316,15 +310,15 @@ public sealed class PageBusinessRuleToolE2ETests {
 			},
 			["actions"] = new object[] {
 				new Dictionary<string, object?> {
-					["type"] = "make-read-only",
+					["type"] = "hide-element",
 					["items"] = new object[] { target.ElementName }
 				}
 			}
 		};
 
-	private static IReadOnlyDictionary<string, object?> CreateFieldStateRule(string actionType) =>
+	private static IReadOnlyDictionary<string, object?> CreateShowElementRule() =>
 		new Dictionary<string, object?> {
-			["caption"] = $"Apply {actionType} for high priority",
+			["caption"] = "Show escalation for high priority",
 			["condition"] = new Dictionary<string, object?> {
 				["logicalOperation"] = "AND",
 				["conditions"] = new object[] {
@@ -340,7 +334,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 			},
 			["actions"] = new object[] {
 				new Dictionary<string, object?> {
-					["type"] = actionType,
+					["type"] = "show-element",
 					["items"] = new object[] { "EscalateButton" }
 				}
 			}

--- a/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
@@ -62,11 +62,15 @@ public sealed class PageBusinessRuleToolE2ETests {
 	}
 
 	[Test]
-	[Description("Binds a show-element page business-rule payload through the real MCP server and reports an invalid environment failure from command execution.")]
+	[Description("Binds a new page field-state action payload through the real MCP server and reports an invalid environment failure from command execution.")]
+	[TestCase("make-editable")]
+	[TestCase("make-read-only")]
+	[TestCase("make-required")]
+	[TestCase("make-optional")]
 	[AllureTag(ToolName)]
-	[AllureName("Page business-rule MCP tool binds show/hide payloads")]
-	[AllureDescription("Starts the real clio MCP server, calls create-page-business-rule with a show-element payload and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
-	public async Task BusinessRuleCreate_Should_Bind_ShowElement_Payload_And_Report_Invalid_Environment() {
+	[AllureName("Page business-rule MCP tool binds field-state payloads")]
+	[AllureDescription("Starts the real clio MCP server, calls create-page-business-rule with a field-state payload and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
+	public async Task BusinessRuleCreate_Should_Bind_Field_State_Payload_And_Report_Invalid_Environment(string actionType) {
 		// Arrange
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
 		string invalidEnvironmentName = $"missing-page-business-rule-env-{Guid.NewGuid():N}";
@@ -78,16 +82,18 @@ public sealed class PageBusinessRuleToolE2ETests {
 				["environmentName"] = invalidEnvironmentName,
 				["packageName"] = "UsrPkg",
 				["pageSchemaName"] = "UsrCase_FormPage",
-				["rule"] = CreateShowElementRule()
+				["rule"] = CreateFieldStateRule(actionType)
 			},
 			arrangeContext.CancellationTokenSource.Token);
 		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
 
 		// Assert
 		callResult.IsError.Should().NotBeTrue(
-			because: "valid show-element payloads should bind and return the standard command execution envelope");
+			because: $"valid {actionType} payloads should bind and return the standard command execution envelope");
 		execution.ExitCode.Should().NotBe(0,
 			because: "the intentionally missing environment should fail during command execution");
+		execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+			because: "missing environments should be reported as command execution errors after payload binding succeeds");
 		execution.Output.Should().Contain(message =>
 				ContainsText(message.Value, invalidEnvironmentName),
 			because: "the failure should come from resolving the requested environment, not from deserializing the page action payload");
@@ -97,7 +103,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 	[Description("Creates a page business rule for Contact_FormPage in the Custom package through the real MCP server and Creatio environment.")]
 	[AllureTag(ToolName)]
 	[AllureName("Page business-rule MCP tool creates a Contact page rule")]
-	[AllureDescription("Requires a reachable sandbox environment and destructive opt-in. Reads Contact_FormPage, builds a valid page show/hide rule from its bundle, and verifies that Creatio command execution succeeds.")]
+	[AllureDescription("Requires a reachable sandbox environment and destructive opt-in. Reads Contact_FormPage, builds a valid page field-state rule from its bundle, and verifies that Creatio command execution succeeds.")]
 	public async Task BusinessRuleCreate_Should_Create_Contact_Page_Rule_In_Creatio() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -130,7 +136,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 
 		// Assert
 		callResult.IsError.Should().NotBeTrue(
-			because: "a valid Contact page show/hide rule should return the standard command execution envelope");
+			because: "a valid Contact page field-state rule should return the standard command execution envelope");
 		execution.ExitCode.Should().Be(0,
 			because: "the Contact page rule should be created in the configured Creatio sandbox");
 		execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Info,
@@ -143,7 +149,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 			packageName,
 			target.RootSchemaUId,
 			caption,
-			"Terrasoft.Core.BusinessRules.Models.Actions.BusinessRuleActionHideElement",
+			"Terrasoft.Core.BusinessRules.Models.Actions.BusinessRuleActionReadonlyElement",
 			[target.ElementName],
 			target.AttributeName,
 			arrangeContext.CancellationTokenSource.Token);
@@ -310,15 +316,15 @@ public sealed class PageBusinessRuleToolE2ETests {
 			},
 			["actions"] = new object[] {
 				new Dictionary<string, object?> {
-					["type"] = "hide-element",
+					["type"] = "make-read-only",
 					["items"] = new object[] { target.ElementName }
 				}
 			}
 		};
 
-	private static IReadOnlyDictionary<string, object?> CreateShowElementRule() =>
+	private static IReadOnlyDictionary<string, object?> CreateFieldStateRule(string actionType) =>
 		new Dictionary<string, object?> {
-			["caption"] = "Show escalation for high priority",
+			["caption"] = $"Apply {actionType} for high priority",
 			["condition"] = new Dictionary<string, object?> {
 				["logicalOperation"] = "AND",
 				["conditions"] = new object[] {
@@ -334,7 +340,7 @@ public sealed class PageBusinessRuleToolE2ETests {
 			},
 			["actions"] = new object[] {
 				new Dictionary<string, object?> {
-					["type"] = "show-element",
+					["type"] = actionType,
 					["items"] = new object[] { "EscalateButton" }
 				}
 			}

--- a/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
@@ -26,10 +26,10 @@ public sealed class PageBusinessRuleToolE2ETests {
 	private const string ToolName = CreatePageBusinessRuleTool.BusinessRuleCreateToolName;
 
 	[Test]
-	[Description("Advertises polymorphic anyOf runtime schema branches only for page show/hide actions through the real MCP server.")]
+	[Description("Advertises polymorphic anyOf runtime schema branches only for page actions through the real MCP server.")]
 	[AllureTag(ToolName)]
 	[AllureName("Page business-rule MCP tool advertises page-only action schema")]
-	[AllureDescription("Starts the real clio MCP server, lists tools, and verifies create-page-business-rule exposes only hide-element and show-element action branches.")]
+	[AllureDescription("Starts the real clio MCP server, lists tools, and verifies create-page-business-rule exposes only page action branches.")]
 	public async Task BusinessRuleCreate_Should_Advertise_Page_Only_Action_Runtime_Schema() {
 		// Arrange
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
@@ -48,9 +48,16 @@ public sealed class PageBusinessRuleToolE2ETests {
 			.GetProperty("actions")
 			.GetProperty("items")
 			.GetProperty("anyOf");
-		anyOf.GetArrayLength().Should().Be(2,
-			because: "the page tool should advertise only page show/hide action payload branches");
-		anyOf.EnumerateArray().Select(GetActionType).Should().BeEquivalentTo(["hide-element", "show-element"],
+		anyOf.GetArrayLength().Should().Be(6,
+			because: "the page tool should advertise only page action payload branches");
+		anyOf.EnumerateArray().Select(GetActionType).Should().BeEquivalentTo([
+				"hide-element",
+				"show-element",
+				"make-editable",
+				"make-read-only",
+				"make-required",
+				"make-optional"
+			],
 			because: "entity-only actions should not appear in the page business-rule runtime schema");
 	}
 

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -634,7 +634,11 @@ public sealed class ToolContractGetToolE2ETests {
 				validator.Name == "enum" &&
 				validator.Field == "rule.actions[*].type" &&
 				validator.Context!.Contains("hide-element", StringComparison.Ordinal) &&
-				validator.Context.Contains("show-element", StringComparison.Ordinal),
+				validator.Context.Contains("show-element", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-editable", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-read-only", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-required", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-optional", StringComparison.Ordinal),
 			because: "the contract should advertise page-only action values");
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "page-element" &&

--- a/clio.tests/Command/BusinessRuleMetadataConverterTests.cs
+++ b/clio.tests/Command/BusinessRuleMetadataConverterTests.cs
@@ -231,6 +231,51 @@ public sealed class BusinessRuleMetadataConverterTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Maps page field-state actions to Creatio page business-rule action metadata type names.")]
+	public void ToPageMetadata_Should_Map_Page_Field_State_Action_Metadata() {
+		// Arrange
+		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap =
+			new Dictionary<string, BusinessRuleAttributeDescriptor>(StringComparer.Ordinal) {
+				["PDS_Status"] = new("PDS_Status", "Text", null)
+			};
+		BusinessRule rule = new(
+			"Change page element state",
+			new BusinessRuleConditionGroup(
+				"AND",
+				[
+					new BusinessRuleCondition(
+						new BusinessRuleExpression("AttributeValue", "PDS_Status", null),
+						"is-filled-in")
+				]),
+			[
+				new MakeEditableBusinessRuleAction(["NameInput"]),
+				new MakeReadOnlyBusinessRuleAction(["AmountInput"]),
+				new MakeRequiredBusinessRuleAction(["CloseDateInput"]),
+				new MakeOptionalBusinessRuleAction(["CommentInput"])
+			]);
+
+		// Act
+		BusinessRuleMetadataDto metadata = BusinessRuleMetadataConverter.ToPageMetadata(attributeMap, rule);
+
+		// Assert
+		metadata.Cases.Single().Actions.Select(action => action.TypeName).Should().Equal([
+				BusinessRuleConstants.BusinessRuleEditableElementTypeName,
+				BusinessRuleConstants.BusinessRuleReadonlyElementTypeName,
+				BusinessRuleConstants.BusinessRuleRequiredElementTypeName,
+				BusinessRuleConstants.BusinessRuleOptionalElementTypeName
+			],
+			because: "page editability and required-state actions should persist using Creatio business-rule metadata type names");
+		metadata.Cases.Single().Actions.Select(action => action.Items).Should().Equal([
+				"NameInput",
+				"AmountInput",
+				"CloseDateInput",
+				"CommentInput"
+			],
+			because: "page action items should stay as page element names");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Maps set-values constant assignments into BusinessRuleActionSetValues metadata with typed item expressions.")]
 	public void ToMetadata_Should_Map_SetValues_Constant_Action_Metadata() {
 		// Arrange

--- a/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
+++ b/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
@@ -456,6 +456,54 @@ public sealed class BusinessRuleToolTests {
 			.Returns(new BusinessRuleCreateResult("BusinessRule_7654321"));
 		CreatePageBusinessRuleTool tool = new(command, ConsoleLogger.Instance, commandResolver);
 		PageBusinessRuleMcpContract rule = new(
+			"Show escalation when priority is high",
+			new BusinessRuleConditionGroup(
+				"AND",
+				[
+					new BusinessRuleCondition(
+						new BusinessRuleExpression("AttributeValue", "PDS_Priority", null),
+						"equal",
+						new BusinessRuleExpression("Const", null,
+							JsonSerializer.Deserialize<JsonElement>("\"High\"")))
+				]),
+			[
+				new PageShowElementBusinessRuleActionMcpContract(["EscalateButton"])
+			]);
+
+		// Act
+		CommandExecutionResult result = tool.BusinessRuleCreate("dev", "UsrPkg", "UsrCase_FormPage", rule);
+
+		// Assert
+		result.ExitCode.Should().Be(0,
+			because: "a successful page business-rule service call should return the standard success exit code");
+		result.Output.Select(message => (string)message.Value).Should().Contain("Rule name: BusinessRule_7654321",
+			because: "the MCP tool should preserve the generated internal rule name in execution logs");
+		commandResolver.Received(1).Resolve<CreatePageBusinessRuleCommand>(Arg.Is<EnvironmentOptions>(options =>
+			options.Environment == "dev"));
+		service.Received(1).Create(
+			Arg.Is<PageBusinessRuleCreateRequest>(request =>
+				request.PackageName == "UsrPkg"
+				&& request.PageSchemaName == "UsrCase_FormPage"
+				&& request.Rule.Caption == "Show escalation when priority is high"
+				&& request.Rule.Condition.LogicalOperation == "AND"
+				&& request.Rule.Actions.Count == 1
+				&& request.Rule.Actions[0].ActionType == "show-element"
+				&& request.Rule.Actions[0].FieldSelectionItems.Single() == "EscalateButton"));
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Maps a page field-state action payload into the page business-rule service request without breaking page element items.")]
+	public void PageBusinessRuleCreate_Should_Map_Field_State_Action_Arguments() {
+		// Arrange
+		IPageBusinessRuleService service = Substitute.For<IPageBusinessRuleService>();
+		CreatePageBusinessRuleCommand command = new(service, ConsoleLogger.Instance);
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreatePageBusinessRuleCommand>(Arg.Any<EnvironmentOptions>()).Returns(command);
+		service.Create(Arg.Any<PageBusinessRuleCreateRequest>())
+			.Returns(new BusinessRuleCreateResult("BusinessRule_7654321"));
+		CreatePageBusinessRuleTool tool = new(command, ConsoleLogger.Instance, commandResolver);
+		PageBusinessRuleMcpContract rule = new(
 			"Make escalation read-only when priority is high",
 			new BusinessRuleConditionGroup(
 				"AND",
@@ -476,16 +524,10 @@ public sealed class BusinessRuleToolTests {
 		// Assert
 		result.ExitCode.Should().Be(0,
 			because: "a successful page business-rule service call should return the standard success exit code");
-		result.Output.Select(message => (string)message.Value).Should().Contain("Rule name: BusinessRule_7654321",
-			because: "the MCP tool should preserve the generated internal rule name in execution logs");
-		commandResolver.Received(1).Resolve<CreatePageBusinessRuleCommand>(Arg.Is<EnvironmentOptions>(options =>
-			options.Environment == "dev"));
 		service.Received(1).Create(
 			Arg.Is<PageBusinessRuleCreateRequest>(request =>
 				request.PackageName == "UsrPkg"
 				&& request.PageSchemaName == "UsrCase_FormPage"
-				&& request.Rule.Caption == "Make escalation read-only when priority is high"
-				&& request.Rule.Condition.LogicalOperation == "AND"
 				&& request.Rule.Actions.Count == 1
 				&& request.Rule.Actions[0].ActionType == "make-read-only"
 				&& request.Rule.Actions[0].FieldSelectionItems.Single() == "EscalateButton"));

--- a/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
+++ b/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
@@ -456,7 +456,7 @@ public sealed class BusinessRuleToolTests {
 			.Returns(new BusinessRuleCreateResult("BusinessRule_7654321"));
 		CreatePageBusinessRuleTool tool = new(command, ConsoleLogger.Instance, commandResolver);
 		PageBusinessRuleMcpContract rule = new(
-			"Show escalation when priority is high",
+			"Make escalation read-only when priority is high",
 			new BusinessRuleConditionGroup(
 				"AND",
 				[
@@ -467,7 +467,7 @@ public sealed class BusinessRuleToolTests {
 							JsonSerializer.Deserialize<JsonElement>("\"High\"")))
 				]),
 			[
-				new PageShowElementBusinessRuleActionMcpContract(["EscalateButton"])
+				new PageMakeReadOnlyBusinessRuleActionMcpContract(["EscalateButton"])
 			]);
 
 		// Act
@@ -484,10 +484,10 @@ public sealed class BusinessRuleToolTests {
 			Arg.Is<PageBusinessRuleCreateRequest>(request =>
 				request.PackageName == "UsrPkg"
 				&& request.PageSchemaName == "UsrCase_FormPage"
-				&& request.Rule.Caption == "Show escalation when priority is high"
+				&& request.Rule.Caption == "Make escalation read-only when priority is high"
 				&& request.Rule.Condition.LogicalOperation == "AND"
 				&& request.Rule.Actions.Count == 1
-				&& request.Rule.Actions[0].ActionType == "show-element"
+				&& request.Rule.Actions[0].ActionType == "make-read-only"
 				&& request.Rule.Actions[0].FieldSelectionItems.Single() == "EscalateButton"));
 	}
 
@@ -554,7 +554,7 @@ public sealed class BusinessRuleToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Deserializes create-page-business-rule show and hide action payloads without accepting entity action branches.")]
+	[Description("Deserializes create-page-business-rule page action payloads without accepting object-only action branches.")]
 	public void PageBusinessRuleCreate_Should_Deserialize_Page_Action_Payload() {
 		// Arrange
 		string payload = """
@@ -584,6 +584,22 @@ public sealed class BusinessRuleToolTests {
 		      {
 		        "type": "hide-element",
 		        "items": [ "EscalateButton" ]
+		      },
+		      {
+		        "type": "make-editable",
+		        "items": [ "PriorityInput" ]
+		      },
+		      {
+		        "type": "make-read-only",
+		        "items": [ "AmountInput" ]
+		      },
+		      {
+		        "type": "make-required",
+		        "items": [ "CloseDateInput" ]
+		      },
+		      {
+		        "type": "make-optional",
+		        "items": [ "CommentInput" ]
 		      }
 		    ]
 		  }
@@ -597,9 +613,21 @@ public sealed class BusinessRuleToolTests {
 		payloadArgs.Should().NotBeNull(
 			because: "page business-rule payloads should deserialize from the MCP JSON shape");
 		BusinessRule rule = payloadArgs!.Rule.ToBusinessRule();
-		rule.Actions.Single().ActionType.Should().Be("hide-element",
-			because: "the page action discriminator should be preserved");
-		rule.Actions.Single().FieldSelectionItems.Should().Equal(["EscalateButton"],
+		rule.Actions.Select(action => action.ActionType).Should().Equal([
+				"hide-element",
+				"make-editable",
+				"make-read-only",
+				"make-required",
+				"make-optional"
+			],
+			because: "the page action discriminators should be preserved");
+		rule.Actions.SelectMany(action => action.FieldSelectionItems).Should().Equal([
+				"EscalateButton",
+				"PriorityInput",
+				"AmountInput",
+				"CloseDateInput",
+				"CommentInput"
+			],
 			because: "page element action items should deserialize as target element names");
 	}
 

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -308,7 +308,7 @@ public sealed class ToolContractGetToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Returns the canonical create-page-business-rule contract with page attribute validation and show/hide workflow guidance.")]
+	[Description("Returns the canonical create-page-business-rule contract with page attribute validation and page-action workflow guidance.")]
 	public void ToolContractGet_Should_Return_PageBusinessRuleCreate_Contract() {
 		// Arrange
 		ToolContractGetTool tool = new();
@@ -328,8 +328,12 @@ public sealed class ToolContractGetToolTests {
 				validator.Name == "enum" &&
 				validator.Field == "rule.actions[*].type" &&
 				validator.Context!.Contains("hide-element", StringComparison.Ordinal) &&
-				validator.Context.Contains("show-element", StringComparison.Ordinal),
-			because: "the page rule contract should advertise only page show/hide actions");
+				validator.Context.Contains("show-element", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-editable", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-read-only", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-required", StringComparison.Ordinal) &&
+				validator.Context.Contains("make-optional", StringComparison.Ordinal),
+			because: "the page rule contract should advertise all supported page actions");
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "page-element" &&
 				validator.Field == "rule.actions[*].items" &&
@@ -370,6 +374,18 @@ public sealed class ToolContractGetToolTests {
 		bool hasShowElementExample = contract.Examples.Any(HasPageActionExample("show-element"));
 		hasShowElementExample.Should().BeTrue(
 			because: "the contract should include a show-element page rule example");
+		bool hasMakeEditableExample = contract.Examples.Any(HasPageActionExample("make-editable"));
+		hasMakeEditableExample.Should().BeTrue(
+			because: "the contract should include a make-editable page rule example");
+		bool hasMakeReadOnlyExample = contract.Examples.Any(HasPageActionExample("make-read-only"));
+		hasMakeReadOnlyExample.Should().BeTrue(
+			because: "the contract should include a make-read-only page rule example");
+		bool hasMakeRequiredExample = contract.Examples.Any(HasPageActionExample("make-required"));
+		hasMakeRequiredExample.Should().BeTrue(
+			because: "the contract should include a make-required page rule example");
+		bool hasMakeOptionalExample = contract.Examples.Any(HasPageActionExample("make-optional"));
+		hasMakeOptionalExample.Should().BeTrue(
+			because: "the contract should include a make-optional page rule example");
 	}
 
 	private static Func<ToolContractExample, bool> HasPageActionExample(string actionType) =>

--- a/clio.tests/Command/PageBusinessRuleElementProviderTests.cs
+++ b/clio.tests/Command/PageBusinessRuleElementProviderTests.cs
@@ -60,6 +60,6 @@ public sealed class PageBusinessRuleElementProviderTests {
 
 		// Assert
 		result.Should().BeEquivalentTo(["Root", "Input_One", "Tab", "RefreshButton", "AddRecordButton", "NestedMetadataButton"],
-			because: "show/hide page actions can target any named element discovered recursively in viewConfig");
+			because: "page actions can target any named element discovered recursively in viewConfig");
 	}
 }

--- a/clio.tests/Command/PageBusinessRuleServiceTests.cs
+++ b/clio.tests/Command/PageBusinessRuleServiceTests.cs
@@ -69,8 +69,8 @@ public sealed class PageBusinessRuleServiceTests {
 			Arg.Any<BusinessRuleMetadataDto>());
 		capturedMetadata.Should().NotBeNull(
 			because: "the service should convert the validated page rule before saving the add-on");
-		capturedMetadata!.Cases.Single().Actions.Single().TypeName.Should().Be(BusinessRuleConstants.BusinessRuleShowElementTypeName,
-			because: "page show-element actions should be converted into the Creatio show element action type");
+		capturedMetadata!.Cases.Single().Actions.Single().TypeName.Should().Be(BusinessRuleConstants.BusinessRuleReadonlyElementTypeName,
+			because: "page field-state actions should be converted into the matching Creatio action type");
 	}
 
 	[Test]
@@ -116,7 +116,7 @@ public sealed class PageBusinessRuleServiceTests {
 
 	private static BusinessRule CreatePageRule(string actionElementName = "Input_One") =>
 		new(
-			"Show input",
+			"Make input read-only",
 			new BusinessRuleConditionGroup(
 				"AND",
 				[
@@ -126,6 +126,6 @@ public sealed class PageBusinessRuleServiceTests {
 						new BusinessRuleExpression("Const", null, JsonSerializer.Deserialize<JsonElement>("\"Ready\"")))
 				]),
 			[
-				new ShowElementBusinessRuleAction([actionElementName])
+				new MakeReadOnlyBusinessRuleAction([actionElementName])
 			]);
 }

--- a/clio.tests/Command/PageBusinessRuleServiceTests.cs
+++ b/clio.tests/Command/PageBusinessRuleServiceTests.cs
@@ -69,8 +69,8 @@ public sealed class PageBusinessRuleServiceTests {
 			Arg.Any<BusinessRuleMetadataDto>());
 		capturedMetadata.Should().NotBeNull(
 			because: "the service should convert the validated page rule before saving the add-on");
-		capturedMetadata!.Cases.Single().Actions.Single().TypeName.Should().Be(BusinessRuleConstants.BusinessRuleReadonlyElementTypeName,
-			because: "page field-state actions should be converted into the matching Creatio action type");
+		capturedMetadata!.Cases.Single().Actions.Single().TypeName.Should().Be(BusinessRuleConstants.BusinessRuleShowElementTypeName,
+			because: "page show-element actions should still be converted into the Creatio show element action type");
 	}
 
 	[Test]
@@ -116,7 +116,7 @@ public sealed class PageBusinessRuleServiceTests {
 
 	private static BusinessRule CreatePageRule(string actionElementName = "Input_One") =>
 		new(
-			"Make input read-only",
+			"Show input",
 			new BusinessRuleConditionGroup(
 				"AND",
 				[
@@ -126,6 +126,6 @@ public sealed class PageBusinessRuleServiceTests {
 						new BusinessRuleExpression("Const", null, JsonSerializer.Deserialize<JsonElement>("\"Ready\"")))
 				]),
 			[
-				new MakeReadOnlyBusinessRuleAction([actionElementName])
+				new ShowElementBusinessRuleAction([actionElementName])
 			]);
 }

--- a/clio.tests/Command/PageBusinessRuleValidatorTests.cs
+++ b/clio.tests/Command/PageBusinessRuleValidatorTests.cs
@@ -45,19 +45,43 @@ public sealed class PageBusinessRuleValidatorTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Rejects entity field-state actions for page business rules.")]
+	[Description("Accepts supported page field-state actions when every target exists in the page viewConfig.")]
+	[TestCase("make-editable")]
+	[TestCase("make-read-only")]
+	[TestCase("make-required")]
+	[TestCase("make-optional")]
+	public void Validate_Should_Accept_Page_Field_State_Action_Type(string actionType) {
+		// Arrange
+		BusinessRule rule = CreatePageRule(
+			action: CreateAction(actionType, ["NameInput"]));
+
+		// Act
+		Action act = () => PageBusinessRuleValidator.Validate(rule, CreateAttributeMap(), CreateElementNames());
+
+		// Assert
+		act.Should().NotThrow(
+			because: "page business rules should allow editable read-only required and optional actions for named page elements");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects object-only or otherwise unsupported actions for page business rules.")]
 	public void Validate_Should_Reject_Unsupported_Page_Action_Type() {
 		// Arrange
 		BusinessRule rule = CreatePageRule(
-			action: new MakeReadOnlyBusinessRuleAction(["NameInput"]));
+			action: new SetValuesBusinessRuleAction([
+				new BusinessRuleSetValueItem(
+					new BusinessRuleExpression("AttributeValue", "NameInput"),
+					new BusinessRuleExpression("Const", value: default))
+			]));
 
 		// Act
 		Action act = () => PageBusinessRuleValidator.Validate(rule, CreateAttributeMap(), CreateElementNames());
 
 		// Assert
 		act.Should().Throw<ArgumentException>()
-			.WithMessage("Unsupported rule.actions[*].type 'make-read-only'. Supported values: hide-element, show-element. Available page elements: NameInput, StatusInput.",
-				because: "page business rules support only show/hide element actions in this scope");
+			.WithMessage("Unsupported rule.actions[*].type 'set-values'. Supported values: hide-element, show-element, make-editable, make-read-only, make-required, make-optional. Available page elements: NameInput, StatusInput.",
+				because: "page business rules should reject unsupported action types with the full page action allow-list");
 	}
 
 	[Test]
@@ -139,5 +163,14 @@ public sealed class PageBusinessRuleValidatorTests {
 		new HashSet<string>(StringComparer.Ordinal) {
 			"NameInput",
 			"StatusInput"
+		};
+
+	private static BusinessRuleAction CreateAction(string actionType, List<string> items) =>
+		actionType switch {
+			"make-editable" => new MakeEditableBusinessRuleAction(items),
+			"make-read-only" => new MakeReadOnlyBusinessRuleAction(items),
+			"make-required" => new MakeRequiredBusinessRuleAction(items),
+			"make-optional" => new MakeOptionalBusinessRuleAction(items),
+			_ => throw new ArgumentOutOfRangeException(nameof(actionType), actionType, null)
 		};
 }

--- a/clio/Command/BusinessRules/BusinessRuleConstants.cs
+++ b/clio/Command/BusinessRules/BusinessRuleConstants.cs
@@ -43,7 +43,8 @@ internal static class BusinessRuleConstants {
 		"equal, not-equal, is-filled-in, is-not-filled-in, greater-than, greater-than-or-equal, less-than, less-than-or-equal";
 	internal const string SupportedActionTypesDescription =
 		"make-editable, make-read-only, make-required, make-optional, set-values";
-	internal const string SupportedPageActionTypesDescription = "hide-element, show-element";
+	internal const string SupportedPageActionTypesDescription =
+		"hide-element, show-element, make-editable, make-read-only, make-required, make-optional";
 
 	internal static readonly JsonSerializerOptions JsonOptions = new() {
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -94,7 +95,11 @@ internal static class BusinessRuleConstants {
 	internal static readonly IReadOnlyDictionary<string, string> SupportedPageActionTypeNames =
 		new Dictionary<string, string> {
 			["hide-element"] = BusinessRuleHideElementTypeName,
-			["show-element"] = BusinessRuleShowElementTypeName
+			["show-element"] = BusinessRuleShowElementTypeName,
+			["make-editable"] = BusinessRuleEditableElementTypeName,
+			["make-read-only"] = BusinessRuleReadonlyElementTypeName,
+			["make-required"] = BusinessRuleRequiredElementTypeName,
+			["make-optional"] = BusinessRuleOptionalElementTypeName
 		};
 
 	internal static readonly IReadOnlyDictionary<string, int> SupportedComparisonTypeValues =

--- a/clio/Command/BusinessRules/BusinessRuleModels.cs
+++ b/clio/Command/BusinessRules/BusinessRuleModels.cs
@@ -157,7 +157,7 @@ public abstract record FieldSelectionBusinessRuleAction : BusinessRuleAction
 
     [JsonPropertyName("items")]
     [Description(
-        "Action items. Field-state actions use attribute names. Page show/hide actions use page element names.")]
+        "Action items. Entity actions use attribute names. Page actions use page element names.")]
     [Required]
     public List<string> Items { get; init; } = [];
 

--- a/clio/Command/McpServer/Tools/BusinessRuleTool.cs
+++ b/clio/Command/McpServer/Tools/BusinessRuleTool.cs
@@ -269,7 +269,7 @@ public sealed record PageBusinessRuleMcpContract
 	/// Gets the page-level actions to execute when the condition group matches.
 	/// </summary>
 	[JsonPropertyName("actions")]
-	[Description("One or more page-level show/hide actions to execute when the condition group matches.")]
+	[Description("One or more page-level actions to execute when the condition group matches.")]
 	[Required]
 	public List<PageBusinessRuleActionMcpContract> Actions { get; init; } = null!;
 
@@ -293,6 +293,10 @@ public sealed record PageBusinessRuleMcpContract
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(PageHideElementBusinessRuleActionMcpContract), "hide-element")]
 [JsonDerivedType(typeof(PageShowElementBusinessRuleActionMcpContract), "show-element")]
+[JsonDerivedType(typeof(PageMakeEditableBusinessRuleActionMcpContract), "make-editable")]
+[JsonDerivedType(typeof(PageMakeReadOnlyBusinessRuleActionMcpContract), "make-read-only")]
+[JsonDerivedType(typeof(PageMakeRequiredBusinessRuleActionMcpContract), "make-required")]
+[JsonDerivedType(typeof(PageMakeOptionalBusinessRuleActionMcpContract), "make-optional")]
 public abstract record PageBusinessRuleActionMcpContract
 {
 	protected PageBusinessRuleActionMcpContract()
@@ -357,6 +361,70 @@ public sealed record PageShowElementBusinessRuleActionMcpContract : PageElementS
 	internal override BusinessRuleAction ToBusinessRuleAction() => new ShowElementBusinessRuleAction(Items ?? []);
 }
 
+/// <summary>
+/// MCP action contract that makes page elements editable.
+/// </summary>
+public sealed record PageMakeEditableBusinessRuleActionMcpContract : PageElementSelectionBusinessRuleActionMcpContract
+{
+	public PageMakeEditableBusinessRuleActionMcpContract()
+	{
+	}
+
+	public PageMakeEditableBusinessRuleActionMcpContract(List<string> items) : base(items)
+	{
+	}
+
+	internal override BusinessRuleAction ToBusinessRuleAction() => new MakeEditableBusinessRuleAction(Items ?? []);
+}
+
+/// <summary>
+/// MCP action contract that makes page elements read-only.
+/// </summary>
+public sealed record PageMakeReadOnlyBusinessRuleActionMcpContract : PageElementSelectionBusinessRuleActionMcpContract
+{
+	public PageMakeReadOnlyBusinessRuleActionMcpContract()
+	{
+	}
+
+	public PageMakeReadOnlyBusinessRuleActionMcpContract(List<string> items) : base(items)
+	{
+	}
+
+	internal override BusinessRuleAction ToBusinessRuleAction() => new MakeReadOnlyBusinessRuleAction(Items ?? []);
+}
+
+/// <summary>
+/// MCP action contract that makes page elements required.
+/// </summary>
+public sealed record PageMakeRequiredBusinessRuleActionMcpContract : PageElementSelectionBusinessRuleActionMcpContract
+{
+	public PageMakeRequiredBusinessRuleActionMcpContract()
+	{
+	}
+
+	public PageMakeRequiredBusinessRuleActionMcpContract(List<string> items) : base(items)
+	{
+	}
+
+	internal override BusinessRuleAction ToBusinessRuleAction() => new MakeRequiredBusinessRuleAction(Items ?? []);
+}
+
+/// <summary>
+/// MCP action contract that makes page elements optional.
+/// </summary>
+public sealed record PageMakeOptionalBusinessRuleActionMcpContract : PageElementSelectionBusinessRuleActionMcpContract
+{
+	public PageMakeOptionalBusinessRuleActionMcpContract()
+	{
+	}
+
+	public PageMakeOptionalBusinessRuleActionMcpContract(List<string> items) : base(items)
+	{
+	}
+
+	internal override BusinessRuleAction ToBusinessRuleAction() => new MakeOptionalBusinessRuleAction(Items ?? []);
+}
+
 [McpServerToolType]
 public sealed class CreatePageBusinessRuleTool(
 	CreatePageBusinessRuleCommand command,
@@ -368,7 +436,7 @@ public sealed class CreatePageBusinessRuleTool(
 
 	[McpServerTool(Name = BusinessRuleCreateToolName, ReadOnly = false, Destructive = true, Idempotent = false,
 		OpenWorld = false)]
-	[Description("Creates a page-level Freedom UI business rule that shows or hides page elements.")]
+	[Description("Creates a page-level Freedom UI business rule that changes page element visibility, editability, or required state.")]
 	public CommandExecutionResult BusinessRuleCreate(
 		[Description("Creatio environment name.")]
 		[Required]

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -1408,14 +1408,14 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildPageBusinessRuleCreate() {
 		return new ToolContractDefinition(
 			CreatePageBusinessRuleTool.BusinessRuleCreateToolName,
-			"Creates a page-level Freedom UI business rule that shows or hides named page elements using datasource-bound page attributes and constants.",
+			"Creates a page-level Freedom UI business rule that changes visibility, editability, or required state of named page elements using datasource-bound page attributes and constants.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameCamelFieldName, PackageNameCamelFieldName, PageSchemaNameCamelFieldName, RuleFieldName],
 				[
 					Field(EnvironmentNameCamelFieldName, StringType, RegisteredEnvironmentNameDescription),
 					Field(PackageNameCamelFieldName, StringType, "Target package name where the page BusinessRule add-on will be saved."),
 					Field(PageSchemaNameCamelFieldName, StringType, "Target Freedom UI page schema name."),
-					Field(RuleFieldName, ObjectType, "Structured page business-rule definition with caption, one top-level condition group, and one or more show/hide actions. AttributeValue paths must be declared page attribute names from get-page bundle.viewModelConfig.attributes, not datasource paths like PDS.Priority. Action items must be page element names from recursive get-page bundle.viewConfig. Lookup constants are supported when supplied as stable GUID strings.")
+					Field(RuleFieldName, ObjectType, "Structured page business-rule definition with caption, one top-level condition group, and one or more page actions. AttributeValue paths must be declared page attribute names from get-page bundle.viewModelConfig.attributes, not datasource paths like PDS.Priority. Action items must be page element names from recursive get-page bundle.viewConfig. Lookup constants are supported when supplied as stable GUID strings.")
 				],
 				Validators: [
 					.. BusinessRuleConditionValidators(),
@@ -1433,6 +1433,41 @@ internal static class ToolContractCatalog {
 			[],
 			[],
 			[
+				PageBusinessRuleExample(
+					"Make priority editable when page status is filled",
+					"Case_FormPage",
+					"Make priority editable when status is filled",
+					"PDS_Status",
+					"is-filled-in",
+					"make-editable",
+					["PriorityInput"]),
+				PageBusinessRuleExample(
+					"Make amount read-only when amount exceeds threshold",
+					"UsrOrder_FormPage",
+					"Make amount read-only over threshold",
+					"PDS_UsrAmount",
+					"greater-than",
+					"make-read-only",
+					["AmountInput"],
+					100000),
+				PageBusinessRuleExample(
+					"Make close date required when stage is closed",
+					"UsrOrder_FormPage",
+					"Require close date for closed stage",
+					"PDS_UsrStage",
+					"equal",
+					"make-required",
+					["CloseDateInput"],
+					"Closed"),
+				PageBusinessRuleExample(
+					"Make comment optional when page flag is false",
+					"UsrOrder_FormPage",
+					"Make comment optional when flag is false",
+					"PDS_UsrFlag",
+					"equal",
+					"make-optional",
+					["CommentInput"],
+					false),
 				PageBusinessRuleExample(
 					"Hide Escalate when priority matches a lookup constant",
 					"Case_FormPage",
@@ -1557,7 +1592,21 @@ internal static class ToolContractCatalog {
 		string comparisonType,
 		string actionType,
 		object[] actionItems,
-		object constantValue) {
+		object? constantValue = null) {
+		Dictionary<string, object?> condition = new() {
+			["leftExpression"] = new Dictionary<string, object?> {
+				["type"] = "AttributeValue",
+				["path"] = leftPath
+			},
+			["comparisonType"] = comparisonType
+		};
+		if (constantValue is not null) {
+			condition["rightExpression"] = new Dictionary<string, object?> {
+				["type"] = "Const",
+				["value"] = constantValue
+			};
+		}
+
 		return Example(summary, new Dictionary<string, object?> {
 			[EnvironmentNameCamelFieldName] = ExampleEnvironmentName,
 			[PackageNameCamelFieldName] = ExamplePackageName,
@@ -1567,17 +1616,7 @@ internal static class ToolContractCatalog {
 				["condition"] = new Dictionary<string, object?> {
 					["logicalOperation"] = "AND",
 					["conditions"] = new object[] {
-						new Dictionary<string, object?> {
-							["leftExpression"] = new Dictionary<string, object?> {
-								["type"] = "AttributeValue",
-								["path"] = leftPath
-							},
-							["comparisonType"] = comparisonType,
-							["rightExpression"] = new Dictionary<string, object?> {
-								["type"] = "Const",
-								["value"] = constantValue
-							}
-						}
+						condition
 					}
 				},
 				["actions"] = new object[] {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -260,7 +260,10 @@ internal static class ToolContractCatalog {
 	private const string PackageNameCamelFieldName = "packageName";
 	private const string EntitySchemaNameCamelFieldName = "entitySchemaName";
 	private const string PageSchemaNameCamelFieldName = "pageSchemaName";
+	private const string ExampleOrderPageSchemaName = "UsrOrder_FormPage";
 	private const string ExampleWorkspacePath = "<workspace>/UsrTaskApp";
+	private const string MakeReadOnlyActionTypeName = "make-read-only";
+	private const string MakeRequiredActionTypeName = "make-required";
 	private const string ValuesFieldName = "values";
 	private const string BindingNameDescription = "Binding name.";
 	private const string WorkspacePathDescription = "Absolute local workspace path. Network-share paths are not supported.";
@@ -1332,7 +1335,7 @@ internal static class ToolContractCatalog {
 				Validators: [
 					.. BusinessRuleConditionValidators(),
 					new ToolContractValidator("enum", "unsupported-action", "rule.actions[*].type",
-						Context: "Supported values: make-editable, make-read-only, make-required, make-optional, set-values."),
+						Context: $"Supported values: {BusinessRuleConstants.SupportedActionTypesDescription}."),
 					new ToolContractValidator("set-values-shape", "invalid-set-values-item", "rule.actions[*].items[*]",
 						Context: "When rule.actions[*].type is set-values, each item must provide expression { type: AttributeValue, path } and value { type: Const, value }. Attribute value sources are not supported in this scope."),
 					new ToolContractValidator("set-values-constant", "unsupported-set-values-constant", "rule.actions[*].items[*].value.value",
@@ -1346,22 +1349,22 @@ internal static class ToolContractCatalog {
 			[
 				BusinessRuleExample("Create a required-field rule when owner equals a lookup constant",
 					"UsrTask", "Require status for a specific owner", "Owner", "equal",
-					"make-required", ["Status"], "00000000-0000-0000-0000-000000000001"),
+					MakeRequiredActionTypeName, ["Status"], "00000000-0000-0000-0000-000000000001"),
 				BusinessRuleExample("Create a readonly rule when a text field is filled in",
 					"UsrTask", "Lock planned date when name is filled", "Name", "is-filled-in",
-					"make-read-only", ["PlannedDate"]),
+					MakeReadOnlyActionTypeName, ["PlannedDate"]),
 				BusinessRuleExample("Create a readonly rule when completed is true",
 					"UsrTask", "Lock name and description when completed", "Completed", "equal",
-					"make-read-only", ["Name", "Description"], true),
+					MakeReadOnlyActionTypeName, ["Name", "Description"], true),
 				BusinessRuleExample("Create a required-field rule when annual revenue reaches a numeric threshold",
 					"Account", "Require owner for high-revenue accounts", "AnnualRevenue", "greater-than-or-equal",
-					"make-required", ["Owner"], 1000000),
+					MakeRequiredActionTypeName, ["Owner"], 1000000),
 				BusinessRuleExample("Create a required-field rule when created date is before a cutoff",
 					"UsrTask", "Require owner before the 2025 cutoff", "CreatedOn", "less-than-or-equal",
-					"make-required", ["Owner"], "2025-01-01T00:00:00Z"),
+					MakeRequiredActionTypeName, ["Owner"], "2025-01-01T00:00:00Z"),
 				BusinessRuleExample("Create a readonly rule when reminder time is after a timezone-aware cutoff",
 					"UsrTask", "Lock reminder note after local noon", "ReminderTime", "greater-than",
-					"make-read-only", ["ReminderNote"], "12:00:00+02:00"),
+					MakeReadOnlyActionTypeName, ["ReminderNote"], "12:00:00+02:00"),
 				BusinessRuleExample("Create a Set values rule with text number boolean Date DateTime and Time constants",
 					"UsrTask", "Populate defaults when name is filled", "Name", "is-filled-in",
 					"set-values", [
@@ -1443,25 +1446,25 @@ internal static class ToolContractCatalog {
 					["PriorityInput"]),
 				PageBusinessRuleExample(
 					"Make amount read-only when amount exceeds threshold",
-					"UsrOrder_FormPage",
+					ExampleOrderPageSchemaName,
 					"Make amount read-only over threshold",
 					"PDS_UsrAmount",
 					"greater-than",
-					"make-read-only",
+					MakeReadOnlyActionTypeName,
 					["AmountInput"],
 					100000),
 				PageBusinessRuleExample(
 					"Make close date required when stage is closed",
-					"UsrOrder_FormPage",
+					ExampleOrderPageSchemaName,
 					"Require close date for closed stage",
 					"PDS_UsrStage",
 					"equal",
-					"make-required",
+					MakeRequiredActionTypeName,
 					["CloseDateInput"],
 					"Closed"),
 				PageBusinessRuleExample(
 					"Make comment optional when page flag is false",
-					"UsrOrder_FormPage",
+					ExampleOrderPageSchemaName,
 					"Make comment optional when flag is false",
 					"PDS_UsrFlag",
 					"equal",
@@ -1479,7 +1482,7 @@ internal static class ToolContractCatalog {
 					"00000000-0000-0000-0000-000000000001"),
 				PageBusinessRuleExample(
 					"Show a warning label when amount exceeds threshold",
-					"UsrOrder_FormPage",
+					ExampleOrderPageSchemaName,
 					"Show warning for high amount",
 					"PDS_UsrAmount",
 					"greater-than",
@@ -1633,7 +1636,7 @@ internal static class ToolContractCatalog {
 		return Example("Hide a warning when two datasource-bound page attributes match", new Dictionary<string, object?> {
 			[EnvironmentNameCamelFieldName] = ExampleEnvironmentName,
 			[PackageNameCamelFieldName] = ExamplePackageName,
-			[PageSchemaNameCamelFieldName] = "UsrOrder_FormPage",
+			[PageSchemaNameCamelFieldName] = ExampleOrderPageSchemaName,
 			[RuleFieldName] = new Dictionary<string, object?> {
 				["caption"] = "Hide warning when planned and actual dates match",
 				["condition"] = new Dictionary<string, object?> {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -206,6 +206,7 @@ internal static class ToolContractCatalog {
 	private const string EnvironmentNameFieldName = "environment-name";
 	private const string ErrorFieldName = "error";
 	private const string ExampleEnvironmentName = "local";
+	private const string ExampleLookupValueId = "00000000-0000-0000-0000-000000000001";
 	private const string ExamplePackageName = "UsrTaskApp";
 	private const string ExampleTaskStatusSchemaName = "UsrTaskStatus";
 	private const string FailureMessageDescription = "Human-readable failure message.";
@@ -1349,7 +1350,7 @@ internal static class ToolContractCatalog {
 			[
 				BusinessRuleExample("Create a required-field rule when owner equals a lookup constant",
 					"UsrTask", "Require status for a specific owner", "Owner", "equal",
-					MakeRequiredActionTypeName, ["Status"], "00000000-0000-0000-0000-000000000001"),
+					MakeRequiredActionTypeName, ["Status"], ExampleLookupValueId),
 				BusinessRuleExample("Create a readonly rule when a text field is filled in",
 					"UsrTask", "Lock planned date when name is filled", "Name", "is-filled-in",
 					MakeReadOnlyActionTypeName, ["PlannedDate"]),
@@ -1479,7 +1480,7 @@ internal static class ToolContractCatalog {
 					"equal",
 					"hide-element",
 					["EscalateButton"],
-					"00000000-0000-0000-0000-000000000001"),
+					ExampleLookupValueId),
 				PageBusinessRuleExample(
 					"Show a warning label when amount exceeds threshold",
 					ExampleOrderPageSchemaName,
@@ -1540,39 +1541,9 @@ internal static class ToolContractCatalog {
 		string comparisonType,
 		string actionType,
 		object[] actionItems,
-		object? constantValue = null) {
-		Dictionary<string, object?> condition = new() {
-			["leftExpression"] = new Dictionary<string, object?> {
-				["type"] = "AttributeValue",
-				["path"] = leftPath
-			},
-			["comparisonType"] = comparisonType
-		};
-		if (constantValue is not null) {
-			condition["rightExpression"] = new Dictionary<string, object?> {
-				["type"] = "Const",
-				["value"] = constantValue
-			};
-		}
-		return Example(summary, new Dictionary<string, object?> {
-			[EnvironmentNameCamelFieldName] = ExampleEnvironmentName,
-			[PackageNameCamelFieldName] = ExamplePackageName,
-			[EntitySchemaNameCamelFieldName] = entitySchemaName,
-			[RuleFieldName] = new Dictionary<string, object?> {
-				["caption"] = caption,
-				["condition"] = new Dictionary<string, object?> {
-					["logicalOperation"] = "AND",
-					["conditions"] = new object[] { condition }
-				},
-				["actions"] = new object[] {
-					new Dictionary<string, object?> {
-						["type"] = actionType,
-						["items"] = actionItems
-					}
-				}
-			}
-		});
-	}
+		object? constantValue = null) =>
+		BusinessRuleExample(summary, EntitySchemaNameCamelFieldName, entitySchemaName, caption, leftPath,
+			comparisonType, actionType, actionItems, constantValue);
 
 	private static Dictionary<string, object?> BusinessRuleSetValueItem(string path, object value) {
 		return new Dictionary<string, object?> {
@@ -1590,6 +1561,19 @@ internal static class ToolContractCatalog {
 	private static ToolContractExample PageBusinessRuleExample(
 		string summary,
 		string pageSchemaName,
+		string caption,
+		string leftPath,
+		string comparisonType,
+		string actionType,
+		object[] actionItems,
+		object? constantValue = null) =>
+		BusinessRuleExample(summary, PageSchemaNameCamelFieldName, pageSchemaName, caption, leftPath,
+			comparisonType, actionType, actionItems, constantValue);
+
+	private static ToolContractExample BusinessRuleExample(
+		string summary,
+		string schemaFieldName,
+		string schemaName,
 		string caption,
 		string leftPath,
 		string comparisonType,
@@ -1613,7 +1597,7 @@ internal static class ToolContractCatalog {
 		return Example(summary, new Dictionary<string, object?> {
 			[EnvironmentNameCamelFieldName] = ExampleEnvironmentName,
 			[PackageNameCamelFieldName] = ExamplePackageName,
-			[PageSchemaNameCamelFieldName] = pageSchemaName,
+			[schemaFieldName] = schemaName,
 			[RuleFieldName] = new Dictionary<string, object?> {
 				["caption"] = caption,
 				["condition"] = new Dictionary<string, object?> {
@@ -2140,7 +2124,7 @@ internal static class ToolContractCatalog {
 					[EnvironmentNameFieldName] = ExampleEnvironmentName,
 					[PackageNameFieldName] = ExamplePackageName,
 					[BindingNameFieldName] = ExampleTaskStatusSchemaName,
-					[KeyValueFieldName] = "00000000-0000-0000-0000-000000000001"
+					[KeyValueFieldName] = ExampleLookupValueId
 				})
 			],
 			Flow([RemoveDataBindingRowDbTool.RemoveDataBindingRowDbToolName], "Standalone DB-first binding maintenance."),
@@ -2288,7 +2272,7 @@ internal static class ToolContractCatalog {
 					[PackageNameFieldName] = ExamplePackageName,
 					[BindingNameFieldName] = ExampleTaskStatusSchemaName,
 					[WorkspacePathFieldName] = ExampleWorkspacePath,
-					[KeyValueFieldName] = "00000000-0000-0000-0000-000000000001"
+					[KeyValueFieldName] = ExampleLookupValueId
 				})
 			],
 			Flow([RemoveDataBindingRowTool.RemoveDataBindingRowToolName], "Standalone local binding maintenance."),

--- a/spec/business-rules/create-page-business-rule-spec.md
+++ b/spec/business-rules/create-page-business-rule-spec.md
@@ -53,8 +53,14 @@ Page-level rule creation must:
    - support action types:
       - hide element
       - show element
+      - make editable
+      - make read-only
+      - make required
+      - make optional
    - support any named page element collected recursively from `bundle.viewConfig`
    - use page element names in payloads, for example `Input_0dqt4ly` or `EscalateButton`
+   - validate only that each target page element exists in the resolved recursive `viewConfig`
+   - do not validate designer group membership or component-specific support for editability, read-only, required, or optional behavior
    - support multiple actions
    - support multiple page elements per action
 - generate internal identifiers automatically


### PR DESCRIPTION
Adds page-level `create-page-business-rule` support for `make-editable`, `make-read-only`, `make-required`, and `make-optional`.

Updates the page action allow-list, MCP contract, metadata/tool-contract guidance, and focused tests. Target validation remains based on page element names resolved from `viewConfig`; object/entity scope is unchanged.

Validated with targeted Command/McpServer unit tests and page business-rule MCP E2E compatibility tests.