### PR TITLE
ENG-90046 fix(create-app-section): respect environment SchemaNamePrefix

### DIFF
--- a/clio.tests/Command/ApplicationSectionCreateServiceTests.cs
+++ b/clio.tests/Command/ApplicationSectionCreateServiceTests.cs
@@ -18,6 +18,7 @@ public sealed class ApplicationSectionCreateServiceTests {
 	private IApplicationClient _applicationClient = null!;
 	private IServiceUrlBuilder _serviceUrlBuilder = null!;
 	private IApplicationInfoService _applicationInfoService = null!;
+	private ISysSettingsManager _sysSettingsManager = null!;
 	private EnvironmentSettings _environmentSettings = null!;
 	private ApplicationSectionCreateService _sut = null!;
 	private ILogger _logger = null!;
@@ -43,12 +44,15 @@ public sealed class ApplicationSectionCreateServiceTests {
 			.Returns(callInfo => $"https://example.invalid/{callInfo.ArgAt<string>(0)}");
 		IServiceUrlBuilderFactory serviceUrlBuilderFactory = Substitute.For<IServiceUrlBuilderFactory>();
 		serviceUrlBuilderFactory.Create(Arg.Any<EnvironmentSettings>()).Returns(_serviceUrlBuilder);
+		_sysSettingsManager = Substitute.For<ISysSettingsManager>();
+		_sysSettingsManager.GetSysSettingValueByCode("SchemaNamePrefix").Returns("Usr");
 		_sut = new ApplicationSectionCreateService(
 			_settingsRepository,
 			_applicationClientFactory,
 			_serviceUrlBuilder,
 			serviceUrlBuilderFactory,
 			_applicationInfoService,
+			_ => _sysSettingsManager,
 			_logger);
 	}
 
@@ -306,6 +310,82 @@ public sealed class ApplicationSectionCreateServiceTests {
 	}
 
 	[Test]
+	[Description("Section code uses the default Usr prefix when SchemaNamePrefix returns Usr.")]
+	public void CreateSection_Should_Generate_Code_With_Usr_Prefix() {
+		// Arrange
+		_sysSettingsManager.GetSysSettingValueByCode("SchemaNamePrefix").Returns("Usr");
+		SetUpPrefixTestMocks("UsrTestSection");
+
+		// Act
+		ApplicationSectionCreateResult result = _sut.CreateSection(
+			"sandbox",
+			new ApplicationSectionCreateRequest(ApplicationCode: "UsrOrdersApp", Caption: "TestSection"));
+
+		// Assert
+		result.Section.Code.Should().Be("UsrTestSection",
+			because: "SchemaNamePrefix=Usr should produce the Usr-prefixed section code");
+		result.Entity!.Name.Should().Be("UsrTestSection",
+			because: "the entity schema name should match the prefix-derived section code");
+	}
+
+	[Test]
+	[Description("Section code uses a custom prefix when SchemaNamePrefix returns a non-default value.")]
+	public void CreateSection_Should_Generate_Code_With_Custom_Prefix() {
+		// Arrange
+		_sysSettingsManager.GetSysSettingValueByCode("SchemaNamePrefix").Returns("Tst");
+		SetUpPrefixTestMocks("TstTestSection");
+
+		// Act
+		ApplicationSectionCreateResult result = _sut.CreateSection(
+			"sandbox",
+			new ApplicationSectionCreateRequest(ApplicationCode: "UsrOrdersApp", Caption: "TestSection"));
+
+		// Assert
+		result.Section.Code.Should().Be("TstTestSection",
+			because: "SchemaNamePrefix=Tst should produce the Tst-prefixed section code instead of the hardcoded Usr");
+		result.Entity!.Name.Should().Be("TstTestSection",
+			because: "the entity schema name should match the prefix-derived section code");
+	}
+
+	[Test]
+	[Description("Section code has no prefix when SchemaNamePrefix is empty.")]
+	public void CreateSection_Should_Generate_Code_With_No_Prefix_When_Prefix_Is_Empty() {
+		// Arrange
+		_sysSettingsManager.GetSysSettingValueByCode("SchemaNamePrefix").Returns(string.Empty);
+		SetUpPrefixTestMocks("TestSection");
+
+		// Act
+		ApplicationSectionCreateResult result = _sut.CreateSection(
+			"sandbox",
+			new ApplicationSectionCreateRequest(ApplicationCode: "UsrOrdersApp", Caption: "TestSection"));
+
+		// Assert
+		result.Section.Code.Should().Be("TestSection",
+			because: "empty SchemaNamePrefix should produce an unprefixed section code");
+		result.Entity!.Name.Should().Be("TestSection",
+			because: "the entity schema name should match the unprefixed section code");
+	}
+
+	[Test]
+	[Description("Section code inserts an underscore separator after the prefix when the caption starts with a digit, using the actual prefix length instead of the legacy hardcoded value.")]
+	public void CreateSection_Should_Insert_Underscore_After_Prefix_When_Caption_Starts_With_Digit() {
+		// Arrange
+		_sysSettingsManager.GetSysSettingValueByCode("SchemaNamePrefix").Returns("MyPrefix");
+		SetUpPrefixTestMocks("MyPrefix_2024Orders");
+
+		// Act
+		ApplicationSectionCreateResult result = _sut.CreateSection(
+			"sandbox",
+			new ApplicationSectionCreateRequest(ApplicationCode: "UsrOrdersApp", Caption: "2024 Orders"));
+
+		// Assert
+		result.Section.Code.Should().Be("MyPrefix_2024Orders",
+			because: "the underscore separator must be inserted at the prefix boundary (length 8) so the identifier does not start with a digit");
+		result.Entity!.Name.Should().Be("MyPrefix_2024Orders",
+			because: "the entity schema name should match the prefix-derived section code");
+	}
+
+	[Test]
 	[Description("Rejects requests that omit application-code before any remote calls are made.")]
 	public void CreateSection_Should_Reject_Missing_ApplicationCode() {
 		// Arrange
@@ -353,6 +433,44 @@ public sealed class ApplicationSectionCreateServiceTests {
 			.WithMessage("*#RRGGBB format*",
 				because: "non-hex strings are never valid palette values");
 		_applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(default!, default!);
+	}
+
+	private void SetUpPrefixTestMocks(string expectedCode) {
+		ApplicationEntityInfoResult entity = new("entity-uid", expectedCode, "TestSection", []);
+		ApplicationInfoResult beforeInfo = new(
+			"pkg-uid", "UsrOrdersApp", [], [], "app-id", "Orders App", "UsrOrdersApp", "8.3.0");
+		ApplicationInfoResult afterInfo = new(
+			"pkg-uid", "UsrOrdersApp", [entity],
+			[new PageListItem { SchemaName = $"{expectedCode}_FormPage", UId = "page-new", PackageName = "UsrOrdersApp", ParentSchemaName = "BasePageV2" }],
+			"app-id", "Orders App", "UsrOrdersApp", "8.3.0");
+		_applicationInfoService.GetApplicationInfo("sandbox", null, "UsrOrdersApp")
+			.Returns(beforeInfo, afterInfo);
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"SysAppIcons\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true,"rows":[{"Id":"11111111-1111-1111-1111-111111111111"}]}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"SysSchema\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true,"rows":[]}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"Code\"", StringComparison.Ordinal) &&
+				!body.Contains("\"filters\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"SectionSchemaUId\"", StringComparison.Ordinal)))
+			.Returns($$$"""{"success":true,"rows":[{"Id":"section-id","ApplicationId":"app-id","Caption":"TestSection","Code":"{{{expectedCode}}}","Description":"","EntitySchemaName":"{{{expectedCode}}}","PackageId":"pkg-uid","SectionSchemaUId":"section-schema-uid","LogoId":"icon-id","IconBackground":null,"ClientTypeId":"195785B4-F55A-4E72-ACE3-6480B54C8FA5"}]}""");
+		_applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Is<string>(body => body.Contains("\"rootSchemaName\":\"ApplicationSection\"", StringComparison.Ordinal) &&
+				body.Contains("\"columnValues\"", StringComparison.Ordinal) &&
+				body.Contains("\"IconBackground\"", StringComparison.Ordinal) &&
+				body.Contains("\"filters\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true}""");
 	}
 }
 

--- a/clio/Command/ApplicationSectionCreateCommand.cs
+++ b/clio/Command/ApplicationSectionCreateCommand.cs
@@ -71,6 +71,7 @@ public sealed class ApplicationSectionCreateService(
 	IServiceUrlBuilder serviceUrlBuilder,
 	IServiceUrlBuilderFactory serviceUrlBuilderFactory,
 	IApplicationInfoService applicationInfoService,
+	Func<EnvironmentSettings, ISysSettingsManager> sysSettingsManagerFactory,
 	ILogger logger)
 	: IApplicationSectionCreateService {
 	private const string ApplicationSectionSchemaName = "ApplicationSection";
@@ -108,6 +109,8 @@ public sealed class ApplicationSectionCreateService(
 		}
 
 		IApplicationClient client = applicationClientFactory.CreateEnvironmentClient(environmentSettings);
+		ISysSettingsManager sysSettingsManager = sysSettingsManagerFactory(environmentSettings);
+		string schemaNamePrefix = SysSettingCodes.ReadSchemaNamePrefix(sysSettingsManager);
 		logger.WriteInfo($"Loading application info for '{request.ApplicationCode}'...");
 		ApplicationInfoResult beforeInfo = applicationInfoService.GetApplicationInfo(
 			environmentName,
@@ -117,7 +120,8 @@ public sealed class ApplicationSectionCreateService(
 			request,
 			beforeInfo,
 			client,
-			environmentSettings);
+			environmentSettings,
+			schemaNamePrefix);
 		string requestBody = JsonSerializer.Serialize(BuildInsertBody(resolvedRequest), JsonOptions);
 		if (string.IsNullOrWhiteSpace(resolvedRequest.EntitySchemaName)) {
 			CheckEntitySchemaDoesNotExist(client, environmentSettings, resolvedRequest.SectionCode, request.Caption);
@@ -161,8 +165,9 @@ public sealed class ApplicationSectionCreateService(
 		ApplicationSectionCreateRequest request,
 		ApplicationInfoResult applicationInfo,
 		IApplicationClient client,
-		EnvironmentSettings environmentSettings) {
-		string sectionCode = GenerateCodeFromCaption(request.Caption);
+		EnvironmentSettings environmentSettings,
+		string schemaNamePrefix) {
+		string sectionCode = GenerateCodeFromCaption(request.Caption, schemaNamePrefix);
 		string iconBackground = string.IsNullOrWhiteSpace(request.IconBackground)
 		? GenerateRandomHexColor()
 		: request.IconBackground.Trim();
@@ -546,7 +551,7 @@ public sealed class ApplicationSectionCreateService(
 			querySource = 0
 		};
 
-	private static string GenerateCodeFromCaption(string caption) {
+	private static string GenerateCodeFromCaption(string caption, string schemaNamePrefix) {
 		string[] words = CodeWordRegex.Split(caption.Trim())
 			.Where(item => !string.IsNullOrWhiteSpace(item))
 			.ToArray();
@@ -556,7 +561,7 @@ public sealed class ApplicationSectionCreateService(
 				nameof(caption));
 		}
 
-		StringBuilder builder = new("Usr");
+		StringBuilder builder = new(schemaNamePrefix);
 		foreach (string word in words) {
 			string normalizedWord = NormalizeWord(word);
 			if (!string.IsNullOrWhiteSpace(normalizedWord)) {
@@ -564,14 +569,15 @@ public sealed class ApplicationSectionCreateService(
 			}
 		}
 
-		if (builder.Length == 3) {
+		int prefixLength = schemaNamePrefix.Length;
+		if (builder.Length == prefixLength) {
 			throw new ArgumentException(
 				$"Section caption '{caption}' contains no valid characters for code generation.",
 				nameof(caption));
 		}
 
-		if (char.IsDigit(builder[3])) {
-			builder.Insert(3, "_");
+		if (prefixLength < builder.Length && char.IsDigit(builder[prefixLength])) {
+			builder.Insert(prefixLength, "_");
 		}
 
 		return builder.ToString();

--- a/clio/docs/commands/create-app-section.md
+++ b/clio/docs/commands/create-app-section.md
@@ -85,7 +85,10 @@ create a web-only section with automatically resolved icon metadata
 
 - --application-code is required.
 - When --entity-schema-name is provided, the section reuses that entity.
-- The section code is generated automatically from the caption.
+- The section code is generated automatically from the caption and prefixed
+  with the active SchemaNamePrefix system setting from the target environment
+  (for example caption "Orders" produces "UsrOrders" when SchemaNamePrefix is
+  "Usr", or "Orders" when the setting is empty).
 
 ## Reporting Bugs
 


### PR DESCRIPTION
## Summary

- `create-app-section` derived the section schema code from the caption with a hardcoded `"Usr"` prefix and a magic-number length of `3`, ignoring the `SchemaNamePrefix` system setting. Sections created on environments with an empty or custom prefix got incorrect schema codes (e.g. `UsrDrivers` instead of `TstDrivers` on a `Tst`-prefix environment).
- Injects `Func<EnvironmentSettings, ISysSettingsManager>` into `ApplicationSectionCreateService`, reads the prefix via `SysSettingCodes.ReadSchemaNamePrefix`, and passes it through to `GenerateCodeFromCaption`. Replaces the magic `3` with `prefixLength` so the digit-insert branch works for any prefix length. Mirrors the existing pattern in `ApplicationCreateService`.
- Updates `clio/docs/commands/create-app-section.md` to mention env-driven prefix behavior.

## Test plan

- [x] Three new unit tests cover the `Usr`, custom-prefix, and empty-prefix cases
- [x] One new test covers the digit-leading caption branch with a non-length-3 prefix (`MyPrefix` + `"2024 Orders"` → `MyPrefix_2024Orders`)
- [x] End-to-end verified on `cust_base_env` with `SchemaNamePrefix=""` (produced unprefixed `Drivers_*` schemas)
- [x] End-to-end verified on `cust_base_env` with `SchemaNamePrefix="Tst"` (produced `TstDrivers_*` schemas)
- [x] `dotnet test --filter "Category=Unit&Module=Command"` — 1226 passed, 0 failed

## MCP review

MCP reviewed, no update required — the prefix is read internally by the service; the MCP tool contract (`ApplicationSectionCreateTool`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)