### PR TITLE
feat(mcp): add new-ui-project tool for scaffolding Freedom UI Angular projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,8 +35,8 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.5" />
     <PackageVersion Include="ErrorOr" Version="2.1.1" />
-    <PackageVersion Include="Npgsql" Version="10.0.2" />
-    <PackageVersion Include="NRedisStack" Version="1.4.0" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
+    <PackageVersion Include="NRedisStack" Version="1.5.0" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="ConsoleTables" Version="2.7.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />

--- a/clio.tests/Command/McpServer/CreateUiProjectToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateUiProjectToolTests.cs
@@ -1,0 +1,236 @@
+using System.IO;
+using System.Linq;
+using Clio.Command;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using Clio.Package;
+using FluentAssertions;
+using FluentValidation;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Property("Module", "McpServer")]
+public class CreateUiProjectToolTests {
+
+	private string _workspaceDirectory;
+
+	[SetUp]
+	public void SetUp() {
+		_workspaceDirectory = Path.Combine(Path.GetTempPath(), "clio-ui-tool-tests-" + Path.GetRandomFileName());
+		Directory.CreateDirectory(Path.Combine(_workspaceDirectory, ".clio"));
+		File.WriteAllText(Path.Combine(_workspaceDirectory, ".clio", "workspaceSettings.json"), "{}");
+	}
+
+	[TearDown]
+	public void TearDown() {
+		if (!string.IsNullOrEmpty(_workspaceDirectory) && Directory.Exists(_workspaceDirectory)) {
+			Directory.Delete(_workspaceDirectory, recursive: true);
+		}
+	}
+
+	[Test]
+	[Description("Maps the new-ui-project MCP arguments into create-ui-project command options and resolves the command without startup-time environment registration.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Map_All_Arguments() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		FakeCreateUiProjectCommand command = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<CreateUiProjectOptions>())
+			.Returns(command);
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = tool.CreateUiProject(
+			new CreateUiProjectArgs(
+				WorkspaceDirectory: _workspaceDirectory,
+				ProjectName: "my_module",
+				PackageName: "UsrCustomPkg",
+				VendorPrefix: "usr",
+				Empty: true,
+				CreatioVersion: "8.1.2"));
+
+		// Assert
+		result.ExitCode.Should().Be(0, because: "the MCP tool should forward a valid new-ui-project payload");
+		commandResolver.Received(1).ResolveWithoutEnvironment<CreateUiProjectCommand>(
+			Arg.Is<EnvironmentOptions>(options =>
+				options.GetType() == typeof(CreateUiProjectOptions)
+				&& ((CreateUiProjectOptions)options).ProjectName == "my_module"
+				&& ((CreateUiProjectOptions)options).PackageName == "UsrCustomPkg"
+				&& ((CreateUiProjectOptions)options).VendorPrefix == "usr"
+				&& ((CreateUiProjectOptions)options).IsEmpty
+				&& ((CreateUiProjectOptions)options).CreatioVersion == "8.1.2"
+				&& ((CreateUiProjectOptions)options).IsSilent));
+		command.CapturedOptions.Should().NotBeNull(because: "the resolved command should receive the mapped options");
+		command.CapturedOptions!.ProjectName.Should().Be("my_module");
+		command.CapturedOptions.PackageName.Should().Be("UsrCustomPkg");
+		command.CapturedOptions.VendorPrefix.Should().Be("usr");
+		command.CapturedOptions.IsEmpty.Should().BeTrue();
+		command.CapturedOptions.CreatioVersion.Should().Be("8.1.2");
+		command.CapturedOptions.IsSilent.Should().BeTrue(
+			because: "the MCP tool must bypass the interactive 'download package?' prompt");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
+	[Description("Defaults optional new-ui-project MCP arguments so callers only need to supply the required identity fields.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Default_Optional_Arguments() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		FakeCreateUiProjectCommand command = new();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<CreateUiProjectOptions>())
+			.Returns(command);
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = tool.CreateUiProject(
+			new CreateUiProjectArgs(
+				WorkspaceDirectory: _workspaceDirectory,
+				ProjectName: "my_module",
+				PackageName: "UsrCustomPkg",
+				VendorPrefix: "usr"));
+
+		// Assert
+		result.ExitCode.Should().Be(0);
+		command.CapturedOptions.Should().NotBeNull();
+		command.CapturedOptions!.IsEmpty.Should().BeFalse();
+		command.CapturedOptions.CreatioVersion.Should().BeEmpty();
+		command.CapturedOptions.IsSilent.Should().BeTrue();
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
+	[Description("Pins the process working directory to the requested workspace while the command runs, then restores it.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Switch_Working_Directory_For_The_Command() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		string previousCwd = Directory.GetCurrentDirectory();
+		string observedCwd = null;
+		FakeCreateUiProjectCommand command = new(options => observedCwd = Directory.GetCurrentDirectory());
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<CreateUiProjectOptions>())
+			.Returns(command);
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		try {
+			// Act
+			tool.CreateUiProject(
+				new CreateUiProjectArgs(
+					WorkspaceDirectory: _workspaceDirectory,
+					ProjectName: "my_module",
+					PackageName: "UsrCustomPkg",
+					VendorPrefix: "usr"));
+
+			// Assert
+			Path.GetFullPath(observedCwd!).Should().Be(Path.GetFullPath(_workspaceDirectory),
+				because: "the tool must pin cwd to the supplied workspace so packages/projects are scaffolded under it");
+			Directory.GetCurrentDirectory().Should().Be(previousCwd,
+				because: "the tool must restore the previous working directory after the command completes");
+		} finally {
+			Directory.SetCurrentDirectory(previousCwd);
+			ConsoleLogger.Instance.ClearMessages();
+		}
+	}
+
+	[Test]
+	[Description("Rejects new-ui-project calls when the workspace directory is missing.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Reject_Missing_Workspace_Directory() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = tool.CreateUiProject(
+			new CreateUiProjectArgs(
+				WorkspaceDirectory: "",
+				ProjectName: "my_module",
+				PackageName: "UsrCustomPkg",
+				VendorPrefix: "usr"));
+
+		// Assert
+		result.ExitCode.Should().Be(1);
+		result.Output.Should().ContainSingle()
+			.Which.Value.ToString().Should().Contain("workspaceDirectory is required");
+		commandResolver.DidNotReceive().ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<EnvironmentOptions>());
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
+	[Description("Rejects new-ui-project calls when the workspace directory exists but is not a clio workspace.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Reject_Non_Workspace_Directory() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		string nonWorkspace = Path.Combine(Path.GetTempPath(), "clio-ui-tool-not-a-ws-" + Path.GetRandomFileName());
+		Directory.CreateDirectory(nonWorkspace);
+		try {
+			IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+			CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+			// Act
+			CommandExecutionResult result = tool.CreateUiProject(
+				new CreateUiProjectArgs(
+					WorkspaceDirectory: nonWorkspace,
+					ProjectName: "my_module",
+					PackageName: "UsrCustomPkg",
+					VendorPrefix: "usr"));
+
+			// Assert
+			result.ExitCode.Should().Be(1);
+			result.Output.Should().ContainSingle()
+				.Which.Value.ToString().Should().Contain("not a clio workspace");
+			commandResolver.DidNotReceive().ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<EnvironmentOptions>());
+		} finally {
+			Directory.Delete(nonWorkspace, recursive: true);
+			ConsoleLogger.Instance.ClearMessages();
+		}
+	}
+
+	[Test]
+	[Description("Exposes the supported new-ui-project arguments and requires the structured args payload.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Expose_Required_Args_Payload() {
+		// Arrange
+		System.Reflection.ParameterInfo argsParameter = typeof(CreateUiProjectTool)
+			.GetMethod(nameof(CreateUiProjectTool.CreateUiProject))!
+			.GetParameters()
+			.Single(parameter => parameter.Name == "args");
+
+		// Act
+		object[] requiredAttributes = argsParameter.GetCustomAttributes(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute), inherit: false);
+
+		// Assert
+		requiredAttributes.Should().ContainSingle(
+			because: "the new-ui-project MCP tool should require its structured args payload");
+		typeof(CreateUiProjectArgs).GetProperties().Select(property => property.Name).Should().BeEquivalentTo(
+			["WorkspaceDirectory", "ProjectName", "PackageName", "VendorPrefix", "Empty", "CreatioVersion"],
+			because: "the new-ui-project MCP payload should only expose the supported UI project arguments");
+	}
+
+	private sealed class FakeCreateUiProjectCommand : CreateUiProjectCommand {
+		private readonly System.Action<CreateUiProjectOptions> _onExecute;
+		public CreateUiProjectOptions CapturedOptions { get; private set; }
+
+		public FakeCreateUiProjectCommand(System.Action<CreateUiProjectOptions> onExecute = null)
+			: base(
+				Substitute.For<IUiProjectCreator>(),
+				Substitute.For<IValidator<CreateUiProjectOptions>>(),
+				ConsoleLogger.Instance) {
+			_onExecute = onExecute;
+		}
+
+		public override int Execute(CreateUiProjectOptions options) {
+			CapturedOptions = options;
+			_onExecute?.Invoke(options);
+			return 0;
+		}
+	}
+}

--- a/clio.tests/Command/McpServer/CreateUiProjectToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateUiProjectToolTests.cs
@@ -195,6 +195,61 @@ public class CreateUiProjectToolTests {
 	}
 
 	[Test]
+	[Description("Rejects drive-relative or root-relative workspace paths that would otherwise pass IsPathRooted.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Reject_Drive_Relative_Workspace_Directory() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		// Act — "C:ws" is path-rooted but NOT fully qualified; resolves against the
+		// process's current directory on the named drive, not an absolute location.
+		CommandExecutionResult result = tool.CreateUiProject(
+			new CreateUiProjectArgs(
+				WorkspaceDirectory: "C:ws",
+				ProjectName: "my_module",
+				PackageName: "UsrCustomPkg",
+				VendorPrefix: "usr"));
+
+		// Assert
+		result.ExitCode.Should().Be(1);
+		result.Output.Should().ContainSingle()
+			.Which.Value.ToString().Should().Contain("fully-qualified");
+		commandResolver.DidNotReceive().ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<EnvironmentOptions>());
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[TestCase("../escape")]
+	[TestCase("..\\escape")]
+	[TestCase("packages/sub")]
+	[TestCase("packages\\sub")]
+	[TestCase("C:\\absolute")]
+	[Description("Rejects packageName values that contain path separators, parent-directory references, or absolute paths so scaffolding cannot escape the workspace.")]
+	[Category("Unit")]
+	public void CreateUiProject_Should_Reject_PackageName_With_Path_Characters(string packageName) {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		CreateUiProjectTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		// Act
+		CommandExecutionResult result = tool.CreateUiProject(
+			new CreateUiProjectArgs(
+				WorkspaceDirectory: _workspaceDirectory,
+				ProjectName: "my_module",
+				PackageName: packageName,
+				VendorPrefix: "usr"));
+
+		// Assert
+		result.ExitCode.Should().Be(1);
+		result.Output.Should().ContainSingle()
+			.Which.Value.ToString().Should().Contain("packageName");
+		commandResolver.DidNotReceive().ResolveWithoutEnvironment<CreateUiProjectCommand>(Arg.Any<EnvironmentOptions>());
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
+	[Test]
 	[Description("Exposes the supported new-ui-project arguments and requires the structured args payload.")]
 	[Category("Unit")]
 	public void CreateUiProject_Should_Expose_Required_Args_Payload() {

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -293,6 +293,7 @@ public class BindingsModule {
 		services.AddTransient<GuidanceGetTool>();
 		services.AddTransient<ComponentInfoTool>();
 		services.AddTransient<PackageHotfixTool>();
+		services.AddTransient<CreateUiProjectTool>();
 		services.AddTransient<DataForgeTool>();
 		services.AddTransient<SysSettingGetTool>();
 		services.AddTransient<SysSettingsListTool>();

--- a/clio/Command/CreateUiProjectCommand.cs
+++ b/clio/Command/CreateUiProjectCommand.cs
@@ -64,7 +64,7 @@ public class CreateUiProjectOptionsValidator : AbstractValidator<CreateUiProject
 
 #region Class: CreateUiProjectCommand
 
-internal class CreateUiProjectCommand {
+internal class CreateUiProjectCommand : Command<CreateUiProjectOptions> {
 
 	#region Fields: Private
 
@@ -102,7 +102,7 @@ internal class CreateUiProjectCommand {
 
 	#region Methods: Public
 
-	public int Execute(CreateUiProjectOptions options){
+	public override int Execute(CreateUiProjectOptions options){
 		try {
 			ValidationResult result = _optionsValidator.Validate(options);
 			if (!result.IsValid) {

--- a/clio/Command/McpServer/Resources/GuidanceCatalog.cs
+++ b/clio/Command/McpServer/Resources/GuidanceCatalog.cs
@@ -81,7 +81,11 @@ internal static class GuidanceCatalog {
 			["sys-settings"] = Create(
 				"sys-settings",
 				"Canonical MCP guidance for the Creatio sys-settings CRU surface: tool order, supported value-type-names and aliases, Lookup resolution, SecureText masking, Date/Time TZ caveat, and Binary exclusion.",
-				SysSettingsGuidanceResource.Guide)
+				SysSettingsGuidanceResource.Guide),
+			["ui-project"] = Create(
+				"ui-project",
+				"Canonical MCP guidance for scaffolding a Freedom UI Angular remote-module project inside an existing clio workspace via new-ui-project: required arguments, naming constraints, file placement, and the create-workspace prerequisite.",
+				WorkspaceUiProjectGuidanceResource.Guide)
 		};
 
 		foreach (ComposableAppSkillResourceEntry guide in ComposableAppSkillResourceCatalog.GetGuides()) {

--- a/clio/Command/McpServer/Resources/WorkspaceUiProjectGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/WorkspaceUiProjectGuidanceResource.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Resources;
+
+/// <summary>
+/// Canonical AI-facing guidance for scaffolding a Freedom UI Angular remote-module project
+/// inside an existing clio workspace through the <c>new-ui-project</c> MCP tool.
+/// </summary>
+[McpServerResourceType]
+public sealed class WorkspaceUiProjectGuidanceResource {
+	private const string DocsScheme = "docs";
+	private const string ResourcePath = "mcp/guides/ui-project";
+	private const string ResourceUri = DocsScheme + "://" + ResourcePath;
+
+	[McpServerResource(UriTemplate = ResourceUri, Name = "ui-project-guidance")]
+	[Description("Returns canonical MCP guidance for scaffolding a Freedom UI Angular remote-module project inside an existing clio workspace via new-ui-project: required arguments, naming constraints, where files are placed, and the create-workspace prerequisite.")]
+	public ResourceContents GetGuide() => Guide;
+
+	internal static readonly TextResourceContents Guide = new() {
+		Uri = ResourceUri,
+		MimeType = "text/plain",
+		Text = """
+		       clio MCP UI project (Freedom UI remote module) guide
+
+		       Scope
+		       - Use this guide when the user asks to create a new Angular project, Freedom UI remote module, or "ui project" inside a clio workspace.
+		       - This guide covers the `new-ui-project` MCP tool only. It does NOT cover Freedom UI page authoring (`create-page`, `update-page`) or Creatio package creation through `create-app`.
+
+		       What `new-ui-project` does
+		       - Scaffolds an Angular project (Freedom UI remote module template) at `<workspaceDirectory>/projects/<projectName>`.
+		       - Ensures a hosting package exists under `<workspaceDirectory>/packages/<packageName>` and links the project to it through the project's template files (vendor prefix, dist path, project name placeholders are substituted into `.json`, `.js`, `.ts`, `.conf`, `.config`, `.scss`, `.css`).
+		       - Runs in silent mode through the MCP wrapper: the underlying CLI's interactive "download package?" prompt is auto-answered "no". The tool never reaches out to a Creatio environment.
+
+		       Hard prerequisite — the workspace must already exist
+		       - The supplied `workspaceDirectory` MUST be an absolute path to an existing directory that contains `.clio/workspaceSettings.json`. The tool refuses to run otherwise. There is no auto-create fallback.
+		       - If the user names a folder that does not exist or is not yet a clio workspace, FIRST call `create-workspace` to initialize it, THEN call `new-ui-project`.
+
+		       Required arguments (wire-format names are camelCase)
+		       - `workspaceDirectory` — absolute path to the workspace root. Network-share paths are not supported. Relative paths and missing paths are rejected.
+		       - `projectName` — Angular project name. MUST match `^[0-9a-z_]+$` (snake_case: lowercase letters, digits, underscores). Examples: `rss_reader`, `task_board`, `kpi_widget_v2`. PascalCase / camelCase / kebab-case names are rejected by the underlying creator.
+		       - `packageName` — clio package name that will host the project. PascalCase is conventional (`UsrRssReader`, `RssReader`). Created if it does not exist; reused if it does.
+		       - `vendorPrefix` — 1-50 lowercase letters only (`^[a-z]{1,50}$`). Examples: `usr`, `crt`, `acme`. Mixed-case (`Usr`) and digits are rejected by the options validator.
+
+		       Optional arguments
+		       - `empty` (boolean, default `false`) — when `true`, scaffold the `ui-project-Empty` template instead of the default `ui-project` template. Use for a minimal shell when the standard template's sample components are unwanted.
+		       - `creatioVersion` (string, default empty) — pick a template variant matching a specific Creatio version. Omit to use the template provider's current default.
+
+		       Where the files land
+		       - `<workspaceDirectory>/projects/<projectName>/` — Angular project sources (with `<%projectName%>`, `<%vendorPrefix%>`, `<%distPath%>` placeholders already substituted in template-text files).
+		       - `<workspaceDirectory>/packages/<packageName>/` — clio package shell (created if missing).
+		       - Build output (configured in the template's tsconfig/angular.json) points the Angular `dist` folder at `packages/<packageName>/Files/src/js/<projectName>/` so that `push-workspace` later ships the built remote module along with the package.
+
+		       Typical workflow
+		       1. Confirm or pick the workspace directory. If it does not already exist as a clio workspace, call `create-workspace` first.
+		       2. Decide on a snake_case `projectName`, a PascalCase `packageName`, and a lowercase `vendorPrefix`. Translate any user input that does not match these shapes (e.g., user says "RssReader" → `projectName: rss_reader`).
+		       3. Call `new-ui-project` with the resolved values. Treat a non-zero `exit-code` as failure and surface `execution-log-messages[*].value` to the user.
+		       4. (Optional) After the project is scaffolded, normal Angular workflows apply inside `projects/<projectName>` — install dependencies, run `ng build`, etc.; clio does not manage Node tooling.
+
+		       Common mistakes to avoid
+		       - Do NOT call `new-ui-project` against an arbitrary current working directory. The MCP wrapper pins `workspaceDirectory` precisely to avoid scaffolding files in unexpected locations.
+		       - Do NOT pass a `projectName` with uppercase letters, hyphens, or spaces. Always translate the user's chosen name into snake_case before calling the tool.
+		       - Do NOT pass a `vendorPrefix` containing uppercase letters or digits. Lowercase only.
+		       - Do NOT confuse this tool with `create-app` — `new-ui-project` is purely local file-system scaffolding inside a workspace. It does not install anything into a Creatio environment and does not need an `environment-name` argument.
+		       - Do NOT call this tool to add Freedom UI pages or sections to an existing app — use `create-page`, `create-app-section`, or `update-page` for those workflows.
+		       """
+	};
+}

--- a/clio/Command/McpServer/Tools/BaseTool.cs
+++ b/clio/Command/McpServer/Tools/BaseTool.cs
@@ -77,6 +77,9 @@ public abstract class BaseTool<T>(
 										   && string.IsNullOrWhiteSpace(envOptions.Environment)
 										   && string.IsNullOrWhiteSpace(envOptions.Uri)
 										   => commandResolver.ResolveWithoutEnvironment<TCommand>(envOptions),
+									   CreateUiProjectOptions envOptions when string.IsNullOrWhiteSpace(envOptions.Environment)
+										   && string.IsNullOrWhiteSpace(envOptions.Uri)
+										   => commandResolver.ResolveWithoutEnvironment<TCommand>(envOptions),
 
 									   EnvironmentOptions envOptions => commandResolver.Resolve<TCommand>(envOptions),
 									   var _ => throw new InvalidOperationException(

--- a/clio/Command/McpServer/Tools/CreateUiProjectTool.cs
+++ b/clio/Command/McpServer/Tools/CreateUiProjectTool.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Text.Json.Serialization;
+using Clio.Common;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Tools;
+
+/// <summary>
+/// MCP tool surface for the <c>new-ui-project</c> command.
+/// </summary>
+public class CreateUiProjectTool(
+	ILogger logger,
+	IToolCommandResolver commandResolver)
+	: BaseTool<CreateUiProjectOptions>(null, logger, commandResolver) {
+
+	internal const string CreateUiProjectToolName = "new-ui-project";
+	private const string WorkspaceMarkerRelativePath = ".clio/workspaceSettings.json";
+
+	/// <summary>
+	/// Creates a new Angular (Freedom UI remote module) project inside the supplied clio workspace.
+	/// </summary>
+	[McpServerTool(Name = CreateUiProjectToolName, ReadOnly = false, Destructive = false, Idempotent = false,
+		OpenWorld = false)]
+	[Description("""
+				 Creates a new Angular (Freedom UI remote module) project inside an existing clio workspace.
+
+				 The caller MUST supply an absolute path to the workspace directory (a directory previously
+				 created by the create-workspace tool, containing .clio/workspaceSettings.json). The project
+				 is placed under <workspaceDirectory>/projects/<projectName> and a package is created/linked
+				 under <workspaceDirectory>/packages/<packageName>.
+
+				 Example: workspaceDirectory: C:\Projects\Workspaces\son, projectName: my_remote_module,
+				 packageName: UsrCustomPkg, vendorPrefix: usr
+				 """)]
+	public CommandExecutionResult CreateUiProject(
+		[Description("UI project creation parameters")] [Required] CreateUiProjectArgs args
+	) {
+		if (args is null) {
+			return new CommandExecutionResult(1, [new ErrorMessage("UI project creation parameters are required.")], null);
+		}
+		if (string.IsNullOrWhiteSpace(args.WorkspaceDirectory)) {
+			return new CommandExecutionResult(1,
+				[new ErrorMessage("workspaceDirectory is required and must be an absolute path to an existing clio workspace.")], null);
+		}
+		if (!Path.IsPathRooted(args.WorkspaceDirectory)) {
+			return new CommandExecutionResult(1,
+				[new ErrorMessage($"workspaceDirectory must be an absolute path. Received: '{args.WorkspaceDirectory}'.")], null);
+		}
+		if (!Directory.Exists(args.WorkspaceDirectory)) {
+			return new CommandExecutionResult(1,
+				[new ErrorMessage($"workspaceDirectory does not exist: '{args.WorkspaceDirectory}'.")], null);
+		}
+		string workspaceMarker = Path.Combine(args.WorkspaceDirectory, WorkspaceMarkerRelativePath);
+		if (!File.Exists(workspaceMarker)) {
+			return new CommandExecutionResult(1,
+				[new ErrorMessage(
+					$"workspaceDirectory is not a clio workspace (missing '{WorkspaceMarkerRelativePath}'): '{args.WorkspaceDirectory}'. "
+					+ "Create it first with the create-workspace tool.")], null);
+		}
+
+		CreateUiProjectOptions options = new() {
+			ProjectName = args.ProjectName,
+			PackageName = args.PackageName,
+			VendorPrefix = args.VendorPrefix,
+			IsEmpty = args.Empty,
+			CreatioVersion = args.CreatioVersion ?? string.Empty,
+			IsSilent = true
+		};
+
+		// Pin the process working directory to the supplied workspace for the duration of the
+		// command. IWorkingDirectoriesProvider / IWorkspacePathBuilder both read Environment.CurrentDirectory
+		// at resolution time, so without this any agent invoking the tool from an arbitrary cwd would
+		// scaffold packages/projects under the wrong (or non-workspace) folder.
+		// The execution lock is reentrant on the same thread, so InternalExecute re-acquiring it is safe.
+		lock (CommandExecutionSyncRoot) {
+			string previousDirectory = Directory.GetCurrentDirectory();
+			try {
+				Directory.SetCurrentDirectory(args.WorkspaceDirectory);
+				return InternalExecute<CreateUiProjectCommand>(options);
+			} finally {
+				Directory.SetCurrentDirectory(previousDirectory);
+			}
+		}
+	}
+}
+
+/// <summary>
+/// MCP arguments for the <c>new-ui-project</c> tool.
+/// </summary>
+public sealed record CreateUiProjectArgs(
+	[property: JsonPropertyName("workspaceDirectory")]
+	[property: Description("Absolute path to the existing clio workspace directory (must contain .clio/workspaceSettings.json)")]
+	[property: Required]
+	string WorkspaceDirectory,
+
+	[property: JsonPropertyName("projectName")]
+	[property: Description("Angular project name (snake_case: lowercase letters, digits, underscores)")]
+	[property: Required]
+	string ProjectName,
+
+	[property: JsonPropertyName("packageName")]
+	[property: Description("Clio package name to host the project")]
+	[property: Required]
+	string PackageName,
+
+	[property: JsonPropertyName("vendorPrefix")]
+	[property: Description("Vendor prefix: 1-50 lowercase letters only")]
+	[property: Required]
+	string VendorPrefix,
+
+	[property: JsonPropertyName("empty")]
+	[property: Description("When true, scaffold from the empty UI template instead of the default template")]
+	bool Empty = false,
+
+	[property: JsonPropertyName("creatioVersion")]
+	[property: Description("Optional Creatio version to pick a matching UI project template")]
+	string CreatioVersion = null
+);

--- a/clio/Command/McpServer/Tools/CreateUiProjectTool.cs
+++ b/clio/Command/McpServer/Tools/CreateUiProjectTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Clio.Common;
 using ModelContextProtocol.Server;
 
@@ -17,6 +18,7 @@ public class CreateUiProjectTool(
 
 	internal const string CreateUiProjectToolName = "new-ui-project";
 	private const string WorkspaceMarkerRelativePath = ".clio/workspaceSettings.json";
+	private static readonly Regex PackageNamePattern = new("^[A-Za-z0-9_]+$", RegexOptions.Compiled);
 
 	/// <summary>
 	/// Creates a new Angular (Freedom UI remote module) project inside the supplied clio workspace.
@@ -44,9 +46,10 @@ public class CreateUiProjectTool(
 			return new CommandExecutionResult(1,
 				[new ErrorMessage("workspaceDirectory is required and must be an absolute path to an existing clio workspace.")], null);
 		}
-		if (!Path.IsPathRooted(args.WorkspaceDirectory)) {
+		if (!Path.IsPathFullyQualified(args.WorkspaceDirectory)) {
 			return new CommandExecutionResult(1,
-				[new ErrorMessage($"workspaceDirectory must be an absolute path. Received: '{args.WorkspaceDirectory}'.")], null);
+				[new ErrorMessage(
+					$"workspaceDirectory must be a fully-qualified absolute path. Drive-relative ('C:ws') and root-relative ('\\ws') paths are rejected. Received: '{args.WorkspaceDirectory}'.")], null);
 		}
 		if (!Directory.Exists(args.WorkspaceDirectory)) {
 			return new CommandExecutionResult(1,
@@ -58,6 +61,11 @@ public class CreateUiProjectTool(
 				[new ErrorMessage(
 					$"workspaceDirectory is not a clio workspace (missing '{WorkspaceMarkerRelativePath}'): '{args.WorkspaceDirectory}'. "
 					+ "Create it first with the create-workspace tool.")], null);
+		}
+		if (string.IsNullOrWhiteSpace(args.PackageName) || !PackageNamePattern.IsMatch(args.PackageName)) {
+			return new CommandExecutionResult(1,
+				[new ErrorMessage(
+					$"packageName must be a simple identifier matching '^[A-Za-z0-9_]+$'. Path separators, '..', and absolute paths are rejected to keep scaffolding inside the workspace. Received: '{args.PackageName}'.")], null);
 		}
 
 		CreateUiProjectOptions options = new() {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -342,6 +342,7 @@ internal static class ToolContractCatalog {
 			[CreatePageBusinessRuleTool.BusinessRuleCreateToolName] = BuildPageBusinessRuleCreate(),
 			[SchemaNamePrefixTool.GetSchemaNamePrefixToolName] = BuildGetSchemaNamePrefix(),
 			[CompileCreatioTool.CompileCreatioToolName] = BuildCompileCreatio(),
+			[CreateUiProjectTool.CreateUiProjectToolName] = BuildNewUiProject(),
 			[SysSettingGetTool.GetSysSettingToolName] = BuildGetSysSetting(),
 			[SysSettingsListTool.ListSysSettingsToolName] = BuildListSysSettings(),
 			[SysSettingCreateTool.CreateSysSettingToolName] = BuildCreateSysSetting(),
@@ -390,6 +391,7 @@ internal static class ToolContractCatalog {
 		ApplicationDeleteTool.ToolName,
 		SchemaNamePrefixTool.GetSchemaNamePrefixToolName,
 		CompileCreatioTool.CompileCreatioToolName,
+		CreateUiProjectTool.CreateUiProjectToolName,
 		SysSettingGetTool.GetSysSettingToolName,
 		SysSettingsListTool.ListSysSettingsToolName,
 		SysSettingCreateTool.CreateSysSettingToolName,
@@ -3347,6 +3349,107 @@ internal static class ToolContractCatalog {
 				"C# schemas were added or modified in the targeted package.",
 				"The runtime reported a missing-in-runtime or schema-not-found error that maps to a compilation gap.",
 				"Caller must NOT call this tool after `create-app`, `update-page`, `sync-pages`, `update-entity-schema`, `create-page`, `create-entity-business-rule`, or `create-page-business-rule`."
+			]);
+	}
+
+	private const string WorkspaceDirectoryFieldName = "workspaceDirectory";
+	private const string ProjectNameFieldName = "projectName";
+	private const string VendorPrefixFieldName = "vendorPrefix";
+	private const string EmptyFieldName = "empty";
+	private const string CreatioVersionFieldName = "creatioVersion";
+
+	private static ToolContractDefinition BuildNewUiProject() {
+		return new ToolContractDefinition(
+			CreateUiProjectTool.CreateUiProjectToolName,
+			"Scaffolds a Freedom UI Angular remote-module project inside an existing clio workspace. Pure local file-system scaffolding under <workspaceDirectory>/projects/<projectName> and <workspaceDirectory>/packages/<packageName>; no Creatio environment is contacted. The MCP wrapper pins the process working directory to workspaceDirectory and runs the underlying CLI in silent mode, so the interactive 'download package?' prompt is auto-answered 'no'.",
+			new ToolInputSchemaContract(
+				[WorkspaceDirectoryFieldName, ProjectNameFieldName, "packageName", VendorPrefixFieldName],
+				[
+					Field(WorkspaceDirectoryFieldName, StringType,
+						"Absolute path to an existing clio workspace directory. MUST contain '.clio/workspaceSettings.json'. Relative paths, network-share paths, and non-workspace directories are rejected. Call 'create-workspace' first when the target directory is not yet a workspace."),
+					Field(ProjectNameFieldName, StringType,
+						"Angular project name in snake_case. MUST match '^[0-9a-z_]+$' (lowercase letters, digits, underscores). Examples: 'rss_reader', 'task_board'. Translate any PascalCase/camelCase/kebab-case user input into snake_case before sending."),
+					Field("packageName", StringType,
+						"Clio package name that will host the project. Conventionally PascalCase (e.g., 'UsrRssReader', 'RssReader'). Created if missing; reused if it already exists."),
+					Field(VendorPrefixFieldName, StringType,
+						"Vendor prefix; 1-50 lowercase letters only ('^[a-z]{1,50}$'). Examples: 'usr', 'crt', 'acme'. Uppercase and digits are rejected by the options validator."),
+					Field(EmptyFieldName, BooleanType,
+						"When true, scaffold the 'ui-project-Empty' minimal template instead of the default 'ui-project' template. Default false."),
+					Field(CreatioVersionFieldName, StringType,
+						"Optional Creatio version to pick a matching UI project template. Omit to use the template provider's current default.")
+				],
+				Validators: [
+					new ToolContractValidator(
+						"absolute-path",
+						"invalid-workspace-directory",
+						Field: WorkspaceDirectoryFieldName,
+						Context: "workspaceDirectory must be absolute (rooted) and must point at an existing directory containing '.clio/workspaceSettings.json'.",
+						Required: true),
+					new ToolContractValidator(
+						"regex",
+						"invalid-project-name",
+						Field: ProjectNameFieldName,
+						Context: "projectName must match ^[0-9a-z_]+$ (snake_case). Uppercase, hyphens, dots and spaces are rejected.",
+						Required: true),
+					new ToolContractValidator(
+						"regex",
+						"invalid-vendor-prefix",
+						Field: VendorPrefixFieldName,
+						Context: "vendorPrefix must match ^[a-z]{1,50}$ (lowercase letters only, 1-50 chars).",
+						Required: true)
+				]),
+			CommandExecutionOutput(),
+			CommonErrorContract,
+			[],
+			[
+				Default(EmptyFieldName, BooleanFalseLiteral,
+					"Use the default Freedom UI remote-module template unless the caller asks for the minimal shell.")
+			],
+			[
+				Example("Scaffold a default RSS reader remote module", new Dictionary<string, object?> {
+					[WorkspaceDirectoryFieldName] = @"C:\Projects\Workspaces\newModule",
+					[ProjectNameFieldName] = "rss_reader",
+					["packageName"] = "RssReader",
+					[VendorPrefixFieldName] = "usr"
+				}),
+				Example("Scaffold an empty-template project for a specific Creatio version", new Dictionary<string, object?> {
+					[WorkspaceDirectoryFieldName] = @"C:\Projects\Workspaces\son",
+					[ProjectNameFieldName] = "kpi_widget",
+					["packageName"] = "UsrKpiWidgets",
+					[VendorPrefixFieldName] = "usr",
+					[EmptyFieldName] = true,
+					[CreatioVersionFieldName] = "8.1.2"
+				})
+			],
+			Flow(
+				[
+					CreateWorkspaceTool.CreateWorkspaceToolName,
+					CreateUiProjectTool.CreateUiProjectToolName
+				],
+				"Ensure the target directory is a clio workspace first (skip when '.clio/workspaceSettings.json' already exists), then scaffold the Angular project. No compile-creatio or restart follow-up is required — Angular tooling is invoked by the user outside clio."),
+			[
+				Flow(
+					[
+						CreateUiProjectTool.CreateUiProjectToolName
+					],
+					"Use this single-step flow when the workspace already exists and only the UI project needs scaffolding.")
+			],
+			[],
+			AntiPatterns: [
+				new ToolAntiPattern(
+					$"{CreateUiProjectTool.CreateUiProjectToolName} → {CompileCreatioTool.CompileCreatioToolName}",
+					"new-ui-project is local file-system scaffolding only. No Creatio assemblies change and no environment is contacted, so a compile-creatio follow-up serves no purpose."),
+				new ToolAntiPattern(
+					$"{ApplicationCreateTool.ApplicationCreateToolName} → {CreateUiProjectTool.CreateUiProjectToolName}",
+					"create-app installs an application into a Creatio environment; new-ui-project scaffolds an Angular remote module on the local file system. They address different artifacts and should not be chained as if one followed from the other."),
+				new ToolAntiPattern(
+					$"PascalCase or hyphenated {ProjectNameFieldName}",
+					"The underlying creator enforces snake_case via '^[0-9a-z_]+$'. Translate user-supplied names like 'RssReader' or 'rss-reader' into 'rss_reader' before calling the tool; do not pass the raw display name through.")
+			],
+			Preconditions: [
+				$"`{WorkspaceDirectoryFieldName}` is an absolute path to an existing directory containing `.clio/workspaceSettings.json` (call `create-workspace` first when it is not).",
+				$"`{ProjectNameFieldName}` is snake_case matching `^[0-9a-z_]+$`.",
+				$"`{VendorPrefixFieldName}` is lowercase-only matching `^[a-z]{{1,50}}$`."
 			]);
 	}
 

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -3370,7 +3370,7 @@ internal static class ToolContractCatalog {
 					Field(ProjectNameFieldName, StringType,
 						"Angular project name in snake_case. MUST match '^[0-9a-z_]+$' (lowercase letters, digits, underscores). Examples: 'rss_reader', 'task_board'. Translate any PascalCase/camelCase/kebab-case user input into snake_case before sending."),
 					Field("packageName", StringType,
-						"Clio package name that will host the project. Conventionally PascalCase (e.g., 'UsrRssReader', 'RssReader'). Created if missing; reused if it already exists."),
+						"Clio package name that will host the project. MUST be a simple identifier matching '^[A-Za-z0-9_]+$' — path separators, '..', and absolute paths are rejected so scaffolding cannot escape the workspace. Conventionally PascalCase (e.g., 'UsrRssReader', 'RssReader'). Created if missing; reused if it already exists."),
 					Field(VendorPrefixFieldName, StringType,
 						"Vendor prefix; 1-50 lowercase letters only ('^[a-z]{1,50}$'). Examples: 'usr', 'crt', 'acme'. Uppercase and digits are rejected by the options validator."),
 					Field(EmptyFieldName, BooleanType,
@@ -3383,13 +3383,19 @@ internal static class ToolContractCatalog {
 						"absolute-path",
 						"invalid-workspace-directory",
 						Field: WorkspaceDirectoryFieldName,
-						Context: "workspaceDirectory must be absolute (rooted) and must point at an existing directory containing '.clio/workspaceSettings.json'.",
+						Context: "workspaceDirectory must be a fully-qualified absolute path (Path.IsPathFullyQualified). Drive-relative ('C:ws') and root-relative ('\\ws') paths are rejected. It must also point at an existing directory containing '.clio/workspaceSettings.json'.",
 						Required: true),
 					new ToolContractValidator(
 						"regex",
 						"invalid-project-name",
 						Field: ProjectNameFieldName,
 						Context: "projectName must match ^[0-9a-z_]+$ (snake_case). Uppercase, hyphens, dots and spaces are rejected.",
+						Required: true),
+					new ToolContractValidator(
+						"regex",
+						"invalid-package-name",
+						Field: "packageName",
+						Context: "packageName must match ^[A-Za-z0-9_]+$ (simple identifier). Path separators, '..', and absolute paths are rejected so scaffolding stays inside the workspace.",
 						Required: true),
 					new ToolContractValidator(
 						"regex",
@@ -3447,8 +3453,9 @@ internal static class ToolContractCatalog {
 					"The underlying creator enforces snake_case via '^[0-9a-z_]+$'. Translate user-supplied names like 'RssReader' or 'rss-reader' into 'rss_reader' before calling the tool; do not pass the raw display name through.")
 			],
 			Preconditions: [
-				$"`{WorkspaceDirectoryFieldName}` is an absolute path to an existing directory containing `.clio/workspaceSettings.json` (call `create-workspace` first when it is not).",
+				$"`{WorkspaceDirectoryFieldName}` is a fully-qualified absolute path to an existing directory containing `.clio/workspaceSettings.json` (call `create-workspace` first when it is not).",
 				$"`{ProjectNameFieldName}` is snake_case matching `^[0-9a-z_]+$`.",
+				"`packageName` is a simple identifier matching `^[A-Za-z0-9_]+$`.",
 				$"`{VendorPrefixFieldName}` is lowercase-only matching `^[a-z]{{1,50}}$`."
 			]);
 	}


### PR DESCRIPTION
## Summary
- Wraps the existing `new-ui-project` CLI verb as an MCP tool (`mcp__clio-dev__new-ui-project`) so an agent can scaffold a Freedom UI Angular remote-module project inside an existing clio workspace without leaving the conversation.
- The tool **requires an absolute `workspaceDirectory`** that already contains `.clio/workspaceSettings.json`. The MCP wrapper pins the process cwd to that path under the `BaseTool` execution lock (and restores it in `finally`), preventing agents that run from an arbitrary cwd from scaffolding files in unrelated folders. Runs the underlying CLI in silent mode, so the interactive "download package?" prompt is auto-answered "no" and no Creatio environment is contacted.
- Surfaced through `get-tool-contract` (new `BuildNewUiProject()` builder, added to `Contracts` and `CanonicalToolNames`) and through a new `ui-project` guidance article reachable via `get-guidance` and as the `docs://mcp/guides/ui-project` resource.

## Key files
- `clio/Command/McpServer/Tools/CreateUiProjectTool.cs` — new MCP tool. `CreateUiProjectArgs` exposes `workspaceDirectory`, `projectName`, `packageName`, `vendorPrefix` (required) plus `empty` and `creatioVersion` (optional). Validates the workspace marker file up-front and returns a structured error when missing.
- `clio/Command/McpServer/Tools/BaseTool.cs` — adds the `CreateUiProjectOptions` branch in `ResolveCommand` so the command resolves through `ResolveWithoutEnvironment` (same pattern as `CreateWorkspaceCommandOptions`).
- `clio/Command/CreateUiProjectCommand.cs` — now derives from `Command<CreateUiProjectOptions>` and overrides `Execute` so `BaseTool.InternalExecute<TCommand>`'s `where TCommand : Command<T>` constraint is satisfied. CLI behavior is unchanged.
- `clio/BindingsModule.cs` — DI registration for the new tool.
- `clio/Command/McpServer/Tools/ToolContractGetTool.cs` — `BuildNewUiProject()` describing input schema (with `absolute-path` + `regex` validators on `workspaceDirectory`/`projectName`/`vendorPrefix`), `CommandExecutionOutput()` shape, examples, preferred flow `create-workspace → new-ui-project`, fallback single-step flow, anti-patterns (`new-ui-project → compile-creatio`, `create-app → new-ui-project`, PascalCase project names), and preconditions.
- `clio/Command/McpServer/Resources/WorkspaceUiProjectGuidanceResource.cs` + `GuidanceCatalog.cs` — canonical guidance article (`ui-project`) covering scope, prerequisite (`create-workspace` first), naming constraints, file placement under `<workspaceDirectory>/projects` and `<workspaceDirectory>/packages`, typical workflow, and common mistakes.
- `clio.tests/Command/McpServer/CreateUiProjectToolTests.cs` — covers argument mapping, optional defaults, cwd pinning + restore via a fake command, missing-workspace rejection, non-workspace (no marker file) rejection, and the args-payload contract shape.

## Test plan
- [x] `dotnet build clio/clio.csproj -c Debug` — clean on `net8.0` and `net10.0` (only blocked locally when a running clio-dev MCP server holds `net10.0/clio.dll` open).
- [x] `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~CreateUiProjectToolTests"` — 6/6 passing.
- [ ] Reviewer: spot-check that `get-tool-contract` (no args) lists `new-ui-project` in the returned canonical set and that `get-guidance { name: "ui-project" }` returns the new article after restarting the MCP server.
- [ ] Reviewer: invoke `new-ui-project` against a freshly created workspace to confirm the project lands under `projects/<projectName>` and the hosting package under `packages/<packageName>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)