### PR TITLE
feat(mcp): business rules: Create for the existing app using the MCP tool. Set values. Attribute

### DIFF
--- a/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
@@ -68,7 +68,7 @@ public sealed class EntityBusinessRuleToolE2ETests {
 	[Description("Binds a Set values business-rule payload through the real MCP server and reports an invalid environment failure from command execution.")]
 	[AllureTag(ToolName)]
 	[AllureName("Entity business-rule MCP tool binds Set values payloads")]
-	[AllureDescription("Starts the real clio MCP server, calls create-entity-business-rule with a Set values constant payload and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
+	[AllureDescription("Starts the real clio MCP server, calls create-entity-business-rule with Set values constant formula and AttributeValue payloads and an intentionally missing environment, then verifies the request reaches command execution instead of failing MCP payload binding.")]
 	public async Task BusinessRuleCreate_Should_Bind_SetValues_Payload_And_Report_Invalid_Environment() {
 		// Arrange
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
@@ -228,7 +228,8 @@ public sealed class EntityBusinessRuleToolE2ETests {
 						CreateSetValuesItem("UsrScore", 42),
 						CreateSetValuesItem("UsrCompleted", true),
 						CreateSetValuesItem("UsrPlannedOn", "2025-01-01T00:00:00Z"),
-						CreateFormulaSetValuesItem("UsrTotalScore", "UsrScore + UsrBonusScore")
+						CreateFormulaSetValuesItem("UsrTotalScore", "UsrScore + UsrBonusScore"),
+						CreateAttributeSetValuesItem("UsrCreatorAge", "CreatedBy.Age")
 					}
 				}
 			}
@@ -250,6 +251,12 @@ public sealed class EntityBusinessRuleToolE2ETests {
 				["type"] = "Formula",
 				["expression"] = formula
 			}
+		};
+
+	private static IReadOnlyDictionary<string, object?> CreateAttributeSetValuesItem(string path, string sourcePath) =>
+		new Dictionary<string, object?> {
+			["expression"] = CreateAttributeExpression(path),
+			["value"] = CreateAttributeExpression(sourcePath)
 		};
 
 	private static IReadOnlyDictionary<string, object?> CreateAttributeExpression(string path) =>

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -555,8 +555,8 @@ public sealed class ToolContractGetToolE2ETests {
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "set-values-shape" &&
 				validator.Field == "rule.actions[*].items[*]" &&
-				validator.Context!.Contains("Attribute value sources, formula functions, comparison operators, and string literals are not supported", StringComparison.Ordinal),
-			because: "the contract should advertise the current Set values scope");
+				validator.Context!.Contains("forward reference paths like LookupColumn.SourceColumn", StringComparison.Ordinal),
+			because: "the contract should advertise AttributeValue source support for Set values");
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "set-values-constant" &&
 				validator.Field == "rule.actions[*].items[*].value.value" &&
@@ -607,6 +607,11 @@ public sealed class ToolContractGetToolE2ETests {
 				StringComparison.Ordinal));
 		hasSetValuesExample.Should().BeTrue(
 			because: "the contract should include a Set values example for constant assignments across supported target families");
+		bool hasSetValuesAttributeExample = contract.Examples.Any(example =>
+			string.Equals(example.Summary, "Create a Set values rule from a forward reference attribute",
+				StringComparison.Ordinal));
+		hasSetValuesAttributeExample.Should().BeTrue(
+			because: "the contract should include a Set values example for AttributeValue source assignments");
 	}
 
 	[Test]

--- a/clio.tests/Command/BusinessRuleMetadataConverterTests.cs
+++ b/clio.tests/Command/BusinessRuleMetadataConverterTests.cs
@@ -447,6 +447,71 @@ public sealed class BusinessRuleMetadataConverterTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Maps set-values AttributeValue assignments into attribute expression metadata and trigger roots.")]
+	public void ToMetadata_Should_Map_SetValues_Attribute_Value_Action_Metadata() {
+		// Arrange
+		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap =
+			new Dictionary<string, BusinessRuleAttributeDescriptor>(StringComparer.Ordinal) {
+				["Status"] = new("Status", "Text", null),
+				["UsrNameCopy"] = new("UsrNameCopy", "Text", null),
+				["Name"] = new("Name", "Text", null),
+				["UsrCreatorAge"] = new("UsrCreatorAge", "Integer", null),
+				["CreatedBy"] = new("CreatedBy", "Lookup", "Contact"),
+				["CreatedBy.Age"] = new("CreatedBy.Age", "Integer", null)
+			};
+		BusinessRule rule = new(
+			"Copy values",
+			new BusinessRuleConditionGroup(
+				"AND",
+				[
+					new BusinessRuleCondition(
+						new BusinessRuleExpression("AttributeValue", "Status", null),
+						"equal",
+						new BusinessRuleExpression("Const", null, Json("Draft")))
+				]),
+			[
+				new SetValuesBusinessRuleAction(
+					new List<BusinessRuleSetValueItem> {
+						new(
+							new BusinessRuleExpression("AttributeValue", "UsrNameCopy", null),
+							new BusinessRuleExpression("AttributeValue", "Name", null)),
+						new(
+							new BusinessRuleExpression("AttributeValue", "UsrCreatorAge", null),
+							new BusinessRuleExpression("AttributeValue", "CreatedBy.Age", null))
+					})
+			]);
+
+		// Act
+		BusinessRuleMetadataDto metadata = BusinessRuleMetadataConverter.ToMetadata(attributeMap, rule, "UsrTask");
+
+		// Assert
+		FieldSelectionBusinessRuleActionMetadataDto action = metadata.Cases[0].Actions.Single();
+		List<BusinessRuleSetValueItemMetadataDto> items = (List<BusinessRuleSetValueItemMetadataDto>)action.Items!;
+		items[0].Value.TypeName.Should().Be(BusinessRuleConstants.BusinessRuleAttributeExpressionTypeName,
+			because: "direct AttributeValue sources should persist as core attribute expressions");
+		items[0].Value.Type.Should().Be("AttributeValue",
+			because: "the source discriminator should stay AttributeValue in add-on metadata");
+		items[0].Value.Path.Should().Be("Name",
+			because: "direct source attribute paths should be preserved");
+		items[1].Value.Path.Should().Be("CreatedBy.Age",
+			because: "forward reference source paths should be preserved for core evaluation");
+		items[1].Value.DataValueTypeName.Should().Be("Integer",
+			because: "the source expression should describe the final source column type");
+		metadata.Triggers.Should().Contain(trigger =>
+				trigger.Type == BusinessRuleConstants.ChangeAttributeValueTriggerType && trigger.Name == "Name",
+			because: "direct AttributeValue sources should recalculate when the source column changes");
+		metadata.Triggers.Should().Contain(trigger =>
+				trigger.Type == BusinessRuleConstants.ChangeAttributeValueTriggerType && trigger.Name == "CreatedBy",
+			because: "forward AttributeValue sources should match designer metadata and trigger on the root lookup column");
+		metadata.Triggers.Should().NotContain(trigger => trigger.Name == "CreatedBy.Age",
+			because: "designer-generated business-rule metadata does not emit full forward-path triggers");
+		metadata.Triggers.Should().Contain(trigger =>
+				trigger.Type == BusinessRuleConstants.DataLoadedTriggerType && trigger.Name == string.Empty,
+			because: "Set values rules should still run on DataLoaded");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Rejects formula assignments when expression translation cannot resolve a source attribute.")]
 	public void ToMetadata_Should_Reject_SetValues_Formula_With_Unknown_Source_Attribute() {
 		// Arrange

--- a/clio.tests/Command/BusinessRuleValidatorTests.cs
+++ b/clio.tests/Command/BusinessRuleValidatorTests.cs
@@ -999,8 +999,8 @@ public sealed class BusinessRuleValidatorTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Rejects set-values actions that try to assign from another attribute.")]
-	public void Validate_Should_Reject_SetValues_Action_With_Attribute_Value_Source() {
+	[Description("Accepts set-values actions that assign from another same-typed attribute.")]
+	public void Validate_Should_Accept_SetValues_Action_With_Attribute_Value_Source() {
 		// Arrange
 		BusinessRule rule = CreateRule(
 			actions: [
@@ -1014,9 +1014,103 @@ public sealed class BusinessRuleValidatorTests {
 		Action act = () => BusinessRuleValidator.Validate(rule, columnMap);
 
 		// Assert
+		act.Should().NotThrow(
+			because: "Set values should support copying values from same-typed source attributes");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects set-values AttributeValue sources that omit the source path.")]
+	public void Validate_Should_Reject_SetValues_Attribute_Source_With_Missing_Path() {
+		// Arrange
+		BusinessRule rule = CreateRule(
+			actions: [
+				CreateSetValuesAction("TextResult", new BusinessRuleExpression("AttributeValue"))
+			]);
+		IReadOnlyDictionary<string, EntitySchemaColumnDto> columnMap = CreateColumnMap(
+			CreateColumn("Status", 1),
+			CreateColumn("TextResult", 1));
+
+		// Act
+		Action act = () => BusinessRuleValidator.Validate(rule, columnMap);
+
+		// Assert
 		act.Should().Throw<ArgumentException>()
-			.WithMessage("rule.actions[*].items[*].value.type must be 'Const' or 'Formula'.",
-				because: "attribute-source assignments must use an explicit Formula when calculation is needed");
+			.WithMessage("rule.actions[*].items[*].value.path is required when value.type is 'AttributeValue'.",
+				because: "attribute-source assignments need an explicit source column path");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects set-values AttributeValue sources when source and target data value types differ.")]
+	public void Validate_Should_Reject_SetValues_Attribute_Source_With_Different_Type() {
+		// Arrange
+		BusinessRule rule = CreateRule(
+			actions: [
+				CreateSetValuesAction("Score", new BusinessRuleExpression("AttributeValue", "Status", null))
+			]);
+		IReadOnlyDictionary<string, EntitySchemaColumnDto> columnMap = CreateColumnMap(
+			CreateColumn("Status", 1),
+			CreateColumn("Score", 4));
+
+		// Act
+		Action act = () => BusinessRuleValidator.Validate(rule, columnMap);
+
+		// Assert
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("rule.actions[*].items[*] assigns source attribute 'Status' (Text) to target attribute 'Score' (Integer). Both attributes must have the same data value type.",
+				because: "copying from another attribute is only safe when the source and target metadata types match");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Accepts set-values AttributeValue sources that use a same-typed forward reference path.")]
+	public void Validate_Should_Accept_SetValues_Attribute_Source_With_Forward_Path() {
+		// Arrange
+		BusinessRule rule = CreateRule(
+			actions: [
+				CreateSetValuesAction("Score", new BusinessRuleExpression("AttributeValue", "Owner.Age", null))
+			]);
+		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap =
+			new Dictionary<string, BusinessRuleAttributeDescriptor>(StringComparer.Ordinal) {
+				["Status"] = new("Status", "Text", null),
+				["Owner"] = new("Owner", "Lookup", "Contact"),
+				["Owner.Age"] = new("Owner.Age", "Integer", null),
+				["Score"] = new("Score", "Integer", null)
+			};
+
+		// Act
+		Action act = () => BusinessRuleValidator.Validate(rule, attributeMap);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "forward-reference sources are valid when their final column type matches the target column");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Allows forward-reference paths only as set-values AttributeValue sources.")]
+	public void Validate_Should_Reject_Forward_Reference_Action_Targets() {
+		// Arrange
+		BusinessRule rule = CreateRule(
+			actions: [
+				CreateSetValuesAction("Owner.Age", new BusinessRuleExpression("AttributeValue", "Score", null))
+			]);
+		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap =
+			new Dictionary<string, BusinessRuleAttributeDescriptor>(StringComparer.Ordinal) {
+				["Status"] = new("Status", "Text", null),
+				["Owner"] = new("Owner", "Lookup", "Contact"),
+				["Owner.Age"] = new("Owner.Age", "Integer", null),
+				["Score"] = new("Score", "Integer", null)
+			};
+
+		// Act
+		Action act = () => BusinessRuleValidator.Validate(rule, attributeMap);
+
+		// Assert
+		act.Should().Throw<ArgumentException>()
+			.WithMessage("rule.actions[*].items[*].expression.path must reference a direct entity attribute. Forward reference paths are supported only in rule.actions[*].items[*].value.path.",
+				because: "Set values can read through a lookup but must still write to a current-object column");
 	}
 
 	[Test]

--- a/clio.tests/Command/EntityBusinessRuleAttributeProviderTests.cs
+++ b/clio.tests/Command/EntityBusinessRuleAttributeProviderTests.cs
@@ -86,4 +86,75 @@ public sealed class EntityBusinessRuleAttributeProviderTests {
 			new BusinessRuleAttributeDescriptor("Status", "Text", null),
 			because: "unused unsupported columns should not prevent valid rule attributes from being resolved");
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Resolves forward-reference attribute paths through lookup reference schemas on demand.")]
+	public void GetAttributes_Should_Resolve_Forward_Reference_Attribute_Path() {
+		// Arrange
+		Guid packageUId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+		IEntityBusinessRuleSchemaProvider schemaProvider = Substitute.For<IEntityBusinessRuleSchemaProvider>();
+		schemaProvider.GetSchema("UsrOrder", packageUId).Returns(new EntityDesignSchemaDto {
+			Name = "UsrOrder",
+			Columns = [
+				new EntitySchemaColumnDto {
+					Name = "CreatedBy",
+					DataValueType = 10,
+					ReferenceSchema = new EntityDesignSchemaDto {
+						Name = "Contact"
+					}
+				}
+			]
+		});
+		schemaProvider.GetSchema("Contact", packageUId).Returns(new EntityDesignSchemaDto {
+			Name = "Contact",
+			Columns = [
+				new EntitySchemaColumnDto {
+					Name = "Age",
+					DataValueType = 4
+				}
+			]
+		});
+		EntityBusinessRuleAttributeProvider provider = new(schemaProvider);
+
+		// Act
+		EntityBusinessRuleAttributeContext context = provider.GetAttributes("UsrOrder", packageUId);
+		bool resolved = context.Attributes.TryGetValue("CreatedBy.Age", out BusinessRuleAttributeDescriptor descriptor);
+
+		// Assert
+		resolved.Should().BeTrue(
+			because: "object Set values rules can assign from fields reachable through a lookup column");
+		descriptor.Should().Be(
+			new BusinessRuleAttributeDescriptor("CreatedBy.Age", "Integer", null),
+			because: "the descriptor should describe the final source attribute in the forward path");
+		context.Attributes.Keys.Should().Equal(["CreatedBy"],
+			because: "enumerating attributes should stay limited to direct entity columns for existing direct-field formula behavior");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Does not resolve forward-reference paths through non-lookup attributes.")]
+	public void GetAttributes_Should_Not_Resolve_Forward_Path_Through_Non_Lookup_Attribute() {
+		// Arrange
+		Guid packageUId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+		IEntityBusinessRuleSchemaProvider schemaProvider = Substitute.For<IEntityBusinessRuleSchemaProvider>();
+		schemaProvider.GetSchema("UsrOrder", packageUId).Returns(new EntityDesignSchemaDto {
+			Name = "UsrOrder",
+			Columns = [
+				new EntitySchemaColumnDto {
+					Name = "Name",
+					DataValueType = 1
+				}
+			]
+		});
+		EntityBusinessRuleAttributeProvider provider = new(schemaProvider);
+
+		// Act
+		EntityBusinessRuleAttributeContext context = provider.GetAttributes("UsrOrder", packageUId);
+		bool resolved = context.Attributes.TryGetValue("Name.Length", out _);
+
+		// Assert
+		resolved.Should().BeFalse(
+			because: "forward references require an intermediate lookup with a reference schema");
+	}
 }

--- a/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
+++ b/clio.tests/Command/McpServer/BusinessRuleToolTests.cs
@@ -373,6 +373,66 @@ public sealed class BusinessRuleToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Deserializes set-values actions with AttributeValue source payloads and preserves direct and forward source paths.")]
+	public void BusinessRuleCreate_Should_Deserialize_SetValues_Action_With_Attribute_Value_Item() {
+		// Arrange
+		string payload = """
+		{
+		  "environment-name": "dev",
+		  "package-name": "UsrPkg",
+		  "entity-schema-name": "UsrOrder",
+		  "rule": {
+		    "caption": "Copy values",
+		    "condition": {
+		      "logicalOperation": "AND",
+		      "conditions": [
+		        {
+		          "leftExpression": {
+		            "type": "AttributeValue",
+		            "path": "Name"
+		          },
+		          "comparisonType": "is-filled-in"
+		        }
+		      ]
+		    },
+		    "actions": [
+		      {
+		        "type": "set-values",
+		        "items": [
+		          {
+		            "expression": {
+		              "type": "AttributeValue",
+		              "path": "UsrCreatorAge"
+		            },
+		            "value": {
+		              "type": "AttributeValue",
+		              "path": "CreatedBy.Age"
+		            }
+		          }
+		        ]
+		      }
+		    ]
+		  }
+		}
+		""";
+
+		// Act
+		BusinessRuleToolPayload? payloadArgs = JsonSerializer.Deserialize<BusinessRuleToolPayload>(payload);
+
+		// Assert
+		payloadArgs.Should().NotBeNull(
+			because: "set-values attribute-source business-rule payloads should deserialize from the MCP JSON shape");
+		BusinessRuleSetValueItem item = payloadArgs!.Rule.ToBusinessRule().Actions.Single().SetValueItems.Single();
+		item.Expression.Path.Should().Be("UsrCreatorAge",
+			because: "the target expression path should be preserved");
+		item.Value.Type.Should().Be("AttributeValue",
+			because: "the attribute-source discriminator should be preserved for downstream metadata conversion");
+		item.Value.Path.Should().Be("CreatedBy.Age",
+			because: "forward reference source paths should survive MCP payload binding");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Deserializes unary business-rule payloads that omit rightExpression for filled-state comparisons.")]
 	public void BusinessRuleCreate_Should_Deserialize_Unary_Payload_Without_Right_Expression() {
 		// Arrange

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -163,8 +163,8 @@ public sealed class ToolContractGetToolTests {
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "set-values-shape" &&
 				validator.Field == "rule.actions[*].items[*]" &&
-				validator.Context!.Contains("Attribute value sources, formula functions, comparison operators, and string literals are not supported", StringComparison.Ordinal),
-			because: "the contract should keep attribute-source assignments out of the current set-values scope");
+				validator.Context!.Contains("forward reference paths like LookupColumn.SourceColumn", StringComparison.Ordinal),
+			because: "the contract should advertise AttributeValue source assignments in the current set-values scope");
 		contract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "set-values-constant" &&
 				validator.Field == "rule.actions[*].items[*].value.value" &&
@@ -316,6 +316,9 @@ public sealed class ToolContractGetToolTests {
 		bool hasSetValuesFormulaExample = contract.Examples.Any(HasSetValuesFormulaExample);
 		hasSetValuesFormulaExample.Should().BeTrue(
 			because: "the contract should include a set-values formula example using direct field names");
+		bool hasSetValuesAttributeExample = contract.Examples.Any(HasSetValuesAttributeExample);
+		hasSetValuesAttributeExample.Should().BeTrue(
+			because: "the contract should include a set-values AttributeValue example using a forward reference source path");
 	}
 
 	[Test]
@@ -452,6 +455,26 @@ public sealed class ToolContractGetToolTests {
 				string.Equals(valueExpression["type"]?.ToString(), "Formula", StringComparison.Ordinal)
 				&& string.Equals(valueExpression["expression"]?.ToString(), "UsrEstimatedEffort + UsrExtraEffort",
 					StringComparison.Ordinal));
+	}
+
+	private static bool HasSetValuesAttributeExample(ToolContractExample example) {
+		if (example.Arguments["rule"] is not Dictionary<string, object?> rule
+			|| !rule.TryGetValue("actions", out object? actionsValue)
+			|| actionsValue is not object[] actions
+			|| actions.SingleOrDefault() is not Dictionary<string, object?> action
+			|| !string.Equals(action["type"]?.ToString(), "set-values", StringComparison.Ordinal)
+			|| !action.TryGetValue("items", out object? itemsValue)
+			|| itemsValue is not object[] items) {
+			return false;
+		}
+
+		return items
+			.OfType<Dictionary<string, object?>>()
+			.Select(item => item["value"])
+			.OfType<Dictionary<string, object?>>()
+			.Any(valueExpression =>
+				string.Equals(valueExpression["type"]?.ToString(), "AttributeValue", StringComparison.Ordinal)
+				&& string.Equals(valueExpression["path"]?.ToString(), "CreatedBy.Age", StringComparison.Ordinal));
 	}
 
 	[Test]

--- a/clio/Command/BusinessRules/BusinessRuleHelpers.cs
+++ b/clio/Command/BusinessRules/BusinessRuleHelpers.cs
@@ -37,6 +37,24 @@ internal static class BusinessRuleHelpers {
 		IReadOnlyDictionary<string, EntitySchemaColumnDto> columnMap) =>
 		new LazyBusinessRuleAttributeDescriptorMap(columnMap);
 
+	internal static BusinessRuleAttributeDescriptor BuildAttributeDescriptor(
+		string path,
+		EntitySchemaColumnDto column) =>
+		new(
+			path,
+			MapDataValueTypeName(column.DataValueType),
+			column.ReferenceSchema?.Name);
+
+	internal static bool IsForwardReferencePath(string path) =>
+		path.Contains('.', StringComparison.Ordinal);
+
+	internal static string GetRootAttributePath(string path) {
+		int separatorIndex = path.IndexOf('.');
+		return separatorIndex > 0
+			? path[..separatorIndex]
+			: path;
+	}
+
 	internal static string MapDataValueTypeName(int? dataValueType) {
 		if (!dataValueType.HasValue) {
 			throw new InvalidOperationException("Entity schema column dataValueType is required.");
@@ -213,7 +231,7 @@ internal static class BusinessRuleHelpers {
 		public IEnumerable<string> Keys => columns.Keys;
 
 		public IEnumerable<BusinessRuleAttributeDescriptor> Values =>
-			columns.Select(pair => BuildDescriptor(pair.Key, pair.Value));
+			columns.Select(pair => BuildAttributeDescriptor(pair.Key, pair.Value));
 
 		public int Count => columns.Count;
 
@@ -230,7 +248,7 @@ internal static class BusinessRuleHelpers {
 				return false;
 			}
 
-			value = BuildDescriptor(key, column);
+			value = BuildAttributeDescriptor(key, column);
 			return true;
 		}
 
@@ -238,18 +256,10 @@ internal static class BusinessRuleHelpers {
 			foreach (KeyValuePair<string, EntitySchemaColumnDto> pair in columns) {
 				yield return new KeyValuePair<string, BusinessRuleAttributeDescriptor>(
 					pair.Key,
-					BuildDescriptor(pair.Key, pair.Value));
+					BuildAttributeDescriptor(pair.Key, pair.Value));
 			}
 		}
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-		private static BusinessRuleAttributeDescriptor BuildDescriptor(
-			string path,
-			EntitySchemaColumnDto column) =>
-			new(
-				path,
-				MapDataValueTypeName(column.DataValueType),
-				column.ReferenceSchema?.Name);
 	}
 }

--- a/clio/Command/BusinessRules/BusinessRuleMetadataConverter.cs
+++ b/clio/Command/BusinessRules/BusinessRuleMetadataConverter.cs
@@ -210,6 +210,7 @@ internal static class BusinessRuleMetadataConverter {
 			attributeMap,
 			item,
 			entitySchemaName,
+			includeAttributeReferenceSchemaName,
 			targetPath,
 			targetDescriptor,
 			dataValueTypeName);
@@ -230,6 +231,7 @@ internal static class BusinessRuleMetadataConverter {
 		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap,
 		BusinessRuleSetValueItem item,
 		string? entitySchemaName,
+		bool includeAttributeReferenceSchemaName,
 		string targetPath,
 		BusinessRuleAttributeDescriptor targetDescriptor,
 		string dataValueTypeName) {
@@ -245,6 +247,17 @@ internal static class BusinessRuleMetadataConverter {
 				BusinessRuleFormulaBuilder.GetRequiredFormulaText(item.Value),
 				dataValueTypeName);
 		}
+
+		if (IsAttributeValueExpression(item.Value)) {
+			string sourcePath = item.Value.Path!;
+			BusinessRuleAttributeDescriptor sourceDescriptor = attributeMap[sourcePath];
+			return BuildAttributeExpression(
+				sourceDescriptor,
+				sourcePath,
+				sourceDescriptor.DataValueTypeName,
+				includeAttributeReferenceSchemaName);
+		}
+
 		object? value = ConvertJsonElement(item.Value.Value!.Value, dataValueTypeName);
 		return new BusinessRuleExpressionMetadataDto {
 			TypeName = BusinessRuleValueExpressionTypeName,
@@ -264,8 +277,11 @@ internal static class BusinessRuleMetadataConverter {
 		IEnumerable<string> formulaTriggers = string.IsNullOrWhiteSpace(entitySchemaName)
 			? Enumerable.Empty<string>()
 			: rule.Actions.SelectMany(action => EnumerateFormulaTriggerNames(action, attributeMap));
+		IEnumerable<string> attributeValueSourceTriggers =
+			rule.Actions.SelectMany(EnumerateSetValuesAttributeSourceTriggerNames);
 		List<BusinessRuleTriggerMetadataDto> triggers = conditionTriggers
 			.Concat(formulaTriggers)
+			.Concat(attributeValueSourceTriggers)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.Select(triggerName => new BusinessRuleTriggerMetadataDto {
 				TypeName = BusinessRuleTriggerTypeName,
@@ -309,6 +325,22 @@ internal static class BusinessRuleMetadataConverter {
 			}
 		}
 	}
+
+	private static IEnumerable<string> EnumerateSetValuesAttributeSourceTriggerNames(BusinessRuleAction action) {
+		if (!string.Equals(action.ActionType, SetValuesActionTypeName, StringComparison.OrdinalIgnoreCase)) {
+			yield break;
+		}
+
+		foreach (BusinessRuleSetValueItem item in action.SetValueItems) {
+			if (IsAttributeValueExpression(item.Value)
+				&& !string.IsNullOrWhiteSpace(item.Value.Path)) {
+				yield return GetRootAttributePath(item.Value.Path);
+			}
+		}
+	}
+
+	private static bool IsAttributeValueExpression(BusinessRuleExpression? expression) =>
+		string.Equals(expression?.Type, "AttributeValue", StringComparison.OrdinalIgnoreCase);
 
 	private static string GenerateBusinessRuleName() => $"BusinessRule_{Guid.NewGuid():N}"[..20];
 }

--- a/clio/Command/BusinessRules/BusinessRuleModels.cs
+++ b/clio/Command/BusinessRules/BusinessRuleModels.cs
@@ -329,7 +329,7 @@ public sealed record BusinessRuleSetValueItem
 
 
     [JsonPropertyName("value")]
-    [Description("Source value expression. Supported values are Const and Formula.")]
+    [Description("Source value expression. Supported values are Const, Formula, and AttributeValue. AttributeValue may use a direct source column path or a forward reference path such as LookupColumn.SourceColumn.")]
     [Required]
     public BusinessRuleExpression Value { get; init; } = null!;
 }

--- a/clio/Command/BusinessRules/BusinessRuleValidator.cs
+++ b/clio/Command/BusinessRules/BusinessRuleValidator.cs
@@ -81,6 +81,9 @@ internal static class BusinessRuleValidator {
 		}
 
 		string leftPath = condition.LeftExpression.Path;
+		ValidateDirectAttributePath(
+			leftPath,
+			"rule.condition.conditions[*].leftExpression.path");
 		BusinessRuleAttributeDescriptor leftDescriptor = ResolveAttribute(
 			attributeMap,
 			leftPath,
@@ -122,6 +125,7 @@ internal static class BusinessRuleValidator {
 				throw new ArgumentException("rule.actions[*].items cannot contain empty attribute names.");
 			}
 
+			ValidateDirectAttributePath(target, "rule.actions[*].items");
 			ResolveAttribute(attributeMap, target, "rule.actions[*].items");
 		}
 	}
@@ -155,6 +159,9 @@ internal static class BusinessRuleValidator {
 			throw new ArgumentException("rule.actions[*].items[*].expression.path is required.");
 		}
 
+		ValidateDirectAttributePath(
+			item.Expression.Path,
+			"rule.actions[*].items[*].expression.path");
 		BusinessRuleAttributeDescriptor targetDescriptor = ResolveAttribute(
 			attributeMap,
 			item.Expression.Path,
@@ -179,7 +186,16 @@ internal static class BusinessRuleValidator {
 			return;
 		}
 
-		throw new ArgumentException("rule.actions[*].items[*].value.type must be 'Const' or 'Formula'.");
+		if (string.Equals(item.Value.Type, "AttributeValue", StringComparison.OrdinalIgnoreCase)) {
+			ValidateSetValueAttributeSource(
+				item.Value,
+				attributeMap,
+				item.Expression.Path,
+				targetDataValueTypeName);
+			return;
+		}
+
+		throw new ArgumentException("rule.actions[*].items[*].value.type must be 'Const', 'Formula', or 'AttributeValue'.");
 	}
 
 	private static void ValidateSetValueFormula(
@@ -188,6 +204,28 @@ internal static class BusinessRuleValidator {
 		string targetPath) {
 		string formula = BusinessRuleFormulaBuilder.GetRequiredFormulaText(value);
 		BusinessRuleFormulaBuilder.ValidateFormulaScope(formula, attributeMap, targetPath);
+	}
+
+	private static void ValidateSetValueAttributeSource(
+		BusinessRuleExpression value,
+		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributeMap,
+		string targetPath,
+		string targetDataValueTypeName) {
+		if (string.IsNullOrWhiteSpace(value.Path)) {
+			throw new ArgumentException(
+				"rule.actions[*].items[*].value.path is required when value.type is 'AttributeValue'.");
+		}
+
+		string sourcePath = value.Path;
+		BusinessRuleAttributeDescriptor sourceDescriptor = ResolveAttribute(
+			attributeMap,
+			sourcePath,
+			"rule.actions[*].items[*].value.path");
+		string sourceDataValueTypeName = sourceDescriptor.DataValueTypeName;
+		if (!string.Equals(targetDataValueTypeName, sourceDataValueTypeName, StringComparison.OrdinalIgnoreCase)) {
+			throw new ArgumentException(
+				$"rule.actions[*].items[*] assigns source attribute '{sourcePath}' ({sourceDataValueTypeName}) to target attribute '{targetPath}' ({targetDataValueTypeName}). Both attributes must have the same data value type.");
+		}
 	}
 
 	private static void ValidateSetValueConstant(JsonElement value, string targetDataValueTypeName) {
@@ -331,6 +369,9 @@ internal static class BusinessRuleValidator {
 		}
 
 		string rightPath = rightExpression.Path;
+		ValidateDirectAttributePath(
+			rightPath,
+			"rule.condition.conditions[*].rightExpression.path");
 		BusinessRuleAttributeDescriptor rightDescriptor = ResolveAttribute(
 			attributeMap,
 			rightPath,
@@ -411,5 +452,12 @@ internal static class BusinessRuleValidator {
 		}
 
 		return descriptor;
+	}
+
+	private static void ValidateDirectAttributePath(string path, string fieldName) {
+		if (IsForwardReferencePath(path)) {
+			throw new ArgumentException(
+				$"{fieldName} must reference a direct entity attribute. Forward reference paths are supported only in rule.actions[*].items[*].value.path.");
+		}
 	}
 }

--- a/clio/Command/BusinessRules/EntityBusinessRuleAttributeProvider.cs
+++ b/clio/Command/BusinessRules/EntityBusinessRuleAttributeProvider.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Clio.Command.EntitySchemaDesigner;
 
 namespace Clio.Command.BusinessRules;
@@ -18,9 +20,112 @@ internal sealed class EntityBusinessRuleAttributeProvider(
 
 	public EntityBusinessRuleAttributeContext GetAttributes(string entitySchemaName, Guid packageUId) {
 		EntityDesignSchemaDto entitySchema = schemaProvider.GetSchema(entitySchemaName, packageUId);
-		IReadOnlyDictionary<string, EntitySchemaColumnDto> columnMap = BusinessRuleHelpers.BuildColumnMap(entitySchema);
 		IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> attributes =
-			BusinessRuleHelpers.BuildAttributeDescriptorMap(columnMap);
+			new EntityBusinessRuleAttributeDescriptorMap(entitySchema, packageUId, schemaProvider);
 		return new EntityBusinessRuleAttributeContext(entitySchema, attributes);
+	}
+}
+
+internal sealed class EntityBusinessRuleAttributeDescriptorMap(
+	EntityDesignSchemaDto rootSchema,
+	Guid packageUId,
+	IEntityBusinessRuleSchemaProvider schemaProvider)
+	: IReadOnlyDictionary<string, BusinessRuleAttributeDescriptor> {
+
+	private readonly Dictionary<string, IReadOnlyDictionary<string, EntitySchemaColumnDto>> _columnMaps =
+		new(StringComparer.Ordinal) {
+			[rootSchema.Name ?? string.Empty] = BusinessRuleHelpers.BuildColumnMap(rootSchema)
+		};
+
+	private readonly Dictionary<string, EntityDesignSchemaDto> _schemas =
+		new(StringComparer.Ordinal) {
+			[rootSchema.Name ?? string.Empty] = rootSchema
+		};
+
+	private IReadOnlyDictionary<string, EntitySchemaColumnDto> RootColumns =>
+		_columnMaps[rootSchema.Name ?? string.Empty];
+
+	public IEnumerable<string> Keys => RootColumns.Keys;
+
+	public IEnumerable<BusinessRuleAttributeDescriptor> Values =>
+		RootColumns.Select(pair => BusinessRuleHelpers.BuildAttributeDescriptor(pair.Key, pair.Value));
+
+	public int Count => RootColumns.Count;
+
+	public BusinessRuleAttributeDescriptor this[string key] =>
+		TryGetValue(key, out BusinessRuleAttributeDescriptor? value)
+			? value
+			: throw new KeyNotFoundException($"Attribute '{key}' was not found.");
+
+	public bool ContainsKey(string key) => TryGetValue(key, out _);
+
+	public bool TryGetValue(string key, out BusinessRuleAttributeDescriptor value) {
+		if (string.IsNullOrWhiteSpace(key)) {
+			value = default!;
+			return false;
+		}
+
+		string[] pathSegments = key.Split('.', StringSplitOptions.RemoveEmptyEntries);
+		if (pathSegments.Length == 0 || string.Join(".", pathSegments) != key) {
+			value = default!;
+			return false;
+		}
+
+		IReadOnlyDictionary<string, EntitySchemaColumnDto> currentColumns = RootColumns;
+		for (int index = 0; index < pathSegments.Length; index++) {
+			string segment = pathSegments[index];
+			if (!currentColumns.TryGetValue(segment, out EntitySchemaColumnDto? column)) {
+				value = default!;
+				return false;
+			}
+
+			bool isLastSegment = index == pathSegments.Length - 1;
+			if (isLastSegment) {
+				value = BusinessRuleHelpers.BuildAttributeDescriptor(key, column);
+				return true;
+			}
+
+			string? referenceSchemaName = column.ReferenceSchema?.Name;
+			if (string.IsNullOrWhiteSpace(referenceSchemaName)) {
+				value = default!;
+				return false;
+			}
+
+			currentColumns = GetColumnMap(referenceSchemaName);
+		}
+
+		value = default!;
+		return false;
+	}
+
+	public IEnumerator<KeyValuePair<string, BusinessRuleAttributeDescriptor>> GetEnumerator() {
+		foreach (KeyValuePair<string, EntitySchemaColumnDto> pair in RootColumns) {
+			yield return new KeyValuePair<string, BusinessRuleAttributeDescriptor>(
+				pair.Key,
+				BusinessRuleHelpers.BuildAttributeDescriptor(pair.Key, pair.Value));
+		}
+	}
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	private IReadOnlyDictionary<string, EntitySchemaColumnDto> GetColumnMap(string schemaName) {
+		if (_columnMaps.TryGetValue(schemaName, out IReadOnlyDictionary<string, EntitySchemaColumnDto>? columns)) {
+			return columns;
+		}
+
+		EntityDesignSchemaDto schema = GetSchema(schemaName);
+		IReadOnlyDictionary<string, EntitySchemaColumnDto> columnMap = BusinessRuleHelpers.BuildColumnMap(schema);
+		_columnMaps[schemaName] = columnMap;
+		return columnMap;
+	}
+
+	private EntityDesignSchemaDto GetSchema(string schemaName) {
+		if (_schemas.TryGetValue(schemaName, out EntityDesignSchemaDto? schema)) {
+			return schema;
+		}
+
+		schema = schemaProvider.GetSchema(schemaName, packageUId);
+		_schemas[schemaName] = schema;
+		return schema;
 	}
 }

--- a/clio/Command/McpServer/Tools/BusinessRuleTool.cs
+++ b/clio/Command/McpServer/Tools/BusinessRuleTool.cs
@@ -206,7 +206,7 @@ public sealed record EntityMakeOptionalBusinessRuleActionMcpContract : EntityFie
 }
 
 /// <summary>
-/// MCP action contract that assigns constant values to entity attributes.
+/// MCP action contract that assigns constants, formulas, or attribute values to entity attributes.
 /// </summary>
 public sealed record EntitySetValuesBusinessRuleActionMcpContract : EntityBusinessRuleActionMcpContract
 {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -1324,25 +1324,25 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildEntityBusinessRuleCreate() {
 		return new ToolContractDefinition(
 			CreateEntityBusinessRuleTool.BusinessRuleCreateToolName,
-			"Creates an entity-level Freedom UI business rule with equality, filled-in, numeric or date/time relational comparisons, and Set values actions from constants or formulas.",
+			"Creates an entity-level Freedom UI business rule with equality, filled-in, numeric or date/time relational comparisons, and Set values actions from constants, formulas, or attributes.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameCamelFieldName, PackageNameCamelFieldName, EntitySchemaNameCamelFieldName, RuleFieldName],
 				[
 					Field(EnvironmentNameCamelFieldName, StringType, RegisteredEnvironmentNameDescription),
 					Field(PackageNameCamelFieldName, StringType, "Target package name."),
 					Field(EntitySchemaNameCamelFieldName, StringType, "Target entity schema name."),
-					Field(RuleFieldName, ObjectType, "Structured entity business-rule definition with caption, one top-level condition group, and one or more actions. Unary filled-in comparisons omit rightExpression. Relational comparisons only support numeric and date/time left attributes (Date, DateTime, Time). Set values actions support Const assignments for text, number, boolean, Date, DateTime, and Time targets, plus Formula assignments with simple direct-field expressions such as Field1 + Field2.")
+					Field(RuleFieldName, ObjectType, "Structured entity business-rule definition with caption, one top-level condition group, and one or more actions. Unary filled-in comparisons omit rightExpression. Relational comparisons only support numeric and date/time left attributes (Date, DateTime, Time). Set values actions support Const assignments for text, number, boolean, Date, DateTime, and Time targets, Formula assignments with simple direct-field expressions such as Field1 + Field2, and AttributeValue assignments from same-typed direct or forward reference paths such as Owner.Age.")
 				],
 				Validators: [
 					.. BusinessRuleConditionValidators(),
 					new ToolContractValidator("enum", "unsupported-action", "rule.actions[*].type",
 						Context: $"Supported values: {BusinessRuleConstants.SupportedActionTypesDescription}."),
 					new ToolContractValidator("set-values-shape", "invalid-set-values-item", "rule.actions[*].items[*]",
-						Context: "When rule.actions[*].type is set-values, each item must provide expression { type: AttributeValue, path } and value { type: Const, value } or { type: Formula, expression }. Formula expression must be a string using a simple direct-field arithmetic expression, for example Field1 + Field2. Attribute value sources, formula functions, comparison operators, and string literals are not supported in this scope."),
+						Context: "When rule.actions[*].type is set-values, each item must provide expression { type: AttributeValue, path } and value { type: Const, value }, { type: Formula, expression }, or { type: AttributeValue, path }. Formula expression must be a string using a simple direct-field arithmetic expression, for example Field1 + Field2. AttributeValue source paths may be direct columns or forward reference paths like LookupColumn.SourceColumn; the final source attribute and target attribute must have the same data value type. Formula functions, comparison operators, and string literals are not supported in formula scope."),
 					new ToolContractValidator("set-values-constant", "unsupported-set-values-constant", "rule.actions[*].items[*].value.value",
 						Context: "Set values supports JSON string constants for text targets, JSON number constants for numeric targets, JSON booleans for Boolean targets, yyyy-MM-dd strings for Date targets, ISO 8601 strings with timezone suffix for DateTime targets, and ISO 8601 time strings with timezone suffix for Time targets."),
 					new ToolContractValidator("set-values-formula", "invalid-set-values-formula", "rule.actions[*].items[*].value.expression",
-						Context: "Formula expressions are translated after payload parsing into expression-schema PowerFx metadata, checked locally against an arithmetic whitelist, then validated remotely through ServiceModel/ExpressionService.svc/Validate before saving. Referenced direct source fields are added as business-rule triggers.")
+						Context: "Formula expressions are translated after payload parsing into expression-schema PowerFx metadata, checked locally against an arithmetic whitelist, then validated remotely through ServiceModel/ExpressionService.svc/Validate before saving. Referenced direct source fields are added as business-rule triggers. AttributeValue sources are serialized as business-rule attribute expressions; direct sources trigger on that source column, and forward sources trigger on the root lookup column.")
 				]),
 			CommandExecutionOutput(),
 			CommonErrorContract,
@@ -1382,6 +1382,11 @@ internal static class ToolContractCatalog {
 					"UsrTask", "Calculate total effort when name is filled", "Name", "is-filled-in",
 					"set-values", [
 						BusinessRuleFormulaSetValueItem("UsrTotalEffort", "UsrEstimatedEffort + UsrExtraEffort")
+					]),
+				BusinessRuleExample("Create a Set values rule from a forward reference attribute",
+					"UsrTask", "Copy creator age when name changes", "Name", "is-filled-in",
+					"set-values", [
+						BusinessRuleAttributeSetValueItem("UsrCreatorAge", "CreatedBy.Age")
 					])
 			],
 			Flow(
@@ -1574,6 +1579,19 @@ internal static class ToolContractCatalog {
 			["value"] = new Dictionary<string, object?> {
 				["type"] = "Formula",
 				["expression"] = formula
+			}
+		};
+	}
+
+	private static Dictionary<string, object?> BusinessRuleAttributeSetValueItem(string path, string sourcePath) {
+		return new Dictionary<string, object?> {
+			["expression"] = new Dictionary<string, object?> {
+				["type"] = "AttributeValue",
+				["path"] = path
+			},
+			["value"] = new Dictionary<string, object?> {
+				["type"] = "AttributeValue",
+				["path"] = sourcePath
 			}
 		};
 	}

--- a/spec/business-rules/create-entity-business-rule-spec.md
+++ b/spec/business-rules/create-entity-business-rule-spec.md
@@ -49,6 +49,7 @@ Entity-level rule creation must:
    - support set value targets:
       - constant value (text, number, boolean, date/time)
       - formula value using a simple direct-field arithmetic expression such as `(Field1 + Field2) / 2`
+      - attribute value from a same-typed direct attribute or forward reference path such as `Lookup.Field`
    - support multiple targets per action
 - generate internal identifiers automatically
 - append the new rule without changing the order of existing rules
@@ -68,6 +69,9 @@ Entity-level rule creation must reject the request when:
 - a relational comparison targets a non-numeric and non-temporal left attribute
 - a referenced condition attribute does not exist in the target entity scope
 - a referenced action target does not exist in the target entity scope
+- a set value attribute source does not exist in the target entity scope
+- a set value attribute source and target have different data value types
+- a set value target uses a forward reference path
 - a referenced formula source attribute does not exist in the target entity scope
 - a formula source does not reference any entity attribute
 - a formula uses a function call, comparison operator, string literal, or another expression shape outside the current arithmetic whitelist


### PR DESCRIPTION
**Review Summary**

This change adds `AttributeValue` source support for `set-values` actions in entity business rules created through the MCP `create-entity-business-rule` tool.

It allows Set values rules to copy a value from another same-typed entity attribute, including forward-reference paths such as `CreatedBy.Age` or `UsrCity.Country.TimeZone.CreatedBy.Age`.

The implementation follows Creatio Designer metadata behavior: forward-reference sources are persisted as `BusinessRuleAttributeExpression`, and their trigger is the root lookup column only.

**What Changed**

- Added `AttributeValue` as a supported source value type for entity `set-values` actions.
- Kept existing source types unchanged:
  - `Const` still uses `value.value`.
  - `Formula` still uses `value.expression`.
  - `AttributeValue` uses `value.path`.
- Added direct attribute source assignments.
- Added forward-reference source assignments through lookup chains.
- Added lazy forward-path descriptor resolution in `EntityBusinessRuleAttributeProvider`.
- Added validation that source and target attributes have the same data value type.
- Kept condition fields and action targets limited to direct entity attributes.
- Added metadata generation as `BusinessRuleAttributeExpression`.
- Added trigger generation matching Designer behavior:
  - direct source -> source column trigger
  - forward source -> root lookup trigger
  - always `DataLoaded`
- Updated MCP tool contract and examples.
- Added unit and MCP E2E coverage.

**Payload Shape**

AttributeValue set-values payload now looks like this:

```json
{
  "type": "set-values",
  "items": [
    {
      "expression": {
        "type": "AttributeValue",
        "path": "UsrNumber1"
      },
      "value": {
        "type": "AttributeValue",
        "path": "CreatedBy.Age"
      }
    }
  ]
}
```

Deep forward-reference paths are also supported:

```json
{
  "type": "AttributeValue",
  "path": "UsrCity.Country.TimeZone.CreatedBy.Age"
}
```

`value.value` is reserved for `Const`; `value.expression` is reserved for `Formula`; attribute sources must use `value.path`.

**Architecture**

```mermaid
flowchart TD
    MCP["MCP create-entity-business-rule"] --> Command["CreateEntityBusinessRuleCommand"]
    Command --> Service["EntityBusinessRuleService"]

    Service --> PackageResolver["BusinessRulePackageResolver"]
    Service --> AttributeProvider["EntityBusinessRuleAttributeProvider"]
    AttributeProvider --> DirectAttributes["Direct entity attributes"]
    AttributeProvider --> ForwardResolver["Lazy forward-reference path resolver"]

    Service --> Validator["BusinessRuleValidator"]
    Validator --> TypeCheck["Source/target data value type check"]

    Service --> Converter["BusinessRuleMetadataConverter"]
    Converter --> AttributeMetadata["BusinessRuleAttributeExpression metadata"]
    Converter --> Triggers["Direct source or root lookup trigger + DataLoaded"]

    Service --> AddonService["BusinessRuleAddonService"]
    AddonService --> AddonDesigner["AddonSchemaDesignerService.svc"]

    PageService["PageBusinessRuleService"] -.shares.-> Converter
    PageService -.does not use entity forward set-values.-> PageRules["Page rules"]
```

**Validation Flow**

Local validation checks:

- `value.type` can be `Const`, `Formula`, or `AttributeValue`.
- `AttributeValue` source has `value.path`.
- Target field exists and is a direct entity attribute.
- Source field exists.
- Forward-reference source paths resolve through lookup reference schemas.
- Final source attribute type matches target attribute type.
- Condition attributes remain direct entity attributes.
- Field-state action targets remain direct entity attributes.

Example valid assignment:

```text
UsrNumber1 <- CreatedBy.Age
```

Example rejected assignment:

```text
UsrNumber1 <- CreatedBy.Name
```

if `UsrNumber1` is `Integer` and `CreatedBy.Name` is `Text`.

**Trigger Behavior**

Designer metadata confirms this behavior:

```text
CreatedBy.Age -> CreatedBy
UsrCity.Country.TimeZone.CreatedBy.Age -> UsrCity
```

So trigger generation is:

- `SourceColumn` -> `SourceColumn`
- `LookupColumn.SourceColumn` -> `LookupColumn`
- `Lookup1.Lookup2.Lookup3.SourceColumn` -> `Lookup1`
- plus `DataLoaded`

This means changes to the root lookup recalculate the rule. Changes inside the referenced record are not tracked live by the business-rule trigger and are picked up on data load/reload, matching Creatio Designer output.

**Why This Fits The Architecture**

The change stays on the entity business-rule path:

- `EntityBusinessRuleService` already owns entity rule creation.
- `EntityBusinessRuleAttributeProvider` now resolves direct and forward entity attributes.
- `BusinessRuleValidator` keeps shared rule validation but allows forward paths only for entity Set values sources.
- `BusinessRuleMetadataConverter` keeps shared metadata conversion and emits the same metadata shape as Designer.
- `PageBusinessRuleService` behavior is unchanged.

No core runtime change is required because Creatio already evaluates attribute paths through the business-rule expression runtime.

**Reviewer Focus Areas**

- `AttributeValue.path` contract for Set values source.
- Forward-reference descriptor resolution through lookup chains.
- Same-type validation between source and target.
- Direct-only restriction for condition fields and action targets.
- Metadata shape for `BusinessRuleAttributeExpression`.
- Trigger generation for deep forward paths: root lookup only.
- MCP contract examples and guidance.

**Test Coverage**

Covered by:

- `EntityBusinessRuleAttributeProviderTests`
  - resolves forward-reference source paths
  - rejects forward paths through non-lookup attributes
- `BusinessRuleValidatorTests`
  - accepts same-typed direct AttributeValue source
  - accepts same-typed forward AttributeValue source
  - rejects missing source path
  - rejects source/target type mismatch
  - rejects forward-reference action targets
- `BusinessRuleMetadataConverterTests`
  - maps AttributeValue source into metadata
  - adds direct source triggers
  - adds root lookup trigger for forward sources
  - does not emit full forward-path trigger
- `BusinessRuleToolTests`
  - verifies MCP JSON deserialization for AttributeValue source shape
- `ToolContractGetToolTests` and MCP E2E tests
  - verifies MCP contract advertises AttributeValue source support
- `EntityBusinessRuleToolE2ETests`
  - covers MCP execution/binding path for Set values payloads with AttributeValue source

**Out Of Scope**

- Forward-reference conditions.
- Forward-reference action targets.
- Live recalculation when a referenced record’s nested field changes without changing the root lookup.
- Page business-rule Set values behavior.
- Runtime browser UI verification.