### PR TITLE
fix(compile-package): resolve hang on Creatio 8.3.3

### DIFF
--- a/clio/Command/CompileConfigurationCommand.cs
+++ b/clio/Command/CompileConfigurationCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -8,8 +7,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
-using ATF.Repository;
-using ATF.Repository.Providers;
 using Clio.Common;
 using Clio.CreatioModel;
 using CommandLine;
@@ -27,7 +24,7 @@ public class CompileConfigurationOptions : RemoteCommandOptions
 		get; set;
 	}
 	protected override int DefaultTimeout => Timeout.Infinite;
-		
+
 }
 
 #endregion
@@ -42,10 +39,10 @@ public interface ICompileConfigurationCommand {
 #endregion
 
 #region Class: CompileConfigurationCommand
-	
+
 public class CompileConfigurationCommand : RemoteCommand<CompileConfigurationOptions>, ICompileConfigurationCommand {
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
-	private readonly IDataProvider _dataProvider;
+	private readonly ICompilationHistoryPoller _compilationHistoryPoller;
 	private readonly ILogger _logger;
 
 	private const string OdataProjName = "Terrasoft.Configuration.ODataEntities.csproj";
@@ -53,47 +50,40 @@ public class CompileConfigurationCommand : RemoteCommand<CompileConfigurationOpt
 	private bool _compileAll;
 
 	private bool _isSuccess = false;
+
 	#region Constructors: Public
 
-	public CompileConfigurationCommand(IApplicationClient applicationClient, 
-		EnvironmentSettings settings, IServiceUrlBuilder serviceUrlBuilder, IDataProvider dataProvider, ILogger logger)
+	public CompileConfigurationCommand(IApplicationClient applicationClient,
+		EnvironmentSettings settings, IServiceUrlBuilder serviceUrlBuilder,
+		ICompilationHistoryPoller compilationHistoryPoller, ILogger logger)
 		: base(applicationClient, settings) {
 		_serviceUrlBuilder = serviceUrlBuilder;
-		_dataProvider = dataProvider;
+		_compilationHistoryPoller = compilationHistoryPoller;
 		_logger = logger;
 	}
 
 	#endregion
 
-	protected override string ServicePath => _compileAll 
-		? _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.CompileAll) 
+	protected override string ServicePath => _compileAll
+		? _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.CompileAll)
 		: _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.Compile);
 
-
 	public override int Execute(CompileConfigurationOptions options) {
-
-		IAppDataContext ctx = AppDataContextFactory.GetAppDataContext(_dataProvider);
-		CompilationHistory lastRecord = ctx.Models<CompilationHistory>()
-										   .OrderByDescending(x => x.CreatedOn).Take(1).FirstOrDefault();
-		
-		// This is the first record, we don't need to print it. We will print records created after this record.
-		if (lastRecord is not null) {
-			_printed.Add(lastRecord.Id);
-		}
+		CompilationHistory baseline = _compilationHistoryPoller.GetBaseline();
 		_compileAll = options.All;
 		options.TimeOut = Timeout.Infinite;
-		Stopwatch sw = new ();
+		Stopwatch sw = new();
 		sw.Start();
 		_logger.WriteLine("=================================================================================");
 		_logger.WriteInfo($"At: {DateTime.Now:HH:mm:ss} Starting compilation...");
 		_logger.WriteLine();
-		
-		using CancellationTokenSource cts = new ();
-		Thread thread = new (()=> {
-			GetLatestCompilationHistory(lastRecord?.CreatedOn ?? DateTime.MinValue, cts.Token);
+
+		using CancellationTokenSource cts = new();
+		Thread thread = new(() => {
+			_compilationHistoryPoller.Poll(baseline?.CreatedOn ?? DateTime.MinValue, cts.Token, LogRecord);
 		});
 		thread.Start();
-		
+
 		//This will take a while to return, so we will check compilation history in parallel to get progress of compilation
 		int execResult = base.Execute(options);
 		sw.Stop();
@@ -107,64 +97,41 @@ public class CompileConfigurationCommand : RemoteCommand<CompileConfigurationOpt
 		return _isSuccess ? execResult : 1;
 	}
 
-
-	private readonly ConcurrentBag<Guid> _printed = [];
-	private void GetLatestCompilationHistory(DateTime lastRecord, CancellationToken cancellationToken) {
-		IAppDataContext ctx = AppDataContextFactory.GetAppDataContext(_dataProvider);
-		while (!cancellationToken.IsCancellationRequested) {
-			List<CompilationHistory> records = ctx.Models<CompilationHistory>()
-												  .OrderByDescending(x => x.CreatedOn)
-												  .Where(x => x.CreatedOn > lastRecord)
-												  .ToList();
-			
-			records.ForEach(x => {
-				if (_printed.Contains(x.Id)) {
-					return;
-				}
-				_printed.Add(x.Id);
-
-				string decoratedDuration = x.DurationInSeconds switch {
-											   >= 10 => ConsoleLogger.WrapRed(x.DurationInSeconds),
-											   >= 5 => ConsoleLogger.WrapYellow(x.DurationInSeconds),
-											   var _ => x.DurationInSeconds.ToString("N0", CultureInfo.InvariantCulture)
-										   };	
-				List<string> specialProj = [OdataProjName, DevProjName];
-				string decoratedProjectName = x.ProjectName switch {
-												  {} y when specialProj.Contains(y) => ConsoleLogger.WrapBlue(y) + ConsoleLogger.WrapGreen(" <============"),
-												  var _ => x.ProjectName
-											  };
-				if (string.Equals(x.ErrorsWarnings,"[]", StringComparison.OrdinalIgnoreCase)) {
-					_logger.WriteInfo($"At: {x.CreatedOn:HH:mm:ss} after: {decoratedDuration} sec. {decoratedProjectName}");
-				}
-				else {
-					_logger.WriteWarning($"At: {x.CreatedOn:HH:mm:ss} after: {decoratedDuration} sec. {decoratedProjectName} with: {ParseErrors(x.ErrorsWarnings)}");
-				}
-			});
-			lastRecord = records.Count > 0 ? records.Max(x => x.CreatedOn) : lastRecord;
-			if (cancellationToken.WaitHandle.WaitOne(1_000)) {
-				break;
-			}
+	private void LogRecord(CompilationHistory record) {
+		string decoratedDuration = record.DurationInSeconds switch {
+			>= 10 => ConsoleLogger.WrapRed(record.DurationInSeconds),
+			>= 5 => ConsoleLogger.WrapYellow(record.DurationInSeconds),
+			var _ => record.DurationInSeconds.ToString("N0", CultureInfo.InvariantCulture)
+		};
+		List<string> specialProj = [OdataProjName, DevProjName];
+		string decoratedProjectName = record.ProjectName switch {
+			{ } y when specialProj.Contains(y) => ConsoleLogger.WrapBlue(y) + ConsoleLogger.WrapGreen(" <============"),
+			var _ => record.ProjectName
+		};
+		if (string.Equals(record.ErrorsWarnings, "[]", StringComparison.OrdinalIgnoreCase)) {
+			_logger.WriteInfo($"At: {record.CreatedOn:HH:mm:ss} after: {decoratedDuration} sec. {decoratedProjectName}");
+		} else {
+			_logger.WriteWarning($"At: {record.CreatedOn:HH:mm:ss} after: {decoratedDuration} sec. {decoratedProjectName} with: {ParseErrors(record.ErrorsWarnings)}");
 		}
 	}
 
-	private static readonly JsonSerializerOptions JsonSerializerOptions = new ()
+	private static readonly JsonSerializerOptions JsonSerializerOptions = new()
 		{ PropertyNameCaseInsensitive = true };
 	private static readonly Func<string, string> ParseErrors = (json) => {
 		try {
 			List<CompError> errors = JsonSerializer.Deserialize<List<CompError>>(json, JsonSerializerOptions);
-			StringBuilder sb = new ();
+			StringBuilder sb = new();
 			int errorNumber = 1;
 			foreach (string message in errors.Select(error => error switch {
-																  var _ when string.IsNullOrWhiteSpace(error.FileName) && error.IsWarning => $"({ConsoleLogger.WrapYellow(error.ErrorNumber)}): {error.ErrorText}",
-																  var _ when string.IsNullOrWhiteSpace(error.FileName) && !error.IsWarning => $"({ConsoleLogger.WrapRed(error.ErrorNumber)}): {error.ErrorText}",
-																  var _ when !string.IsNullOrWhiteSpace(error.FileName) && error.IsWarning => $"({ConsoleLogger.WrapYellow(error.ErrorNumber)}) in {ConsoleLogger.WrapYellow(error.FileName)} at ({error.Line},{error.Column}): {error.ErrorText}",
-																  var _ when !string.IsNullOrWhiteSpace(error.FileName) && !error.IsWarning => $"({ConsoleLogger.WrapRed(error.ErrorNumber)}) in {ConsoleLogger.WrapYellow(error.FileName)} at ({error.Line},{error.Column}) : {error.ErrorText}",
-																  var _ => json //We should never be here, this is to make compiler happy
-															  })) {
+				var _ when string.IsNullOrWhiteSpace(error.FileName) && error.IsWarning => $"({ConsoleLogger.WrapYellow(error.ErrorNumber)}): {error.ErrorText}",
+				var _ when string.IsNullOrWhiteSpace(error.FileName) && !error.IsWarning => $"({ConsoleLogger.WrapRed(error.ErrorNumber)}): {error.ErrorText}",
+				var _ when !string.IsNullOrWhiteSpace(error.FileName) && error.IsWarning => $"({ConsoleLogger.WrapYellow(error.ErrorNumber)}) in {ConsoleLogger.WrapYellow(error.FileName)} at ({error.Line},{error.Column}): {error.ErrorText}",
+				var _ when !string.IsNullOrWhiteSpace(error.FileName) && !error.IsWarning => $"({ConsoleLogger.WrapRed(error.ErrorNumber)}) in {ConsoleLogger.WrapYellow(error.FileName)} at ({error.Line},{error.Column}) : {error.ErrorText}",
+				var _ => json //We should never be here, this is to make compiler happy
+			})) {
 				sb.AppendLine().Append('\t').Append($"{errorNumber++} of {errors.Count} ").Append(message);
 			}
 			return sb.ToString();
-			
 		}
 		// Could not parse errors, return original json
 		catch {
@@ -217,50 +184,50 @@ public class CompileConfigurationCommand : RemoteCommand<CompileConfigurationOpt
 public class CreatioResponse
 {
 	[JsonPropertyName("errorInfo")]
-    public ErrorInfo ErrorInfo { get; set; }
-	
+	public ErrorInfo ErrorInfo { get; set; }
+
 	[JsonPropertyName("success")]
 	public bool Success { get; set; }
-	
+
 	[JsonPropertyName("buildResult")]
-    public int BuildResult { get; set; }
-	
+	public int BuildResult { get; set; }
+
 	[JsonPropertyName("errors")]
-    public object Errors { get; set; }
-	
+	public object Errors { get; set; }
+
 	[JsonPropertyName("message")]
-    public object Message { get; set; }
+	public object Message { get; set; }
 }
 
 public class ErrorInfo
 {
 	[JsonPropertyName("errorCode")]
-    public string ErrorCode { get; set; }
-	
+	public string ErrorCode { get; set; }
+
 	[JsonPropertyName("message")]
-    public string Message { get; set; }
-	
+	public string Message { get; set; }
+
 	[JsonPropertyName("stackTrace")]
-    public object StackTrace { get; set; }
+	public object StackTrace { get; set; }
 }
 
 public class CompError
 {
 	[JsonPropertyName("Line")]
-    public int Line { get; set; }
-	
+	public int Line { get; set; }
+
 	[JsonPropertyName("Column")]
-    public int Column { get; set; }
-	
+	public int Column { get; set; }
+
 	[JsonPropertyName("ErrorNumber")]
-    public string ErrorNumber { get; set; }
-	
+	public string ErrorNumber { get; set; }
+
 	[JsonPropertyName("ErrorText")]
-    public string ErrorText { get; set; }
-	
+	public string ErrorText { get; set; }
+
 	[JsonPropertyName("IsWarning")]
-    public bool IsWarning { get; set; }
-	
+	public bool IsWarning { get; set; }
+
 	[JsonPropertyName("FileName")]
-    public string FileName { get; set; }
+	public string FileName { get; set; }
 }

--- a/clio/Common/CompilationHistoryPoller.cs
+++ b/clio/Common/CompilationHistoryPoller.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using ATF.Repository;
+using ATF.Repository.Providers;
+using Clio.CreatioModel;
+
+namespace Clio.Common;
+
+public interface ICompilationHistoryPoller {
+
+	CompilationHistory GetBaseline();
+
+	void Poll(DateTime baseline, CancellationToken ct, Action<CompilationHistory> onNewRecord);
+
+}
+
+public class CompilationHistoryPoller : ICompilationHistoryPoller {
+
+	private readonly IDataProvider _dataProvider;
+
+	public CompilationHistoryPoller(IDataProvider dataProvider) {
+		_dataProvider = dataProvider;
+	}
+
+	public CompilationHistory GetBaseline() {
+		IAppDataContext ctx = AppDataContextFactory.GetAppDataContext(_dataProvider);
+		return ctx.Models<CompilationHistory>()
+			.OrderByDescending(x => x.CreatedOn)
+			.Take(1)
+			.FirstOrDefault();
+	}
+
+	public void Poll(DateTime baseline, CancellationToken ct, Action<CompilationHistory> onNewRecord) {
+		IAppDataContext ctx = AppDataContextFactory.GetAppDataContext(_dataProvider);
+		var seen = new HashSet<Guid>();
+		while (!ct.IsCancellationRequested) {
+			List<CompilationHistory> records = ctx.Models<CompilationHistory>()
+				.OrderByDescending(x => x.CreatedOn)
+				.Where(x => x.CreatedOn > baseline)
+				.ToList();
+
+			foreach (CompilationHistory record in records) {
+				if (seen.Add(record.Id)) {
+					baseline = record.CreatedOn > baseline ? record.CreatedOn : baseline;
+					onNewRecord(record);
+				}
+			}
+
+			if (ct.WaitHandle.WaitOne(1_000)) {
+				break;
+			}
+		}
+	}
+
+}

--- a/clio/Package/PackageBuilder.cs
+++ b/clio/Package/PackageBuilder.cs
@@ -1,7 +1,10 @@
 namespace Clio.Package
 {
+	using System;
+	using System.Threading;
 	using System.Collections.Generic;
 	using Clio.Common;
+	using Clio.CreatioModel;
 
 	#region Interface: IPackageBuilder
 
@@ -24,20 +27,29 @@ namespace Clio.Package
 
 	public class PackageBuilder : IPackageBuilder
 	{
-		
+
+		#region Constants: Private
+
+		private const int CompilationSettleSeconds = 5;
+		private const int CompilationTimeoutMinutes = 10;
+
+		#endregion
+
 		#region Fields: Private
 
 		private readonly EnvironmentSettings _environmentSettings;
 		private readonly IApplicationClientFactory _applicationClientFactory;
 		private readonly IServiceUrlBuilder _serviceUrlBuilder;
 		private readonly ILogger _logger;
+		private readonly ICompilationHistoryPoller _compilationHistoryPoller;
 
 		#endregion
 
 		#region Constructors: Public
 
 		public PackageBuilder(EnvironmentSettings environmentSettings,
-			IApplicationClientFactory applicationClientFactory, IServiceUrlBuilder serviceUrlBuilder, ILogger logger){
+			IApplicationClientFactory applicationClientFactory, IServiceUrlBuilder serviceUrlBuilder,
+			ILogger logger, ICompilationHistoryPoller compilationHistoryPoller = null) {
 			environmentSettings.CheckArgumentNull(nameof(environmentSettings));
 			applicationClientFactory.CheckArgumentNull(nameof(applicationClientFactory));
 			serviceUrlBuilder.CheckArgumentNull(nameof(serviceUrlBuilder));
@@ -46,6 +58,7 @@ namespace Clio.Package
 			_applicationClientFactory = applicationClientFactory;
 			_serviceUrlBuilder = serviceUrlBuilder;
 			_logger = logger;
+			_compilationHistoryPoller = compilationHistoryPoller;
 		}
 
 		#endregion
@@ -61,21 +74,94 @@ namespace Clio.Package
 				.Replace(" ", string.Empty)
 				.Replace(",", "\",\"");
 
-		private void Compilation(IEnumerable<string> packagesNames, bool force){
+		private void Compilation(IEnumerable<string> packagesNames, bool force) {
 			IApplicationClient applicationClient = CreateClient();
 			string compilationName = force ? "rebuild" : "build";
 			string fullBuildPackageUrl = _serviceUrlBuilder.Build(
 				force
-				? ServiceUrlBuilder.KnownRoute.RebuildPackage 
+				? ServiceUrlBuilder.KnownRoute.RebuildPackage
 				: ServiceUrlBuilder.KnownRoute.BuildPackage);
 
 			foreach (string packageName in packagesNames) {
 				string safePackageName = GetSafePackageName(packageName);
 				_logger.WriteLine($"Start {compilationName} packages ({safePackageName}).");
-				var requestData = CreateRequestData(safePackageName);
-				applicationClient.ExecutePostRequest(fullBuildPackageUrl, requestData);
+				string requestData = CreateRequestData(safePackageName);
+
+				if (_compilationHistoryPoller is not null) {
+					CompileWithPolling(applicationClient, fullBuildPackageUrl, requestData);
+				} else {
+					applicationClient.ExecutePostRequest(fullBuildPackageUrl, requestData);
+				}
+
 				_logger.WriteLine($"End {compilationName} packages ({safePackageName}).");
 			}
+		}
+
+		// In Creatio 8.3.3+, RebuildPackage no longer sends back an HTTP response —
+		// the server compiles in the background and drops the connection. We fire the
+		// request in a daemon thread and use the same CompilationHistoryPoller pattern
+		// as CompileConfigurationCommand to detect completion via OData.
+		private void CompileWithPolling(IApplicationClient client, string url, string requestData) {
+			CompilationHistory baseline = _compilationHistoryPoller.GetBaseline();
+			DateTime baselineCreatedOn = baseline?.CreatedOn ?? DateTime.MinValue;
+
+			Exception httpException = null;
+			bool httpDone = false;
+
+			Thread httpThread = new(() => {
+				try {
+					client.ExecutePostRequest(url, requestData);
+				} catch (Exception ex) {
+					httpException = ex;
+				} finally {
+					httpDone = true;
+				}
+			}) { IsBackground = true };
+			httpThread.Start();
+
+			DateTime timeoutAt = DateTime.UtcNow.AddMinutes(CompilationTimeoutMinutes);
+			DateTime? lastActivityAt = null;
+			bool hasErrors = false;
+			string errorDetails = null;
+
+			using CancellationTokenSource cts = new();
+			Thread pollThread = new(() => {
+				_compilationHistoryPoller.Poll(baselineCreatedOn, cts.Token, record => {
+					lastActivityAt = DateTime.UtcNow;
+					if (!record.Result && !string.IsNullOrEmpty(record.ErrorsWarnings) && record.ErrorsWarnings != "[]") {
+						hasErrors = true;
+						errorDetails = record.ErrorsWarnings;
+					}
+				});
+			});
+			pollThread.Start();
+
+			while (DateTime.UtcNow < timeoutAt) {
+				if (httpDone) {
+					cts.Cancel();
+					pollThread.Join();
+					if (httpException is not null) {
+						throw httpException;
+					}
+					return;
+				}
+
+				if (lastActivityAt.HasValue &&
+					(DateTime.UtcNow - lastActivityAt.Value).TotalSeconds >= CompilationSettleSeconds) {
+					cts.Cancel();
+					pollThread.Join();
+					if (hasErrors) {
+						throw new Exception($"Package compilation failed: {errorDetails}");
+					}
+					return;
+				}
+
+				Thread.Sleep(500);
+			}
+
+			cts.Cancel();
+			pollThread.Join();
+			throw new TimeoutException($"Package compilation did not complete within {CompilationTimeoutMinutes} minutes.");
 		}
 
 		#endregion


### PR DESCRIPTION
In Creatio 8.3.3 the WorkspaceExplorerService.svc/RebuildPackage endpoint starts compilation asynchronously but never sends back an HTTP response, causing `clio compile-package` to hang indefinitely (issue #530).

Introduce ICompilationHistoryPoller — a shared OData-based service that polls CompilationHistory for new records (extracted from CompileConfigurationCommand.GetLatestCompilationHistory). Both commands now use the same polling mechanism:

- CompileConfigurationCommand: poller runs in a background thread, HTTP response drives completion (unchanged behaviour).
- PackageBuilder: HTTP request fires in a daemon thread; the poller runs in a background thread; a 5-second settle window on the main thread drives completion so the command exits correctly even when the server never replies.

Verified on Creatio 8.3.3.3193 (kanban env): compile-package exits 0 and compile-configuration polls and prints progress correctly.