### PR TITLE
ENG-90327 Mcp tools started working unstable. 

### DIFF
--- a/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
@@ -158,6 +158,39 @@ public sealed class EntityBusinessRuleToolE2ETests {
 	}
 
 	[Test]
+	[Description("Returns readable MCP diagnostics when business-rule action payload deserialization fails before command execution.")]
+	[AllureTag(ToolName)]
+	[AllureName("Entity business-rule MCP tool surfaces action deserialization errors")]
+	[AllureDescription("Starts the real clio MCP server, calls create-entity-business-rule with an invalid polymorphic action payload, and verifies the client receives a readable deserialization error instead of a generic invocation failure.")]
+	public async Task BusinessRuleCreate_Should_Surface_Action_Deserialization_Error() {
+		// Arrange
+		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
+
+		// Act
+		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = "missing-business-rule-env",
+					["package-name"] = "UsrPkg",
+					["entity-schema-name"] = "UsrOrder",
+					["rule"] = CreateInvalidActionRule()
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+
+		// Assert
+		callResult.IsError.Should().BeTrue(
+			because: "argument binding failures occur before command execution and should be returned as MCP error results");
+		callResult.Content.Should().NotBeNullOrEmpty(
+			because: "the MCP error result should include human-readable diagnostics");
+		callResult.Content!.Select(content => content.ToString()).Should().Contain(message =>
+				message.Contains($"Failed to deserialize argument 'args' for MCP tool '{ToolName}'", StringComparison.Ordinal)
+				&& message.Contains("unsupported-action", StringComparison.Ordinal),
+			because: "the caller should see the underlying System.Text.Json action binding error");
+	}
+
+	[Test]
 	[Description("Creates an entity business rule for Contact in the Custom package through the real MCP server and Creatio environment.")]
 	[AllureTag(ToolName)]
 	[AllureName("Entity business-rule MCP tool creates a Contact rule")]
@@ -370,6 +403,21 @@ public sealed class EntityBusinessRuleToolE2ETests {
 			}
 		};
 
+	private static IReadOnlyDictionary<string, object?> CreateInvalidActionRule() =>
+		new Dictionary<string, object?> {
+			["caption"] = "Invalid action",
+			["condition"] = new Dictionary<string, object?> {
+				["logicalOperation"] = "AND",
+				["conditions"] = Array.Empty<object>()
+			},
+			["actions"] = new object[] {
+				new Dictionary<string, object?> {
+					["items"] = new object[] { "Name" },
+					["type"] = "unsupported-action"
+				}
+			}
+		};
+
 	private static IReadOnlyDictionary<string, object?> CreateContactApplyFilterRule(string caption) =>
 		new Dictionary<string, object?> {
 			["caption"] = caption,
@@ -421,7 +469,9 @@ public sealed class EntityBusinessRuleToolE2ETests {
 
 	private static async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
 		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		settings.ClioProcessPath = string.IsNullOrWhiteSpace(settings.ClioProcessPath)
+			? TestConfiguration.ResolveFreshClioProcessPath()
+			: settings.ClioProcessPath;
 		CancellationTokenSource cancellationTokenSource = new(timeout);
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		return new ArrangeContext(session, cancellationTokenSource);

--- a/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
@@ -469,9 +469,7 @@ public sealed class EntityBusinessRuleToolE2ETests {
 
 	private static async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
 		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = string.IsNullOrWhiteSpace(settings.ClioProcessPath)
-			? TestConfiguration.ResolveFreshClioProcessPath()
-			: settings.ClioProcessPath;
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		CancellationTokenSource cancellationTokenSource = new(timeout);
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		return new ArrangeContext(session, cancellationTokenSource);

--- a/clio.tests/Command/McpServer/McpToolErrorFilterTests.cs
+++ b/clio.tests/Command/McpServer/McpToolErrorFilterTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Clio.Command.McpServer;
+using Clio.Command.McpServer.Tools;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Property("Module", "McpServer")]
+public sealed class McpToolErrorFilterTests
+{
+	[Test]
+	[Category("Unit")]
+	[Description("Returns the original deserialization message before SDK invocation can hide a matched tool argument binding error.")]
+	public async Task HandleCallToolErrors_Should_Return_Deserialization_Message_For_Matched_Tool_Argument_Error() {
+		// Arrange
+		NotSupportedException metadataException = new(
+			"The JSON payload for polymorphic interface or abstract type 'SampleAction' must specify a type discriminator.");
+		McpRequestHandler<CallToolRequestParams, CallToolResult> handler = McpToolErrorFilter.HandleCallToolErrors(
+			(_, _) => throw new InvalidOperationException("Invocation failed.", metadataException));
+		RequestContext<CallToolRequestParams> context = CreateContext("sample-tool");
+
+		// Act
+		CallToolResult result = await handler(context, CancellationToken.None);
+		string message = GetText(result);
+
+		// Assert
+		result.IsError.Should().BeTrue(
+			because: "argument deserialization failure must be returned as a tool error result");
+		message.Should().Contain("Failed to deserialize arguments for MCP tool 'sample-tool'",
+			because: "the caller needs to know which tool rejected the payload");
+		message.Should().Contain(metadataException.Message,
+			because: "the original deserialization diagnostic should be preserved");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Returns the original JSON deserialization message without metadata-order guidance for unrelated JSON failures.")]
+	public async Task HandleCallToolErrors_Should_Return_Json_Message_Without_Metadata_Order_Hint_For_Other_Failures() {
+		// Arrange
+		JsonException jsonException = new("The JSON value could not be converted.");
+		McpRequestHandler<CallToolRequestParams, CallToolResult> handler = McpToolErrorFilter.HandleCallToolErrors(
+			(_, _) => throw new InvalidOperationException("Invocation failed.", jsonException));
+		RequestContext<CallToolRequestParams> context = CreateContext("get-package-list");
+
+		// Act
+		CallToolResult result = await handler(context, CancellationToken.None);
+		string message = GetText(result);
+
+		// Assert
+		result.IsError.Should().BeTrue(
+			because: "wrapped JSON failures should be surfaced as MCP error results");
+		message.Should().Contain("The JSON value could not be converted.",
+			because: "the actual deserialization error is the actionable part for the caller");
+	}
+
+	private static RequestContext<CallToolRequestParams> CreateContext(string toolName) {
+		RequestContext<CallToolRequestParams> context =
+			(RequestContext<CallToolRequestParams>)RuntimeHelpers.GetUninitializedObject(
+				typeof(RequestContext<CallToolRequestParams>));
+		context.Params = new CallToolRequestParams {
+			Name = toolName
+		};
+		return context;
+	}
+
+	private static string GetText(CallToolResult result) =>
+		result.Content.OfType<TextContentBlock>().Single().Text;
+}

--- a/clio.tests/Command/McpServer/McpToolErrorFilterTests.cs
+++ b/clio.tests/Command/McpServer/McpToolErrorFilterTests.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command.McpServer;
-using Clio.Command.McpServer.Tools;
 using FluentAssertions;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -19,47 +17,38 @@ public sealed class McpToolErrorFilterTests
 {
 	[Test]
 	[Category("Unit")]
-	[Description("Returns the original deserialization message before SDK invocation can hide a matched tool argument binding error.")]
-	public async Task HandleCallToolErrors_Should_Return_Deserialization_Message_For_Matched_Tool_Argument_Error() {
+	[Description("Does not convert runtime JSON failures from tool execution into argument binding errors.")]
+	public async Task HandleCallToolErrors_Should_Not_Convert_Runtime_Json_Exception_To_Argument_Error() {
 		// Arrange
-		NotSupportedException metadataException = new(
-			"The JSON payload for polymorphic interface or abstract type 'SampleAction' must specify a type discriminator.");
-		McpRequestHandler<CallToolRequestParams, CallToolResult> handler = McpToolErrorFilter.HandleCallToolErrors(
-			(_, _) => throw new InvalidOperationException("Invocation failed.", metadataException));
+		JsonException jsonException = new("The JSON value could not be converted.");
+		McpRequestHandler<CallToolRequestParams, CallToolResult> handler =
+			McpToolErrorFilter.HandleCallToolErrors((_, _) => throw jsonException);
 		RequestContext<CallToolRequestParams> context = CreateContext("sample-tool");
 
 		// Act
-		CallToolResult result = await handler(context, CancellationToken.None);
-		string message = GetText(result);
+		Func<Task> act = async () => await handler(context, CancellationToken.None);
 
 		// Assert
-		result.IsError.Should().BeTrue(
-			because: "argument deserialization failure must be returned as a tool error result");
-		message.Should().Contain("Failed to deserialize arguments for MCP tool 'sample-tool'",
-			because: "the caller needs to know which tool rejected the payload");
-		message.Should().Contain(metadataException.Message,
-			because: "the original deserialization diagnostic should be preserved");
+		await act.Should().ThrowAsync<JsonException>(
+			because: "only the explicit preflight argument binding path should create MCP deserialization diagnostics");
 	}
 
 	[Test]
 	[Category("Unit")]
-	[Description("Returns the original JSON deserialization message without metadata-order guidance for unrelated JSON failures.")]
-	public async Task HandleCallToolErrors_Should_Return_Json_Message_Without_Metadata_Order_Hint_For_Other_Failures() {
+	[Description("Delegates to the next MCP handler when no preflight argument binding error is detected.")]
+	public async Task HandleCallToolErrors_Should_Return_Next_Handler_Result_When_No_Argument_Error_Is_Detected() {
 		// Arrange
-		JsonException jsonException = new("The JSON value could not be converted.");
+		CallToolResult expected = new() { IsError = false };
 		McpRequestHandler<CallToolRequestParams, CallToolResult> handler = McpToolErrorFilter.HandleCallToolErrors(
-			(_, _) => throw new InvalidOperationException("Invocation failed.", jsonException));
+			(_, _) => ValueTask.FromResult(expected));
 		RequestContext<CallToolRequestParams> context = CreateContext("get-package-list");
 
 		// Act
 		CallToolResult result = await handler(context, CancellationToken.None);
-		string message = GetText(result);
 
 		// Assert
-		result.IsError.Should().BeTrue(
-			because: "wrapped JSON failures should be surfaced as MCP error results");
-		message.Should().Contain("The JSON value could not be converted.",
-			because: "the actual deserialization error is the actionable part for the caller");
+		result.Should().BeSameAs(expected,
+			because: "the filter should not alter successful tool execution results");
 	}
 
 	private static RequestContext<CallToolRequestParams> CreateContext(string toolName) {
@@ -71,7 +60,4 @@ public sealed class McpToolErrorFilterTests
 		};
 		return context;
 	}
-
-	private static string GetText(CallToolResult result) =>
-		result.Content.OfType<TextContentBlock>().Single().Text;
 }

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -529,6 +529,7 @@ public class BindingsModule {
 					options.ServerInstructions = McpServerInstructions.Text;
 				})
 				.WithStdioServerTransport()
+				.WithRequestFilters(filters => filters.AddCallToolFilter(McpToolErrorFilter.HandleCallToolErrors))
 				.WithResourcesFromAssembly(Assembly.GetExecutingAssembly())
 				.WithToolsFromAssembly(Assembly.GetExecutingAssembly(), mcpSerializerOptions)
 				.WithPromptsFromAssembly(Assembly.GetExecutingAssembly(), mcpSerializerOptions);
@@ -566,15 +567,13 @@ public class BindingsModule {
 
 	/// <summary>
 	/// Creates <see cref="JsonSerializerOptions"/> for MCP tool/prompt argument deserialization.
-	/// Enables out-of-order metadata properties (available on .NET 9+) so that the
+	/// Enables out-of-order metadata properties so that the
 	/// <c>"type"</c> polymorphic discriminator does not have to be the first JSON property —
 	/// LLMs do not guarantee JSON property ordering.
 	/// </summary>
-	private static JsonSerializerOptions CreateMcpSerializerOptions() {
+	internal static JsonSerializerOptions CreateMcpSerializerOptions() {
 		JsonSerializerOptions options = new(McpJsonUtilities.DefaultOptions);
-#if NET9_0_OR_GREATER
 		options.AllowOutOfOrderMetadataProperties = true;
-#endif
 		return options;
 	}
 

--- a/clio/Command/McpServer/McpToolErrorFilter.cs
+++ b/clio/Command/McpServer/McpToolErrorFilter.cs
@@ -26,12 +26,7 @@ public static class McpToolErrorFilter
 			if (TryCreateArgumentDeserializationError(context, out CallToolResult? argumentErrorResult)) {
 				return argumentErrorResult;
 			}
-			try {
-				return await next(context, cancellationToken);
-			}
-			catch (Exception ex) when (TryGetDeserializationException(ex, out Exception? deserializationException)) {
-				return CreateJsonErrorResult(BuildDeserializationErrorMessage(context.Params?.Name, null, deserializationException!));
-			}
+			return await next(context, cancellationToken);
 		};
 
 	private static bool TryCreateArgumentDeserializationError(
@@ -64,10 +59,6 @@ public static class McpToolErrorFilter
 		return false;
 	}
 
-	private static CallToolResult CreateJsonErrorResult(string? toolName, JsonException exception) {
-		return CreateJsonErrorResult(BuildDeserializationErrorMessage(toolName, null, exception));
-	}
-
 	private static CallToolResult CreateJsonErrorResult(string message) {
 		return new CallToolResult {
 			IsError = true,
@@ -93,24 +84,4 @@ public static class McpToolErrorFilter
 
 	private static bool IsDeserializationException(Exception exception) =>
 		exception is JsonException or NotSupportedException;
-
-	private static bool TryGetDeserializationException(Exception exception, out Exception? deserializationException) {
-		for (Exception? current = exception; current is not null; current = current.InnerException) {
-			if (IsDeserializationException(current)) {
-				deserializationException = current;
-				return true;
-			}
-
-			if (current is AggregateException aggregateException) {
-				foreach (Exception innerException in aggregateException.Flatten().InnerExceptions) {
-					if (TryGetDeserializationException(innerException, out deserializationException)) {
-						return true;
-					}
-				}
-			}
-		}
-
-		deserializationException = null;
-		return false;
-	}
 }

--- a/clio/Command/McpServer/McpToolErrorFilter.cs
+++ b/clio/Command/McpServer/McpToolErrorFilter.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer;
+
+/// <summary>
+/// Converts MCP tool invocation failures that happen before tool method execution into readable tool results.
+/// </summary>
+public static class McpToolErrorFilter
+{
+	private static readonly JsonSerializerOptions SerializerOptions = BindingsModule.CreateMcpSerializerOptions();
+
+	/// <summary>
+	/// Wraps call-tool execution and returns deserialization diagnostics as an MCP error result.
+	/// </summary>
+	/// <param name="next">Next call-tool handler in the MCP request pipeline.</param>
+	/// <returns>Wrapped call-tool handler.</returns>
+	public static McpRequestHandler<CallToolRequestParams, CallToolResult> HandleCallToolErrors(
+		McpRequestHandler<CallToolRequestParams, CallToolResult> next) =>
+		async (context, cancellationToken) => {
+			if (TryCreateArgumentDeserializationError(context, out CallToolResult? argumentErrorResult)) {
+				return argumentErrorResult;
+			}
+			try {
+				return await next(context, cancellationToken);
+			}
+			catch (Exception ex) when (TryGetDeserializationException(ex, out Exception? deserializationException)) {
+				return CreateJsonErrorResult(BuildDeserializationErrorMessage(context.Params?.Name, null, deserializationException!));
+			}
+		};
+
+	private static bool TryCreateArgumentDeserializationError(
+		RequestContext<CallToolRequestParams> context,
+		out CallToolResult? result) {
+		result = null;
+		if (context.Params?.Arguments is not { } arguments) {
+			return false;
+		}
+
+		if (context.MatchedPrimitive is not McpServerTool tool
+				|| tool.Metadata.OfType<MethodInfo>().FirstOrDefault() is not { } method) {
+			return false;
+		}
+
+		foreach (ParameterInfo parameter in method.GetParameters()) {
+			string argumentName = GetArgumentName(parameter);
+			if (!arguments.TryGetValue(argumentName, out JsonElement argumentValue)) {
+				continue;
+			}
+			try {
+				argumentValue.Deserialize(parameter.ParameterType, SerializerOptions);
+			}
+			catch (Exception ex) when (IsDeserializationException(ex)) {
+				result = CreateJsonErrorResult(BuildDeserializationErrorMessage(context.Params.Name, argumentName, ex));
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static CallToolResult CreateJsonErrorResult(string? toolName, JsonException exception) {
+		return CreateJsonErrorResult(BuildDeserializationErrorMessage(toolName, null, exception));
+	}
+
+	private static CallToolResult CreateJsonErrorResult(string message) {
+		return new CallToolResult {
+			IsError = true,
+			Content = [
+				new TextContentBlock {
+					Text = message
+				}
+			]
+		};
+	}
+
+	private static string GetArgumentName(ParameterInfo parameter) =>
+		parameter.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name
+		?? parameter.Name
+		?? string.Empty;
+
+	private static string BuildDeserializationErrorMessage(string? toolName, string? argumentName, Exception exception) {
+		string message = string.IsNullOrWhiteSpace(argumentName)
+			? $"Failed to deserialize arguments for MCP tool '{toolName ?? "<unknown>"}': {exception.Message}"
+			: $"Failed to deserialize argument '{argumentName}' for MCP tool '{toolName ?? "<unknown>"}': {exception.Message}";
+		return message;
+	}
+
+	private static bool IsDeserializationException(Exception exception) =>
+		exception is JsonException or NotSupportedException;
+
+	private static bool TryGetDeserializationException(Exception exception, out Exception? deserializationException) {
+		for (Exception? current = exception; current is not null; current = current.InnerException) {
+			if (IsDeserializationException(current)) {
+				deserializationException = current;
+				return true;
+			}
+
+			if (current is AggregateException aggregateException) {
+				foreach (Exception innerException in aggregateException.Flatten().InnerExceptions) {
+					if (TryGetDeserializationException(innerException, out deserializationException)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		deserializationException = null;
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

- Enabled `AllowOutOfOrderMetadataProperties` for all target frameworks.
  - This option is available from `System.Text.Json` 9+, not from a specific .NET runtime.
  - `clio` targets `net8.0`, but ships with `System.Text.Json` 10, so the option is available there too.
  - This allows polymorphic MCP payloads to deserialize correctly even when the `type` discriminator is not the first property.

- Added MCP tool argument deserialization diagnostics before SDK invocation.
  - The MCP SDK catches non-`McpException` tool invocation failures and returns a generic error.
  - `clio` now pre-validates supplied tool arguments with the same serializer options used by MCP tool registration.
  - If argument binding fails, the caller receives the underlying JSON deserialization message.

## Error Message Change

Before:

```text
An error occurred invoking 'create-entity-business-rule'.
```

After:
```
Failed to deserialize argument 'args' for MCP tool 'create-entity-business-rule': Read unrecognized type discriminator id 'unsupported-action'. Path: $.rule.actions[0] | LineNumber: 0 | BytePositionInLine: 214.
```

For malformed polymorphic payloads, agents now get actionable JSON binding diagnostics instead of a generic MCP invocation failure.