### PR TITLE
ENG-89962 Align MCP guidance prose on 'page modification'

### DIFF
--- a/clio/Command/McpServer/Resources/AppModelingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/AppModelingGuidanceResource.cs
@@ -17,7 +17,7 @@ public sealed class AppModelingGuidanceResource {
 	/// Returns the canonical guidance article for DB-first app creation, schema modeling, and page workflows.
 	/// </summary>
 	[McpServerResource(UriTemplate = ResourceUri, Name = "app-modeling-guidance")]
-	[Description("Returns canonical MCP guidance for Creatio application modeling, schema design, and page-editing workflows.")]
+	[Description("Returns canonical MCP guidance for Creatio application modeling, schema design, and page modification workflows.")]
 	public ResourceContents GetGuide() => Guide;
 
 	internal static readonly TextResourceContents Guide = new() {

--- a/clio/Command/McpServer/Resources/GuidanceCatalog.cs
+++ b/clio/Command/McpServer/Resources/GuidanceCatalog.cs
@@ -16,7 +16,7 @@ internal static class GuidanceCatalog {
 		Dictionary<string, GuidanceCatalogEntry> entries = new(StringComparer.OrdinalIgnoreCase) {
 			["app-modeling"] = Create(
 				"app-modeling",
-				"Canonical MCP guidance for Creatio application modeling, schema design, and page-editing workflows.",
+				"Canonical MCP guidance for Creatio application modeling, schema design, and page modification workflows.",
 				AppModelingGuidanceResource.Guide),
 			["data-bindings"] = Create(
 				"data-bindings",

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -443,7 +443,7 @@ Good MCP-level candidates:
 - application modeling rules tied directly to tool behavior, especially that `create-app` typically returns the canonical main entity for single-record-type apps
 - lookup modeling rules tied directly to `create-lookup`, especially `BaseLookup` inheritance, inherited `Name` / `Description`, and `Name` as the display field
 - default-value semantics that are tool-domain specific, such as seed rows not satisfying a `defaults to X` requirement without explicit schema or UI defaults
-- page-editing workflow guidance tied to MCP tools, for example `get-tool-contract` -> `list-pages` -> `get-page` -> `component-info` -> `update-page` or `sync-pages`
+- page modification workflow guidance tied to MCP tools, for example `get-tool-contract` -> `list-pages` -> `get-page` -> `component-info` -> `update-page` or `sync-pages`
 
 Guidance that should stay outside clio MCP:
 


### PR DESCRIPTION
## Summary

Three prose alignments in MCP-surfaced guidance descriptions: replace `"page-editing workflows"` with `"page modification workflows"` so AI agents stop misreading the hyphenated phrase as a registered guidance identifier and trying to fetch a non-existent `page-editing` guide.

The canonical hyphenated identifier `page-modification` (the registered guide name) is unchanged.

- `clio/Command/McpServer/Resources/AppModelingGuidanceResource.cs:20` — `[Description(...)]` returned by MCP resource discovery
- `clio/Command/McpServer/Resources/GuidanceCatalog.cs:19` — catalog description surfaced when listing the `app-modeling` entry
- `docs/McpCapabilityMap.md:446` — capability map prose

## Verification

### Build
- `dotnet build clio/clio.csproj` — **succeeded**, 0 errors (2 unrelated NuGet vulnerability-data fetch warnings)
- `dotnet build clio.tests/clio.tests.csproj` — **succeeded**, 0 errors (10 pre-existing CS0114 hiding warnings, unrelated)

### Tests
- `dotnet test --filter "FullyQualifiedName~McpServer"` — **805/805 passed in 12s**
- No test assertions pin the old `"page-editing"` string; all affected tests already use the canonical `"page-modification"` form (`GuidanceGetToolTests.cs:62,72,128,135,137`, `PageToolsTests.cs:183,262,291`).

### MCP review (per repo AGENTS.md policy)
- Change is description-only (no URI, no contract, no semantic shift).
- `clio.mcp.e2e/McpGuidanceResourceE2ETests.cs` and `GuidanceGetToolE2ETests.cs` assert on URIs and article text content — not on `[Description(...)]` attribute strings.
- **MCP reviewed, no E2E update required.**

## Test plan

- [x] Build clio
- [x] Build clio.tests
- [x] Run McpServer test suite (805/805 passed)
- [x] Confirm no other tests pin the old `page-editing` phrasing

## Related

- Jira: https://creatio.atlassian.net/browse/ENG-89962
- Paired toolkit fix in `ai-driven-app-creation` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)