### PR TITLE
ENG-88547: move MCP E2E seeded test data from appsettings to consts

### DIFF
--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -22,6 +22,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	private const string SectionListToolName = ApplicationSectionGetListTool.ApplicationSectionGetListToolName;
 	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
+	private const string ApplicationCode = "AutoTestClioMcp";
 
 	[Test]
 	[Description("Advertises list-app-sections in the MCP tool list so callers can discover the installed-app section discovery tool.")]
@@ -116,7 +117,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that list-app-sections returns a structured section envelope for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application AutoTestClioMcp, and verifies that list-app-sections returns a structured section envelope for that application.")]
 	[AllureFeature(SectionListToolName)]
 	[AllureTag(SectionListToolName)]
 	[AllureName("Application section list returns structured section metadata")]
@@ -132,7 +133,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 			session,
 			cancellationTokenSource.Token,
 			environmentName,
-			settings.Sandbox.ApplicationCode);
+			ApplicationCode);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -268,13 +269,12 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
-		string? applicationCode = settings.Sandbox.ApplicationCode;
 		if (!settings.AllowDestructiveMcpTests) {
 			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive delete-app-section lifecycle test.");
 		}
 
-		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to run the delete-app-section lifecycle test.");
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run the delete-app-section lifecycle test.");
 		}
 
 		string caption = $"E2E Del {Guid.NewGuid():N}"[..24];
@@ -288,7 +288,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["caption"] = caption
 					}
 				},
@@ -308,7 +308,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 
 			// Act 2: list sections and confirm the new section is present
 			ApplicationSectionListContextResponseEnvelope listBefore = await CallListSectionsAsync(
-				session, cancellationTokenSource.Token, environmentName!, applicationCode!);
+				session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 
 			listBefore.Success.Should().BeTrue(
 				because: $"list-app-sections should succeed for the seeded application before deletion. Error: {listBefore.Error}");
@@ -323,7 +323,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["section-code"] = createdSectionCode
 					}
 				},
@@ -344,7 +344,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 
 			// Act 4: re-list sections and confirm the section is gone
 			ApplicationSectionListContextResponseEnvelope listAfter = await CallListSectionsAsync(
-				session, cancellationTokenSource.Token, environmentName!, applicationCode!);
+				session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 
 			listAfter.Success.Should().BeTrue(
 				because: $"list-app-sections should succeed for the seeded application after deletion. Error: {listAfter.Error}");
@@ -361,7 +361,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 						new Dictionary<string, object?> {
 							["args"] = new Dictionary<string, object?> {
 								["environment-name"] = environmentName,
-								["application-code"] = applicationCode,
+								["application-code"] = ApplicationCode,
 								["section-code"] = createdSectionCode
 							}
 						},

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -21,6 +21,7 @@ namespace Clio.Mcp.E2E;
 public sealed class ApplicationSectionToolE2ETests {
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
 	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
+	private const string ApplicationCode = "AutoTestClioMcp";
 
 	[Test]
 	[Description("Advertises create-app-section in the MCP tool list so callers can discover the existing-app section creation tool.")]
@@ -200,13 +201,12 @@ public sealed class ApplicationSectionToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
-		string? applicationCode = settings.Sandbox.ApplicationCode;
 		if (!settings.AllowDestructiveMcpTests) {
 			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
 		}
 
-		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
 		}
 
 		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
@@ -220,7 +220,7 @@ public sealed class ApplicationSectionToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["caption"] = caption
 					}
 				},
@@ -249,7 +249,7 @@ public sealed class ApplicationSectionToolE2ETests {
 						new Dictionary<string, object?> {
 							["args"] = new Dictionary<string, object?> {
 								["environment-name"] = environmentName,
-								["application-code"] = applicationCode,
+								["application-code"] = ApplicationCode,
 								["section-code"] = createdSectionCode
 							}
 						},
@@ -268,13 +268,12 @@ public sealed class ApplicationSectionToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
-		string? applicationCode = settings.Sandbox.ApplicationCode;
 		if (!settings.AllowDestructiveMcpTests) {
 			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
 		}
 
-		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
 		}
 
 		const string platformEntitySchemaName = "Case";
@@ -289,7 +288,7 @@ public sealed class ApplicationSectionToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["caption"] = caption,
 						["entity-schema-name"] = platformEntitySchemaName
 					}
@@ -319,7 +318,7 @@ public sealed class ApplicationSectionToolE2ETests {
 						new Dictionary<string, object?> {
 							["args"] = new Dictionary<string, object?> {
 								["environment-name"] = environmentName,
-								["application-code"] = applicationCode,
+								["application-code"] = ApplicationCode,
 								["section-code"] = createdSectionCode
 							}
 						},

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -22,6 +22,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 	private const string SectionUpdateToolName = ApplicationSectionUpdateTool.ApplicationSectionUpdateToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
 	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
+	private const string ApplicationCode = "AutoTestClioMcp";
 
 	[Test]
 	[Description("Advertises update-app-section in the MCP tool list so callers can discover the existing-section update tool.")]
@@ -242,13 +243,12 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
-		string? applicationCode = settings.Sandbox.ApplicationCode;
 		if (!settings.AllowDestructiveMcpTests) {
 			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive update-app-section lifecycle test.");
 		}
 
-		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(applicationCode)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName and McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
 		}
 
 		string initialCaption = $"E2E UpdBefore {Guid.NewGuid():N}"[..24];
@@ -264,7 +264,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["caption"] = initialCaption
 					}
 				},
@@ -288,7 +288,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = applicationCode,
+						["application-code"] = ApplicationCode,
 						["section-code"] = createdSectionCode,
 						["caption"] = updatedCaption,
 						["description"] = updatedDescription
@@ -325,7 +325,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 						new Dictionary<string, object?> {
 							["args"] = new Dictionary<string, object?> {
 								["environment-name"] = environmentName,
-								["application-code"] = applicationCode,
+								["application-code"] = ApplicationCode,
 								["section-code"] = createdSectionCode
 							}
 						},

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -28,6 +28,10 @@ public sealed class ApplicationToolE2ETests {
 	private const string CreateToolName = ApplicationCreateTool.ApplicationCreateToolName;
 	private const string DeleteToolName = ApplicationDeleteTool.ToolName;
 	private const string SchemaSyncToolName = SchemaSyncTool.ToolName;
+	private const string ApplicationTemplateCode = "AppFreedomUI";
+	private const string ApplicationIconId = "00199a08-771c-46cd-b7e4-27f0171f8a6b";
+	private const string ApplicationIconBackground = "#0058EF";
+	private const string ApplicationCode = "AutoTestClioMcp";
 
 
 	[Test]
@@ -35,7 +39,7 @@ public sealed class ApplicationToolE2ETests {
 	[AllureFeature(ListToolName)]
 	[AllureTag(ListToolName)]
 	[AllureName("Application get list returns structured installed applications")]
-	[AllureDescription("Uses the real clio MCP server to call list-apps for the configured environment, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that the seeded application exposes the expected structured selectors and metadata fields.")]
+	[AllureDescription("Uses the real clio MCP server to call list-apps for the configured environment, resolves the seeded installed application AutoTestClioMcp, and verifies that the seeded application exposes the expected structured selectors and metadata fields.")]
 	public async Task ApplicationGetList_Should_Return_Structured_Applications() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -47,7 +51,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Assert
 		listResult.CallResult.IsError.Should().NotBeTrue(
@@ -65,11 +69,11 @@ public sealed class ApplicationToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that get-app-info returns structured metadata for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application AutoTestClioMcp through list-apps, and verifies that get-app-info returns structured metadata for that application.")]
 	[AllureFeature(InfoToolName)]
 	[AllureTag(InfoToolName)]
 	[AllureName("Application get info returns structured package and entity metadata")]
-	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that get-app-info returns the expected structured metadata envelope for that application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application AutoTestClioMcp through list-apps, and verifies that get-app-info returns the expected structured metadata envelope for that application.")]
 	public async Task ApplicationGetInfo_Should_Return_Structured_Metadata() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -79,7 +83,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Act
 		ApplicationInfoActResult infoResult = await ActInfoAsync(
@@ -152,13 +156,13 @@ public sealed class ApplicationToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that its id can be reused with get-app-info.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application AutoTestClioMcp through list-apps, and verifies that its id can be reused with get-app-info.")]
 	[AllureFeature(ListToolName)]
 	[AllureFeature(InfoToolName)]
 	[AllureTag(ListToolName)]
 	[AllureTag(InfoToolName)]
 	[AllureName("Application list returns ids usable by get-app-info when applications exist")]
-	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode through list-apps, and verifies that the returned application id is accepted by get-app-info and resolves the same application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application AutoTestClioMcp through list-apps, and verifies that the returned application id is accepted by get-app-info and resolves the same application.")]
 	public async Task ApplicationGetList_Should_Return_Ids_Usable_By_GetAppInfo_When_Applications_Exist() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -168,7 +172,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName);
-		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, settings.Sandbox.ApplicationCode, arrangeContext.EnvironmentName);
+		ApplicationListItemEnvelope installedApplication = SeededApplicationResolver.GetOrIgnore(listResult.Result, ApplicationCode, arrangeContext.EnvironmentName);
 
 		// Act
 		ApplicationInfoActResult infoResult = await ActInfoAsync(
@@ -286,14 +290,8 @@ public sealed class ApplicationToolE2ETests {
 		TestConfiguration.EnsureSandboxIsConfigured(settings);
 		await using ApplicationArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(10));
 		string suffix = Guid.NewGuid().ToString("N")[..8];
-		string applicationCode = $"UsrCodex{suffix}";
+		string createdApplicationCode = $"UsrCodex{suffix}";
 		string applicationName = $"Codex E2E {suffix}";
-
-		if (string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationTemplateCode) ||
-			string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationIconId) ||
-			string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationIconBackground)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:ApplicationTemplateCode, ApplicationIconId, and ApplicationIconBackground to run create-app success E2E.");
-		}
 
 		// Act
 		ApplicationInfoActResult actResult = await ActCreateAsync(
@@ -301,11 +299,11 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			applicationName,
-			applicationCode,
+			createdApplicationCode,
 			description: null,
-			settings.Sandbox.ApplicationTemplateCode!,
-			settings.Sandbox.ApplicationIconId!,
-			settings.Sandbox.ApplicationIconBackground!,
+			ApplicationTemplateCode,
+			ApplicationIconId,
+			ApplicationIconBackground,
 			optionalTemplateDataJson: null);
 
 		// Assert
@@ -317,9 +315,9 @@ public sealed class ApplicationToolE2ETests {
 			because: "successful create-app calls should return the created application's primary package identifier");
 		actResult.Result.PackageName.Should().NotBeNullOrWhiteSpace(
 			because: "successful create-app calls should return the created application's primary package name");
-		actResult.Result.CanonicalMainEntityName.Should().Be(applicationCode,
+		actResult.Result.CanonicalMainEntityName.Should().Be(createdApplicationCode,
 			because: "create-app should surface the canonical main entity explicitly for MCP clients");
-		actResult.Result.ApplicationCode.Should().Be(applicationCode,
+		actResult.Result.ApplicationCode.Should().Be(createdApplicationCode,
 			because: "create-app should return the created installed application code in the same envelope shape as get-app-info");
 		actResult.Result.ApplicationName.Should().Be(applicationName,
 			because: "create-app should return the created installed application display name");
@@ -334,7 +332,7 @@ public sealed class ApplicationToolE2ETests {
 		actResult.Result.DataForge.Coverage.Should().NotBeNull(
 			because: "create-app should expose Data Forge coverage flags even when the enrichment stage is degraded");
 		ApplicationEntityEnvelope? canonicalMainEntity = actResult.Result.Entities?
-			.FirstOrDefault(entity => string.Equals(entity.Name, applicationCode, StringComparison.OrdinalIgnoreCase));
+			.FirstOrDefault(entity => string.Equals(entity.Name, createdApplicationCode, StringComparison.OrdinalIgnoreCase));
 		canonicalMainEntity.Should().NotBeNull(
 			because: "successful create-app calls should include the canonical main entity payload");
 		canonicalMainEntity!.Caption.Should().Be(applicationName,
@@ -363,26 +361,20 @@ public sealed class ApplicationToolE2ETests {
 		TestConfiguration.EnsureSandboxIsConfigured(settings);
 		await using ApplicationArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(10));
 		string suffix = Guid.NewGuid().ToString("N")[..8];
-		string applicationCode = $"UsrCodex{suffix}";
+		string createdApplicationCode = $"UsrCodex{suffix}";
 		string applicationName = $"Codex E2E {suffix}";
 		string addedColumnName = $"UsrStatus{suffix[..4]}";
-
-		if (string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationTemplateCode) ||
-			string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationIconId) ||
-			string.IsNullOrWhiteSpace(settings.Sandbox.ApplicationIconBackground)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:ApplicationTemplateCode, ApplicationIconId, and ApplicationIconBackground to run application/sync-schemas regression E2E.");
-		}
 
 		ApplicationInfoActResult createResult = await ActCreateAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			applicationName,
-			applicationCode,
+			createdApplicationCode,
 			description: null,
-			settings.Sandbox.ApplicationTemplateCode!,
-			settings.Sandbox.ApplicationIconId!,
-			settings.Sandbox.ApplicationIconBackground!,
+			ApplicationTemplateCode,
+			ApplicationIconId,
+			ApplicationIconBackground,
 			optionalTemplateDataJson: null);
 
 		// Act
@@ -391,7 +383,7 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			createResult.Result.PackageName!,
-			applicationCode,
+			createdApplicationCode,
 			addedColumnName);
 		JsonElement schemaSyncResponse = ExtractSchemaSyncResponse(schemaSyncCallResult);
 		ApplicationInfoActResult infoResult = await ActInfoAsync(
@@ -399,9 +391,9 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			id: null,
-			code: applicationCode);
+			code: createdApplicationCode);
 		ApplicationEntityEnvelope? canonicalMainEntity = infoResult.Result.Entities?
-			.FirstOrDefault(entity => string.Equals(entity.Name, applicationCode, StringComparison.OrdinalIgnoreCase));
+			.FirstOrDefault(entity => string.Equals(entity.Name, createdApplicationCode, StringComparison.OrdinalIgnoreCase));
 
 		// Assert
 		createResult.Result.Success.Should().BeTrue(
@@ -521,8 +513,8 @@ public sealed class ApplicationToolE2ETests {
 			$"UsrBad{Guid.NewGuid():N}"[..14],
 			description: null,
 			invalidTemplateCode,
-			settings.Sandbox.ApplicationIconId ?? "11111111-1111-1111-1111-111111111111",
-			settings.Sandbox.ApplicationIconBackground,
+			ApplicationIconId,
+			ApplicationIconBackground,
 			optionalTemplateDataJson: null);
 
 		// Assert
@@ -554,9 +546,9 @@ public sealed class ApplicationToolE2ETests {
 			name: $"Codex Invalid Json {suffix}",
 			code: $"UsrBadJson{suffix}",
 			description: null,
-			templateCode: settings.Sandbox.ApplicationTemplateCode ?? "AppFreedomUI",
-			iconId: settings.Sandbox.ApplicationIconId ?? "11111111-1111-1111-1111-111111111111",
-			iconBackground: settings.Sandbox.ApplicationIconBackground,
+			templateCode: ApplicationTemplateCode,
+			iconId: ApplicationIconId,
+			iconBackground: ApplicationIconBackground,
 			optionalTemplateDataJson: "{not-json");
 
 		// Assert
@@ -592,9 +584,9 @@ public sealed class ApplicationToolE2ETests {
 			name: $"Codex Auto Icon {suffix}",
 			code: $"UsrAutoIcon{suffix}",
 			description: null,
-			templateCode: settings.Sandbox.ApplicationTemplateCode ?? "AppFreedomUI",
+			templateCode: ApplicationTemplateCode,
 			iconId: "auto",
-			iconBackground: settings.Sandbox.ApplicationIconBackground,
+			iconBackground: ApplicationIconBackground,
 			optionalTemplateDataJson: null);
 
 		// Assert

--- a/clio.mcp.e2e/PageCreateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageCreateToolE2ETests.cs
@@ -23,6 +23,7 @@ namespace Clio.Mcp.E2E;
 public sealed class PageCreateToolE2ETests {
 	private const string ToolName = PageCreateTool.ToolName;
 	private const string ListTemplatesToolName = PageTemplatesListTool.ToolName;
+	private const string PackageName = "Custom";
 
 	[Test]
 	[Description("Advertises create-page and list-page-templates in the MCP tool manifest.")]
@@ -143,7 +144,6 @@ public sealed class PageCreateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(5));
-		string packageName = await ResolveWritablePackageAsync(settings, environmentName, arrangeContext.CancellationTokenSource.Token);
 		string schemaName = $"UsrE2E_BlankPage_{Guid.NewGuid():N}".Substring(0, 40);
 
 		// Act
@@ -153,7 +153,7 @@ public sealed class PageCreateToolE2ETests {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
 					["template"] = "BlankPageTemplate",
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["caption"] = "E2E blank page",
 					["environment-name"] = environmentName
 				}
@@ -163,11 +163,11 @@ public sealed class PageCreateToolE2ETests {
 
 		// Assert create
 		createResult.IsError.Should().NotBeTrue();
-		createResponse.Success.Should().BeTrue(because: $"create-page must succeed for a fresh schema name '{schemaName}' in package '{packageName}'. Error: {createResponse.Error}");
+		createResponse.Success.Should().BeTrue(because: $"create-page must succeed for a fresh schema name '{schemaName}' in the editable '{PackageName}' package. Error: {createResponse.Error}");
 		createResponse.SchemaName.Should().Be(schemaName);
 		createResponse.SchemaUId.Should().NotBeNullOrWhiteSpace();
 		createResponse.TemplateName.Should().Be("BlankPageTemplate");
-		createResponse.PackageName.Should().Be(packageName);
+		createResponse.PackageName.Should().Be(PackageName);
 
 		// Act read-back
 		CallToolResult getResult = await arrangeContext.Session.CallToolAsync(
@@ -200,7 +200,6 @@ public sealed class PageCreateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(5));
-		string packageName = await ResolveWritablePackageAsync(settings, environmentName, arrangeContext.CancellationTokenSource.Token);
 		string schemaName = $"UsrE2E_DupPage_{Guid.NewGuid():N}".Substring(0, 40);
 
 		// Create the page first
@@ -210,7 +209,7 @@ public sealed class PageCreateToolE2ETests {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
 					["template"] = "BlankPageTemplate",
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["environment-name"] = environmentName
 				}
 			},
@@ -225,7 +224,7 @@ public sealed class PageCreateToolE2ETests {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
 					["template"] = "BlankPageTemplate",
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["environment-name"] = environmentName
 				}
 			},
@@ -300,24 +299,6 @@ public sealed class PageCreateToolE2ETests {
 		} catch (OperationCanceledException) {
 			return false;
 		}
-	}
-
-	private static async Task<string> ResolveWritablePackageAsync(
-		McpE2ESettings settings, string environmentName, CancellationToken cancellationToken) {
-		string? configured = settings.Sandbox.PackageName;
-		if (!string.IsNullOrWhiteSpace(configured)) {
-			return configured;
-		}
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["get-pkg-list", "-e", environmentName],
-			cancellationToken: cancellationToken);
-		if (result.ExitCode == 0 && result.StandardOutput.Contains("Custom")) {
-			return "Custom";
-		}
-		Assert.Ignore(
-			$"create-page MCP E2E requires a writable package. Configure McpE2E:Sandbox:PackageName or ensure a 'Custom' package exists in environment '{environmentName}'.");
-		return string.Empty;
 	}
 
 	private sealed record ArrangeContext(

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -22,6 +22,8 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class PageGetToolE2ETests {
 	private const string ToolName = PageGetTool.ToolName;
+	private const string ApplicationCode = "AutoTestClioMcp";
+	private const string SavePage = "ClioMcp_BlankPageToSave";
 
 	[Test]
 	[Description("Advertises get-page MCP tool in the server tool list so callers can discover it.")]
@@ -44,19 +46,71 @@ public sealed class PageGetToolE2ETests {
 	}
 
 	[Test]
-	[Description("Deferred positive coverage for get-page and update-page round-trip when the E2E environment has a known editable page.")]
+	[Description("Reads the seeded Freedom UI page ClioMcp_BlankPageToSave via get-page and verifies update-page dry-run accepts the same body unchanged.")]
 	[AllureTag(ToolName)]
-	[AllureName("get-page returns bundle and raw body for a sandbox form page")]
-	[AllureDescription("Placeholder for a future seeded-data E2E that reads a known editable page with get-page and reuses raw.body in update-page dry-run.")]
-	public void PageGetTool_Should_Return_Bundle_And_Support_DryRun_RoundTrip() {
-		Assert.Ignore("TODO: add predefined editable page data to the E2E environment, then restore this get-page to update-page dry-run round-trip scenario.");
+	[AllureName("get-page raw body round-trips through update-page dry-run")]
+	[AllureDescription("Uses the real clio MCP server to call get-page for the seeded page ClioMcp_BlankPageToSave in AutoTestClioMcp, reads the materialized body from disk, sends it back through update-page in dry-run mode, and verifies that the dry-run accepts the unchanged body so the read and write formats stay in sync.")]
+	public async Task PageGetTool_Should_Return_Bundle_And_Support_DryRun_RoundTrip() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
+
+		// Act 1: get-page reads the seeded page's body to disk
+		CallToolResult getResult = await arrangeContext.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = SavePage,
+					["environment-name"] = arrangeContext.EnvironmentName
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		PageGetResponse getResponse = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(getResult);
+
+		// Assert get-page succeeded and materialized a non-empty body
+		getResult.IsError.Should().NotBeTrue(
+			because: $"get-page should return a structured payload for the seeded page '{SavePage}' before the round-trip can run");
+		getResponse.Success.Should().BeTrue(
+			because: $"get-page must succeed for the seeded page '{SavePage}' in '{ApplicationCode}'. Error: {getResponse.Error}");
+		getResponse.Files.Should().NotBeNull(
+			because: "successful get-page calls must return the materialized file paths");
+		getResponse.Files.BodyFile.Should().NotBeNullOrWhiteSpace(
+			because: "the round-trip needs a body-file path to read the raw body from disk");
+		File.Exists(getResponse.Files.BodyFile).Should().BeTrue(
+			because: "get-page must materialize body.js on disk for update-page reuse");
+		string body = await File.ReadAllTextAsync(getResponse.Files.BodyFile);
+		body.Should().NotBeNullOrWhiteSpace(
+			because: "the round-trip is only meaningful if get-page returns a non-empty body");
+
+		// Act 2: update-page dry-run consumes the same body unchanged
+		CallToolResult updateResult = await arrangeContext.Session.CallToolAsync(
+			PageUpdateTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = SavePage,
+					["body"] = body,
+					["dry-run"] = true,
+					["environment-name"] = arrangeContext.EnvironmentName
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		PageUpdateResponse updateResponse = EntitySchemaStructuredResultParser.Extract<PageUpdateResponse>(updateResult);
+
+		// Assert update-page dry-run accepted the unchanged body
+		updateResult.IsError.Should().NotBeTrue(
+			because: "the round-trip body should produce a structured update-page response instead of a transport-level error");
+		updateResponse.Success.Should().BeTrue(
+			because: $"update-page dry-run must accept the body get-page produced for '{SavePage}', confirming get-page output is valid update-page input. Error: {updateResponse.Error}");
+		updateResponse.Error.Should().BeNullOrWhiteSpace(
+			because: "a successful dry-run should not include an error payload");
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode and one of its pages, and verifies the structured get-page metadata contract for that page.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application AutoTestClioMcp and one of its pages, and verifies the structured get-page metadata contract for that page.")]
 	[AllureTag(ToolName)]
 	[AllureName("get-page returns stable metadata contract for a real page")]
-	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode and the first page in that application, and verifies the stable get-page metadata and raw-body contract for the seeded page.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application AutoTestClioMcp and the first page in that application, and verifies the stable get-page metadata and raw-body contract for the seeded page.")]
 	public async Task PageGetTool_Should_Return_Stable_Metadata_Contract_For_Real_Page() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -66,7 +120,7 @@ public sealed class PageGetToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
-			settings.Sandbox.ApplicationCode);
+			ApplicationCode);
 
 		// Act
 		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
@@ -181,11 +235,11 @@ public sealed class PageGetToolE2ETests {
 	}
 
 	[Test]
-	[Description("Starts the real clio MCP server, resolves the seeded installed application configured via Sandbox.ApplicationCode, and verifies that list-pages returns structured page summaries for that application.")]
+	[Description("Starts the real clio MCP server, resolves the seeded installed application AutoTestClioMcp, and verifies that list-pages returns structured page summaries for that application.")]
 	[AllureFeature(PageListTool.ToolName)]
 	[AllureTag(PageListTool.ToolName)]
 	[AllureName("list-pages returns structured page summaries")]
-	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application configured via Sandbox.ApplicationCode and verifies the structured list-pages summary envelope for that application.")]
+	[AllureDescription("Uses the real clio MCP server to look up the seeded installed application AutoTestClioMcp and verifies the structured list-pages summary envelope for that application.")]
 	public async Task PageListTool_Should_Return_Structured_PageSummaries() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
@@ -195,7 +249,7 @@ public sealed class PageGetToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
-			settings.Sandbox.ApplicationCode);
+			ApplicationCode);
 
 		// Act
 		PageListResponse response = await CallPageListAsync(
@@ -239,12 +293,12 @@ public sealed class PageGetToolE2ETests {
 		McpServerSession session,
 		CancellationToken cancellationToken,
 		string environmentName,
-		string? configuredApplicationCode) {
+		string applicationCode) {
 		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session,
 			cancellationToken,
 			environmentName,
-			configuredApplicationCode);
+			applicationCode);
 		PageListResponse pageList = await CallPageListAsync(
 			session,
 			cancellationToken,

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -30,6 +30,7 @@ namespace Clio.Mcp.E2E;
 public sealed class PageSyncToolE2ETests {
 
 	private const string ToolName = PageSyncTool.ToolName;
+	private const string SavePage = "ClioMcp_BlankPageToSave";
 	private const string ValidPageBody = "define('TestPage', /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, " +
 		"function(/**SCHEMA_ARGS*//**SCHEMA_ARGS*/) { return { " +
 		"/**SCHEMA_VIEW_CONFIG_DIFF*/[]/**SCHEMA_VIEW_CONFIG_DIFF*/, " +
@@ -356,12 +357,73 @@ public sealed class PageSyncToolE2ETests {
 	}
 
 	[Test]
-	[Description("Deferred positive coverage for sync-pages save-and-verify when the E2E environment has a known editable page.")]
+	[Description("Reads the seeded Freedom UI page ClioMcp_BlankPageToSave via get-page, sends the unchanged body back through sync-pages with validate=true, and verifies the no-op save succeeds.")]
 	[AllureTag(ToolName)]
 	[AllureName("sync-pages saves and verifies a real page with structured read-back")]
-	[AllureDescription("Placeholder for a future seeded-data E2E that saves and verifies a known editable page through sync-pages.")]
-	public void PageSyncTool_Should_Save_And_Verify_Real_Page_With_NoOp_Body() {
-		Assert.Ignore("TODO: add predefined editable page data to the E2E environment, then restore this positive sync-pages save-and-verify scenario.");
+	[AllureDescription("Uses the real clio MCP server to call get-page for the seeded page ClioMcp_BlankPageToSave in AutoTestClioMcp, then sends the unchanged body back through sync-pages with validate=true, and verifies the save succeeds without validation drift so the seed page's body remains stable across read-write cycles.")]
+	public async Task PageSyncTool_Should_Save_And_Verify_Real_Page_With_NoOp_Body() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive sync-pages save-and-verify test.");
+		}
+		string environmentName = await ResolveReachableEnvironmentAsync(settings);
+		await using ArrangeContext context = await ArrangeAsync();
+
+		// Act 1: get-page reads the seeded page's body to disk
+		CallToolResult getResult = await context.Session.CallToolAsync(
+			PageGetTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = SavePage,
+					["environment-name"] = environmentName
+				}
+			},
+			context.CancellationTokenSource.Token);
+		PageGetResponse getResponse = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(getResult);
+
+		getResult.IsError.Should().NotBeTrue(
+			because: $"get-page should return a structured payload for the seeded page '{SavePage}' before the no-op save can run");
+		getResponse.Success.Should().BeTrue(
+			because: $"get-page must succeed for the seeded page '{SavePage}'. Error: {getResponse.Error}");
+		getResponse.Files.Should().NotBeNull(
+			because: "successful get-page calls must return the materialized file paths");
+		getResponse.Files.BodyFile.Should().NotBeNullOrWhiteSpace(
+			because: "sync-pages needs a body-file path to read the raw body from disk");
+		string body = await File.ReadAllTextAsync(getResponse.Files.BodyFile);
+		body.Should().NotBeNullOrWhiteSpace(
+			because: "the no-op save is only meaningful if get-page returns a non-empty body");
+
+		// Act 2: sync-pages saves the unchanged body back with validation
+		CallToolResult syncResult = await context.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["pages"] = new[] {
+						new Dictionary<string, object?> {
+							["schema-name"] = SavePage,
+							["body"] = body
+						}
+					},
+					["validate"] = true
+				}
+			},
+			context.CancellationTokenSource.Token);
+		PageSyncResponse syncResponse = EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(syncResult);
+
+		// Assert sync-pages save-and-verify succeeded
+		syncResult.IsError.Should().NotBeTrue(
+			because: "the no-op save should produce a structured sync-pages response instead of a transport-level error");
+		syncResponse.Success.Should().BeTrue(
+			because: $"sync-pages must accept and persist the body get-page produced for '{SavePage}'. Per-page error: {syncResponse.Pages.FirstOrDefault()?.Error}");
+		syncResponse.Pages.Should().ContainSingle(
+			because: "one page was submitted for sync");
+		syncResponse.Pages[0].Success.Should().BeTrue(
+			because: $"per-page sync-pages result must succeed for '{SavePage}'. Error: {syncResponse.Pages[0].Error}");
+		syncResponse.Pages[0].Error.Should().BeNullOrWhiteSpace(
+			because: "a successful no-op save should not include an error payload");
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {

--- a/clio.mcp.e2e/SchemaCreateToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaCreateToolE2ETests.cs
@@ -19,6 +19,7 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class SchemaCreateToolE2ETests {
 	private const string ToolName = SchemaCreateTool.ToolName;
+	private const string PackageName = "Custom";
 
 	[Test]
 	[Description("Advertises create-schema in the MCP tool manifest.")]
@@ -96,7 +97,6 @@ public sealed class SchemaCreateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(5));
-		string packageName = await ResolveWritablePackageAsync(settings, environmentName, arrangeContext.CancellationTokenSource.Token);
 		string schemaName = $"UsrE2EHelper{Guid.NewGuid():N}".Substring(0, 35);
 
 		CallToolResult createResult = await arrangeContext.Session.CallToolAsync(
@@ -104,7 +104,7 @@ public sealed class SchemaCreateToolE2ETests {
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["caption"] = "E2E test helper",
 					["environment-name"] = environmentName
 				}
@@ -115,10 +115,10 @@ public sealed class SchemaCreateToolE2ETests {
 
 		createResult.IsError.Should().NotBeTrue();
 		createResponse.Success.Should().BeTrue(
-			because: $"create-schema must succeed for a fresh schema name '{schemaName}' in package '{packageName}'. Error: {createResponse.Error}");
+			because: $"create-schema must succeed for a fresh schema name '{schemaName}' in the editable '{PackageName}' package. Error: {createResponse.Error}");
 		createResponse.SchemaName.Should().Be(schemaName);
 		createResponse.SchemaUId.Should().NotBeNullOrWhiteSpace();
-		createResponse.PackageName.Should().Be(packageName);
+		createResponse.PackageName.Should().Be(PackageName);
 		createResponse.Caption.Should().Be("E2E test helper");
 	}
 
@@ -131,7 +131,6 @@ public sealed class SchemaCreateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(5));
-		string packageName = await ResolveWritablePackageAsync(settings, environmentName, arrangeContext.CancellationTokenSource.Token);
 		string schemaName = $"UsrE2EDupHelper{Guid.NewGuid():N}".Substring(0, 35);
 
 		CallToolResult first = await arrangeContext.Session.CallToolAsync(
@@ -139,7 +138,7 @@ public sealed class SchemaCreateToolE2ETests {
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["environment-name"] = environmentName
 				}
 			},
@@ -152,7 +151,7 @@ public sealed class SchemaCreateToolE2ETests {
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
 					["schema-name"] = schemaName,
-					["package-name"] = packageName,
+					["package-name"] = PackageName,
 					["environment-name"] = environmentName
 				}
 			},
@@ -201,24 +200,6 @@ public sealed class SchemaCreateToolE2ETests {
 		} catch (OperationCanceledException) {
 			return false;
 		}
-	}
-
-	private static async Task<string> ResolveWritablePackageAsync(
-		McpE2ESettings settings, string environmentName, CancellationToken cancellationToken) {
-		string? configured = settings.Sandbox.PackageName;
-		if (!string.IsNullOrWhiteSpace(configured)) {
-			return configured;
-		}
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["get-pkg-list", "-e", environmentName],
-			cancellationToken: cancellationToken);
-		if (result.ExitCode == 0 && result.StandardOutput.Contains("Custom")) {
-			return "Custom";
-		}
-		Assert.Ignore(
-			$"create-schema MCP E2E requires a writable package. Configure McpE2E:Sandbox:PackageName or ensure a 'Custom' package exists in environment '{environmentName}'.");
-		return string.Empty;
 	}
 
 	private sealed record ArrangeContext(

--- a/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
+++ b/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
@@ -19,15 +19,7 @@ internal sealed class SandboxSettings {
 
 	public string? ApplicationPackagePath { get; set; }
 
-	public string? ApplicationTemplateCode { get; set; }
-
-	public string? ApplicationIconId { get; set; }
-
-	public string? ApplicationIconBackground { get; set; }
-
 	public string? PackageName { get; set; }
-
-	public string? ApplicationCode { get; set; }
 
 	public string SeedKeyPrefix { get; set; } = "clio-mcp-e2e";
 }

--- a/clio.mcp.e2e/Support/Mcp/SeededApplicationResolver.cs
+++ b/clio.mcp.e2e/Support/Mcp/SeededApplicationResolver.cs
@@ -5,9 +5,9 @@ using ModelContextProtocol.Protocol;
 namespace Clio.Mcp.E2E.Support.Mcp;
 
 /// <summary>
-/// Resolves the seeded installed application configured through <c>McpE2E:Sandbox:ApplicationCode</c>
-/// against a list-apps response. Fires <see cref="Assert.Ignore(string)"/> with a clear setup message
-/// when the configured code is missing or the seeded application is absent from the target environment.
+/// Resolves a seeded installed application by code against a list-apps response.
+/// Fires <see cref="Assert.Ignore(string)"/> when the seeded application is absent
+/// from the target environment.
 /// </summary>
 internal static class SeededApplicationResolver {
 	/// <summary>
@@ -16,24 +16,19 @@ internal static class SeededApplicationResolver {
 	/// </summary>
 	public static ApplicationListItemEnvelope GetOrIgnore(
 		ApplicationListResponseEnvelope listResponse,
-		string? configuredApplicationCode,
+		string applicationCode,
 		string environmentName) {
-		if (string.IsNullOrWhiteSpace(configuredApplicationCode)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:ApplicationCode to point at the seeded installed application before running this test.");
-			return null!;
-		}
-
 		ApplicationListItemEnvelope? installedApplication = listResponse.Applications?
 			.FirstOrDefault(application => string.Equals(
 				application.Code,
-				configuredApplicationCode,
+				applicationCode,
 				StringComparison.OrdinalIgnoreCase));
 		if (installedApplication is not null) {
 			return installedApplication;
 		}
 
 		Assert.Ignore(
-			$"Seeded application with code '{configuredApplicationCode}' was not found on environment '{environmentName}'. Install the seed application or update McpE2E:Sandbox:ApplicationCode.");
+			$"Seeded application with code '{applicationCode}' was not found on environment '{environmentName}'. Install the seed package before running E2E tests.");
 		return null!;
 	}
 
@@ -46,7 +41,7 @@ internal static class SeededApplicationResolver {
 		McpServerSession session,
 		CancellationToken cancellationToken,
 		string environmentName,
-		string? configuredApplicationCode) {
+		string applicationCode) {
 		CallToolResult callResult = await session.CallToolAsync(
 			ApplicationGetListTool.ApplicationGetListToolName,
 			new Dictionary<string, object?> {
@@ -56,6 +51,6 @@ internal static class SeededApplicationResolver {
 			},
 			cancellationToken);
 		ApplicationListResponseEnvelope response = ApplicationResultParser.ExtractList(callResult);
-		return GetOrIgnore(response, configuredApplicationCode, environmentName);
+		return GetOrIgnore(response, applicationCode, environmentName);
 	}
 }

--- a/clio.mcp.e2e/appsettings.example.json
+++ b/clio.mcp.e2e/appsettings.example.json
@@ -6,9 +6,6 @@
       "EnvironmentName": "sandbox-env-name",
       "ProcessCode": "sandbox-process-code",
       "ApplicationPackagePath": "C:\\Packages\\application-package.gz",
-      "ApplicationTemplateCode": "AppFreedomUI",
-      "ApplicationIconId": "auto",
-      "ApplicationIconBackground": "#0058EF",
       "SeedKeyPrefix": "clio-mcp-e2e"
     }
   }


### PR DESCRIPTION
## Summary

- Move MCP E2E seeded test data from `appsettings(.example).json` (`Sandbox.*`) into per-fixture `const` strings.
- Use the `AutoTestClioMcp` seed package data for the affected fixtures.
- Removed `Sandbox` properties from `SandboxSettings` and `appsettings.example.json`:
  - `ApplicationCode`
  - `ApplicationTemplateCode`
  - `ApplicationIconId`
  - `ApplicationIconBackground`

## Test summary (8 fixtures touched by this commit)

| Fixture | Result |
|---|---|
| `ApplicationSectionMaintenanceToolE2ETests` | 3/3 pass |
| `ApplicationSectionToolE2ETests` | 1/2 pass — 1 failure unrelated (see below) |
| `ApplicationSectionUpdateToolE2ETests` | 1/1 pass |
| `ApplicationToolE2ETests` | 9/9 pass |
| `PageCreateToolE2ETests` | 2/2 pass |
| `PageGetToolE2ETests` | 4/5 pass — 1 failure unrelated (see below) |
| `PageSyncToolE2ETests` | 2/2 pass |
| `SchemaCreateToolE2ETests` | 2/2 pass |

**Overall for tests touched in this commit: 24 pass, 2 fail.** Both failures are unrelated to this change:
- `ApplicationSectionCreate_WithPlatformEntity_Should_Return_Structured_Readback_Data` — pre-existing `InsertQuery failed` (platform-entity section path); reproduces locally too.
- `PageListTool_Should_Reject_Legacy_AppCode_Alias` — error-message wording drift between the MCP tool and the test's expected string.

## Test plan

- [ ] CI E2E run is green for the fixtures listed above (modulo the two pre-existing unrelated failures)
- [ ] No regressions in unrelated fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)