### PR TITLE
ENG-88547: predefined test data + Allure async deadlock fixes

### DIFF
--- a/clio.mcp.e2e/AGENTS.md
+++ b/clio.mcp.e2e/AGENTS.md
@@ -51,8 +51,10 @@ Environment variables should use the standard double-underscore form, for exampl
 - Every test method must include `[Description("...")]`.
 - Decorate every MCP test with `AllureTag` naming the tool under test plus human-readable `AllureName` and `AllureDescription`.
 - Prefer `[AllureFeature("<clio-command-name>")]` when the MCP tool maps directly to a `clio` command, for example `[AllureFeature("clear-redis-db")]`.
-- Split long tests into explicit Allure step methods with `[AllureStep]` for `Arrange`, `Act`, and `Assert`.
-- Do not collapse multiple assertions into a single Allure assert step; expose each important assertion as its own `[AllureStep]` with `AllureDescription` so reports stay readable.
+- Split long tests into explicit Allure steps for `Arrange`, `Act`, and `Assert` so reports stay readable. Use `await AllureApi.Step("description", async () => { ... })` for async test bodies and helpers; use `[AllureStep]` on extracted **synchronous** step methods. `grep` for `AllureApi.Step` in this project to find live async examples.
+- Do not collapse multiple assertions into a single step; expose each important assertion as its own `AllureApi.Step(...)` (or its own `[AllureStep]` sync method) with a clear description.
+- Do NOT decorate async methods or async helpers with `[AllureStep]`. The attribute is implemented via AspectInjector AOP, and the wrapper deadlocks on the first `await` — the test hangs with no timeout or error. Convert the helper to use `AllureApi.Step` instead.
+- Be cautious with `[AllureNUnit]` at the fixture level. In fixtures whose tests perform many sequential `await` calls, the per-test bookkeeping has been observed to block async continuations and deadlock the test. Fixtures that hit this deadlock pattern omit `[AllureNUnit]` and explain the omission in a top-of-class comment starting with `// [AllureNUnit] is intentionally omitted.` — `grep` for that line to find the live set. If a new long-running async fixture hangs with no timeout, suspect `[AllureNUnit]` first and add the same comment block when you remove it.
 - Successful command-path assertions should verify that MCP output includes at least one `Info` log message.
 - Failed command-path assertions should verify that MCP output includes at least one `Error` log message when execution output is available.
 - Add negative MCP tests for important failure modes such as invalid environment names and assert both failure diagnostics and absence of unintended side effects.

--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -21,6 +21,7 @@ namespace Clio.Mcp.E2E;
 public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	private const string SectionListToolName = ApplicationSectionGetListTool.ApplicationSectionGetListToolName;
 	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
+	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
 
 	[Test]
 	[Description("Advertises list-app-sections in the MCP tool list so callers can discover the installed-app section discovery tool.")]
@@ -115,11 +116,11 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, discovers an installed application through list-apps, and verifies that list-app-sections returns a structured section envelope for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that list-app-sections returns a structured section envelope for that application.")]
 	[AllureFeature(SectionListToolName)]
 	[AllureTag(SectionListToolName)]
 	[AllureName("Application section list returns structured section metadata")]
-	[AllureDescription("Uses the real clio MCP server to discover an installed application via list-apps, ignores when none exist, and otherwise verifies that list-app-sections returns the expected structured installed-application section envelope.")]
+	[AllureDescription("Uses the real clio MCP server to look up the configured seeded installed application via list-apps and verifies that list-app-sections returns the expected structured installed-application section envelope for that application.")]
 	public async Task ApplicationSectionGetList_Should_Return_Structured_Section_List() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -127,10 +128,11 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
 		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		ApplicationListItemEnvelope installedApplication = await ResolveInstalledApplicationOrIgnoreAsync(
+		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session,
 			cancellationTokenSource.Token,
-			environmentName);
+			environmentName,
+			settings.Sandbox.ApplicationCode);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -148,13 +150,13 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		callResult.IsError.Should().NotBeTrue(
 			because: $"structured list-app-sections success should be returned in the payload instead of as an MCP invocation error. Actual result: {DescribeCallResult(callResult)}");
 		response.Success.Should().BeTrue(
-			because: "list-app-sections should succeed for a discovered installed application");
+			because: "list-app-sections should succeed for the seeded installed application");
 		response.ApplicationId.Should().Be(installedApplication.Id,
-			because: "the section list envelope should resolve the same installed application discovered through list-apps");
+			because: "the section list envelope should resolve the same seeded installed application returned by list-apps");
 		response.ApplicationCode.Should().Be(installedApplication.Code,
-			because: "the section list envelope should preserve the discovered installed application code");
+			because: "the section list envelope should preserve the seeded installed application code");
 		response.ApplicationName.Should().Be(installedApplication.Name,
-			because: "the section list envelope should preserve the discovered installed application name");
+			because: "the section list envelope should preserve the seeded installed application name");
 		response.Sections.Should().NotBeNull(
 			because: "list-app-sections should always include the sections collection so clients can handle empty and populated applications uniformly");
 		response.Error.Should().BeNullOrWhiteSpace(
@@ -256,13 +258,136 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	}
 
 	[Test]
-	[Description("Deferred positive coverage for delete-app-section when the E2E environment has a known installed application and section lifecycle data.")]
+	[Description("Starts the real clio MCP server, creates a section in the seeded installed application via create-app-section, lists sections to confirm the new section appears, deletes the section via delete-app-section, and verifies that the deleted section is removed from the section list.")]
 	[AllureFeature(SectionDeleteToolName)]
 	[AllureTag(SectionDeleteToolName)]
 	[AllureName("Application section delete removes a created section from the section list")]
-	[AllureDescription("Placeholder for a future seeded-data E2E that creates, lists, deletes, and re-lists a section in a known installed application.")]
-	public void ApplicationSectionDelete_Should_Remove_Created_Section_From_Section_List() {
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment, then restore this positive delete-app-section lifecycle scenario.");
+	[AllureDescription("Uses the real clio MCP server to drive the full create → list → delete → re-list lifecycle for delete-app-section against the configured seeded application, and verifies that the deleted section no longer appears in the list-app-sections response.")]
+	public async Task ApplicationSectionDelete_Should_Remove_Created_Section_From_Section_List() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		string? environmentName = settings.Sandbox.EnvironmentName;
+		string? applicationCode = settings.Sandbox.ApplicationCode;
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive delete-app-section lifecycle test.");
+		}
+
+		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to run the delete-app-section lifecycle test.");
+		}
+
+		string caption = $"E2E Del {Guid.NewGuid():N}"[..24];
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		string? createdSectionCode = null;
+		try {
+			// Act 1: create a new section in the seeded application
+			CallToolResult createResult = await session.CallToolAsync(
+				SectionCreateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["caption"] = caption
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionContextResponseEnvelope createResponse = ApplicationResultParser.ExtractSectionCreate(createResult);
+
+			createResult.IsError.Should().NotBeTrue(
+				because: $"create-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(createResult)}");
+			createResponse.Success.Should().BeTrue(
+				because: $"create-app-section must succeed before the delete lifecycle can be verified. Error: {createResponse.Error}");
+			createResponse.Section.Should().NotBeNull(
+				because: "create-app-section readback must include the created section metadata");
+			createResponse.Section!.Code.Should().NotBeNullOrWhiteSpace(
+				because: "the readback must expose the created section code");
+
+			createdSectionCode = createResponse.Section.Code;
+
+			// Act 2: list sections and confirm the new section is present
+			ApplicationSectionListContextResponseEnvelope listBefore = await CallListSectionsAsync(
+				session, cancellationTokenSource.Token, environmentName!, applicationCode!);
+
+			listBefore.Success.Should().BeTrue(
+				because: $"list-app-sections should succeed for the seeded application before deletion. Error: {listBefore.Error}");
+			listBefore.Sections.Should().NotBeNull(
+				because: "list-app-sections must return the sections collection so the test can assert membership");
+			listBefore.Sections!.Should().Contain(section => section.Code == createdSectionCode,
+				because: "the section created above should appear in list-app-sections before it is deleted");
+
+			// Act 3: delete the created section
+			CallToolResult deleteResult = await session.CallToolAsync(
+				SectionDeleteToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["section-code"] = createdSectionCode
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionDeleteContextResponseEnvelope deleteResponse = ApplicationResultParser.ExtractSectionDelete(deleteResult);
+
+			deleteResult.IsError.Should().NotBeTrue(
+				because: $"delete-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(deleteResult)}");
+			deleteResponse.Success.Should().BeTrue(
+				because: $"delete-app-section must succeed for the section created above. Error: {deleteResponse.Error}");
+			deleteResponse.DeletedSection.Should().NotBeNull(
+				because: "the delete readback must include the deleted section metadata");
+			deleteResponse.DeletedSection!.Code.Should().Be(createdSectionCode,
+				because: "the delete readback must echo the deleted section code so callers can correlate the deletion");
+
+			// Mark the section as cleaned up so the finally block does not double-delete
+			createdSectionCode = null;
+
+			// Act 4: re-list sections and confirm the section is gone
+			ApplicationSectionListContextResponseEnvelope listAfter = await CallListSectionsAsync(
+				session, cancellationTokenSource.Token, environmentName!, applicationCode!);
+
+			listAfter.Success.Should().BeTrue(
+				because: $"list-app-sections should succeed for the seeded application after deletion. Error: {listAfter.Error}");
+			listAfter.Sections.Should().NotBeNull(
+				because: "list-app-sections must return the sections collection after deletion so the test can assert removal");
+			listAfter.Sections!.Should().NotContain(section => section.Code == deleteResponse.DeletedSection!.Code,
+				because: "the deleted section must no longer appear in list-app-sections after delete-app-section succeeds");
+		} finally {
+			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
+				try {
+					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+					await session.CallToolAsync(
+						SectionDeleteToolName,
+						new Dictionary<string, object?> {
+							["args"] = new Dictionary<string, object?> {
+								["environment-name"] = environmentName,
+								["application-code"] = applicationCode,
+								["section-code"] = createdSectionCode
+							}
+						},
+						cleanupCts.Token);
+				} catch (Exception ex) {
+					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+				}
+			}
+		}
+	}
+
+	private static async Task<ApplicationSectionListContextResponseEnvelope> CallListSectionsAsync(
+		McpServerSession session,
+		CancellationToken cancellationToken,
+		string environmentName,
+		string applicationCode) {
+		CallToolResult callResult = await session.CallToolAsync(
+			SectionListToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = applicationCode
+				}
+			},
+			cancellationToken);
+		return ApplicationResultParser.ExtractSectionList(callResult);
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
@@ -293,28 +418,6 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		} catch (OperationCanceledException) {
 			return false;
 		}
-	}
-
-	private static async Task<ApplicationListItemEnvelope> ResolveInstalledApplicationOrIgnoreAsync(
-		McpServerSession session,
-		CancellationToken cancellationToken,
-		string environmentName) {
-		CallToolResult callResult = await session.CallToolAsync(
-			ApplicationGetListTool.ApplicationGetListToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName
-				}
-			},
-			cancellationToken);
-		ApplicationListResponseEnvelope response = ApplicationResultParser.ExtractList(callResult);
-		ApplicationListItemEnvelope? installedApplication = response.Applications?.FirstOrDefault();
-		if (installedApplication is not null) {
-			return installedApplication;
-		}
-
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment.");
-		return null!;
 	}
 
 	private static string DescribeCallResult(CallToolResult callResult) {

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -206,7 +206,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		}
 
 		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment — Sandbox.EnvironmentName or Sandbox.ApplicationCode is not configured.");
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
 		}
 
 		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
@@ -274,7 +274,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		}
 
 		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment — Sandbox.EnvironmentName or Sandbox.ApplicationCode is not configured.");
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
 		}
 
 		const string platformEntitySchemaName = "Case";

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -20,6 +20,8 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ApplicationSectionUpdateToolE2ETests {
 	private const string SectionUpdateToolName = ApplicationSectionUpdateTool.ApplicationSectionUpdateToolName;
+	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
+	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 
 	[Test]
 	[Description("Advertises update-app-section in the MCP tool list so callers can discover the existing-section update tool.")]
@@ -230,13 +232,109 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 	}
 
 	[Test]
-	[Description("Deferred positive coverage for update-app-section when the E2E environment has a known installed application and section.")]
+	[Description("Starts the real clio MCP server, creates a section in the seeded installed application, updates its caption and description via update-app-section, and verifies that the structured before-and-after read-back exposes both the prior and updated values.")]
 	[AllureFeature(SectionUpdateToolName)]
 	[AllureTag(SectionUpdateToolName)]
 	[AllureName("Application section update returns structured before-and-after readback data")]
-	[AllureDescription("Placeholder for a future seeded-data E2E that updates a known section and verifies persisted before-and-after read-back data.")]
-	public void ApplicationSectionUpdate_Should_Return_Structured_Readback_Data() {
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application and section data to the E2E environment, then restore this positive update-app-section scenario.");
+	[AllureDescription("Uses the real clio MCP server to drive the full create → update → delete lifecycle for update-app-section against the configured seeded application, and verifies that the structured read-back exposes the prior caption/description in previous-section and the new caption/description in section.")]
+	public async Task ApplicationSectionUpdate_Should_Return_Structured_Readback_Data() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		string? environmentName = settings.Sandbox.EnvironmentName;
+		string? applicationCode = settings.Sandbox.ApplicationCode;
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive update-app-section lifecycle test.");
+		}
+
+		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
+		}
+
+		string initialCaption = $"E2E UpdBefore {Guid.NewGuid():N}"[..24];
+		string updatedCaption = $"E2E UpdAfter {Guid.NewGuid():N}"[..24];
+		const string updatedDescription = "E2E update lifecycle";
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		string? createdSectionCode = null;
+		try {
+			// Act 1: create a section with the initial caption
+			CallToolResult createResult = await session.CallToolAsync(
+				SectionCreateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["caption"] = initialCaption
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionContextResponseEnvelope createResponse = ApplicationResultParser.ExtractSectionCreate(createResult);
+
+			createResult.IsError.Should().NotBeTrue(
+				because: $"create-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(createResult)}");
+			createResponse.Success.Should().BeTrue(
+				because: $"create-app-section must succeed before the update lifecycle can be verified. Error: {createResponse.Error}");
+			createResponse.Section.Should().NotBeNull(
+				because: "create-app-section readback must include the created section metadata");
+			createResponse.Section!.Code.Should().NotBeNullOrWhiteSpace(
+				because: "the readback must expose the created section code so update-app-section can target it");
+
+			createdSectionCode = createResponse.Section.Code;
+
+			// Act 2: update the section's caption and description
+			CallToolResult updateResult = await session.CallToolAsync(
+				SectionUpdateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = applicationCode,
+						["section-code"] = createdSectionCode,
+						["caption"] = updatedCaption,
+						["description"] = updatedDescription
+					}
+				},
+				cancellationTokenSource.Token);
+			ApplicationSectionUpdateContextResponseEnvelope updateResponse = ApplicationResultParser.ExtractSectionUpdate(updateResult);
+
+			// Assert
+			updateResult.IsError.Should().NotBeTrue(
+				because: $"update-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(updateResult)}");
+			updateResponse.Success.Should().BeTrue(
+				because: $"update-app-section must succeed for the freshly created section. Error: {updateResponse.Error}");
+			updateResponse.PreviousSection.Should().NotBeNull(
+				because: "update-app-section must include the pre-update section snapshot so callers can diff before-and-after");
+			updateResponse.PreviousSection!.Code.Should().Be(createdSectionCode,
+				because: "the previous-section snapshot must identify the same section that was updated");
+			updateResponse.PreviousSection.Caption.Should().Be(initialCaption,
+				because: "the previous-section snapshot must preserve the caption that existed before update-app-section was invoked");
+			updateResponse.Section.Should().NotBeNull(
+				because: "update-app-section must include the post-update section state for the caller to confirm the new values landed");
+			updateResponse.Section!.Code.Should().Be(createdSectionCode,
+				because: "the post-update section must report the same code as the previous-section snapshot");
+			updateResponse.Section.Caption.Should().Be(updatedCaption,
+				because: "the post-update section must reflect the new caption that update-app-section was asked to apply");
+			updateResponse.Section.Description.Should().Be(updatedDescription,
+				because: "the post-update section must reflect the new description that update-app-section was asked to apply");
+		} finally {
+			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
+				try {
+					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+					await session.CallToolAsync(
+						SectionDeleteToolName,
+						new Dictionary<string, object?> {
+							["args"] = new Dictionary<string, object?> {
+								["environment-name"] = environmentName,
+								["application-code"] = applicationCode,
+								["section-code"] = createdSectionCode
+							}
+						},
+						cleanupCts.Token);
+				} catch (Exception ex) {
+					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+				}
+			}
+		}
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -35,7 +35,7 @@ public sealed class ApplicationToolE2ETests {
 	[AllureFeature(ListToolName)]
 	[AllureTag(ListToolName)]
 	[AllureName("Application get list returns structured installed applications")]
-	[AllureDescription("Uses the real clio MCP server to call list-apps for the configured environment, ignores when no installed applications are available, and otherwise verifies that the first installed application exposes the expected structured selectors and metadata fields.")]
+	[AllureDescription("Uses the real clio MCP server to call list-apps for the configured environment, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that the seeded application exposes the expected structured selectors and metadata fields.")]
 	public async Task ApplicationGetList_Should_Return_Structured_Applications() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -47,13 +47,13 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = GetInstalledApplicationOrIgnore(listResult.Result);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Assert
 		listResult.CallResult.IsError.Should().NotBeTrue(
 			because: $"a valid list-apps request should return a structured MCP payload instead of a transport-level error. Actual result: {DescribeCallResult(listResult.CallResult)}");
 		listResult.Result.Success.Should().BeTrue(
-			because: "list-apps should succeed before a discovered installed application can be validated");
+			because: "list-apps should succeed before the seeded installed application can be validated");
 		installedApplication.Id.Should().NotBeNullOrWhiteSpace(
 			because: "installed application list items should expose an id for follow-up MCP targeting");
 		installedApplication.Code.Should().NotBeNullOrWhiteSpace(
@@ -65,11 +65,11 @@ public sealed class ApplicationToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, discovers an installed application through list-apps, and verifies that get-app-info returns structured metadata for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that get-app-info returns structured metadata for that application.")]
 	[AllureFeature(InfoToolName)]
 	[AllureTag(InfoToolName)]
 	[AllureName("Application get info returns structured package and entity metadata")]
-	[AllureDescription("Uses the real clio MCP server to discover an installed application via list-apps, ignores when none exist, and otherwise verifies that get-app-info returns the expected structured metadata envelope for that application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that get-app-info returns the expected structured metadata envelope for that application.")]
 	public async Task ApplicationGetInfo_Should_Return_Structured_Metadata() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -79,7 +79,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = GetInstalledApplicationOrIgnore(listResult.Result);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Act
 		ApplicationInfoActResult infoResult = await ActInfoAsync(
@@ -93,7 +93,7 @@ public sealed class ApplicationToolE2ETests {
 		infoResult.CallResult.IsError.Should().NotBeTrue(
 			because: $"a valid get-app-info request should return structured metadata instead of a transport-level error. Actual result: {DescribeCallResult(infoResult.CallResult)}");
 		infoResult.Result.Success.Should().BeTrue(
-			because: "get-app-info should succeed for a discovered installed application");
+			because: "get-app-info should succeed for the seeded installed application");
 		infoResult.Result.ApplicationId.Should().Be(installedApplication.Id,
 			because: "get-app-info should resolve the same installed application selected from list-apps");
 		infoResult.Result.ApplicationCode.Should().Be(installedApplication.Code,
@@ -152,13 +152,13 @@ public sealed class ApplicationToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, discovers an installed application through list-apps, and verifies that its id can be reused with get-app-info.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that its id can be reused with get-app-info.")]
 	[AllureFeature(ListToolName)]
 	[AllureFeature(InfoToolName)]
 	[AllureTag(ListToolName)]
 	[AllureTag(InfoToolName)]
 	[AllureName("Application list returns ids usable by get-app-info when applications exist")]
-	[AllureDescription("Uses the real clio MCP server to discover an installed application via list-apps, ignores when none exist, and otherwise verifies that the returned application id is accepted by get-app-info and resolves the same application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that the returned application id is accepted by get-app-info and resolves the same application.")]
 	public async Task ApplicationGetList_Should_Return_Ids_Usable_By_GetAppInfo_When_Applications_Exist() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -168,7 +168,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = GetInstalledApplicationOrIgnore(listResult.Result);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Act
 		ApplicationInfoActResult infoResult = await ActInfoAsync(
@@ -180,7 +180,7 @@ public sealed class ApplicationToolE2ETests {
 
 		// Assert
 		infoResult.Result.Success.Should().BeTrue(
-			because: "a discovered list-apps identifier should be reusable as a valid get-app-info selector");
+			because: "the seeded list-apps identifier should be reusable as a valid get-app-info selector");
 		infoResult.Result.ApplicationId.Should().Be(installedApplication.Id,
 			because: "get-app-info should resolve the same installed application id that list-apps returned");
 		infoResult.Result.ApplicationCode.Should().Be(installedApplication.Code,
@@ -1091,16 +1091,6 @@ public sealed class ApplicationToolE2ETests {
 			StructuredContent = callResult.StructuredContent,
 			Content = callResult.Content
 		});
-	}
-
-	private static ApplicationListItemEnvelope GetInstalledApplicationOrIgnore(ApplicationListResponseEnvelope listResponse) {
-		ApplicationListItemEnvelope? installedApplication = listResponse.Applications?.FirstOrDefault();
-		if (installedApplication is not null) {
-			return installedApplication;
-		}
-
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment.");
-		return null!;
 	}
 
 	private sealed record ApplicationArrangeContext(

--- a/clio.mcp.e2e/AssertInfrastructureToolE2ETests.cs
+++ b/clio.mcp.e2e/AssertInfrastructureToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -40,31 +41,33 @@ public sealed class AssertInfrastructureToolE2ETests
 		AssertDatabaseCandidatesAreNormalized(actResult);
 	}
 
-	[AllureStep("Arrange assert-infrastructure MCP session")]
-	[AllureDescription("Arrange by starting a real clio MCP server session for the assert-infrastructure tool")]
 	private static async Task<AssertInfrastructureArrangeContext> ArrangeAsync()
 	{
-		McpE2ESettings settings = TestConfiguration.Load();
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new AssertInfrastructureArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange assert-infrastructure MCP session", async () =>
+		{
+			McpE2ESettings settings = TestConfiguration.Load();
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new AssertInfrastructureArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking assert-infrastructure through MCP")]
-	[AllureDescription("Act by discovering the assert-infrastructure MCP tool and invoking it without arguments")]
 	private static async Task<AssertInfrastructureActResult> ActAsync(AssertInfrastructureArrangeContext arrangeContext)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the assert-infrastructure MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking assert-infrastructure through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the assert-infrastructure MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?>(),
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?>(),
+				arrangeContext.CancellationTokenSource.Token);
 
-		AssertInfrastructureEnvelope execution = AssertInfrastructureResultParser.Extract(callResult);
-		return new AssertInfrastructureActResult(callResult, execution);
+			AssertInfrastructureEnvelope execution = AssertInfrastructureResultParser.Extract(callResult);
+			return new AssertInfrastructureActResult(callResult, execution);
+		});
 	}
 
 	[AllureStep("Assert MCP tool result is successful at protocol level")]

--- a/clio.mcp.e2e/ClearRedisToolE2ETests.cs
+++ b/clio.mcp.e2e/ClearRedisToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Common;
@@ -106,79 +107,79 @@ public sealed class ClearRedisToolE2ETests {
 		await AssertSeededKeyRemainsAsync(arrangeContext);
 	}
 
-	[AllureStep("Arrange clear-redis sandbox state")]
-	[AllureDescription("Arrange by seeding a Redis key in the sandbox environment and starting an MCP server session")]
 	private async Task<ClearRedisArrangeContext> ArrangeAsync() {
-		McpE2ESettings settings = TestConfiguration.Load();
-		if (!settings.AllowDestructiveMcpTests) {
-			Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive MCP end-to-end tests.");
-		}
+		return await AllureApi.Step("Arrange clear-redis sandbox state", async () => {
+			McpE2ESettings settings = TestConfiguration.Load();
+			if (!settings.AllowDestructiveMcpTests) {
+				Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive MCP end-to-end tests.");
+			}
 
-		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		_sandboxContext = SandboxEnvironmentResolver.Resolve(settings);
-		_seedKey = $"{settings.Sandbox.SeedKeyPrefix}:{Guid.NewGuid():N}";
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			TestConfiguration.EnsureSandboxIsConfigured(settings);
+			_sandboxContext = SandboxEnvironmentResolver.Resolve(settings);
+			_seedKey = $"{settings.Sandbox.SeedKeyPrefix}:{Guid.NewGuid():N}";
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
 
-		RedisSandboxClient redis = await RedisSandboxClient.ConnectAsync(_sandboxContext.RedisConnectionString);
-		await redis.SeedKeyAsync(_seedKey, "seeded-by-clio-mcp-e2e");
-		(await redis.KeyExistsAsync(_seedKey)).Should().BeTrue(
-			because: "the test must prove clear-redis removes data that was present before the MCP call");
+			RedisSandboxClient redis = await RedisSandboxClient.ConnectAsync(_sandboxContext.RedisConnectionString);
+			await redis.SeedKeyAsync(_seedKey, "seeded-by-clio-mcp-e2e");
+			(await redis.KeyExistsAsync(_seedKey)).Should().BeTrue(
+				because: "the test must prove clear-redis removes data that was present before the MCP call");
 
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new ClearRedisArrangeContext(_sandboxContext, _seedKey, redis, session, cancellationTokenSource);
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new ClearRedisArrangeContext(_sandboxContext, _seedKey, redis, session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking clear-redis through MCP")]
-	[AllureDescription("Act by discovering the clear-redis MCP tool and invoking it with the configured sandbox environment name")]
 	private static async Task<ClearRedisActResult> ActAsync(ClearRedisArrangeContext arrangeContext) {
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(EnvironmentToolName,
-			because: "the sandbox test path depends on the environment-name clear-redis tool being advertised by the MCP server");
+		return await AllureApi.Step("Act by invoking clear-redis through MCP", async () => {
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(EnvironmentToolName,
+				because: "the sandbox test path depends on the environment-name clear-redis tool being advertised by the MCP server");
 
-		return await ActWithEnvironmentNameAsync(arrangeContext, arrangeContext.SandboxContext.EnvironmentName);
+			return await ActWithEnvironmentNameAsync(arrangeContext, arrangeContext.SandboxContext.EnvironmentName);
+		});
 	}
 
-	[AllureStep("Act by invoking clear-redis with invalid environment name")]
-	[AllureDescription("Act by invoking the environment-name clear-redis MCP tool with an environment key that is not registered in clio")]
 	private static async Task<ClearRedisActResult> ActWithEnvironmentNameAsync(
 		ClearRedisArrangeContext arrangeContext,
 		string environmentName) {
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			EnvironmentToolName,
-			new Dictionary<string, object?> {
-				["environmentName"] = environmentName
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new ClearRedisActResult(callResult, execution);
+		return await AllureApi.Step("Act by invoking clear-redis with invalid environment name", async () => {
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				EnvironmentToolName,
+				new Dictionary<string, object?> {
+					["environmentName"] = environmentName
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new ClearRedisActResult(callResult, execution);
+		});
 	}
 
-	[AllureStep("Act by invoking clear-redis with explicit credentials")]
-	[AllureDescription("Act by invoking the credentials clear-redis MCP tool with the registered sandbox URL and credentials")]
 	private static async Task<ClearRedisActResult> ActWithCredentialsAsync(
 		ClearRedisArrangeContext arrangeContext,
 		string password,
 		string? url = null,
 		bool? isNetCore = null) {
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(CredentialsToolName,
-			because: "the credentials clear-redis tool must be advertised by the MCP server for credentials-path end-to-end coverage");
+		return await AllureApi.Step("Act by invoking clear-redis with explicit credentials", async () => {
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(CredentialsToolName,
+				because: "the credentials clear-redis tool must be advertised by the MCP server for credentials-path end-to-end coverage");
 
-		Dictionary<string, object?> arguments = new() {
-			["url"] = url ?? arrangeContext.SandboxContext.Uri,
-			["userName"] = arrangeContext.SandboxContext.Login,
-			["password"] = password
-		};
-		if (isNetCore.HasValue) {
-			arguments["isNetCore"] = isNetCore.Value;
-		}
+			Dictionary<string, object?> arguments = new() {
+				["url"] = url ?? arrangeContext.SandboxContext.Uri,
+				["userName"] = arrangeContext.SandboxContext.Login,
+				["password"] = password
+			};
+			if (isNetCore.HasValue) {
+				arguments["isNetCore"] = isNetCore.Value;
+			}
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			CredentialsToolName,
-			arguments,
-			arrangeContext.CancellationTokenSource.Token);
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new ClearRedisActResult(callResult, execution);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				CredentialsToolName,
+				arguments,
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new ClearRedisActResult(callResult, execution);
+		});
 	}
 
 	[AllureStep("Assert MCP tool result is successful")]
@@ -212,15 +213,15 @@ public sealed class ClearRedisToolE2ETests {
 			because: "the sandbox resolver must capture the database connection string for later MCP end-to-end scenarios");
 	}
 
-	[AllureStep("Assert seeded Redis key was deleted")]
-	[AllureDescription("Assert that the seeded Redis key disappears after the clear-redis MCP tool runs")]
 	private static async Task AssertSeededKeyWasDeletedAsync(ClearRedisArrangeContext arrangeContext) {
-		await arrangeContext.Redis.WaitUntilKeyDeletedAsync(
-			arrangeContext.SeedKey,
-			TimeSpan.FromSeconds(10),
-			arrangeContext.CancellationTokenSource.Token);
-		(await arrangeContext.Redis.KeyExistsAsync(arrangeContext.SeedKey)).Should().BeFalse(
-			because: "clear-redis must remove the key that was seeded before the MCP tool call");
+		await AllureApi.Step("Assert seeded Redis key was deleted", async () => {
+			await arrangeContext.Redis.WaitUntilKeyDeletedAsync(
+				arrangeContext.SeedKey,
+				TimeSpan.FromSeconds(10),
+				arrangeContext.CancellationTokenSource.Token);
+			(await arrangeContext.Redis.KeyExistsAsync(arrangeContext.SeedKey)).Should().BeFalse(
+				because: "clear-redis must remove the key that was seeded before the MCP tool call");
+		});
 	}
 
 	[AllureStep("Assert failed clear-redis request reported failure")]
@@ -271,11 +272,11 @@ public sealed class ClearRedisToolE2ETests {
 			because: "the failure log should help a human understand that the credentials-based request failed because the target URL was invalid");
 	}
 
-	[AllureStep("Assert seeded Redis key remains after failed request")]
-	[AllureDescription("Assert that a failed clear-redis request targeting an invalid environment does not remove the seeded sandbox Redis key")]
 	private static async Task AssertSeededKeyRemainsAsync(ClearRedisArrangeContext arrangeContext) {
-		(await arrangeContext.Redis.KeyExistsAsync(arrangeContext.SeedKey)).Should().BeTrue(
-			because: "a failed clear-redis invocation against an invalid environment must not mutate the sandbox Redis state");
+		await AllureApi.Step("Assert seeded Redis key remains after failed request", async () => {
+			(await arrangeContext.Redis.KeyExistsAsync(arrangeContext.SeedKey)).Should().BeTrue(
+				because: "a failed clear-redis invocation against an invalid environment must not mutate the sandbox Redis state");
+		});
 	}
 
 	[TearDown]

--- a/clio.mcp.e2e/CompileCreatioToolE2ETests.cs
+++ b/clio.mcp.e2e/CompileCreatioToolE2ETests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -43,33 +44,37 @@ public sealed class CompileCreatioToolE2ETests
 		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
 	}
 
-	[AllureStep("Arrange compile-creatio MCP session")]
 	private static async Task<CompileCreatioArrangeContext> ArrangeAsync(McpE2ESettings settings)
 	{
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new CompileCreatioArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange compile-creatio MCP session", async () =>
+		{
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new CompileCreatioArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking compile-creatio through MCP")]
 	private static async Task<CompileCreatioActResult> ActAsync(
 		CompileCreatioArrangeContext arrangeContext,
 		string environmentName)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the compile-creatio MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking compile-creatio through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the compile-creatio MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new CompileCreatioActResult(callResult, execution);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new CompileCreatioActResult(callResult, execution);
+		});
 	}
 
 	[AllureStep("Assert compile-creatio tool call failed")]

--- a/clio.mcp.e2e/CreateWorkspaceToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateWorkspaceToolE2ETests.cs
@@ -16,7 +16,12 @@ namespace Clio.Mcp.E2E;
 /// End-to-end tests for the create-workspace MCP tool.
 /// </summary>
 [TestFixture]
-[AllureNUnit]
+// [AllureNUnit] is intentionally omitted.
+// NUnit runs each async test on a single thread, and [AllureNUnit] adds
+// per-test bookkeeping that runs on that same thread. In tests with many
+// sequential awaits, that bookkeeping appears to block async continuations
+// from resuming — the test deadlocks with no timeout or error. Removing the
+// attribute restores normal execution.
 [AllureFeature("create-workspace")]
 [NonParallelizable]
 public sealed class CreateWorkspaceToolE2ETests {

--- a/clio.mcp.e2e/DownloadConfigurationToolE2ETests.cs
+++ b/clio.mcp.e2e/DownloadConfigurationToolE2ETests.cs
@@ -16,7 +16,12 @@ namespace Clio.Mcp.E2E;
 /// End-to-end tests for the download-configuration MCP tools.
 /// </summary>
 [TestFixture]
-[AllureNUnit]
+// [AllureNUnit] is intentionally omitted.
+// NUnit runs each async test on a single thread, and [AllureNUnit] adds
+// per-test bookkeeping that runs on that same thread. In tests with many
+// sequential awaits, that bookkeeping appears to block async continuations
+// from resuming — the test deadlocks with no timeout or error. Removing the
+// attribute restores normal execution.
 [AllureFeature("download-configuration")]
 [NonParallelizable]
 public sealed class DownloadConfigurationToolE2ETests {

--- a/clio.mcp.e2e/FindEmptyIisPortToolE2ETests.cs
+++ b/clio.mcp.e2e/FindEmptyIisPortToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -60,29 +61,33 @@ public sealed class FindEmptyIisPortToolE2ETests
 		}
 	}
 
-	[AllureStep("Arrange find-empty-iis-port MCP session")]
 	private static async Task<ArrangeContext> ArrangeAsync()
 	{
-		McpE2ESettings settings = TestConfiguration.Load();
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new ArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange find-empty-iis-port MCP session", async () =>
+		{
+			McpE2ESettings settings = TestConfiguration.Load();
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new ArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking find-empty-iis-port through MCP")]
 	private static async Task<ActResult> ActAsync(ArrangeContext arrangeContext)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the find-empty-iis-port MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking find-empty-iis-port through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the find-empty-iis-port MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?>(),
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?>(),
+				arrangeContext.CancellationTokenSource.Token);
 
-		FindAvailableIisPortEnvelope execution = FindAvailableIisPortResultParser.Extract(callResult);
-		return new ActResult(callResult, execution);
+			FindAvailableIisPortEnvelope execution = FindAvailableIisPortResultParser.Extract(callResult);
+			return new ActResult(callResult, execution);
+		});
 	}
 
 	private sealed record ArrangeContext(

--- a/clio.mcp.e2e/FsmModeToolE2ETests.cs
+++ b/clio.mcp.e2e/FsmModeToolE2ETests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -85,48 +86,54 @@ public sealed class FsmModeToolE2ETests
 		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
 	}
 
-	[AllureStep("Arrange FSM MCP session")]
 	private static async Task<FsmModeArrangeContext> ArrangeAsync(McpE2ESettings settings)
 	{
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new FsmModeArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange FSM MCP session", async () =>
+		{
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new FsmModeArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking get-fsm-mode through MCP")]
 	private static async Task<CallToolResult> ActGetAsync(FsmModeArrangeContext arrangeContext, string environmentName)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(GetToolName,
-			because: "the get-fsm-mode MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking get-fsm-mode through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(GetToolName,
+				because: "the get-fsm-mode MCP tool must be advertised before the end-to-end call can be executed");
 
-		return await arrangeContext.Session.CallToolAsync(
-			GetToolName,
-			new Dictionary<string, object?> { ["environmentName"] = environmentName },
-			arrangeContext.CancellationTokenSource.Token);
+			return await arrangeContext.Session.CallToolAsync(
+				GetToolName,
+				new Dictionary<string, object?> { ["environmentName"] = environmentName },
+				arrangeContext.CancellationTokenSource.Token);
+		});
 	}
 
-	[AllureStep("Act by invoking set-fsm-mode through MCP")]
 	private static async Task<CommandExecutionActResult> ActSetAsync(
 		FsmModeArrangeContext arrangeContext,
 		string environmentName,
 		string mode)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(SetToolName,
-			because: "the set-fsm-mode MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking set-fsm-mode through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(SetToolName,
+				because: "the set-fsm-mode MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			SetToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName,
-					["mode"] = mode
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new CommandExecutionActResult(callResult, execution);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				SetToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["mode"] = mode
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new CommandExecutionActResult(callResult, execution);
+		});
 	}
 
 	[AllureStep("Assert get-fsm-mode call failed for invalid environment")]

--- a/clio.mcp.e2e/GetPkgListToolE2ETests.cs
+++ b/clio.mcp.e2e/GetPkgListToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -44,34 +45,36 @@ public sealed class GetPkgListToolE2ETests {
 		AssertStructuredPackagesReturned(actResult);
 	}
 
-	[AllureStep("Arrange list-packages MCP session")]
 	private static async Task<GetPkgListArrangeContext> ArrangeAsync(McpE2ESettings settings) {
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
-			settings,
-			settings.Sandbox.EnvironmentName!,
-			cancellationTokenSource.Token);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new GetPkgListArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange list-packages MCP session", async () => {
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+			await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
+				settings,
+				settings.Sandbox.EnvironmentName!,
+				cancellationTokenSource.Token);
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new GetPkgListArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking list-packages through MCP")]
 	private static async Task<GetPkgListActResult> ActAsync(GetPkgListArrangeContext arrangeContext, string environmentName) {
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the list-packages MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking list-packages through MCP", async () => {
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the list-packages MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
 
-		IReadOnlyList<GetPkgListEnvelope> packages = GetPkgListResultParser.Extract(callResult);
-		return new GetPkgListActResult(callResult, packages);
+			IReadOnlyList<GetPkgListEnvelope> packages = GetPkgListResultParser.Extract(callResult);
+			return new GetPkgListActResult(callResult, packages);
+		});
 	}
 
 	[AllureStep("Assert MCP tool result is successful")]

--- a/clio.mcp.e2e/LinkFromRepositoryToolE2ETests.cs
+++ b/clio.mcp.e2e/LinkFromRepositoryToolE2ETests.cs
@@ -16,7 +16,12 @@ namespace Clio.Mcp.E2E;
 /// End-to-end tests for the link-from-repository MCP tools.
 /// </summary>
 [TestFixture]
-[AllureNUnit]
+// [AllureNUnit] is intentionally omitted.
+// NUnit runs each async test on a single thread, and [AllureNUnit] adds
+// per-test bookkeeping that runs on that same thread. In tests with many
+// sequential awaits, that bookkeeping appears to block async continuations
+// from resuming — the test deadlocks with no timeout or error. Removing the
+// attribute restores normal execution.
 [AllureFeature("link-from-repository")]
 [NonParallelizable]
 public sealed class LinkFromRepositoryToolE2ETests {

--- a/clio.mcp.e2e/PackageHotfixToolE2ETests.cs
+++ b/clio.mcp.e2e/PackageHotfixToolE2ETests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -96,30 +97,32 @@ public sealed class PackageHotfixToolE2ETests {
 		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
 	}
 
-	[AllureStep("Arrange MCP server session")]
 	private static async Task<PackageHotfixArrangeContext> ArrangeAsync(McpE2ESettings settings) {
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new PackageHotfixArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange MCP server session", async () => {
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new PackageHotfixArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking hotfix tool through MCP")]
 	private static async Task<CommandExecutionActResult> ActAsync(
 		PackageHotfixArrangeContext arrangeContext,
 		string toolName,
 		string packageName,
 		string environmentName) {
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			toolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["package-name"] = packageName,
-					["environment-name"] = environmentName
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new CommandExecutionActResult(callResult, execution);
+		return await AllureApi.Step("Act by invoking hotfix tool through MCP", async () => {
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				toolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["package-name"] = packageName,
+						["environment-name"] = environmentName
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new CommandExecutionActResult(callResult, execution);
+		});
 	}
 
 	[AllureStep("Assert tool is advertised by MCP server")]

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -53,19 +53,20 @@ public sealed class PageGetToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, discovers an installed application page when available, and verifies the structured get-page metadata contract for that page.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode and one of its pages, and verifies the structured get-page metadata contract for that page.")]
 	[AllureTag(ToolName)]
 	[AllureName("get-page returns stable metadata contract for a real page")]
-	[AllureDescription("Uses the real clio MCP server to discover an installed application and one of its pages, ignores when no such data exists, and otherwise verifies the stable get-page metadata and raw-body contract for the discovered page.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode and the first page in that application, and verifies the stable get-page metadata and raw-body contract for the seeded page.")]
 	public async Task PageGetTool_Should_Return_Stable_Metadata_Contract_For_Real_Page() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
-		PageDiscoveryCandidate candidate = await ResolvePageCandidateOrIgnoreAsync(
+		PageDiscoveryCandidate candidate = await ResolveSeededPageCandidateOrIgnoreAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			arrangeContext.EnvironmentName);
+			arrangeContext.EnvironmentName,
+			settings.Sandbox.ApplicationCode);
 
 		// Act
 		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
@@ -81,9 +82,9 @@ public sealed class PageGetToolE2ETests {
 
 		// Assert
 		callResult.IsError.Should().NotBeTrue(
-			because: "a discovered page should return a structured get-page payload instead of a transport-level error");
+			because: "the seeded page should return a structured get-page payload instead of a transport-level error");
 		response.Success.Should().BeTrue(
-			because: "get-page should succeed for a discovered page in a discovered installed application");
+			because: "get-page should succeed for a seeded page in the seeded installed application");
 		response.Page.Should().NotBeNull(
 			because: "successful get-page calls should include page metadata");
 		response.Page.SchemaName.Should().Be(candidate.Page.SchemaName,
@@ -180,20 +181,21 @@ public sealed class PageGetToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, discovers an installed application when available, and verifies that list-pages returns structured page summaries for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that list-pages returns structured page summaries for that application.")]
 	[AllureFeature(PageListTool.ToolName)]
 	[AllureTag(PageListTool.ToolName)]
 	[AllureName("list-pages returns structured page summaries")]
-	[AllureDescription("Uses the real clio MCP server to discover an installed application, ignores when no applications or pages exist, and otherwise verifies the structured list-pages summary envelope for the discovered application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode and verifies the structured list-pages summary envelope for that application.")]
 	public async Task PageListTool_Should_Return_Structured_PageSummaries() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
-		ApplicationListItemEnvelope installedApplication = await ResolveInstalledApplicationOrIgnoreAsync(
+		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			arrangeContext.EnvironmentName);
+			arrangeContext.EnvironmentName,
+			settings.Sandbox.ApplicationCode);
 
 		// Act
 		PageListResponse response = await CallPageListAsync(
@@ -201,15 +203,12 @@ public sealed class PageGetToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			installedApplication.Code);
-		if (response.Pages is null || response.Pages.Count == 0) {
-			Assert.Ignore("TODO: ENG-88547 add predefined installed application/page data to the E2E environment.");
-		}
 
 		// Assert
 		response.Success.Should().BeTrue(
-			because: "list-pages should succeed for a discovered installed application");
+			because: $"list-pages should succeed for the seeded installed application. Error: {response.Error}");
 		response.Pages.Should().NotBeNullOrEmpty(
-			because: "this discovery-backed test should only continue when the discovered application exposes at least one page");
+			because: "the seeded application must expose at least one Freedom UI page so list-pages has something meaningful to verify");
 		response.Count.Should().Be(response.Pages.Count,
 			because: "list-pages should keep the explicit count aligned with the returned page collection");
 		response.Pages.Should().OnlyContain(page =>
@@ -236,47 +235,28 @@ public sealed class PageGetToolE2ETests {
 		}
 	}
 
-	private static async Task<ApplicationListItemEnvelope> ResolveInstalledApplicationOrIgnoreAsync(
+	private static async Task<PageDiscoveryCandidate> ResolveSeededPageCandidateOrIgnoreAsync(
 		McpServerSession session,
 		CancellationToken cancellationToken,
-		string environmentName) {
-		CallToolResult callResult = await session.CallToolAsync(
-			ApplicationGetListTool.ApplicationGetListToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName
-				}
-			},
-			cancellationToken);
-		ApplicationListResponseEnvelope response = ApplicationResultParser.ExtractList(callResult);
-		ApplicationListItemEnvelope? installedApplication = response.Applications?.FirstOrDefault();
-		if (installedApplication is not null) {
-			return installedApplication;
-		}
-
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application data to the E2E environment.");
-		return null!;
-	}
-
-	private static async Task<PageDiscoveryCandidate> ResolvePageCandidateOrIgnoreAsync(
-		McpServerSession session,
-		CancellationToken cancellationToken,
-		string environmentName) {
-		ApplicationListItemEnvelope installedApplication = await ResolveInstalledApplicationOrIgnoreAsync(
+		string environmentName,
+		string? configuredApplicationCode) {
+		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session,
 			cancellationToken,
-			environmentName);
+			environmentName,
+			configuredApplicationCode);
 		PageListResponse pageList = await CallPageListAsync(
 			session,
 			cancellationToken,
 			environmentName,
 			installedApplication.Code);
-		PageListItem? discoveredPage = pageList.Pages.FirstOrDefault();
-		if (discoveredPage is not null) {
-			return new PageDiscoveryCandidate(installedApplication, discoveredPage);
+		PageListItem? seededPage = pageList.Pages?.FirstOrDefault();
+		if (seededPage is not null) {
+			return new PageDiscoveryCandidate(installedApplication, seededPage);
 		}
 
-		Assert.Ignore("TODO: ENG-88547 add predefined installed application/page data to the E2E environment.");
+		Assert.Ignore(
+			$"Seeded application '{installedApplication.Code}' has no Freedom UI pages on environment '{environmentName}'. Add at least one page to the seed application.");
 		return null!;
 	}
 

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -250,6 +250,8 @@ public sealed class PageGetToolE2ETests {
 			cancellationToken,
 			environmentName,
 			installedApplication.Code);
+		pageList.Success.Should().BeTrue(
+			because: $"list-pages must succeed before a seeded page can be resolved; treating an MCP-level failure as 'no pages' would hide real runtime regressions. Error: {pageList.Error}");
 		PageListItem? seededPage = pageList.Pages?.FirstOrDefault();
 		if (seededPage is not null) {
 			return new PageDiscoveryCandidate(installedApplication, seededPage);

--- a/clio.mcp.e2e/ShowPassingInfrastructureToolE2ETests.cs
+++ b/clio.mcp.e2e/ShowPassingInfrastructureToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -50,29 +51,33 @@ public sealed class ShowPassingInfrastructureToolE2ETests
 		AssertRecommendationShape(actResult.Execution.RecommendedByEngine.Mssql);
 	}
 
-	[AllureStep("Arrange show-passing-infrastructure MCP session")]
 	private static async Task<ArrangeContext> ArrangeAsync()
 	{
-		McpE2ESettings settings = TestConfiguration.Load();
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new ArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange show-passing-infrastructure MCP session", async () =>
+		{
+			McpE2ESettings settings = TestConfiguration.Load();
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new ArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking show-passing-infrastructure through MCP")]
 	private static async Task<ActResult> ActAsync(ArrangeContext arrangeContext)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the show-passing-infrastructure MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking show-passing-infrastructure through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the show-passing-infrastructure MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?>(),
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?>(),
+				arrangeContext.CancellationTokenSource.Token);
 
-		ShowPassingInfrastructureEnvelope execution = ShowPassingInfrastructureResultParser.Extract(callResult);
-		return new ActResult(callResult, execution);
+			ShowPassingInfrastructureEnvelope execution = ShowPassingInfrastructureResultParser.Extract(callResult);
+			return new ActResult(callResult, execution);
+		});
 	}
 
 	private static void AssertCandidateShapes(

--- a/clio.mcp.e2e/ShowWebAppListToolE2ETests.cs
+++ b/clio.mcp.e2e/ShowWebAppListToolE2ETests.cs
@@ -1,3 +1,4 @@
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -43,29 +44,31 @@ public sealed class ShowWebAppListToolE2ETests
 		AssertSensitiveValuesAreNotMasked(actResult, settings.Sandbox.EnvironmentName!, sandboxEnvironment);
 	}
 
-	[AllureStep("Arrange show-webApp-list MCP session")]
-	[AllureDescription("Arrange by starting a real clio MCP server session for the show-webApp-list tool")]
 	private static async Task<ShowWebAppListArrangeContext> ArrangeAsync(McpE2ESettings settings)
 	{
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new ShowWebAppListArrangeContext(session, cancellationTokenSource);
+		return await AllureApi.Step("Arrange show-webApp-list MCP session", async () =>
+		{
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new ShowWebAppListArrangeContext(session, cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking show-webApp-list through MCP")]
-	[AllureDescription("Act by discovering the show-webApp-list MCP tool and invoking it without arguments")]
 	private static async Task<ShowWebAppListActResult> ActAsync(ShowWebAppListArrangeContext arrangeContext)
 	{
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(ToolName,
-			because: "the show-webApp-list MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking show-webApp-list through MCP", async () =>
+		{
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(ToolName,
+				because: "the show-webApp-list MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?>(),
-			arrangeContext.CancellationTokenSource.Token);
-		IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments = ShowWebAppListResultParser.Extract(callResult);
-		return new ShowWebAppListActResult(callResult, environments);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?>(),
+				arrangeContext.CancellationTokenSource.Token);
+			IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments = ShowWebAppListResultParser.Extract(callResult);
+			return new ShowWebAppListActResult(callResult, environments);
+		});
 	}
 
 	[AllureStep("Assert MCP tool result is successful at protocol level")]

--- a/clio.mcp.e2e/SkillManagementToolE2ETests.cs
+++ b/clio.mcp.e2e/SkillManagementToolE2ETests.cs
@@ -17,7 +17,12 @@ namespace Clio.Mcp.E2E;
 /// End-to-end tests for workspace-local skill management MCP tools.
 /// </summary>
 [TestFixture]
-[AllureNUnit]
+// [AllureNUnit] is intentionally omitted.
+// NUnit runs each async test on a single thread, and [AllureNUnit] adds
+// per-test bookkeeping that runs on that same thread. In tests with many
+// sequential awaits, that bookkeeping appears to block async continuations
+// from resuming — the test deadlocks with no timeout or error. Removing the
+// attribute restores normal execution.
 [AllureFeature("workspace-skill-management")]
 [NonParallelizable]
 public sealed class SkillManagementToolE2ETests {

--- a/clio.mcp.e2e/Support/Mcp/SeededApplicationResolver.cs
+++ b/clio.mcp.e2e/Support/Mcp/SeededApplicationResolver.cs
@@ -1,0 +1,61 @@
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Results;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E.Support.Mcp;
+
+/// <summary>
+/// Resolves the seeded installed application configured through <c>McpE2E:Sandbox:ApplicationCode</c>
+/// against a list-apps response. Fires <see cref="Assert.Ignore(string)"/> with a clear setup message
+/// when the configured code is missing or the seeded application is absent from the target environment.
+/// </summary>
+internal static class SeededApplicationResolver {
+	/// <summary>
+	/// Looks up the seeded installed application inside a pre-parsed list-apps envelope.
+	/// Use this overload when the caller already has the list-apps response in scope.
+	/// </summary>
+	public static ApplicationListItemEnvelope GetOrIgnore(
+		ApplicationListResponseEnvelope listResponse,
+		string? configuredApplicationCode,
+		string environmentName) {
+		if (string.IsNullOrWhiteSpace(configuredApplicationCode)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
+			return null!;
+		}
+
+		ApplicationListItemEnvelope? installedApplication = listResponse.Applications?
+			.FirstOrDefault(application => string.Equals(
+				application.Code,
+				configuredApplicationCode,
+				StringComparison.OrdinalIgnoreCase));
+		if (installedApplication is not null) {
+			return installedApplication;
+		}
+
+		Assert.Ignore(
+			$"Seeded application with code '{configuredApplicationCode}' was not found on environment '{environmentName}'. Install the seed application or update McpE2E:Sandbox:ApplicationCode.");
+		return null!;
+	}
+
+	/// <summary>
+	/// Calls list-apps via the MCP session and resolves the seeded installed application using
+	/// <see cref="GetOrIgnore"/>. Use this overload when the caller does not already have a parsed
+	/// list-apps envelope.
+	/// </summary>
+	public static async Task<ApplicationListItemEnvelope> ResolveOrIgnoreAsync(
+		McpServerSession session,
+		CancellationToken cancellationToken,
+		string environmentName,
+		string? configuredApplicationCode) {
+		CallToolResult callResult = await session.CallToolAsync(
+			ApplicationGetListTool.ApplicationGetListToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName
+				}
+			},
+			cancellationToken);
+		ApplicationListResponseEnvelope response = ApplicationResultParser.ExtractList(callResult);
+		return GetOrIgnore(response, configuredApplicationCode, environmentName);
+	}
+}

--- a/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -153,117 +154,121 @@ public sealed class WorkspaceSyncToolE2ETests {
 		AssertPushWorkspaceToolAdvertisesSkipBackup(tools);
 	}
 
-	[AllureStep("Arrange workspace-sync invalid-environment MCP session")]
 	private static async Task<WorkspaceSyncArrangeContext> ArrangeInvalidEnvironmentAsync(string toolPrefix) {
-		string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-{toolPrefix}-mcp-e2e-{Guid.NewGuid():N}");
-		string workspacePath = Path.Combine(rootDirectory, "workspace");
-		string restoreWorkspacePath = Path.Combine(rootDirectory, "restore-workspace");
-		string environmentName = $"missing-{toolPrefix}-env-{Guid.NewGuid():N}";
-		Directory.CreateDirectory(workspacePath);
+		return await AllureApi.Step("Arrange workspace-sync invalid-environment MCP session", async () => {
+			string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-{toolPrefix}-mcp-e2e-{Guid.NewGuid():N}");
+			string workspacePath = Path.Combine(rootDirectory, "workspace");
+			string restoreWorkspacePath = Path.Combine(rootDirectory, "restore-workspace");
+			string environmentName = $"missing-{toolPrefix}-env-{Guid.NewGuid():N}";
+			Directory.CreateDirectory(workspacePath);
 
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new WorkspaceSyncArrangeContext(
-			settings,
-			rootDirectory,
-			workspacePath,
-			WorkspaceName: "workspace",
-			restoreWorkspacePath,
-			RestoreWorkspaceName: "restore-workspace",
-			environmentName,
-			PackageName: string.Empty,
-			PackageMetadata: null,
-			session,
-			cancellationTokenSource);
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new WorkspaceSyncArrangeContext(
+				settings,
+				rootDirectory,
+				workspacePath,
+				WorkspaceName: "workspace",
+				restoreWorkspacePath,
+				RestoreWorkspaceName: "restore-workspace",
+				environmentName,
+				PackageName: string.Empty,
+				PackageMetadata: null,
+				session,
+				cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Arrange workspace-sync sandbox lifecycle")]
 	private static async Task<WorkspaceSyncArrangeContext> ArrangeSandboxWorkspaceAsync() {
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		if (!settings.AllowDestructiveMcpTests) {
-			Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive MCP end-to-end tests.");
-		}
+		return await AllureApi.Step("Arrange workspace-sync sandbox lifecycle", async () => {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			if (!settings.AllowDestructiveMcpTests) {
+				Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive MCP end-to-end tests.");
+			}
 
-		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-workspace-sync-e2e-{Guid.NewGuid():N}");
-		Directory.CreateDirectory(rootDirectory);
+			TestConfiguration.EnsureSandboxIsConfigured(settings);
+			string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-workspace-sync-e2e-{Guid.NewGuid():N}");
+			Directory.CreateDirectory(rootDirectory);
 
-		string workspaceName = $"workspace-{Guid.NewGuid():N}";
-		string workspacePath = Path.Combine(rootDirectory, workspaceName);
-		string restoreWorkspaceName = $"restore-{Guid.NewGuid():N}";
-		string restoreWorkspacePath = Path.Combine(rootDirectory, restoreWorkspaceName);
-		string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
-		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+			string workspaceName = $"workspace-{Guid.NewGuid():N}";
+			string workspacePath = Path.Combine(rootDirectory, workspaceName);
+			string restoreWorkspaceName = $"restore-{Guid.NewGuid():N}";
+			string restoreWorkspacePath = Path.Combine(rootDirectory, restoreWorkspaceName);
+			string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
+			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 
-		await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
-			settings,
-			settings.Sandbox.EnvironmentName!,
-			cancellationTokenSource.Token);
-		await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationTokenSource.Token);
-		await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
-		PackageMetadata packageMetadata = ReadPackageMetadata(workspacePath, packageName);
+			await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
+				settings,
+				settings.Sandbox.EnvironmentName!,
+				cancellationTokenSource.Token);
+			await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationTokenSource.Token);
+			await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
+			PackageMetadata packageMetadata = ReadPackageMetadata(workspacePath, packageName);
 
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		return new WorkspaceSyncArrangeContext(
-			settings,
-			rootDirectory,
-			workspacePath,
-			workspaceName,
-			restoreWorkspacePath,
-			restoreWorkspaceName,
-			settings.Sandbox.EnvironmentName!,
-			packageName,
-			packageMetadata,
-			session,
-			cancellationTokenSource);
+			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			return new WorkspaceSyncArrangeContext(
+				settings,
+				rootDirectory,
+				workspacePath,
+				workspaceName,
+				restoreWorkspacePath,
+				restoreWorkspaceName,
+				settings.Sandbox.EnvironmentName!,
+				packageName,
+				packageMetadata,
+				session,
+				cancellationTokenSource);
+		});
 	}
 
-	[AllureStep("Act by invoking workspace-sync tool through MCP")]
 	private static async Task<WorkspaceCommandActResult> ActWorkspaceCommandAsync(
 		WorkspaceSyncArrangeContext arrangeContext,
 		string toolName,
 		string workspacePath) {
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(toolName,
-			because: "the requested workspace-sync MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking workspace-sync tool through MCP", async () => {
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(toolName,
+				because: "the requested workspace-sync MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			toolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["workspace-path"] = workspacePath
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				toolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = arrangeContext.EnvironmentName,
+						["workspace-path"] = workspacePath
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
 
-		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
-		return new WorkspaceCommandActResult(callResult, execution);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+			return new WorkspaceCommandActResult(callResult, execution);
+		});
 	}
 
-	[AllureStep("Act by invoking list-packages through MCP")]
 	private static async Task<PackageListActResult> ActGetPkgListAsync(
 		WorkspaceSyncArrangeContext arrangeContext,
 		string filter) {
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
-		tools.Select(tool => tool.Name).Should().Contain(PackageListToolName,
-			because: "the list-packages MCP tool must be advertised before the end-to-end call can be executed");
+		return await AllureApi.Step("Act by invoking list-packages through MCP", async () => {
+			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
+			tools.Select(tool => tool.Name).Should().Contain(PackageListToolName,
+				because: "the list-packages MCP tool must be advertised before the end-to-end call can be executed");
 
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			PackageListToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["filter"] = filter
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				PackageListToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = arrangeContext.EnvironmentName,
+						["filter"] = filter
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
 
-		IReadOnlyList<GetPkgListEnvelope> packages = GetPkgListResultParser.Extract(callResult);
-		return new PackageListActResult(callResult, packages);
+			IReadOnlyList<GetPkgListEnvelope> packages = GetPkgListResultParser.Extract(callResult);
+			return new PackageListActResult(callResult, packages);
+		});
 	}
 
 	[AllureStep("Assert MCP tool call failed")]


### PR DESCRIPTION
## Jira
[ENG-88547 — Run MCP E2E tests against predefined test data](https://creatio.atlassian.net/browse/ENG-88547)

## Summary
- **Predefined-data resolution.** Replaces random `list-apps` `FirstOrDefault()` discovery in MCP E2E helpers with a seeded lookup against `McpE2E:Sandbox:ApplicationCode`. Closes all 9 `TODO: ENG-88547` ignore sites across `ApplicationToolE2ETests`, `ApplicationSectionMaintenanceToolE2ETests`, `ApplicationSectionToolE2ETests`, `ApplicationSectionUpdateToolE2ETests`, and `PageGetToolE2ETests`.
- **Lifecycle test bodies.** Fills in the two placeholder tests that were `Assert.Ignore`-only:
  - `ApplicationSectionDelete_Should_Remove_Created_Section_From_Section_List` — create → list → delete → re-list
  - `ApplicationSectionUpdate_Should_Return_Structured_Readback_Data` — create → update → assert before/after → delete
- **Allure async deadlock fix** (commits `7c5d2ad5`, `2d333cb2`). Converts `[AllureStep]` on async helpers to `await AllureApi.Step(...)` in 7 fixtures; omits `[AllureNUnit]` on 5 fixtures with many sequential awaits. Each affected fixture verified per-file: hung in HEAD, completes after the change.
- **Shared resolver.** Extracts `SeededApplicationResolver` into `clio.mcp.e2e/Support/Mcp/` so the three test fixtures that look up the seeded app no longer copy-paste the same lookup logic.
- **AGENTS.md update.** Tells future agents to use `await AllureApi.Step(...)` for async step grouping (not `[AllureStep]`), and to find fixtures that omit `[AllureNUnit]` by grepping the marker comment `// [AllureNUnit] is intentionally omitted.` instead of trusting a hard-coded fixture list.

## Test plan
- [ ] `dotnet test clio.mcp.e2e` passes locally against the seeded sandbox env with `Sandbox.ApplicationCode = ClioMcpE2ETest` — no skips on ENG-88547 TODO sites, no hangs in the Allure-touched fixtures.
- [ ] `git grep "TODO: ENG-88547" clio.mcp.e2e/` returns nothing.
- [ ] TeamCity build runs the suite cleanly (after CI wires `Sandbox.ApplicationCode` via env-var override or overlay).

## Notes
- `clio.mcp.e2e/appsettings.json` is intentionally **not** in this PR — local-dev value vs. CI value should be wired via env-var override (`McpE2E__Sandbox__EnvironmentName`, `McpE2E__Sandbox__ApplicationCode`) or a per-environment overlay file, not committed defaults.
- Seeded-data prerequisite: the target environment must have an installed Freedom UI app whose code matches `Sandbox.ApplicationCode`. Tests ignore with an actionable "configure this / install the seed" message when the app or config is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)