### PR TITLE
fix: write env URI before ResolveIsNetCore to prevent null URI in health-check

### DIFF
--- a/clio.tests/Command/RegAppCommand.Tests.cs
+++ b/clio.tests/Command/RegAppCommand.Tests.cs
@@ -43,7 +43,7 @@ public class RegAppCommandTestCase {
 		command.Execute(options);
 
 		// Assert
-		settingsRepository.Received(1).ConfigureEnvironment(name, Arg.Is<EnvironmentSettings>(
+		settingsRepository.Received().ConfigureEnvironment(name, Arg.Is<EnvironmentSettings>(
 			e => e.Login == login
 				&& e.Password == password
 				&& e.Uri == uri

--- a/clio.tests/Command/RegAppCommandAutoDetectionTests.cs
+++ b/clio.tests/Command/RegAppCommandAutoDetectionTests.cs
@@ -42,7 +42,7 @@ public sealed class RegAppCommandAutoDetectionTests {
 			settings.Uri == "http://example.invalid"
 			&& settings.Login == "Supervisor"
 			&& settings.Password == "Supervisor"));
-		settingsRepository.Received(1).ConfigureEnvironment("sandbox", Arg.Is<EnvironmentSettings>(settings =>
+		settingsRepository.Received().ConfigureEnvironment("sandbox", Arg.Is<EnvironmentSettings>(settings =>
 			settings.Uri == "http://example.invalid"
 			&& settings.IsNetCore));
 	}

--- a/clio/Command/RegAppCommand.cs
+++ b/clio/Command/RegAppCommand.cs
@@ -110,22 +110,29 @@ public class RegAppCommand : Command<RegAppOptions> {
 			EnvironmentSettings? existingEnvironment = string.IsNullOrWhiteSpace(options.EnvironmentName)
 				? null
 				: _settingsRepository.FindEnvironment(options.EnvironmentName);
-			bool resolvedIsNetCore = ResolveIsNetCore(options, existingEnvironment);
+			
 			EnvironmentSettings environment = new() {
 				Login = options.Login,
 				Password = options.Password,
 				Uri = options.Uri?.TrimEnd('/'),
 				Maintainer = options.Maintainer,
 				Safe = options.SafeValue ?? false,
-				IsNetCore = resolvedIsNetCore,
+				IsNetCore = options.IsNetCore ?? existingEnvironment?.IsNetCore ?? false,
 				DeveloperModeEnabled = options.DeveloperModeEnabled,
 				ClientId = options.ClientId,
 				ClientSecret = options.ClientSecret,
 				AuthAppUri = options.AuthAppUri,
-				WorkspacePathes = options.WorkspacePathes, 
+				WorkspacePathes = options.WorkspacePathes,
 				EnvironmentPath = options.EnvironmentPath
 			};
 			_settingsRepository.ConfigureEnvironment(options.EnvironmentName, environment);
+
+			bool resolvedIsNetCore = ResolveIsNetCore(options, existingEnvironment);
+			if (resolvedIsNetCore != environment.IsNetCore) {
+				environment.IsNetCore = resolvedIsNetCore;
+				_settingsRepository.ConfigureEnvironment(options.EnvironmentName, environment);
+			}
+
 			_logger.WriteInfo($"Environment {options.EnvironmentName} was configured...");
 			environment = _settingsRepository.GetEnvironment(options);
 

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.37</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.38</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>

--- a/cliogate/descriptor.json
+++ b/cliogate/descriptor.json
@@ -5,7 +5,7 @@
     "Name": "cliogate",
     "Type": 0,
     "ProjectPath": "",
-    "ModifiedOnUtc": "/Date(1778186795000)/",
+    "ModifiedOnUtc": "/Date(1779887531000)/",
     "Maintainer": "Advanced Technologies Foundation",
     "DependsOn": []
   }


### PR DESCRIPTION
## Summary
- `deploy-creatio --deployment dotnet` was logging 10 health-check errors (~45 s of wasted retries) because `HealthCheckCommand` received a null base URI
- Root cause: `RegAppCommand.Execute` called `ResolveIsNetCore` (which could block on auto-detection) **before** writing the environment entry to `appsettings.json`, leaving a window where concurrent readers found no entry and resolved `Uri = null`
- Fix: write the complete environment entry first (using `options.IsNetCore ?? existingEnvironment?.IsNetCore ?? false` as a provisional value), then resolve — and only write a second time if the resolved value actually changed. When `--IsNetCore true` is passed (as `deploy-creatio` always does), `ResolveIsNetCore` fast-paths with no network call and the second write never happens

## Test plan
- [ ] `RegAppCommandAutoDetectionTests` — auto-detect path still persists the resolved runtime
- [ ] `RegAppCommandTestCase` — credentials and URI are written correctly
- [ ] `Execute_Should_Preserve_Existing_Runtime_When_Uri_Is_Not_Provided` — existing runtime flag is kept when URI is unchanged
- [ ] `Execute_Should_Use_Discovered_Iis_Runtime_When_AddFromIis_Is_Enabled` — IIS import unaffected
- [ ] Run `clio deploy-creatio --deployment dotnet -e <new-env>` and confirm no `UriFormatException` retries in the health-check loop