### PR TITLE
fix(mcp): harden compile-creatio guardrails against page-body false positives

### DIFF
--- a/clio.tests/Command/McpServer/CompileCreatioToolTests.cs
+++ b/clio.tests/Command/McpServer/CompileCreatioToolTests.cs
@@ -135,7 +135,7 @@ public sealed class CompileCreatioToolTests
 
 	[Test]
 	[Category("Unit")]
-	[Description("Exposes non-read-only MCP metadata for compilation because the command mutates build state but is not destructive.")]
+	[Description("Exposes destructive MCP metadata for compilation so hosts can prompt for confirmation before the long-running runtime reload.")]
 	public void CompileCreatio_Should_Expose_Expected_Mcp_Metadata()
 	{
 		// Arrange
@@ -151,8 +151,8 @@ public sealed class CompileCreatioToolTests
 			because: "the metadata should reuse the production tool-name constant");
 		attribute.ReadOnly.Should().BeFalse(
 			because: "compilation changes target environment build state");
-		attribute.Destructive.Should().BeFalse(
-			because: "compilation should not be classified as a destructive operation");
+		attribute.Destructive.Should().BeTrue(
+			because: "compilation forces a runtime reload that interrupts the active session, so hosts must treat it as destructive");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -72,6 +72,37 @@ public sealed class ToolContractGetToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Returns the canonical compile-creatio contract with explicit preconditions and anti-patterns so callers can decide when compilation is required.")]
+	public void ToolContractGet_Should_Return_CompileCreatio_Contract_With_Preconditions_And_AntiPatterns() {
+		// Arrange
+		ToolContractGetTool tool = new();
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs([
+			CompileCreatioTool.CompileCreatioToolName
+		]));
+
+		// Assert
+		result.Success.Should().BeTrue(
+			because: "compile-creatio is part of the canonical executable contract surface");
+		ToolContractDefinition contract = result.Tools!.Single();
+		contract.Name.Should().Be(CompileCreatioTool.CompileCreatioToolName);
+		contract.Preconditions.Should().NotBeNullOrEmpty(
+			because: "the contract must spell out when compilation is actually required");
+		contract.Preconditions!.Should().Contain(precondition => precondition.Contains("set-fsm-mode", StringComparison.Ordinal),
+			because: "FSM-mode toggles are a canonical trigger for full compilation");
+		contract.Preconditions!.Should().Contain(precondition => precondition.Contains("C# schemas", StringComparison.Ordinal),
+			because: "C# schema changes are the primary precondition for package compilation");
+		contract.AntiPatterns.Should().NotBeNullOrEmpty(
+			because: "the contract must call out flows where compilation is never required");
+		contract.AntiPatterns!.Should().Contain(pattern => pattern.Pattern.Contains(PageUpdateTool.ToolName, StringComparison.Ordinal),
+			because: "page-body edits applied through update-page must never be followed by compile-creatio");
+		contract.AntiPatterns!.Should().Contain(pattern => pattern.Pattern.Contains(ApplicationCreateTool.ApplicationCreateToolName, StringComparison.Ordinal),
+			because: "create-app never requires a follow-up compilation");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Returns the canonical get-guidance contract so callers can retrieve guidance through a tool instead of docs URI routing.")]
 	public void ToolContractGet_Should_Return_Guidance_Get_Contract() {
 		// Arrange

--- a/clio/Command/McpServer/Resources/PageSchemaConvertersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageSchemaConvertersGuidanceResource.cs
@@ -106,6 +106,10 @@ public sealed class PageSchemaConvertersGuidanceResource {
 			             };
 			           });
 
+			       Server-side compilation
+			       - Converters live in the Freedom UI page body, which is an AMD module served at runtime. After `update-page` or `sync-pages` your changes are live.
+			       - Do NOT call `compile-creatio` — it is for C# schema changes, not page-body JavaScript. Compilation forces a runtime reload, breaks the active session, and is never required as a follow-up to a page-body edit.
+
 			       NON-NEGOTIABLES
 			       - `SCHEMA_CONVERTERS` is an OBJECT, not an array.
 			       - Converters affect DISPLAY only. They do not write back to the model. Never put side effects inside a converter function.

--- a/clio/Command/McpServer/Resources/PageSchemaHandlersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageSchemaHandlersGuidanceResource.cs
@@ -69,6 +69,10 @@ public sealed class PageSchemaHandlersGuidanceResource {
 		         | deployed page-body handler in `SCHEMA_HANDLERS` | `await request.$context.executeRequest(...)` | page-body handlers already work through the live view-model context and this is the default authoring API for page edits |
 		       - Do NOT default to `sdk.HandlerChainService.instance.process(...)` in deployed page-body handlers; use `request.$context.executeRequest(...)` unless the task explicitly matches an advanced SDK pattern from `page-schema-creatio-devkit-common`.
 
+		       Server-side compilation
+		       - Handlers live in the Freedom UI page body, which is an AMD module served at runtime. After `update-page` or `sync-pages` your changes are live.
+		       - Do NOT call `compile-creatio` — it is for C# schema changes, not page-body JavaScript. Compilation forces a runtime reload, breaks the active session, and is never required as a follow-up to a page-body edit.
+
 		       NON-NEGOTIABLES
 		       - Use handler signatures like `async (request, next) => { ... }` only inside `SCHEMA_HANDLERS`.
 		       - `handlers` is an ARRAY, not an object.

--- a/clio/Command/McpServer/Resources/PageSchemaValidatorsGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageSchemaValidatorsGuidanceResource.cs
@@ -52,6 +52,10 @@ public sealed class PageSchemaValidatorsGuidanceResource {
 			       - Create a custom `usr.*Validator` only when the requirement is not covered by `crt.Required`, `crt.EmptyOrWhiteSpace`, `crt.MinLength`, `crt.MaxLength`, `crt.Min`, or `crt.Max`, or when the validation logic is genuinely domain-specific.
 			       - All `crt.*` validators accept an optional `message` param to override the built-in localized error text (e.g., `"message": "#ResourceString(SomeKey)#"`). Omit `message` to use the automatic built-in error text. Only add `message` when you specifically need to override the default error.
 
+			       Server-side compilation
+			       - Validators live in the Freedom UI page body, which is an AMD module served at runtime. After `update-page` or `sync-pages` your changes are live.
+			       - Do NOT call `compile-creatio` — it is for C# schema changes, not page-body JavaScript. Compilation forces a runtime reload, breaks the active session, and is never required as a follow-up to a page-body edit.
+
 			       NON-NEGOTIABLES
 			       - Keep validators focused on field-value validation.
 			       - Implement field validation as a validator entry, not as logic inside a handler.

--- a/clio/Command/McpServer/Tools/CompileCreatioTool.cs
+++ b/clio/Command/McpServer/Tools/CompileCreatioTool.cs
@@ -28,8 +28,8 @@ public sealed class CompileCreatioTool(
 	/// <summary>
 	/// Compiles Creatio fully or rebuilds a single package for a registered environment.
 	/// </summary>
-	[McpServerTool(Name = CompileCreatioToolName, ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
-	[Description("Compiles a registered Creatio environment. Omit `package-name` to run a full compilation (`clio cc -e ENV_NAME --all`). Provide `package-name` to compile only one package. This tool is recommended after `set-fsm-mode`.")]
+	[McpServerTool(Name = CompileCreatioToolName, ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
+	[Description("Long-running, may take several minutes; recompiles a registered Creatio environment and forces a runtime reload. Omit `package-name` to run a full compilation (`clio cc -e ENV_NAME --all`). Provide `package-name` to compile only one package. Call only when: (1) C# schemas were added or modified, (2) `set-fsm-mode` has just been toggled, or (3) the runtime reports a missing-in-runtime/schema-not-found error. Do NOT call after `create-app`, `update-page`, `sync-pages`, `update-entity-schema`, `create-page`, or any Freedom UI page-body edit — those changes are AMD modules applied at runtime and DDL is handled by `update-entity-schema`.")]
 	public CommandExecutionResult CompileCreatio(
 		[Description("Compilation parameters")] [Required] CompileCreatioArgs args)
 	{

--- a/clio/Command/McpServer/Tools/LoadPackagesTool.cs
+++ b/clio/Command/McpServer/Tools/LoadPackagesTool.cs
@@ -19,7 +19,7 @@ public class LoadPackagesTool(
 	/// </summary>
 	/// <param name="environmentName">Target environment name.</param>
 	/// <returns>Execution result for the operation.</returns>
-	[McpServerTool(Name = "pkg-to-file-system", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[McpServerTool(Name = "pkg-to-file-system", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
 	[Description("Loads packages from the database into the file system on a Creatio web application")]
 	public CommandExecutionResult LoadPackagesToFileSystem(
 		[Description("Target environment name")] [Required] string environmentName
@@ -35,7 +35,7 @@ public class LoadPackagesTool(
 	/// </summary>
 	/// <param name="environmentName">Target environment name.</param>
 	/// <returns>Execution result for the operation.</returns>
-	[McpServerTool(Name = "pkg-to-db", ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[McpServerTool(Name = "pkg-to-db", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
 	[Description("Loads packages from the file system into the database on a Creatio web application")]
 	public CommandExecutionResult LoadPackagesToDb(
 		[Description("Target environment name")] [Required] string environmentName

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -102,7 +102,8 @@ public sealed record ToolContractDefinition(
 	[property: JsonPropertyName("preferred-flow")] ToolFlowHint PreferredFlow,
 	[property: JsonPropertyName("fallback-flow")] IReadOnlyList<ToolFlowHint> FallbackFlow,
 	[property: JsonPropertyName("deprecations")] IReadOnlyList<ToolDeprecation> Deprecations,
-	[property: JsonPropertyName("anti-patterns")] IReadOnlyList<ToolAntiPattern>? AntiPatterns = null
+	[property: JsonPropertyName("anti-patterns")] IReadOnlyList<ToolAntiPattern>? AntiPatterns = null,
+	[property: JsonPropertyName("preconditions")] IReadOnlyList<string>? Preconditions = null
 );
 
 public sealed record ToolInputSchemaContract(
@@ -322,7 +323,8 @@ internal static class ToolContractCatalog {
 			[ApplicationDeleteTool.ToolName] = BuildApplicationDelete(),
 			[CreateEntityBusinessRuleTool.BusinessRuleCreateToolName] = BuildEntityBusinessRuleCreate(),
 			[CreatePageBusinessRuleTool.BusinessRuleCreateToolName] = BuildPageBusinessRuleCreate(),
-			[SchemaNamePrefixTool.GetSchemaNamePrefixToolName] = BuildGetSchemaNamePrefix()
+			[SchemaNamePrefixTool.GetSchemaNamePrefixToolName] = BuildGetSchemaNamePrefix(),
+			[CompileCreatioTool.CompileCreatioToolName] = BuildCompileCreatio()
 		};
 
 	private static readonly string[] CanonicalToolNames = [
@@ -361,7 +363,8 @@ internal static class ToolContractCatalog {
 		ComponentInfoTool.ToolName,
 		PageUpdateTool.ToolName,
 		ApplicationDeleteTool.ToolName,
-		SchemaNamePrefixTool.GetSchemaNamePrefixToolName
+		SchemaNamePrefixTool.GetSchemaNamePrefixToolName,
+		CompileCreatioTool.CompileCreatioToolName
 	];
 
 	internal static ToolContractGetResponse GetContracts(IReadOnlyList<string>? toolNames) {
@@ -2946,6 +2949,62 @@ internal static class ToolContractCatalog {
 				"Use before create-entity-schema, create-lookup, create-page, or sync-schemas when neither create-app nor get-app-info has been called yet in the session."),
 			[],
 			[]);
+	}
+
+	private static ToolContractDefinition BuildCompileCreatio() {
+		return new ToolContractDefinition(
+			CompileCreatioTool.CompileCreatioToolName,
+			"Recompiles a registered Creatio environment and forces a runtime reload. Long-running (often several minutes). Reserved for C# schema changes, FSM-mode transitions, and schema-missing runtime errors. Freedom UI page-body edits (validators, handlers, converters) do NOT require compilation — those changes are AMD modules served at runtime.",
+			new ToolInputSchemaContract(
+				[EnvironmentNameFieldName],
+				[
+					Field(EnvironmentNameFieldName, StringType, RegisteredEnvironmentNameDescription),
+					Field(PackageNameFieldName, StringType, "Optional package name. When omitted, runs a full compilation (`clio cc -e ENV_NAME --all`). When provided, recompiles only that single package. Comma-separated lists are not supported.")
+				]),
+			CommandExecutionOutput(),
+			CommonErrorContract,
+			[],
+			[],
+			[
+				Example("Run a full compilation after toggling FSM mode", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName
+				}),
+				Example("Recompile a single package after a C# schema change", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName,
+					[PackageNameFieldName] = ExamplePackageName
+				})
+			],
+			Flow(
+				[
+					FsmModeTool.SetFsmModeToolName,
+					CompileCreatioTool.CompileCreatioToolName
+				],
+				"Call only after C# schema work, after `set-fsm-mode`, or in response to a runtime schema-missing error. Skip this tool entirely when the work touches only Freedom UI page bodies or DDL changes routed through `update-entity-schema`."),
+			[],
+			[],
+			AntiPatterns: [
+				new ToolAntiPattern(
+					$"{PageUpdateTool.ToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"Freedom UI page bodies are AMD modules served at runtime. `update-page` and `sync-pages` make changes live; running `compile-creatio` afterward forces an unnecessary runtime reload and breaks the active session."),
+				new ToolAntiPattern(
+					$"{UpdateEntitySchemaTool.UpdateEntitySchemaToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"`update-entity-schema` applies DDL changes directly. No compilation is required as a follow-up."),
+				new ToolAntiPattern(
+					$"{ApplicationCreateTool.ApplicationCreateToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"`create-app` provisions a starter section, entity, and pages without any compilation step. Calling `compile-creatio` afterward serves no purpose and forces a runtime reload."),
+				new ToolAntiPattern(
+					$"{PageCreateTool.ToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"`create-page` writes a page schema into the runtime catalog directly. The new page becomes available without compilation."),
+				new ToolAntiPattern(
+					$"{CreateEntityBusinessRuleTool.BusinessRuleCreateToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"Business-rule creation writes add-on metadata directly. Successful rule creation does not need compilation as a routine post-step.")
+			],
+			Preconditions: [
+				"`set-fsm-mode` was just toggled (full compilation only).",
+				"C# schemas were added or modified in the targeted package.",
+				"The runtime reported a missing-in-runtime or schema-not-found error that maps to a compilation gap.",
+				"Caller must NOT call this tool after `create-app`, `update-page`, `sync-pages`, `update-entity-schema`, `create-page`, `create-entity-business-rule`, or `create-page-business-rule`."
+			]);
 	}
 
 	private static ToolOutputContract CommandExecutionOutput() {


### PR DESCRIPTION
## Summary

Closes four guardrails behind a session where an agent called `compile-creatio` twice after `update-page` on a Freedom UI page body — neither call was needed, because page bodies are AMD modules served at runtime.

- Rewrite `compile-creatio` description with a hard-conditional `Call only when` / `Do NOT call` formulation and a long-running prefix; drop the soft "recommended after `set-fsm-mode`" phrasing. ([CompileCreatioTool.cs](clio/Command/McpServer/Tools/CompileCreatioTool.cs))
- Add an identical `Server-side compilation` block to the [validators](clio/Command/McpServer/Resources/PageSchemaValidatorsGuidanceResource.cs), [handlers](clio/Command/McpServer/Resources/PageSchemaHandlersGuidanceResource.cs), and [converters](clio/Command/McpServer/Resources/PageSchemaConvertersGuidanceResource.cs) guides stating that page-body edits never need compilation.
- Add an optional `preconditions` field to `ToolContractDefinition` and a canonical `compile-creatio` entry listing three legitimate triggers and five forbidden after-flows. ([ToolContractGetTool.cs](clio/Command/McpServer/Tools/ToolContractGetTool.cs))
- Flip `Destructive=true` on `compile-creatio`, `pkg-to-db`, and `pkg-to-file-system` so `destructiveHint`-aware hosts can prompt the user before execution. ([LoadPackagesTool.cs](clio/Command/McpServer/Tools/LoadPackagesTool.cs))