### PR TITLE
fix: pass URI directly to HealthCheckCommand to fix UriFormatException on fresh environments

### DIFF
--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -26,7 +26,7 @@ namespace Clio.Command.CreatioInstallCommand;
 ///     Defines operations for deploying a Creatio application and restoring its database.
 /// </summary>
 public interface ICreatioInstallerService {
-	
+
 	#region Methods: Public
 
 	/// <summary>
@@ -1073,9 +1073,9 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			   };
 	}
 
-	private bool WaitForServerReady(string environmentName) {
-		const int initialDelaySeconds = 15; // Initial delay to allow server to start
-		const int maxAttempts = 10; // Increased attempts for longer wait time
+	private bool WaitForServerReady(string baseUri, bool isNetCore) {
+		const int initialDelaySeconds = 15;
+		const int maxAttempts = 10;
 		const int delaySeconds = 3;
 
 		_logger.WriteInfo($"Waiting {initialDelaySeconds} seconds for server to start...");
@@ -1083,7 +1083,8 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 
 		for (int attempt = 1; attempt <= maxAttempts; attempt++) {
 			HealthCheckOptions healthOptions = new() {
-				Environment = environmentName
+				Uri = baseUri,
+				IsNetCore = isNetCore
 			};
 			int result = _healthCheckCommand.Execute(healthOptions);
 			if (result == 0) {
@@ -1172,7 +1173,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	//
 	// 		string str = $"""
 	// 					  [Copy deployment files]
-	// 					      From: {unzippedDirectoryPath} 
+	// 					      From: {unzippedDirectoryPath}
 	// 					      To:   {deploymentFolder}
 	// 					  """;
 	// 		_logger.WriteInfo(str);
@@ -1410,7 +1411,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 
 		string str = $"""
 					  [Copy deployment files]
-					      From: {unzippedDirectoryPath} 
+					      From: {unzippedDirectoryPath}
 					      To:   {deploymentFolder}
 					  """;
 		_logger.WriteInfo(str);
@@ -1476,20 +1477,20 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			uri = $"http://{InstallerHelper.FetFQDN()}:{options.SitePort}";
 		}
 
+		bool isNetCore = InstallerHelper.DetectFrameworkByPath(deploymentFolder) == InstallerHelper.FrameworkType.NetCore;
 		_registerCommand.Execute(new RegAppOptions {
 			EnvironmentName = options.SiteName,
 			Login = "Supervisor",
 			Password = "Supervisor",
 			Uri = uri,
-			IsNetCore
-				= InstallerHelper.DetectFrameworkByPath(deploymentFolder) == InstallerHelper.FrameworkType.NetCore,
+			IsNetCore = isNetCore,
 			EnvironmentPath = deploymentFolder
 		});
 
 		// For DotNet deployments, wait for the server to become ready before proceeding
 		if (!isIisDeployment) {
 			_logger.WriteInfo("Waiting for server to become ready...");
-			if (!WaitForServerReady(options.SiteName)) {
+			if (!WaitForServerReady(uri, isNetCore)) {
 				_logger.WriteWarning("Server did not become ready within the timeout period.");
 			}
 		}

--- a/clio/Command/HealthCheckCommand.cs
+++ b/clio/Command/HealthCheckCommand.cs
@@ -30,7 +30,7 @@ namespace Clio.Command
 
 	public class HealthCheckCommand : RemoteCommand<HealthCheckOptions>
 	{
-	
+
 		public HealthCheckCommand(IApplicationClient applicationClient, EnvironmentSettings settings): base(applicationClient, settings)
 		{
 			EnvironmentSettings = settings;
@@ -97,6 +97,10 @@ namespace Clio.Command
 		}
 
 		public override int Execute(HealthCheckOptions options) {
+			if (!string.IsNullOrEmpty(options.Uri))
+				EnvironmentSettings.Uri = options.Uri;
+			if (options.IsNetCore.HasValue)
+				EnvironmentSettings.IsNetCore = options.IsNetCore.Value;
 			RequestTimeout = options.TimeOut;
 			RetryCount = options.RetryCount;
 			DelaySec = options.RetryDelay;

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -9,7 +9,7 @@
 		<PackageTags>cli ATF clio creatio</PackageTags>
 		<NeutralLanguage>en</NeutralLanguage>
 		<!-- Fallback for environments without git tags; overridden by SetVersionFromGitTag target or CI /p:AssemblyVersion -->
-		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.38</AssemblyVersion>
+		<AssemblyVersion Condition="'$(AssemblyVersion)' == ''">8.1.0.40</AssemblyVersion>
 		<FileVersion Condition="'$(FileVersion)' == ''">$(AssemblyVersion)</FileVersion>
 		<Version Condition="'$(Version)' == ''">$(AssemblyVersion)</Version>
 		<Description>CLI interface for Creatio</Description>

--- a/cliogate/descriptor.json
+++ b/cliogate/descriptor.json
@@ -5,7 +5,7 @@
     "Name": "cliogate",
     "Type": 0,
     "ProjectPath": "",
-    "ModifiedOnUtc": "/Date(1779887531000)/",
+    "ModifiedOnUtc": "/Date(1780041706000)/",
     "Maintainer": "Advanced Technologies Foundation",
     "DependsOn": []
   }


### PR DESCRIPTION
### Problem
When deploying a fresh (unregistered) environment, EnvironmentSettings.Uri is empty at the point WaitForServerReady fires. BuildUri() then produces a path-only string (no scheme/host), which causes UriFormatException during the health-check loop — making clio deploy-creatio fail even though the application deployed and started successfully.

This was especially impactful on Linux/macOS (.NET Core) where the health-check runs through a different code path than on IIS.

### Fix
Pass `baseUri` and `isNetCore` directly into `HealthCheckOptions` at the call site in `CreatioInstallerService.cs`
Apply them at the top of `HealthCheckCommand.Execute()` so the command always has a valid URI regardless of what EnvironmentSettings contains
#### Files changed
`CreatioInstallerService.cs` — pass URI and isNetCore into HealthCheckOptions
`HealthCheckCommand.cs` — consume baseUri/isNetCore from options at execute time