### PR TITLE
Release 8.1.0.13

### DIFF
--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.12</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.13</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>


### PR DESCRIPTION
## Summary
Bump AssemblyVersion 8.1.0.12 → 8.1.0.13. Includes #587 (ENG-88747).

## Changes
**#587 — ENG-88747: Add converters support in AI instructions**
Adds two structural validators in `SchemaValidationService`, wired into `update-page`, `sync-pages`, and `validate-page` MCP tools, to catch broken custom validators/converters before they reach the Creatio runtime.
