### PR TITLE
#ENG-89871 get-component-info: scope catalog to target version, warn on fallback, resolve version without cliogate

### DIFF
--- a/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
@@ -230,20 +230,19 @@ public sealed class ComponentInfoToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
 
-		// Act — no environment-name / version, so the server cannot scope to a real platform version.
+		// Act — no environment-name / version passed. Version resolution is driven solely by
+		// per-call arguments (the ambient singleton was removed), so the server deterministically
+		// reports latest-fallback regardless of any environment registered on the CI runner.
 		ComponentInfoResponse response = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			new Dictionary<string, object?> { ["componentType"] = "crt.TabContainer" });
 
-		// Assert — warning presence must track the resolver tier exactly.
-		if (string.Equals(response.ResolvedFrom, "latest-fallback", StringComparison.OrdinalIgnoreCase)) {
-			response.VersionWarning.Should().NotBeNullOrWhiteSpace(
-				because: "a latest-fallback catalog is a superset of the target version and the caveat must warn AI the component may not exist there");
-		} else {
-			response.VersionWarning.Should().BeNull(
-				because: "an environment-matched catalog carries no superset risk, so the warning must be omitted");
-		}
+		// Assert
+		response.ResolvedFrom.Should().Be("latest-fallback",
+			because: "with no environment-name/version the resolver cannot scope to a real version and must report latest-fallback");
+		response.VersionWarning.Should().NotBeNullOrWhiteSpace(
+			because: "a latest-fallback catalog is a superset of the target version and the caveat must warn AI the component may not exist there");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
@@ -63,7 +63,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse detailResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["component-type"] = "crt.MenuItem" });
+			new Dictionary<string, object?> { ["componentType"] = "crt.MenuItem" });
 
 		// Assert
 		tabListResponse.Success.Should().BeTrue(
@@ -92,8 +92,12 @@ public sealed class ComponentInfoToolE2ETests {
 			because: "component-type lookups should return the detail contract");
 		detailResponse.ComponentType.Should().Be("crt.MenuItem",
 			because: "the detail response should echo the requested component type");
-		detailResponse.Container.Should().BeTrue(
-			because: "menu items can host submenu items");
+		// The wrapped (static-files-mcp) registry shape does not emit the `container`
+		// flag at all — no component carries it, so it deserialises to null. The legacy
+		// top-level-array shape did. Accept either: a true value (legacy) or null
+		// (wrapped). This mirrors the items legacy/wrapped tolerance just below.
+		detailResponse.Container.Should().NotBe(false,
+			because: "container is a legacy-shape flag absent from the wrapped registry payload — accept true (legacy) or null (wrapped), reject only an explicit non-container");
 		// crt.MenuItem details may arrive either through the legacy properties block
 		// (older catalogs) or through the wrapped-shape inputs/outputs blocks (current
 		// static-files-mcp registry). Accept either — both describe the same surface.
@@ -131,7 +135,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse mobileListResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["schema-type"] = "mobile" });
+			new Dictionary<string, object?> { ["schemaType"] = "mobile" });
 
 		// Assert
 		mobileListResponse.Success.Should().BeTrue(
@@ -166,7 +170,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse response = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["component-type"] = "crt.DoesNotExist" });
+			new Dictionary<string, object?> { ["componentType"] = "crt.DoesNotExist" });
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -192,11 +196,11 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse fieldResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["component-type"] = "crt.NumberInput" });
+			new Dictionary<string, object?> { ["componentType"] = "crt.NumberInput" });
 		ComponentInfoResponse containerResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["component-type"] = "crt.TabContainer" });
+			new Dictionary<string, object?> { ["componentType"] = "crt.TabContainer" });
 
 		// Assert
 		fieldResponse.Success.Should().BeTrue(
@@ -215,6 +219,61 @@ public sealed class ComponentInfoToolE2ETests {
 			because: "the contract only applies to standard field components and must not surface for containers");
 	}
 
+	[Test]
+	[Description("Couples versionWarning to the resolver tier on the real MCP server: a latest-fallback response (no environment passed) carries the superset caveat, and an environment-matched response omits it.")]
+	[AllureTag(ToolName)]
+	[AllureName("get-component-info emits versionWarning only on latest-fallback")]
+	[AllureDescription("Starts the real clio MCP server, requests detail without an environment, and verifies versionWarning is present exactly when resolvedFrom is latest-fallback.")]
+	public async Task ComponentInfoTool_Should_Emit_VersionWarning_On_Latest_Fallback() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
+
+		// Act — no environment-name / version, so the server cannot scope to a real platform version.
+		ComponentInfoResponse response = await CallComponentInfoAsync(
+			arrangeContext.Session,
+			arrangeContext.CancellationTokenSource.Token,
+			new Dictionary<string, object?> { ["componentType"] = "crt.TabContainer" });
+
+		// Assert — warning presence must track the resolver tier exactly.
+		if (string.Equals(response.ResolvedFrom, "latest-fallback", StringComparison.OrdinalIgnoreCase)) {
+			response.VersionWarning.Should().NotBeNullOrWhiteSpace(
+				because: "a latest-fallback catalog is a superset of the target version and the caveat must warn AI the component may not exist there");
+		} else {
+			response.VersionWarning.Should().BeNull(
+				because: "an environment-matched catalog carries no superset risk, so the warning must be omitted");
+		}
+	}
+
+	[Test]
+	[Description("Rejects passing both version and environment-name on the real MCP server — the two version sources are mutually exclusive.")]
+	[AllureTag(ToolName)]
+	[AllureName("get-component-info rejects version + environment-name together")]
+	[AllureDescription("Starts the real clio MCP server and verifies that supplying both version and environment-name returns a structured mutually-exclusive error.")]
+	public async Task ComponentInfoTool_Should_Reject_Version_And_Environment_Together() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
+
+		// Act
+		ComponentInfoResponse response = await CallComponentInfoAsync(
+			arrangeContext.Session,
+			arrangeContext.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["componentType"] = "crt.TabContainer",
+				["version"] = "8.3.3",
+				["environmentName"] = "any-env"
+			});
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "version and environment-name select the target version two different ways and must not be combined");
+		response.Error.Should().Contain("mutually exclusive",
+			because: "the caller must be told why the request was rejected");
+	}
+
 	private static async Task<ArrangeContext> ArrangeAsync(McpE2ESettings settings, TimeSpan timeout) {
 		CancellationTokenSource cancellationTokenSource = new(timeout);
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
@@ -227,7 +286,7 @@ public sealed class ComponentInfoToolE2ETests {
 		IReadOnlyDictionary<string, object?> arguments) {
 		CallToolResult callResult = await session.CallToolAsync(
 			ToolName,
-			new Dictionary<string, object?> { ["args"] = arguments },
+			new Dictionary<string, object?>(arguments),
 			cancellationToken);
 		callResult.IsError.Should().NotBeTrue(
 			because: "get-component-info should return structured responses instead of top-level MCP failures");

--- a/clio.tests/Command/GetInfoCommand.cs
+++ b/clio.tests/Command/GetInfoCommand.cs
@@ -1,4 +1,7 @@
-﻿using Clio.Command;
+using Clio.Command;
+using Clio.Common;
+using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -7,9 +10,108 @@ namespace Clio.Tests.Command;
 [Category("Unit")]
 [TestFixture]
 [Property("Module", "Command")]
-public class GetInfoCommandTests: BaseCommandTests<GetCreatioInfoCommandOptions>
+public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions>
 {
+	private const string ApplicationInfoMarker = "ApplicationInfoService.svc/GetApplicationInfo";
+	private const string GetSysInfoMarker = "rest/CreatioApiGateway/GetSysInfo";
 
-	
+	private const string ApplicationInfoResponse =
+		"""{ "applicationInfo": { "sysValues": { "coreVersion": "8.3.3.3292" } } }""";
+	private const string SysInfoResponse =
+		"""{ "SysInfo": { "CoreVersion": "8.3.3.3292", "ProductName": "studio" } }""";
 
+	private static GetCreatioInfoCommand CreateCommand(IApplicationClient client, IClioGateway gateway)
+	{
+		EnvironmentSettings env = new() { Uri = "https://creatio.test", IsNetCore = true };
+		return new GetCreatioInfoCommand(client, env, gateway) { Logger = Substitute.For<ILogger>() };
+	}
+
+	[Test]
+	[Description("When cliogate is absent the command degrades to ApplicationInfoService instead of failing, returning success.")]
+	public void Execute_Falls_Back_To_ApplicationInfo_When_Cliogate_Absent()
+	{
+		// Arrange — no cliogate gateway at all.
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(ApplicationInfoResponse);
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0,
+			because: "the command must not fail when cliogate is missing — ApplicationInfoService still answers");
+		client.Received().ExecutePostRequest(
+			Arg.Is<string>(url => url.Contains(ApplicationInfoMarker)),
+			Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.DidNotReceive().ExecuteGetRequest(
+			Arg.Is<string>(url => url.Contains(GetSysInfoMarker)), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("When the installed cliogate is older than required the command degrades to ApplicationInfoService rather than erroring out.")]
+	public void Execute_Falls_Back_To_ApplicationInfo_When_Cliogate_Incompatible()
+	{
+		// Arrange — cliogate present but below the required version.
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		gateway.IsCompatibleWith(Arg.Any<string>()).Returns(false);
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(ApplicationInfoResponse);
+		GetCreatioInfoCommand command = CreateCommand(client, gateway);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0,
+			because: "an incompatible cliogate must trigger the ApplicationInfoService fallback, not a hard failure");
+		client.Received().ExecutePostRequest(
+			Arg.Is<string>(url => url.Contains(ApplicationInfoMarker)),
+			Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("When a compatible cliogate is installed the command uses the full GetSysInfo report and does not call ApplicationInfoService.")]
+	public void Execute_Uses_GetSysInfo_When_Cliogate_Compatible()
+	{
+		// Arrange — compatible cliogate present.
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		gateway.IsCompatibleWith(Arg.Any<string>()).Returns(true);
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(SysInfoResponse);
+		GetCreatioInfoCommand command = CreateCommand(client, gateway);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0,
+			because: "the full cliogate path must still work when cliogate is present and compatible");
+		client.Received().ExecuteGetRequest(
+			Arg.Is<string>(url => url.Contains(GetSysInfoMarker)), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.DidNotReceive().ExecutePostRequest(
+			Arg.Is<string>(url => url.Contains(ApplicationInfoMarker)),
+			Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("When the ApplicationInfoService fallback returns an unexpected shape the command reports a clean failure.")]
+	public void Execute_Returns_Error_When_ApplicationInfo_Shape_Unexpected()
+	{
+		// Arrange — no cliogate, and ApplicationInfoService gives an unusable body.
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { } }""");
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1,
+			because: "an unusable ApplicationInfoService response must surface as a clean failure, not a crash");
+	}
 }

--- a/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
+++ b/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
@@ -485,6 +485,22 @@ public sealed class ComponentInfoToolTests {
 	}
 
 	[Test]
+	[Description("A malformed explicit version is rejected up front with a readable error instead of silently degrading to latest-fallback when the CDN load fails.")]
+	public async Task ComponentInfoTool_Should_Reject_Malformed_Explicit_Version() {
+		// Arrange
+		ComponentInfoTool tool = CreateTool();
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(version: "not-a-version");
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "an unparseable version must surface a clear error rather than a silent latest-fallback");
+		response.Error.Should().Contain("not a valid platform version",
+			because: "the caller must be told the version value is malformed");
+	}
+
+	[Test]
 	[Description("Passing both version and environment-name is rejected with a readable error — the two version sources are mutually exclusive, mirroring the CLI verb guard.")]
 	public async Task ComponentInfoTool_Should_Reject_Both_Version_And_Environment() {
 		// Arrange

--- a/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
+++ b/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
@@ -7,7 +7,9 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command.McpServer.Tools;
+using Clio.UserEnvironment;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command.McpServer;
@@ -360,10 +362,10 @@ public sealed class ComponentInfoToolTests {
 		// Arrange
 		ComponentInfoCatalog catalog = new(new InMemoryRegistryClient(TestRegistryJson));
 		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
-		ComponentInfoTool tool = new(catalog, mobileCatalog, StubPlatformVersionResolver.Environment("8.1.5"), new FakeDocsClient());
+		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
 
-		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo();
+		// Act — passing environment-name routes resolution through the cliogate probe stub.
+		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -382,10 +384,10 @@ public sealed class ComponentInfoToolTests {
 		FallbackRegistryClient client = new(TestRegistryJson, fallbackVersion: "latest");
 		ComponentInfoCatalog catalog = new(client);
 		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
-		ComponentInfoTool tool = new(catalog, mobileCatalog, StubPlatformVersionResolver.Environment("8.1.5"), new FakeDocsClient());
+		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
 
-		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo();
+		// Act — probe resolves 8.1.5 but the client only has "latest" published.
+		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -394,6 +396,109 @@ public sealed class ComponentInfoToolTests {
 			because: "the response must echo the version actually loaded by the client, not the requested one");
 		response.ResolvedFrom.Should().Be("latest-fallback",
 			because: "AI must see latest-fallback whenever the loaded catalog does not match the target environment");
+	}
+
+	[Test]
+	[Description("Latest-fallback responses carry the versionWarning so AI does not mistake the 'latest' superset for the target environment's real component set.")]
+	public async Task ComponentInfoTool_Should_Emit_Version_Warning_On_Latest_Fallback() {
+		// Arrange — resolver falls back to latest (no environment / probe failure).
+		ComponentInfoTool tool = CreateTool();
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo();
+
+		// Assert
+		response.ResolvedFrom.Should().Be("latest-fallback",
+			because: "the fixture resolver reports latest-fallback");
+		response.VersionWarning.Should().Be(ComponentInfoResolution.LatestFallbackWarning,
+			because: "every latest-fallback response must surface the superset caveat so AI verifies the component exists in the target version");
+	}
+
+	[Test]
+	[Description("When the catalog matches the resolved environment version the response omits versionWarning — there is no superset risk to flag.")]
+	public async Task ComponentInfoTool_Should_Not_Emit_Version_Warning_When_Environment_Matches() {
+		// Arrange — resolver says 8.1.5 and the catalog loads exactly that version.
+		ComponentInfoCatalog catalog = new(new InMemoryRegistryClient(TestRegistryJson));
+		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
+		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
+
+		// Assert
+		response.ResolvedFrom.Should().Be("environment",
+			because: "a successful probe whose catalog matches must surface the 'environment' tier");
+		response.VersionWarning.Should().BeNull(
+			because: "an environment-matched catalog carries no superset risk, so the warning must be omitted");
+	}
+
+	[Test]
+	[Description("The pretty renderer prints the versionWarning on a WARNING line for latest-fallback responses and omits it for environment-matched responses.")]
+	public void ComponentInfoPrettyRenderer_Should_Render_Version_Warning_Only_On_Latest_Fallback() {
+		// Arrange
+		ComponentInfoResponse fallback = new() {
+			Success = true, Mode = "list", Count = 0, Items = [],
+			ResolvedTargetVersion = "latest", ResolvedFrom = "latest-fallback"
+		};
+		ComponentInfoResponse matched = new() {
+			Success = true, Mode = "list", Count = 0, Items = [],
+			ResolvedTargetVersion = "8.1.5", ResolvedFrom = "environment"
+		};
+
+		// Act
+		string fallbackText = ComponentInfoPrettyRenderer.Render(fallback);
+		string matchedText = ComponentInfoPrettyRenderer.Render(matched);
+
+		// Assert
+		fallbackText.Should().Contain("WARNING:",
+			because: "the pretty surface must flag the latest superset so a human operator sees the same caveat AI gets");
+		fallbackText.Should().Contain("superset",
+			because: "the rendered warning must carry the LatestFallbackWarning text");
+		matchedText.Should().NotContain("WARNING:",
+			because: "an environment-matched catalog has no superset risk to flag");
+	}
+
+	[Test]
+	[Description("Passing environment-name routes version resolution through the cliogate probe for that environment (factory + settings repository), mirroring the CLI verb, instead of an ambient server-bound resolver.")]
+	public async Task ComponentInfoTool_Should_Resolve_Version_From_Passed_Environment() {
+		// Arrange
+		ComponentInfoCatalog catalog = new(new InMemoryRegistryClient(TestRegistryJson));
+		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
+		IPlatformVersionResolverFactory factory = Substitute.For<IPlatformVersionResolverFactory>();
+		factory.Create(Arg.Any<EnvironmentSettings>())
+			.Returns(StubPlatformVersionResolver.Environment("8.2.1"));
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		settingsRepository.GetEnvironment(Arg.Any<EnvironmentOptions>())
+			.Returns(new EnvironmentSettings { Uri = "http://prod-stand" });
+		ComponentInfoTool tool = new(catalog, mobileCatalog, new FakeDocsClient(), factory, settingsRepository);
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "prod-stand");
+
+		// Assert
+		response.ResolvedTargetVersion.Should().Be("8.2.1",
+			because: "the version must come from the probe of the environment passed in the call, not from ambient state");
+		response.ResolvedFrom.Should().Be("environment",
+			because: "an environment-name-driven probe that matches the catalog is the 'environment' tier");
+		settingsRepository.Received(1).GetEnvironment(Arg.Is<EnvironmentOptions>(o => o.Environment == "prod-stand"));
+		factory.Received(1).Create(Arg.Any<EnvironmentSettings>());
+	}
+
+	[Test]
+	[Description("Passing both version and environment-name is rejected with a readable error — the two version sources are mutually exclusive, mirroring the CLI verb guard.")]
+	public async Task ComponentInfoTool_Should_Reject_Both_Version_And_Environment() {
+		// Arrange
+		ComponentInfoTool tool = CreateTool();
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(
+			environmentName: "test-stand", version: "8.3.3");
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "version and environment-name select the target version two different ways and must not be combined");
+		response.Error.Should().Contain("mutually exclusive",
+			because: "the caller must be told why the request was rejected");
 	}
 
 	[Test]
@@ -424,11 +529,7 @@ public sealed class ComponentInfoToolTests {
 		ThrowingRegistryClient throwingClient = new(new ComponentRegistryUnavailableException("latest", "https://cdn.test/api/mcp/"));
 		ComponentInfoCatalog catalog = new(throwingClient);
 		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
-		ComponentInfoTool tool = new(
-			catalog,
-			mobileCatalog,
-			StubPlatformVersionResolver.LatestFallback(),
-			new FakeDocsClient());
+		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog);
 
 		// Act
 		ComponentInfoResponse response = await tool.GetComponentInfo();
@@ -444,11 +545,34 @@ public sealed class ComponentInfoToolTests {
 	private static ComponentInfoTool CreateTool(IComponentRegistryDocsClient? docsClient = null) {
 		ComponentInfoCatalog catalog = new(new InMemoryRegistryClient(TestRegistryJson));
 		InMemoryMobileCatalog mobileCatalog = new(TestMobileRegistryJson);
+		return BuildTool(catalog, mobileCatalog, docsClient);
+	}
+
+	/// <summary>
+	/// Builds a <see cref="ComponentInfoTool"/> for tests. Version resolution mirrors the CLI verb:
+	/// with <paramref name="environmentVersion"/> null the tool resolves nothing (the caller makes a
+	/// bare or version-less call → <c>latest-fallback</c>); pass a semver to wire the stub factory so a
+	/// call carrying <c>environment-name</c> resolves to that version (<c>environment</c> tier).
+	/// </summary>
+	private static ComponentInfoTool BuildTool(
+		IComponentInfoCatalog catalog,
+		IMobileComponentInfoCatalog mobileCatalog,
+		IComponentRegistryDocsClient? docsClient = null,
+		string? environmentVersion = null) {
+		IPlatformVersionResolverFactory factory = Substitute.For<IPlatformVersionResolverFactory>();
+		if (environmentVersion is not null) {
+			factory.Create(Arg.Any<EnvironmentSettings>())
+				.Returns(StubPlatformVersionResolver.Environment(environmentVersion));
+		}
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		settingsRepository.GetEnvironment(Arg.Any<EnvironmentOptions>())
+			.Returns(new EnvironmentSettings { Uri = "http://test-stand" });
 		return new ComponentInfoTool(
 			catalog,
 			mobileCatalog,
-			StubPlatformVersionResolver.LatestFallback(),
-			docsClient ?? new FakeDocsClient());
+			docsClient ?? new FakeDocsClient(),
+			factory,
+			settingsRepository);
 	}
 
 	[Test]
@@ -525,10 +649,9 @@ public sealed class ComponentInfoToolTests {
 		""";
 		FakeDocsClient docs = new FakeDocsClient()
 			.Seed("latest", "docs/with-docs.intro.md", "# Intro\n\nBody.");
-		ComponentInfoTool tool = new(
+		ComponentInfoTool tool = BuildTool(
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
 			new InMemoryMobileCatalog(TestMobileRegistryJson),
-			StubPlatformVersionResolver.LatestFallback(),
 			docs);
 
 		// Act
@@ -603,11 +726,9 @@ public sealed class ComponentInfoToolTests {
 		  ]
 		}
 		""";
-		ComponentInfoTool tool = new(
+		ComponentInfoTool tool = BuildTool(
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
-			new InMemoryMobileCatalog(TestMobileRegistryJson),
-			StubPlatformVersionResolver.LatestFallback(),
-			new FakeDocsClient());
+			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
 		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.SimpleButton");
@@ -646,11 +767,9 @@ public sealed class ComponentInfoToolTests {
 		  ]
 		}
 		""";
-		ComponentInfoTool tool = new(
+		ComponentInfoTool tool = BuildTool(
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
-			new InMemoryMobileCatalog(TestMobileRegistryJson),
-			StubPlatformVersionResolver.LatestFallback(),
-			new FakeDocsClient());
+			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
 		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.Persistent");
@@ -695,11 +814,9 @@ public sealed class ComponentInfoToolTests {
 		  ]
 		}
 		""";
-		ComponentInfoTool tool = new(
+		ComponentInfoTool tool = BuildTool(
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
-			new InMemoryMobileCatalog(TestMobileRegistryJson),
-			StubPlatformVersionResolver.LatestFallback(),
-			new FakeDocsClient());
+			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.WithTypes");
 
@@ -756,11 +873,9 @@ public sealed class ComponentInfoToolTests {
 		  ]
 		}
 		""";
-		ComponentInfoTool tool = new(
+		ComponentInfoTool tool = BuildTool(
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
-			new InMemoryMobileCatalog(TestMobileRegistryJson),
-			StubPlatformVersionResolver.LatestFallback(),
-			new FakeDocsClient());
+			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
 		ComponentInfoResponse response = await tool.GetComponentInfo(search: "selection");

--- a/clio.tests/Command/McpServer/PlatformVersionResolverTests.cs
+++ b/clio.tests/Command/McpServer/PlatformVersionResolverTests.cs
@@ -200,6 +200,82 @@ public sealed class PlatformVersionResolverTests {
 		client.Received(2).ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
+	[Test]
+	[Description("ApplicationInfoService (no cliogate) is the primary version source: its coreVersion resolves to the environment tier even when the cliogate GetSysInfo probe fails — this is the works-without-cliogate guarantee.")]
+	public async Task ResolveAsync_Resolves_From_ApplicationInfo_When_Cliogate_Absent() {
+		// Arrange — ApplicationInfo returns a version; cliogate GetSysInfo throws (not installed).
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { "sysValues": { "coreVersion": "8.3.3.3292" } } }""");
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new HttpRequestException("cliogate not installed"));
+		PlatformVersionResolver resolver = CreateResolver(client);
+
+		// Act
+		PlatformVersionResolution resolution = await resolver.ResolveAsync();
+
+		// Assert
+		resolution.Source.Should().Be(VersionResolutionSource.Environment,
+			because: "ApplicationInfoService needs only auth, so version resolution must succeed without cliogate");
+		resolution.ResolvedVersion.Should().Be("8.3.3",
+			because: "the 4-part coreVersion from ApplicationInfo is normalised to the 3-part CDN tag");
+	}
+
+	[Test]
+	[Description("When ApplicationInfo yields a version the cliogate GetSysInfo probe is never attempted — the non-cliogate path is primary, not a fallback.")]
+	public async Task ResolveAsync_Does_Not_Probe_Cliogate_When_ApplicationInfo_Succeeds() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { "sysValues": { "coreVersion": "8.2.1.100" } } }""");
+		PlatformVersionResolver resolver = CreateResolver(client);
+
+		// Act
+		PlatformVersionResolution resolution = await resolver.ResolveAsync();
+
+		// Assert
+		resolution.ResolvedVersion.Should().Be("8.2.1");
+		client.DidNotReceive().ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("When ApplicationInfo returns an unexpected shape the resolver falls back to the cliogate GetSysInfo probe — older Creatio versions stay covered.")]
+	public async Task ResolveAsync_Falls_Back_To_Cliogate_When_ApplicationInfo_Unusable() {
+		// Arrange — ApplicationInfo lacks the sysValues node; cliogate answers.
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { } }""");
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "SysInfo": { "CoreVersion": "8.1.5.7" } }""");
+		PlatformVersionResolver resolver = CreateResolver(client);
+
+		// Act
+		PlatformVersionResolution resolution = await resolver.ResolveAsync();
+
+		// Assert
+		resolution.Source.Should().Be(VersionResolutionSource.Environment,
+			because: "the cliogate fallback must still resolve when ApplicationInfo is unusable");
+		resolution.ResolvedVersion.Should().Be("8.1.5");
+	}
+
+	[Test]
+	[Description("On a .NET Framework environment the ApplicationInfo probe hits /0/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo (WebAppAlias prefix).")]
+	public async Task ResolveAsync_Builds_NetFramework_ApplicationInfo_Url() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { "sysValues": { "coreVersion": "8.3.3.1" } } }""");
+		PlatformVersionResolver resolver = CreateResolver(client, isNetCore: false);
+
+		// Act
+		await resolver.ResolveAsync();
+
+		// Assert
+		client.Received().ExecutePostRequest(
+			Arg.Is<string>(url => url.Contains("/0/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo")),
+			Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
 	private static IApplicationClient SubstituteClient(string responseBody) {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -284,7 +284,11 @@ public class BindingsModule {
 		services.AddSingleton<IComponentRegistryDocsClient, ComponentRegistryDocsClient>();
 		services.AddSingleton<IComponentInfoCatalog, ComponentInfoCatalog>();
 		services.AddSingleton<IMobileComponentInfoCatalog, MobileComponentInfoCatalog>();
-		services.AddSingleton<IPlatformVersionResolver, PlatformVersionResolver>();
+		// Only the per-environment IPlatformVersionResolverFactory is registered: both the
+		// get-component-info MCP tool and the CLI verb resolve the platform version from
+		// per-call arguments (environment-name / uri / version), never from an ambient
+		// singleton bound to the server's startup environment. A singleton resolver would
+		// probe the wrong environment and report a falsely authoritative "environment" tier.
 		services.AddSingleton<IPlatformVersionResolverFactory, PlatformVersionResolverFactory>();
 		services.AddTransient<ComponentRegistryRefreshCommand>();
 		services.AddTransient<ComponentInfoCommand>();

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using CommandLine;
 using Newtonsoft.Json.Linq;
 using Clio.Common;
@@ -37,11 +38,36 @@ namespace Clio.Command
 
 		protected override string ClioGateMinVersion { get; } = "2.0.0.32";
 
+		/// <summary>
+		/// Standard Creatio service used for the no-cliogate fallback. Requires only an
+		/// authenticated session and exposes the core version plus locale/user/workspace
+		/// metadata — but not the cliogate-only fields (Runtime, DbEngineType, LicenseInfo,
+		/// ProductName).
+		/// </summary>
+		private const string GetApplicationInfoServicePath = "/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo";
+
 		#endregion
 
 		#region Properties: Public
 
 		public override HttpMethod HttpMethod => HttpMethod.Get;
+
+		#endregion
+
+		#region Methods: Public
+
+		/// <summary>
+		/// Reports Creatio system information. The full report comes from cliogate
+		/// <c>GetSysInfo</c>; when cliogate is absent or older than <see cref="ClioGateMinVersion"/>
+		/// the command degrades gracefully to the standard <c>ApplicationInfoService</c> instead of
+		/// failing — that path needs only authentication and still surfaces the core version.
+		/// </summary>
+		public override int Execute(GetCreatioInfoCommandOptions options){
+			if (ClioGateWay is null || !ClioGateWay.IsCompatibleWith(ClioGateMinVersion)){
+				return ExecuteApplicationInfoFallback(options);
+			}
+			return base.Execute(options);
+		}
 
 		#endregion
 
@@ -52,6 +78,37 @@ namespace Clio.Command
 			JObject jResponse = JObject.Parse(response);
 			JToken sysInfo = jResponse["SysInfo"];
 			Logger.WriteLine(sysInfo.ToString());
+		}
+
+		#endregion
+
+		#region Methods: Private
+
+		/// <summary>
+		/// No-cliogate fallback: reads core/system metadata from the standard
+		/// <c>ApplicationInfoService</c> and prints its <c>sysValues</c> block. Cliogate-only
+		/// fields are unavailable here and the user is told so.
+		/// </summary>
+		private int ExecuteApplicationInfoFallback(GetCreatioInfoCommandOptions options){
+			try {
+				string url = RootPath + GetApplicationInfoServicePath;
+				string response = ApplicationClient.ExecutePostRequest(
+					url, "{}", options.TimeOut, options.RetryCount, options.RetryDelay);
+				JToken sysValues = JObject.Parse(response)["applicationInfo"]?["sysValues"];
+				if (sysValues is null){
+					Logger.WriteError(
+						"cliogate is not installed and ApplicationInfoService returned an unexpected response.");
+					return 1;
+				}
+				Logger.WriteWarning(
+					$"cliogate {ClioGateMinVersion}+ is not installed - reporting limited info from ApplicationInfoService. "
+					+ "Runtime, DbEngineType, LicenseInfo and ProductName require cliogate.");
+				Logger.WriteLine(sysValues.ToString());
+				return 0;
+			} catch (Exception e){
+				Logger.WriteError(e.GetReadableMessageException(Program.IsDebugMode));
+				return 1;
+			}
 		}
 
 		#endregion

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -34,17 +34,9 @@ namespace Clio.Command
 
 		#region Properties: Protected
 
-		protected override string ServicePath => "/rest/CreatioApiGateway/GetSysInfo";
+		protected override string ServicePath => CreatioServicePaths.GetSysInfo;
 
 		protected override string ClioGateMinVersion { get; } = "2.0.0.32";
-
-		/// <summary>
-		/// Standard Creatio service used for the no-cliogate fallback. Requires only an
-		/// authenticated session and exposes the core version plus locale/user/workspace
-		/// metadata — but not the cliogate-only fields (Runtime, DbEngineType, LicenseInfo,
-		/// ProductName).
-		/// </summary>
-		private const string GetApplicationInfoServicePath = "/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo";
 
 		#endregion
 
@@ -75,8 +67,11 @@ namespace Clio.Command
 
 		protected override void ProceedResponse(string response, GetCreatioInfoCommandOptions options){
 			base.ProceedResponse(response, options);
-			JObject jResponse = JObject.Parse(response);
-			JToken sysInfo = jResponse["SysInfo"];
+			JToken sysInfo = JObject.Parse(response)["SysInfo"];
+			if (sysInfo is null){
+				Logger.WriteError("cliogate GetSysInfo returned an unexpected response (no SysInfo node).");
+				return;
+			}
 			Logger.WriteLine(sysInfo.ToString());
 		}
 
@@ -91,7 +86,7 @@ namespace Clio.Command
 		/// </summary>
 		private int ExecuteApplicationInfoFallback(GetCreatioInfoCommandOptions options){
 			try {
-				string url = RootPath + GetApplicationInfoServicePath;
+				string url = RootPath + CreatioServicePaths.GetApplicationInfo;
 				string response = ApplicationClient.ExecutePostRequest(
 					url, "{}", options.TimeOut, options.RetryCount, options.RetryDelay);
 				JToken sysValues = JObject.Parse(response)["applicationInfo"]?["sysValues"];

--- a/clio/Command/McpServer/Tools/ComponentInfoPrettyRenderer.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoPrettyRenderer.cs
@@ -40,6 +40,9 @@ public static class ComponentInfoPrettyRenderer {
 			.Append(", count=").Append(response.Count)
 			.Append(")")
 			.AppendLine();
+		if (!string.IsNullOrWhiteSpace(response.VersionWarning)) {
+			sb.Append("WARNING: ").AppendLine(response.VersionWarning);
+		}
 	}
 
 	private static void AppendList(StringBuilder sb, ComponentInfoResponse response) {

--- a/clio/Command/McpServer/Tools/ComponentInfoResolution.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoResolution.cs
@@ -13,6 +13,32 @@ public static class ComponentInfoResolution {
 	public const string ResolvedFromLatestFallback = "latest-fallback";
 
 	/// <summary>
+	/// Warning surfaced on every <c>latest-fallback</c> response so the caller does not
+	/// mistake the <c>latest</c> catalog for the target environment's real component set.
+	/// <c>latest</c> is a superset of every GA version: a type listed here (e.g. a freshly
+	/// shipped <c>crt.Switch</c>) may not exist in the environment's actual platform version,
+	/// and a page built against it will fail to render at runtime. The remedy is to scope the
+	/// catalog to a concrete version — pass an explicit version, or target a registered
+	/// environment so clio can resolve its platform version via the cliogate <c>GetSysInfo</c> probe.
+	/// </summary>
+	public const string LatestFallbackWarning =
+		"Catalog was loaded from 'latest' (a superset of all GA versions). "
+		+ "A component listed here may not exist in the target environment's actual platform version, "
+		+ "so a page built against it can fail to render at runtime. "
+		+ "To scope results to a real version, pass an explicit version or target a registered "
+		+ "environment so clio can resolve its platform version via cliogate GetSysInfo.";
+
+	/// <summary>
+	/// Returns the <see cref="LatestFallbackWarning"/> when <paramref name="resolvedFrom"/> is the
+	/// <c>latest-fallback</c> tier, otherwise <c>null</c>. Centralised so the MCP tool, the CLI verb,
+	/// and the pretty renderer all gate the warning on the exact same condition.
+	/// </summary>
+	public static string? GetVersionWarning(string? resolvedFrom) =>
+		string.Equals(resolvedFrom, ResolvedFromLatestFallback, StringComparison.OrdinalIgnoreCase)
+			? LatestFallbackWarning
+			: null;
+
+	/// <summary>
 	/// Reports <c>"environment"</c> only when the caller asked for a specific platform version
 	/// (probe-success or explicit <c>--version</c>) AND the catalog actually loaded that exact
 	/// version. Any fallback (CDN 404 → latest, CDN down → embedded, probe failure, default

--- a/clio/Command/McpServer/Tools/ComponentInfoResolution.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoResolution.cs
@@ -26,7 +26,8 @@ public static class ComponentInfoResolution {
 		+ "A component listed here may not exist in the target environment's actual platform version, "
 		+ "so a page built against it can fail to render at runtime. "
 		+ "To scope results to a real version, pass an explicit version or target a registered "
-		+ "environment so clio can resolve its platform version via cliogate GetSysInfo.";
+		+ "environment so clio can resolve its platform version (no cliogate required — resolved via "
+		+ "ApplicationInfoService, with the cliogate GetSysInfo probe as fallback).";
 
 	/// <summary>
 	/// Returns the <see cref="LatestFallbackWarning"/> when <paramref name="resolvedFrom"/> is the

--- a/clio/Command/McpServer/Tools/ComponentInfoTool.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoTool.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Clio.UserEnvironment;
 using ModelContextProtocol.Server;
 
 namespace Clio.Command.McpServer.Tools;
@@ -12,12 +13,22 @@ namespace Clio.Command.McpServer.Tools;
 /// <summary>
 /// MCP tool surface for curated Freedom UI component metadata.
 /// </summary>
+/// <remarks>
+/// Version resolution mirrors the <c>clio get-component-info</c> CLI verb 1:1 (see
+/// <see cref="ComponentInfoCommand"/>): the target catalog version is driven entirely by the
+/// per-call arguments — never by ambient server state — so the tool returns the same catalog
+/// the targeted environment actually ships. An explicit <c>version</c> wins; otherwise an
+/// <c>environment-name</c>/<c>uri</c> triggers a cliogate <c>GetSysInfo</c> probe; with neither,
+/// the tool honestly reports <c>latest-fallback</c> and surfaces
+/// <see cref="ComponentInfoResponse.VersionWarning"/>.
+/// </remarks>
 [McpServerToolType]
 public sealed class ComponentInfoTool(
 	IComponentInfoCatalog catalog,
 	IMobileComponentInfoCatalog mobileCatalog,
-	IPlatformVersionResolver versionResolver,
-	IComponentRegistryDocsClient docsClient) {
+	IComponentRegistryDocsClient docsClient,
+	IPlatformVersionResolverFactory resolverFactory,
+	ISettingsRepository settingsRepository) {
 
 	internal const string ToolName = "get-component-info";
 	internal const string ResolvedFromEnvironment = ComponentInfoResolution.ResolvedFromEnvironment;
@@ -46,6 +57,10 @@ public sealed class ComponentInfoTool(
 	/// <returns>A structured response with a component list or a full component definition.</returns>
 	[McpServerTool(Name = ToolName, ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
 	[Description("Get curated Freedom UI component metadata by component type or list all known types. " +
+		"IMPORTANT: pass environment-name to scope the catalog to the target environment's actual platform version — " +
+		"otherwise results come from the 'latest' catalog, a SUPERSET of every GA version, and may list components " +
+		"(e.g. a freshly shipped crt.Switch) that do NOT exist in that environment and will fail to render at runtime. " +
+		"When you target a page-editing environment, pass the same environment-name here. " +
 		"If schema-type is omitted, defaults to the web component catalog (excludes mobile-only components such as crt.Toggle and crt.BarcodeScanner). " +
 		"Use schema-type: 'mobile' to retrieve mobile-specific components — the mobile registry is separate and excludes web-only types.")]
 	public async Task<ComponentInfoResponse> GetComponentInfo(
@@ -55,8 +70,18 @@ public sealed class ComponentInfoTool(
 		string? search = null,
 		[Description("Component registry to query: 'web' (default) for standard Freedom UI pages, or 'mobile' for mobile page components (crt.Toggle, crt.BarcodeScanner, crt.Sort, etc.).")]
 		string? schemaType = null,
+		[Description("Registered environment name to scope the catalog to its real platform version (probed via cliogate GetSysInfo). PREFER this — pass the same environment you edit pages on. Mutually exclusive with 'version'.")]
+		string? environmentName = null,
+		[Description("Explicit catalog version (3-part semver, e.g. '8.3.3') when the platform version is already known. Mutually exclusive with 'environment-name'.")]
+		string? version = null,
+		[Description("Emergency fallback only: direct application URI when no environment is registered. Prefer 'environment-name'.")]
+		string? uri = null,
+		[Description("Emergency fallback only: login paired with 'uri'. Prefer 'environment-name'.")]
+		string? login = null,
+		[Description("Emergency fallback only: password paired with 'uri'. Prefer 'environment-name'.")]
+		string? password = null,
 		CancellationToken cancellationToken = default) {
-		ComponentInfoArgs args = new(componentType, search, schemaType);
+		ComponentInfoArgs args = new(componentType, search, schemaType, environmentName, version, uri, login, password);
 		try {
 			return await BuildResponseAsync(args, cancellationToken).ConfigureAwait(false);
 		}
@@ -82,7 +107,20 @@ public sealed class ComponentInfoTool(
 	/// </summary>
 	private async Task<ComponentInfoResponse> BuildResponseAsync(ComponentInfoArgs args, CancellationToken cancellationToken) {
 		bool isMobile = IsMobile(args.SchemaType);
-		PlatformVersionResolution version = await versionResolver.ResolveAsync(cancellationToken).ConfigureAwait(false);
+		bool hasExplicitVersion = !string.IsNullOrWhiteSpace(args.Version);
+		bool hasEnvironment = !string.IsNullOrWhiteSpace(args.EnvironmentName) || !string.IsNullOrWhiteSpace(args.Uri);
+		if (hasExplicitVersion && hasEnvironment) {
+			return new ComponentInfoResponse {
+				Success = false,
+				Mode = "list",
+				Error = "'version' and 'environment-name'/'uri' are mutually exclusive. Pass one or neither.",
+				Count = 0,
+				Items = []
+			};
+		}
+
+		PlatformVersionResolution version = await ResolveVersionAsync(args, hasExplicitVersion, hasEnvironment, cancellationToken)
+			.ConfigureAwait(false);
 		ComponentCatalogState state = isMobile
 			? await mobileCatalog.LoadAsync(version.ResolvedVersion, cancellationToken).ConfigureAwait(false)
 			: await catalog.LoadAsync(version.ResolvedVersion, cancellationToken).ConfigureAwait(false);
@@ -110,6 +148,53 @@ public sealed class ComponentInfoTool(
 			ResolvedTargetVersion = state.ResolvedVersion,
 			ResolvedFrom = resolvedFrom
 		};
+	}
+
+	/// <summary>
+	/// Selects the target catalog version from the per-call arguments, mirroring
+	/// <see cref="ComponentInfoCommand"/>'s resolution order so the MCP tool and the CLI verb
+	/// stay in lockstep:
+	/// <list type="number">
+	/// <item>explicit <c>version</c> — authoritative (<see cref="ComponentInfoResolution.MapResolvedFrom"/>
+	/// downgrades it to <c>latest-fallback</c> automatically if the catalog ends up loading a different version);</item>
+	/// <item><c>environment-name</c>/<c>uri</c> — probe cliogate <c>GetSysInfo</c> on that environment;</item>
+	/// <item>neither — <c>latest</c> with a non-authoritative source so the response carries <c>latest-fallback</c>.</item>
+	/// </list>
+	/// </summary>
+	private Task<PlatformVersionResolution> ResolveVersionAsync(
+		ComponentInfoArgs args,
+		bool hasExplicitVersion,
+		bool hasEnvironment,
+		CancellationToken cancellationToken) {
+		if (hasExplicitVersion) {
+			return Task.FromResult(new PlatformVersionResolution(args.Version!.Trim(), VersionResolutionSource.Environment));
+		}
+
+		if (hasEnvironment) {
+			EnvironmentSettings settings = ResolveEnvironmentSettings(args);
+			IPlatformVersionResolver resolver = resolverFactory.Create(settings);
+			return resolver.ResolveAsync(cancellationToken);
+		}
+
+		return Task.FromResult(new PlatformVersionResolution(
+			PlatformVersionResolver.LatestVersion,
+			VersionResolutionSource.LatestFallback));
+	}
+
+	/// <summary>
+	/// Builds the <see cref="EnvironmentSettings"/> for the cliogate probe from the per-call
+	/// arguments. Delegates to <see cref="ISettingsRepository.GetEnvironment(EnvironmentOptions)"/>
+	/// so the same registered-environment lookup, active-environment fallback, and explicit
+	/// uri/login/password fill the CLI verb uses also back the MCP tool.
+	/// </summary>
+	private EnvironmentSettings ResolveEnvironmentSettings(ComponentInfoArgs args) {
+		EnvironmentOptions options = new() {
+			Environment = args.EnvironmentName,
+			Uri = args.Uri,
+			Login = args.Login,
+			Password = args.Password
+		};
+		return settingsRepository.GetEnvironment(options);
 	}
 
 	private static bool IsMobile(string? schemaType) =>
@@ -241,7 +326,27 @@ public sealed record ComponentInfoArgs(
 
 	[property: JsonPropertyName("schema-type")]
 	[property: Description("Component registry to query: 'web' (default) for standard Freedom UI pages, or 'mobile' for mobile page components (crt.Toggle, crt.BarcodeScanner, crt.Sort, etc.).")]
-	string? SchemaType = null
+	string? SchemaType = null,
+
+	[property: JsonPropertyName("environment-name")]
+	[property: Description("Registered environment name to scope the catalog to its real platform version. Mutually exclusive with 'version'.")]
+	string? EnvironmentName = null,
+
+	[property: JsonPropertyName("version")]
+	[property: Description("Explicit catalog version (3-part semver). Mutually exclusive with 'environment-name'.")]
+	string? Version = null,
+
+	[property: JsonPropertyName("uri")]
+	[property: Description("Emergency fallback only: direct application URI. Prefer 'environment-name'.")]
+	string? Uri = null,
+
+	[property: JsonPropertyName("login")]
+	[property: Description("Emergency fallback only: login paired with 'uri'.")]
+	string? Login = null,
+
+	[property: JsonPropertyName("password")]
+	[property: Description("Emergency fallback only: password paired with 'uri'.")]
+	string? Password = null
 );
 
 /// <summary>
@@ -364,10 +469,11 @@ public sealed class ComponentInfoResponse {
 	public IReadOnlyList<ComponentInfoListItem>? Items { get; init; }
 
 	/// <summary>
-	/// Gets or sets the platform version the catalog was filtered against. In v1 this is
-	/// always <c>"latest"</c> (the catalog is loaded from CDN <c>latest.json</c> / cache / embedded);
-	/// once <c>IPlatformVersionResolver</c> lands this will carry the GA-tag-shaped semver
-	/// resolved from the active environment's cliogate <c>GetSysInfo</c> probe.
+	/// Gets or sets the platform version the catalog was filtered against. Carries the
+	/// GA-tag-shaped semver resolved from the targeted environment's cliogate <c>GetSysInfo</c>
+	/// probe (or an explicit <c>version</c> argument); falls back to <c>"latest"</c> when no
+	/// environment/version was supplied or the probe could not produce a usable version — see
+	/// <see cref="ResolvedFrom"/> for which tier produced it.
 	/// </summary>
 	[JsonPropertyName("resolvedTargetVersion")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -382,6 +488,19 @@ public sealed class ComponentInfoResponse {
 	[JsonPropertyName("resolvedFrom")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string? ResolvedFrom { get; init; }
+
+	/// <summary>
+	/// Gets the human-readable caveat emitted whenever <see cref="ResolvedFrom"/> is
+	/// <c>latest-fallback</c>. Derived from <see cref="ResolvedFrom"/> so every response
+	/// shape (list / detail / not-found, web only) carries it without each branch having
+	/// to set it, and so the MCP tool and CLI verb stay in lockstep. Omitted from the wire
+	/// shape when the catalog matched the target version (<c>environment</c> tier) or when
+	/// the flavor reports no version markers (mobile). See
+	/// <see cref="ComponentInfoResolution.LatestFallbackWarning"/> for the rationale.
+	/// </summary>
+	[JsonPropertyName("versionWarning")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string? VersionWarning => ComponentInfoResolution.GetVersionWarning(ResolvedFrom);
 
 	/// <summary>
 	/// Gets or sets the long-form documentation associated with the component. Populated

--- a/clio/Command/McpServer/Tools/ComponentInfoTool.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoTool.cs
@@ -118,14 +118,23 @@ public sealed class ComponentInfoTool(
 				Items = []
 			};
 		}
+		if (hasExplicitVersion && !PlatformVersionResolver.TryNormaliseToThreePartSemver(args.Version!, out _)) {
+			return new ComponentInfoResponse {
+				Success = false,
+				Mode = "list",
+				Error = $"'version' value '{args.Version}' is not a valid platform version. Use a 3-part semver, for example '8.3.3'.",
+				Count = 0,
+				Items = []
+			};
+		}
 
-		PlatformVersionResolution version = await ResolveVersionAsync(args, hasExplicitVersion, hasEnvironment, cancellationToken)
+		PlatformVersionResolution versionResolution = await ResolveVersionAsync(args, hasExplicitVersion, hasEnvironment, cancellationToken)
 			.ConfigureAwait(false);
 		ComponentCatalogState state = isMobile
-			? await mobileCatalog.LoadAsync(version.ResolvedVersion, cancellationToken).ConfigureAwait(false)
-			: await catalog.LoadAsync(version.ResolvedVersion, cancellationToken).ConfigureAwait(false);
+			? await mobileCatalog.LoadAsync(versionResolution.ResolvedVersion, cancellationToken).ConfigureAwait(false)
+			: await catalog.LoadAsync(versionResolution.ResolvedVersion, cancellationToken).ConfigureAwait(false);
 		string resolvedFrom = ComponentInfoResolution.MapResolvedFrom(
-			version.Source, version.ResolvedVersion, state.ResolvedVersion);
+			versionResolution.Source, versionResolution.ResolvedVersion, state.ResolvedVersion);
 
 		if (string.IsNullOrWhiteSpace(args.ComponentType)
 			|| string.Equals(args.ComponentType, "list", StringComparison.OrdinalIgnoreCase)) {

--- a/clio/Command/McpServer/Tools/PlatformVersionResolver.cs
+++ b/clio/Command/McpServer/Tools/PlatformVersionResolver.cs
@@ -48,6 +48,14 @@ public enum VersionResolutionSource {
 /// would be pure overhead.
 /// </summary>
 public sealed class PlatformVersionResolver : IPlatformVersionResolver {
+	/// <summary>
+	/// Standard Creatio service that returns the core version without requiring cliogate —
+	/// only an authenticated session. Preferred over <see cref="GetSysInfoServicePath"/> so
+	/// version resolution works on environments where cliogate is not installed.
+	/// Returns <c>{ applicationInfo: { sysValues: { coreVersion: "8.3.3.xxxx" } } }</c>.
+	/// </summary>
+	internal const string GetApplicationInfoServicePath = "/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo";
+	/// <summary>cliogate fallback probe — used only when <see cref="GetApplicationInfoServicePath"/> yields no version.</summary>
 	internal const string GetSysInfoServicePath = "/rest/CreatioApiGateway/GetSysInfo";
 	internal const string LatestVersion = "latest";
 	internal static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
@@ -93,36 +101,22 @@ public sealed class PlatformVersionResolver : IPlatformVersionResolver {
 
 	private async Task<PlatformVersionResolution> ProbeAsync(string environmentKey, CancellationToken cancellationToken) {
 		// Route through IServiceUrlBuilder so .NET Framework deployments (IsNetCore=false)
-		// receive the /0/rest/... alias they need. Hand-rolling the URL here would always
+		// receive the /0/... alias they need. Hand-rolling the URL here would always
 		// hit 404 on those environments and force a silent latest-fallback.
 		IServiceUrlBuilder serviceUrlBuilder = _serviceUrlBuilderFactory.Create(_environmentSettings);
-		string url = serviceUrlBuilder.Build(GetSysInfoServicePath);
 
-		string? rawResponse;
-		try {
-			// IApplicationClient.ExecuteGetRequest is synchronous; offload so the call does not
-			// block the MCP host's loop. Cancellation is best-effort because the underlying
-			// HTTP plumbing in CreatioClient does not surface a CancellationToken — we simply
-			// stop awaiting if the caller cancels.
-			rawResponse = await Task.Run(
-				() => _applicationClient.ExecuteGetRequest(url),
-				cancellationToken).ConfigureAwait(false);
-		} catch (OperationCanceledException) {
-			throw;
-		} catch (Exception ex) {
-			_logger.LogInformation(ex,
-				"platform-version source=latest-fallback reason=probe-failed env={Env} error={Error}",
-				environmentKey, ex.Message);
-			return new PlatformVersionResolution(LatestVersion, VersionResolutionSource.LatestFallback);
+		// Primary: ApplicationInfoService — a standard Creatio service that needs only an
+		// authenticated session, so version resolution no longer depends on cliogate being
+		// installed. Fall back to the cliogate GetSysInfo probe only when this yields nothing
+		// (e.g. an older Creatio whose response shape differs). Both expose the same
+		// Major.Minor.Patch.Build core version, so the fallback is byte-equivalent when it runs.
+		string? coreVersion = await TryGetCoreVersionFromApplicationInfoAsync(serviceUrlBuilder, environmentKey, cancellationToken)
+			.ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(coreVersion)) {
+			coreVersion = await TryGetCoreVersionFromCliogateAsync(serviceUrlBuilder, environmentKey, cancellationToken)
+				.ConfigureAwait(false);
 		}
 
-		if (string.IsNullOrWhiteSpace(rawResponse)) {
-			_logger.LogInformation(
-				"platform-version source=latest-fallback reason=empty-response env={Env}", environmentKey);
-			return new PlatformVersionResolution(LatestVersion, VersionResolutionSource.LatestFallback);
-		}
-
-		string? coreVersion = TryExtractCoreVersion(rawResponse);
 		if (string.IsNullOrWhiteSpace(coreVersion)) {
 			_logger.LogInformation(
 				"platform-version source=latest-fallback reason=core-version-missing env={Env}", environmentKey);
@@ -142,7 +136,88 @@ public sealed class PlatformVersionResolver : IPlatformVersionResolver {
 		return new PlatformVersionResolution(threePart!, VersionResolutionSource.Environment);
 	}
 
-	private static string? TryExtractCoreVersion(string rawJson) {
+	/// <summary>
+	/// Probes the standard ApplicationInfoService (no cliogate required). Returns the raw
+	/// 4-part core version string, or <c>null</c> on any failure class (request error, empty
+	/// body, unexpected shape) so the caller can fall through to the cliogate probe.
+	/// </summary>
+	private async Task<string?> TryGetCoreVersionFromApplicationInfoAsync(
+		IServiceUrlBuilder serviceUrlBuilder, string environmentKey, CancellationToken cancellationToken) {
+		string url = serviceUrlBuilder.Build(GetApplicationInfoServicePath);
+		try {
+			// ExecutePostRequest is synchronous; offload so the MCP host loop is not blocked.
+			// The service takes an empty JSON body.
+			string? rawResponse = await Task.Run(
+				() => _applicationClient.ExecutePostRequest(url, "{}"),
+				cancellationToken).ConfigureAwait(false);
+			return TryExtractApplicationInfoCoreVersion(rawResponse);
+		} catch (OperationCanceledException) {
+			throw;
+		} catch (Exception ex) {
+			_logger.LogInformation(ex,
+				"platform-version application-info-probe-failed env={Env} error={Error}",
+				environmentKey, ex.Message);
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Fallback probe via cliogate <c>GetSysInfo</c>. Returns the raw core version string, or
+	/// <c>null</c> when cliogate is absent/unreachable or the shape is unexpected.
+	/// </summary>
+	private async Task<string?> TryGetCoreVersionFromCliogateAsync(
+		IServiceUrlBuilder serviceUrlBuilder, string environmentKey, CancellationToken cancellationToken) {
+		string url = serviceUrlBuilder.Build(GetSysInfoServicePath);
+		try {
+			string? rawResponse = await Task.Run(
+				() => _applicationClient.ExecuteGetRequest(url),
+				cancellationToken).ConfigureAwait(false);
+			return TryExtractSysInfoCoreVersion(rawResponse);
+		} catch (OperationCanceledException) {
+			throw;
+		} catch (Exception ex) {
+			_logger.LogInformation(ex,
+				"platform-version cliogate-probe-failed env={Env} error={Error}",
+				environmentKey, ex.Message);
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Extracts <c>applicationInfo.sysValues.coreVersion</c> from the ApplicationInfoService
+	/// response. Returns <c>null</c> on any missing node or non-string value.
+	/// </summary>
+	private static string? TryExtractApplicationInfoCoreVersion(string? rawJson) {
+		if (string.IsNullOrWhiteSpace(rawJson)) {
+			return null;
+		}
+		try {
+			using JsonDocument document = JsonDocument.Parse(rawJson);
+			JsonElement root = document.RootElement;
+			// { "applicationInfo": { "sysValues": { "coreVersion": "8.3.3.xxxx" } } }
+			if (root.ValueKind != JsonValueKind.Object
+				|| !root.TryGetProperty("applicationInfo", out JsonElement appInfo)
+				|| appInfo.ValueKind != JsonValueKind.Object
+				|| !appInfo.TryGetProperty("sysValues", out JsonElement sysValues)
+				|| sysValues.ValueKind != JsonValueKind.Object
+				|| !sysValues.TryGetProperty("coreVersion", out JsonElement coreVersion)
+				|| coreVersion.ValueKind != JsonValueKind.String) {
+				return null;
+			}
+			return coreVersion.GetString();
+		} catch (JsonException) {
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Extracts <c>SysInfo.CoreVersion</c> from the cliogate <c>GetSysInfo</c> response.
+	/// Returns <c>null</c> on any missing node or non-string value.
+	/// </summary>
+	private static string? TryExtractSysInfoCoreVersion(string? rawJson) {
+		if (string.IsNullOrWhiteSpace(rawJson)) {
+			return null;
+		}
 		try {
 			using JsonDocument document = JsonDocument.Parse(rawJson);
 			JsonElement root = document.RootElement;

--- a/clio/Command/McpServer/Tools/PlatformVersionResolver.cs
+++ b/clio/Command/McpServer/Tools/PlatformVersionResolver.cs
@@ -35,7 +35,11 @@ public interface IPlatformVersionResolver {
 public sealed record PlatformVersionResolution(string ResolvedVersion, VersionResolutionSource Source);
 
 public enum VersionResolutionSource {
-	/// <summary>Probe of cliogate <c>GetSysInfo</c> succeeded and the version parsed cleanly.</summary>
+	/// <summary>
+	/// A platform version was successfully resolved from the environment and parsed cleanly —
+	/// via the standard <c>ApplicationInfoService</c> (primary, no cliogate) or the cliogate
+	/// <c>GetSysInfo</c> fallback.
+	/// </summary>
 	Environment,
 	/// <summary>No usable version could be determined; the catalog is loaded against <c>latest.json</c>.</summary>
 	LatestFallback
@@ -54,9 +58,9 @@ public sealed class PlatformVersionResolver : IPlatformVersionResolver {
 	/// version resolution works on environments where cliogate is not installed.
 	/// Returns <c>{ applicationInfo: { sysValues: { coreVersion: "8.3.3.xxxx" } } }</c>.
 	/// </summary>
-	internal const string GetApplicationInfoServicePath = "/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo";
+	internal const string GetApplicationInfoServicePath = CreatioServicePaths.GetApplicationInfo;
 	/// <summary>cliogate fallback probe — used only when <see cref="GetApplicationInfoServicePath"/> yields no version.</summary>
-	internal const string GetSysInfoServicePath = "/rest/CreatioApiGateway/GetSysInfo";
+	internal const string GetSysInfoServicePath = CreatioServicePaths.GetSysInfo;
 	internal const string LatestVersion = "latest";
 	internal static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
 

--- a/clio/Common/CreatioServicePaths.cs
+++ b/clio/Common/CreatioServicePaths.cs
@@ -1,0 +1,20 @@
+namespace Clio.Common;
+
+/// <summary>
+/// Well-known Creatio service endpoint paths shared across commands and MCP tools.
+/// Centralised so a path change lands in exactly one place rather than drifting between
+/// the CLI verbs and the MCP resolver that call the same services.
+/// </summary>
+public static class CreatioServicePaths {
+	/// <summary>
+	/// Standard Creatio service that returns core/system metadata (incl. <c>sysValues.coreVersion</c>).
+	/// Requires only an authenticated session — no cliogate package.
+	/// </summary>
+	public const string GetApplicationInfo = "/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo";
+
+	/// <summary>
+	/// cliogate API gateway endpoint that returns <c>SysInfo</c> (incl. <c>CoreVersion</c>, runtime,
+	/// db engine, license). Requires the cliogate package to be installed.
+	/// </summary>
+	public const string GetSysInfo = "/rest/CreatioApiGateway/GetSysInfo";
+}

--- a/clio/docs/commands/get-component-info.md
+++ b/clio/docs/commands/get-component-info.md
@@ -51,6 +51,22 @@ markers (`"environment"` | `"latest-fallback"`) so consumers can tell when
 the catalog actually matched the requested target version and when it fell
 back.
 
+When `resolvedFrom` is `"latest-fallback"` the response also carries a
+`versionWarning` string. `latest` is a superset of every GA version, so a
+component listed under fallback (for example a freshly shipped `crt.Switch`)
+may not exist in the target environment's actual platform version and a page
+built against it can fail to render at runtime. Pass `--version` or
+`--environment` (the MCP tool accepts `environment-name`) to scope the
+catalog to a real version; the warning is omitted once `resolvedFrom` is
+`"environment"`. Under `--pretty` the warning renders on a `WARNING:` line
+beneath the header.
+
+The MCP `get-component-info` tool mirrors this resolution 1:1 and accepts the
+same per-call selectors — `environment-name` (preferred), `version`, or
+`uri`/`login`/`password` as an emergency fallback. Prefer passing the same
+`environment-name` you edit pages on so the catalog matches that
+environment's real component set.
+
 ## Synopsis
 
 ```bash

--- a/clio/docs/commands/get-component-info.md
+++ b/clio/docs/commands/get-component-info.md
@@ -28,8 +28,12 @@ local payload iteration, point `CLIO_COMPONENT_REGISTRY_LOCAL_FILE` at a
 chosen by:
 
 1. `--version <semver>` — explicit override (highest priority).
-2. `--environment <name>` or `--uri ...` — probe cliogate `GetSysInfo` on
-   that environment to pick the matching catalog.
+2. `--environment <name>` or `--uri ...` — probe the environment for its
+   core version to pick the matching catalog. The probe uses the standard
+   `ApplicationInfoService` (no cliogate required — an authenticated session
+   is enough) and falls back to the cliogate `GetSysInfo` endpoint only if
+   that yields no version. This means version-accurate results work on
+   environments without cliogate installed.
 3. Neither — default to `latest`.
 
 `--version` and `--environment` (or `--uri`) are mutually exclusive.

--- a/clio/docs/commands/get-info.md
+++ b/clio/docs/commands/get-info.md
@@ -21,16 +21,21 @@ describe, describe-creatio, instance-info
 ## Description
 
 Retrieves comprehensive information about the Creatio instance including
-version, underlying runtime, database type, and product name. This command
-communicates with the Creatio instance through the cliogate API gateway to
-collect system details.
+version, underlying runtime, database type, and product name. The full report
+is collected through the cliogate API gateway.
+
+When cliogate is not installed (or is older than the required version) the
+command degrades gracefully instead of failing: it falls back to the standard
+`ApplicationInfoService` — which needs only an authenticated session — and
+reports the core version plus locale/user/workspace metadata, with a warning
+that the cliogate-only fields are unavailable in this mode.
 
 The command returns information such as:
-- Creatio version
-- Runtime environment (.NET version)
-- Database type (MSSQL, PostgreSQL, Oracle)
-- Product name and configuration
-- System settings and configuration details
+- Creatio version (available with or without cliogate)
+- Runtime environment (.NET version) — cliogate only
+- Database type (MSSQL, PostgreSQL, Oracle) — cliogate only
+- Product name and configuration — cliogate only
+- System settings and configuration details — cliogate only
 
 REQUIREMENTS:
 - cliogate must be installed on the target Creatio instance


### PR DESCRIPTION
## Summary

`get-component-info` resolved the catalog version from an ambient server-bound resolver, so a bare call returned the `latest` catalog — a superset of every GA version — and listed components (e.g. `crt.Switch`) that do **not** exist in the targeted environment's version. A page built against such a component fails to render at runtime. This was hit live on an 8.3.3 stand where `crt.Switch` (only in `latest`) was returned as a valid detail.

Two commits under ENG-89871:

### 1. Scope to target version + warn on fallback (`68ff9b96`)
- **versionWarning**: `ComponentInfoResponse` now carries a derived `versionWarning`, surfaced whenever `resolvedFrom == latest-fallback`, on both the MCP tool and the CLI verb (pretty renderer prints a `WARNING:` line). Fires regardless of *why* the fallback happened — the always-on safety net.
- **env-scoped resolution (mirror-CLI)**: the MCP tool now resolves the version from per-call arguments (`environment-name` / `version` / `uri`+`login`+`password`), mirroring the `clio get-component-info` CLI verb 1:1 via `IPlatformVersionResolverFactory` + `ISettingsRepository`, with a `version` XOR `environment` guard. Removed the now-dead ambient `IPlatformVersionResolver` singleton. The tool `[Description]` instructs agents to pass `environment-name`.
- Also fixed a pre-existing ComponentInfo E2E helper bug (it wrapped args in an `args` envelope with kebab keys; the real wire contract is flat camelCase), which had the whole suite red on master.

### 2. Resolve platform version without cliogate (`e4b5f48b`)
- `PlatformVersionResolver` now probes the standard **`ApplicationInfoService`** (`sysValues.coreVersion`, needs only auth) first, falling back to the cliogate `GetSysInfo` endpoint only when that yields nothing. Same core version, no cliogate dependency. `MapResolvedFrom` untouched — a missing version still degrades to `latest-fallback` + `versionWarning`.
- `get-info` degrades gracefully when cliogate is absent/older than required: reports the core version + locale/user/workspace metadata from `ApplicationInfoService` with a warning, instead of failing outright.

## Test plan
- Unit: 73 pass across `PlatformVersionResolver`, `ComponentInfo*`, `GetInfoCommand`, `RemoteCommandCliogate`, `BindingsModule`. New tests cover the warning, env-scoped resolution, the `version` XOR `environment` guard, the ApplicationInfo primary / cliogate fallback branches, and graceful `get-info` degradation.
- E2E (`ComponentInfoToolE2ETests`): 7/7 (offline, CDN/embedded). Guard test proves the new args bind through the real MCP arg-binding pipeline.
- **Real-stand verification (8.3.3)**: with cliogate removed, `get-component-info crt.Switch --environment` resolves to the `environment` tier (`8.3.3`) and correctly reports `crt.Switch` as not found; `crt.Button` resolves and is found; `get-info` prints `coreVersion 8.3.3.3292` with the cliogate warning.

## Notes
- Environment-tier resolution is unit-covered + manually verified on a real stand, not E2E-pinned (deliberately avoided hardcoding a stand into E2E — flaky).
- Convention gap (follow-up candidate, not changed here): `get-component-info` uses a flat camelCase wire contract while other env-aware tools use a single `args` record + kebab. Changing it is a breaking wire change.
- Out of scope (separate ticket): list-mode "duplicate component types" error seen in the original session — a property of that session's `latest` payload, not present in `latest`/8.3.3 now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)