### PR TITLE
fix(compile-package): resolve hang on Creatio 8.3.3

### DIFF
--- a/clio.tests/Command/McpServer/CompileCreatioToolTests.cs
+++ b/clio.tests/Command/McpServer/CompileCreatioToolTests.cs
@@ -184,7 +184,7 @@ public sealed class CompileCreatioToolTests
 				Substitute.For<IApplicationClient>(),
 				new EnvironmentSettings(),
 				Substitute.For<IServiceUrlBuilder>(),
-				Substitute.For<ATF.Repository.Providers.IDataProvider>(),
+				Substitute.For<ICompilationHistoryPoller>(),
 				Substitute.For<ILogger>())
 		{
 		}


### PR DESCRIPTION
## Summary
- Resolves a hang in `compile-package` against Creatio 8.3.3 by switching to `ICompilationHistoryPoller` instead of polling `IDataProvider` directly
- Updates `FakeCompileConfigurationCommand` in tests to match the updated constructor signature (fixes CS1503 CI build failure)

## Test plan
- [ ] Unit tests pass (CI: Unit Tests job)
- [ ] No regression in Analyzer Tests or Integration Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)