### PR TITLE
ENG-89649 Add mobile pages creation support into AI app creation instructions :: entity BR fix

### DIFF
--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -51,6 +51,8 @@ using Creatio.Client;
 using FluentValidation;
 using k8s;
 using Microsoft.Extensions.DependencyInjection;
+using System.Text.Json;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using YamlDotNet.Serialization;
@@ -516,6 +518,7 @@ public class BindingsModule {
 		services.AddTransient<WikiHelpViewer>();
 		
 		services.AddTransient<McpServerCommand>();
+		JsonSerializerOptions mcpSerializerOptions = CreateMcpSerializerOptions();
 		services.AddMcpServer(options => {
 					options.Capabilities ??= new();
 					options.Capabilities.Logging = new();
@@ -523,8 +526,8 @@ public class BindingsModule {
 				})
 				.WithStdioServerTransport()
 				.WithResourcesFromAssembly(Assembly.GetExecutingAssembly())
-				.WithToolsFromAssembly(Assembly.GetExecutingAssembly())
-				.WithPromptsFromAssembly(Assembly.GetExecutingAssembly());
+				.WithToolsFromAssembly(Assembly.GetExecutingAssembly(), mcpSerializerOptions)
+				.WithPromptsFromAssembly(Assembly.GetExecutingAssembly(), mcpSerializerOptions);
 		
 		services.AddTransient<Func<EnvironmentSettings, ISysSettingsManager>>(_ =>
 			envSettings => {
@@ -555,6 +558,20 @@ public class BindingsModule {
 			return bootstrapResult.ResolvedEnvironment ?? CreateBootstrapPlaceholderEnvironment();
 		}
 		return CreateBootstrapPlaceholderEnvironment();
+	}
+
+	/// <summary>
+	/// Creates <see cref="JsonSerializerOptions"/> for MCP tool/prompt argument deserialization.
+	/// Enables out-of-order metadata properties (available on .NET 9+) so that the
+	/// <c>"type"</c> polymorphic discriminator does not have to be the first JSON property —
+	/// LLMs do not guarantee JSON property ordering.
+	/// </summary>
+	private static JsonSerializerOptions CreateMcpSerializerOptions() {
+		JsonSerializerOptions options = new(McpJsonUtilities.DefaultOptions);
+#if NET9_0_OR_GREATER
+		options.AllowOutOfOrderMetadataProperties = true;
+#endif
+		return options;
 	}
 
 	private static EnvironmentSettings CreateBootstrapPlaceholderEnvironment() {


### PR DESCRIPTION
## Fix non-deterministic `create-entity-business-rule` MCP failures caused by JSON property ordering

### Problem

MCP tool calls to `create-entity-business-rule` (and `create-page-business-rule`) fail intermittently with:

```
MCP server 'clio': An error occurred invoking 'create-entity-business-rule'.
```

The root cause is `System.Text.Json`'s polymorphic deserialization requirement that the type discriminator property (`"type"`) must appear as the **first property** in the JSON object. The `EntityBusinessRuleActionMcpContract` hierarchy uses `[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]` with derived types like `set-values`, `make-required`, etc.

LLMs do not guarantee JSON property ordering. When the caller generates:

```json
{ "type": "set-values", "items": [...] }   ← works
{ "items": [...], "type": "set-values" }   ← fails
```

The failure is **non-deterministic** — the same logical request may succeed or fail depending on how the LLM serializes the JSON.

### Fix

Pass custom `JsonSerializerOptions` with `AllowOutOfOrderMetadataProperties = true` to `WithToolsFromAssembly()` and `WithPromptsFromAssembly()` in the MCP server registration. This tells `System.Text.Json` to buffer polymorphic objects and locate the discriminator regardless of property position.

The option is guarded by `#if NET9_0_OR_GREATER` since it was introduced in .NET 9 and doesn't exist on `net8.0`.

### Changes

- **BindingsModule.cs**: Added `CreateMcpSerializerOptions()` that copies `McpJsonUtilities.DefaultOptions` and enables `AllowOutOfOrderMetadataProperties`. Passed the custom options to `WithToolsFromAssembly()` and `WithPromptsFromAssembly()`.

### Impact

- **`net10.0`**: All polymorphic MCP tool arguments (business rules, page rules, and any future polymorphic contracts) now tolerate arbitrary JSON property ordering.
- **`net8.0`**: No behavior change (the property doesn't exist in that TFM; the `#if` guard compiles it out).

### Validated

```
dotnet build clio/clio.csproj -c Debug --no-incremental
# Build succeeded. 0 Warning(s) 0 Error(s) — both net8.0 and net10.0
```