### PR TITLE
ENG-88997: Remove entity schema name length validation

### DIFF
--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -649,7 +649,7 @@ public sealed class EntitySchemaToolE2ETests {
 			string workspaceName = $"workspace-{Guid.NewGuid():N}";
 			string workspacePath = Path.Combine(rootDirectory, workspaceName);
 			string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
-			string schemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
+			string schemaName = $"Usr{Guid.NewGuid():N}";
 			string initialColumnName = "UsrName";
 			string lookupColumnName = "UsrSortOrder";
 			string addedColumnName = "UsrCode";

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -349,8 +349,8 @@ public sealed class SchemaSyncToolE2ETests {
 			}
 
 			packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
-			entitySchemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
-			lookupSchemaName = $"Usr{Guid.NewGuid():N}".Substring(0, 22);
+			entitySchemaName = $"Usr{Guid.NewGuid():N}";
+			lookupSchemaName = $"Usr{Guid.NewGuid():N}";
 			await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
 			await PushWorkspaceAsync(
 				settings,

--- a/clio.tests/Command/CreateEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/CreateEntitySchemaCommandTests.cs
@@ -65,22 +65,6 @@ internal class CreateEntitySchemaCommandTests : BaseCommandTests<CreateEntitySch
 	}
 
 	[Test]
-	public void Execute_ReturnsFailure_WhenSchemaNameIsTooLong()
-	{
-		var options = new CreateEntitySchemaOptions {
-			Package = "UsrPkg",
-			SchemaName = "UsrCodexEntitySchemaTest0307",
-			Title = "Vehicle"
-		};
-
-		var result = _command.Execute(options);
-
-		result.Should().Be(1);
-		_creator.DidNotReceiveWithAnyArgs().Create(default);
-		_logger.Received(1).WriteError(Arg.Is<string>(message => message.Contains("must not exceed 22 characters")));
-	}
-
-	[Test]
 	[Description("Preserves semicolons inside structured JSON --column payloads so valid captions and defaults are not split by the command-line parser.")]
 	public void Parse_Should_Preserve_Semicolons_In_Json_Column_Payload() {
 		// Arrange

--- a/clio.tests/Command/CreateLookupCommandTests.cs
+++ b/clio.tests/Command/CreateLookupCommandTests.cs
@@ -94,27 +94,6 @@ public sealed class CreateLookupCommandTests : BaseCommandTests<CreateLookupOpti
 	}
 
 	[Test]
-	[Description("Returns failure when schema name exceeds 22 characters.")]
-	public void Execute_Should_Return_Failure_When_SchemaName_Is_Too_Long()
-	{
-		// Arrange
-		CreateLookupOptions options = new() {
-			Environment = "dev",
-			Package = "UsrPkg",
-			SchemaName = "UsrVeryLongSchemaNameThatExceeds22",
-			Title = "Title"
-		};
-
-		// Act
-		int exitCode = _command.Execute(options);
-
-		// Assert
-		exitCode.Should().Be(1, because: "a schema name longer than 22 characters must be rejected");
-		_createEntitySchemaCommand.DidNotReceiveWithAnyArgs().Execute(default!);
-		_logger.Received(1).WriteError(Arg.Is<string>(m => m.Contains("22")));
-	}
-
-	[Test]
 	[Description("Returns failure exit code and logs an error when the environment is missing.")]
 	public void Execute_Should_Return_Failure_When_Environment_Is_Missing()
 	{

--- a/clio/Command/CreateEntitySchemaCommand.cs
+++ b/clio/Command/CreateEntitySchemaCommand.cs
@@ -71,9 +71,6 @@ public class CreateEntitySchemaCommand : Command<CreateEntitySchemaOptions>
 		if (string.IsNullOrWhiteSpace(options.SchemaName)) {
 			throw new InvalidOperationException("Schema name is required.");
 		}
-		if (options.SchemaName.Trim().Length > 22) {
-			throw new InvalidOperationException("Schema name must not exceed 22 characters.");
-		}
 		if (string.IsNullOrWhiteSpace(options.Title)) {
 			throw new InvalidOperationException("Schema title is required.");
 		}

--- a/clio/Command/CreateLookupCommand.cs
+++ b/clio/Command/CreateLookupCommand.cs
@@ -20,7 +20,7 @@ public sealed class CreateLookupOptions : RemoteCommandOptions
 		set { if (!string.IsNullOrEmpty(value)) Package = value; }
 	}
 
-	[Option("name", Required = true, HelpText = "Schema name (max 22 characters)")]
+	[Option("name", Required = true, HelpText = "Schema name")]
 	public string SchemaName { get; set; } = string.Empty;
 
 	[Option("title", Required = true, HelpText = "Schema title")]
@@ -54,9 +54,6 @@ public sealed class CreateLookupCommand(
 			}
 			if (string.IsNullOrWhiteSpace(options.SchemaName)) {
 				throw new InvalidOperationException("Schema name is required.");
-			}
-			if (options.SchemaName.Trim().Length > 22) {
-				throw new InvalidOperationException("Schema name must not exceed 22 characters.");
 			}
 			if (string.IsNullOrWhiteSpace(options.Title)) {
 				throw new InvalidOperationException("Schema title is required.");

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -513,7 +513,7 @@ public abstract record EntitySchemaCreateArgsBase(
 	string PackageName,
 
 	[property: JsonPropertyName("schema-name")]
-	[property: Description("Entity schema name. Maximum length is 22 characters. " +
+	[property: Description("Entity schema name. " +
 		"Must use the active SchemaNamePrefix as prefix (e.g. 'UsrAlpha' when prefix is 'Usr', 'MyPrefixAlpha' when prefix is 'MyPrefix'). " +
 		"When `schema-name-prefix` is empty, use no prefix (plain PascalCase, e.g. 'Alpha'). " +
 		"Read the prefix from the `schema-name-prefix` field returned by `get-app-info`, " +

--- a/clio/docs/commands/create-lookup.md
+++ b/clio/docs/commands/create-lookup.md
@@ -31,7 +31,7 @@ clio create-lookup [options]
 ```bash
 --package                        Target package name. Required.
 
---name                           Schema name (max 22 characters). Required.
+--name                           Schema name. Required.
 
 --title                          Schema title. Required.
 
@@ -60,7 +60,6 @@ clio create-lookup --package UsrSalesApp --name UsrDealType --title "Deal Type" 
 ## Notes
 
 - --package, --name, and --title are required.
-- Schema name must not exceed 22 characters.
 - BaseLookup already provides Name and Description; do not add those via --column.
 - cliogate must be installed in the target environment.
 

--- a/clio/help/en/create-entity-schema.txt
+++ b/clio/help/en/create-entity-schema.txt
@@ -33,7 +33,7 @@ DESCRIPTION
 
 OPTIONS
     --package              Target package name
-    --name                 Entity schema name. Maximum length is 22 characters
+    --name                 Entity schema name
     --title                Entity schema title/caption
     --parent               Parent schema name
     --extend-parent        Create a replacement schema. Requires --parent
@@ -93,7 +93,6 @@ NOTES
       validation error and requests explicit code/Guid input
     - Binary, Image, and File columns do not support --default-value or --default-value-source Const
     - After save, the schema is reloaded immediately; save is treated as failed if the schema cannot be read back
-    - Schema names longer than 22 characters are rejected before the server call
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio

--- a/clio/help/en/create-lookup.txt
+++ b/clio/help/en/create-lookup.txt
@@ -21,7 +21,7 @@ SYNOPSIS
 OPTIONS
     --package                        Target package name. Required.
 
-    --name                           Schema name (max 22 characters). Required.
+    --name                           Schema name. Required.
 
     --title                          Schema title. Required.
 


### PR DESCRIPTION
## Summary
Removes the schema name length restriction (>22 characters) from `create-entity-schema` and `create-lookup` commands at all levels.

## Changes
**Runtime validation removed:**
- `clio/Command/CreateEntitySchemaCommand.cs` — dropped `if (SchemaName.Length > 22)` check
- `clio/Command/CreateLookupCommand.cs` — dropped same check + helptext mention

**Documentation updated:**
- `clio/Command/McpServer/Tools/EntitySchemaTool.cs` — removed `Maximum length is 22 characters` from MCP `[Description]`
- `clio/help/en/create-entity-schema.txt` — removed 2 mentions
- `clio/help/en/create-lookup.txt` — removed mention on `--name`
- `clio/docs/commands/create-lookup.md` — removed 2 mentions

**Tests removed:**
- `CreateEntitySchemaCommandTests.Execute_ReturnsFailure_WhenSchemaNameIsTooLong`
- `CreateLookupCommandTests.Execute_Should_Return_Failure_When_SchemaName_Is_Too_Long`

## Verification
- `grep` for `22 character|exceed.*22|Length > 22|Maximum length is 22` — 0 matches
- `dotnet build clio/clio.csproj -c Debug --no-incremental` — succeeded
- Validated: `dotnet test --filter "Category=Unit&(Module=Command|Module=McpServer)"` — Passed 2003 / Failed 0 / Skipped 11

Ticket: ENG-88997