### PR TITLE
feat(cli): surface closest matching alias in unknown-command suggestions

### DIFF
--- a/clio.tests/CommonProgramTest.cs
+++ b/clio.tests/CommonProgramTest.cs
@@ -249,10 +249,10 @@ internal class CommonProgramTest : BaseClioModuleTests{
 			because: "the expanded unknown-command UX should show up to ten command suggestions when enough matches exist");
 		suggestionLines.Should().Equal(suggestionLines.OrderBy(line => line, StringComparer.Ordinal).ToArray(),
 			because: "the rendered suggestion list should now be sorted alphabetically for easier scanning");
-		suggestionLines.Should().Contain("  clio list-apps",
-			because: "the closest visible list command should be suggested");
-		suggestionLines.Should().Contain("  clio list-packages",
-			because: "commands sharing the same get/list intent should be suggested");
+		suggestionLines.Should().Contain("  clio get-app-list",
+			because: "the closest visible list alias should be suggested when it beats the canonical name on token overlap");
+		suggestionLines.Should().Contain("  clio get-pkg-list",
+			because: "the alias sharing the same get/list intent should be suggested over its canonical name");
 		outputLines.Should().Contain("See all commands: clio help",
 			because: "the user should get a generic recovery path after an unknown command");
 		outputLines.Should().Contain("See command help: clio <command> --help",
@@ -260,8 +260,8 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	}
 
 	[Test]
-	[Description("Uses aliases for ranking but prints the canonical command name in suggestions.")]
-	public void ExecuteCommands_WithAliasLikeInput_ShouldSuggestCanonicalCommandName() {
+	[Description("Surfaces the shortest matching alias instead of the canonical name when the alias is a closer fit.")]
+	public void ExecuteCommands_WithAliasLikeInput_ShouldSuggestShortestMatchingAlias() {
 		StringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
@@ -274,12 +274,35 @@ internal class CommonProgramTest : BaseClioModuleTests{
 			.Where(line => line.StartsWith("  clio ", StringComparison.Ordinal))
 			.ToArray();
 
-		suggestionLines.Should().Contain("  clio list-environments",
-			because: "alias similarity should still surface the environment listing command while output stays canonical");
+		suggestionLines.Should().Contain("  clio envs",
+			because: "the shortest alias that best matches the typo should be surfaced so the user can pick the concise form");
+		suggestionLines.Should().NotContain("  clio list-environments",
+			because: "when an alias beats the canonical name on similarity, only the closer alias should be displayed");
 		suggestionLines.Should().Equal(suggestionLines.OrderBy(line => line, StringComparer.Ordinal).ToArray(),
 			because: "alias-driven suggestions should follow the same alphabetical rendering as every other unknown command");
-		outputLines.Should().NotContain("  clio envs",
-			because: "the CLI should display canonical command names instead of aliases in suggestion output");
+	}
+
+	[Test]
+	[Description("Reflects the alias closest to a typo such as 'encvs' instead of forcing the user to read the canonical name.")]
+	public void ExecuteCommands_WithTypoNearShortAlias_ShouldSuggestThatAlias() {
+		StringWriter consoleOutput = new();
+		Console.SetOut(consoleOutput);
+		Console.SetError(consoleOutput);
+		string[] args = ["encvs"];
+
+		Program.ExecuteCommands(args);
+		string[] outputLines = consoleOutput.ToString()
+			.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+		string[] suggestionLines = outputLines
+			.Where(line => line.StartsWith("  clio ", StringComparison.Ordinal))
+			.ToArray();
+
+		outputLines.Should().Contain("Maybe you meant:",
+			because: "an unknown verb that is one edit away from a known alias should still produce a suggestion block");
+		suggestionLines.Should().Contain("  clio envs",
+			because: "the alias 'envs' is one character away from 'encvs' and should be the surfaced suggestion");
+		suggestionLines.Should().NotContain("  clio list-environments",
+			because: "the user is closer to the short alias and should not be redirected to the longer canonical form");
 	}
 
 	[Test]

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -219,7 +219,7 @@ internal class Program {
 	public static IAppUpdater _appUpdater;
 
 	private sealed record CommandSuggestionEntry(string CanonicalName, IReadOnlyList<string> SearchTerms);
-	private sealed record CommandSuggestionScore(string CanonicalName, int TokenOverlap, int EditDistance);
+	private sealed record CommandSuggestionScore(string CanonicalName, string DisplayName, int TokenOverlap, int EditDistance);
 
 	internal static IReadOnlyList<Type> GetCommandOptionTypes() => CommandOption;
 
@@ -716,7 +716,7 @@ internal class Program {
 			.Select(entry => BuildCommandSuggestionScore(requestedCommand, entry))
 			.OrderByDescending(score => score.TokenOverlap)
 			.ThenBy(score => score.EditDistance)
-			.ThenBy(score => score.CanonicalName, StringComparer.OrdinalIgnoreCase)
+			.ThenBy(score => score.DisplayName, StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 		if (scores.Length == 0) {
 			return [];
@@ -731,7 +731,7 @@ internal class Program {
 		}
 		return relevantScores
 			.Take(CommandSuggestionLimit)
-			.Select(score => score.CanonicalName)
+			.Select(score => score.DisplayName)
 			.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 	}
@@ -742,6 +742,7 @@ internal class Program {
 		string comparableRequestedCommand = NormalizeComparableCommandName(requestedCommand);
 		int bestTokenOverlap = 0;
 		int bestEditDistance = int.MaxValue;
+		string bestSearchTerm = entry.CanonicalName;
 		foreach (string searchTerm in entry.SearchTerms) {
 			string normalizedSearchTerm = NormalizeComparableCommandName(searchTerm);
 			int tokenOverlap = CountTokenOverlap(requestedTokens, TokenizeCommandName(searchTerm));
@@ -751,9 +752,10 @@ internal class Program {
 			if (tokenOverlap > bestTokenOverlap || tokenOverlap == bestTokenOverlap && editDistance < bestEditDistance) {
 				bestTokenOverlap = tokenOverlap;
 				bestEditDistance = editDistance;
+				bestSearchTerm = searchTerm;
 			}
 		}
-		return new CommandSuggestionScore(entry.CanonicalName, bestTokenOverlap, bestEditDistance);
+		return new CommandSuggestionScore(entry.CanonicalName, bestSearchTerm, bestTokenOverlap, bestEditDistance);
 	}
 
 	private static int GetEffectiveEditDistance(string comparableRequestedCommand, string canonicalName, string searchTerm,


### PR DESCRIPTION
## Summary
- When the user mistypes a verb (e.g. `clio encvs`), the suggestion block now shows the closest matching alias (`clio envs`) instead of forcing the longer canonical name (`clio list-environments`).
- Ranking logic is untouched — short aliases that beat canonical names on edit-distance / token-overlap were already winning internally; only the rendered name now reflects that winner.
- Existing safeguards stay in place: hidden verbs are still filtered out, low-confidence input still skips suggestions, and the downweight for very short aliases on long inputs (e.g. `skill` not matching `sql`) is preserved.

## What changed
- `clio/Program.cs`
  - `CommandSuggestionScore` got a `DisplayName` field.
  - `BuildCommandSuggestionScore` tracks the winning search term and stores it as `DisplayName`.
  - `GetUnknownCommandSuggestions` renders / sorts by `DisplayName` instead of `CanonicalName`.
- `clio.tests/CommonProgramTest.cs`
  - `WithUnknownVerb_ShouldPrintSuggestionsAndKeepExitCodeOne` updated: for `get-list` the surfaced suggestions are now `get-app-list` / `get-pkg-list` (the aliases with the higher token overlap).
  - `WithAliasLikeInput_ShouldSuggestCanonicalCommandName` renamed to `…ShouldSuggestShortestMatchingAlias` with inverted expectations.
  - New test `WithTypoNearShortAlias_ShouldSuggestThatAlias` pins the `encvs → envs` behaviour from the original bug report.

## Before / after

Before:
```
$ clio encvs

ERROR(S):
  Verb 'encvs' is not recognized.

Maybe you meant:
  clio list-environments
```

After:
```
$ clio encvs

ERROR(S):
  Verb 'encvs' is not recognized.

Maybe you meant:
  clio envs
```

## Test plan
- [x] `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~CommonProgramTest"` — 27/27 pass.
- [x] Manual: `dotnet run --project clio -- encvs` prints `Maybe you meant: clio envs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)