### PR TITLE
feat(new-ui-project): integrate generated Angular project into MainSolution via .esproj

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,22 +3,27 @@ project_name: "clio"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -66,54 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -124,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -152,3 +123,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/clio.tests/Command/Link4RepoCommand.PreparationTests.cs
+++ b/clio.tests/Command/Link4RepoCommand.PreparationTests.cs
@@ -18,6 +18,11 @@ namespace Clio.Tests.Command;
 
 [TestFixture]
 [Property("Module", "Command")]
+// Asserts on messages read back from the shared ConsoleLogger.Instance singleton. Fixtures run in
+// parallel, so a concurrent fixture toggling PreserveMessages / ClearMessages would wipe these
+// messages mid-test. Run non-parallel to isolate the singleton (same approach as
+// LastCompilationLogCommandTestFixture / ConsoleLoggerTests).
+[NonParallelizable]
 public class Link4RepoCommandPreparationTests : BaseCommandTests<Link4RepoOptions> {
 
 	#region Fields: Private

--- a/clio.tests/Command/Link4RepoCommand.UnlockedTests.cs
+++ b/clio.tests/Command/Link4RepoCommand.UnlockedTests.cs
@@ -7,6 +7,7 @@ using Clio.Command;
 using Clio.Common;
 using Clio.Package;
 using Clio.UserEnvironment;
+using ConsoleTables;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
@@ -29,6 +30,7 @@ public class Link4RepoCommandUnlockedTests : BaseCommandTests<Link4RepoOptions> 
 	private IJsonConverter _jsonConverter = null!;
 	private TestableUnlockedLink4RepoCommand _command = null!;
 	private MockFileSystem _mockFs = null!;
+	private CapturedLogger _logger = null!;
 
 	#endregion
 
@@ -44,8 +46,13 @@ public class Link4RepoCommandUnlockedTests : BaseCommandTests<Link4RepoOptions> 
 		_validator.Validate(Arg.Any<Link4RepoOptions>()).Returns(new ValidationResult());
 		_packageListProvider = Substitute.For<IApplicationPackageListProvider>();
 		_jsonConverter = Substitute.For<IJsonConverter>();
+		// Use a fixture-local recording logger rather than the process-wide ConsoleLogger.Instance
+		// singleton: the singleton is shared across the whole test run, so another fixture toggling
+		// PreserveMessages / ClearMessages between this command's writes and the snapshot makes the
+		// message assertions flaky.
+		_logger = new CapturedLogger();
 		_command = new TestableUnlockedLink4RepoCommand(
-			ConsoleLogger.Instance,
+			_logger,
 			Substitute.For<IMediator>(),
 			_settingsRepository,
 			_fileSystem,
@@ -59,14 +66,10 @@ public class Link4RepoCommandUnlockedTests : BaseCommandTests<Link4RepoOptions> 
 			Substitute.For<ISysSettingsManager>(),
 			Substitute.For<IPackageLockManager>(),
 			Substitute.For<IFileDesignModePackages>());
-		ConsoleLogger.Instance.PreserveMessages = true;
-		ConsoleLogger.Instance.ClearMessages();
 	}
 
 	[TearDown]
 	public override void TearDown() {
-		ConsoleLogger.Instance.ClearMessages();
-		ConsoleLogger.Instance.PreserveMessages = false;
 		base.TearDown();
 	}
 
@@ -347,8 +350,7 @@ public class Link4RepoCommandUnlockedTests : BaseCommandTests<Link4RepoOptions> 
 		_packageListProvider.Received(1).GetPackages(Arg.Any<string>());
 		_command.CapturedSitePath.Should().BeNull("because dry-run should not create symlinks");
 		_command.VersionedLinkCalls.Should().BeEmpty("because dry-run should not link");
-		var logMessages = ConsoleLogger.Instance.FlushAndSnapshotMessages()
-			.Select(m => m.Value.ToString()).ToList();
+		List<string> logMessages = _logger.Messages;
 		logMessages.Should().Contain(m => m.Contains("[dry-run]") && m.Contains("unlocked package(s)"));
 		logMessages.Should().Contain(m => m.Contains("Repository structure:"));
 		logMessages.Should().Contain(m => m.Contains("[dry-run] No changes applied."));
@@ -373,6 +375,41 @@ public class Link4RepoCommandUnlockedTests : BaseCommandTests<Link4RepoOptions> 
 			UId = Guid.NewGuid()
 		};
 		return new PackageInfo(descriptor, string.Empty, []);
+	}
+
+	#endregion
+
+	#region CapturedLogger
+
+	/// <summary>
+	/// Fixture-local <see cref="ILogger"/> that records every written message into <see cref="Messages"/>.
+	/// Replaces the process-wide <c>ConsoleLogger.Instance</c> singleton so message assertions are not
+	/// affected by other fixtures running in the same test process.
+	/// </summary>
+	private sealed class CapturedLogger : ILogger, IDisposable {
+
+		public List<string> Messages { get; } = [];
+
+		public void Write(string value) => Messages.Add(value);
+		public void WriteLine() => Messages.Add(string.Empty);
+		public void WriteLine(string value) => Messages.Add(value);
+		public void WriteError(string value) => Messages.Add(value);
+		public void WriteInfo(string value) => Messages.Add(value);
+		public void WriteWarning(string value) => Messages.Add(value);
+		public void WriteDebug(string value) => Messages.Add(value);
+
+		// No-op infrastructure required by the ILogger contract.
+		List<LogMessage> ILogger.LogMessages { get; } = [];
+		bool ILogger.PreserveMessages { get; set; }
+		public void ClearMessages() => Messages.Clear();
+		public IDisposable BeginScopedFileSink(string logFilePath) => this;
+		public void Start(string logFilePath = "") { }
+		public void StartWithStream() { }
+		public void Stop() { }
+		public void SetCreatioLogStreamer(ILogStreamer creatioLogStreamer) { }
+		public void PrintTable(ConsoleTable table) { }
+		public void PrintValidationFailureErrors(IEnumerable<ValidationFailure> errors) { }
+		public void Dispose() { }
 	}
 
 	#endregion

--- a/clio.tests/Command/McpServer/BaseToolTests.cs
+++ b/clio.tests/Command/McpServer/BaseToolTests.cs
@@ -10,6 +10,11 @@ namespace Clio.Tests.Command.McpServer;
 
 [TestFixture]
 [Property("Module", "McpServer")]
+// Asserts on messages read back from the shared ConsoleLogger.Instance singleton. Fixtures run in
+// parallel, so a concurrent fixture toggling PreserveMessages / ClearMessages would wipe these
+// messages mid-test. Run non-parallel to isolate the singleton (same approach as
+// LastCompilationLogCommandTestFixture / ConsoleLoggerTests).
+[NonParallelizable]
 public sealed class BaseToolTests {
 
 	[Test]

--- a/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+++ b/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Xml;
+using Clio.Common;
+using Clio.Package;
+using Clio.Workspace;
+using Clio.Workspaces;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using AbstractionsFileSystem = System.IO.Abstractions.FileSystem;
+
+namespace Clio.Tests.Package;
+
+/// <summary>
+/// Exercises <see cref="UiProjectCreator"/> against the <b>real</b> shipped templates
+/// (<c>tpl/esproj.tpl</c>, <c>tpl/ui-project</c>, <c>tpl/workspace/MainSolution.slnx</c>) and a real
+/// filesystem in a temp workspace, then asserts the four esproj-integration artifacts on disk.
+/// This is the test that catches a malformed template or a not-copied-to-output template.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[Property("Module", "Package")]
+public class UiProjectCreatorIntegrationTests {
+
+	#region Constants: Private
+
+	private const string ProjectName = "rss_reader";
+	private const string PackageName = "UsrRssReader";
+	private const string VendorPrefix = "usr";
+
+	#endregion
+
+	#region Fields: Private
+
+	private string _tempDir;
+	private UiProjectCreator _creator;
+
+	#endregion
+
+	#region Methods: Public
+
+	[SetUp]
+	public void SetUp() {
+		_tempDir = Path.Combine(Path.GetTempPath(), "clio-tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+
+		AbstractionsFileSystem abstractionsFileSystem = new();
+		IFileSystem fileSystem = new FileSystem(abstractionsFileSystem);
+		ILogger logger = Substitute.For<ILogger>();
+		IWorkingDirectoriesProvider workingDirectoriesProvider = new WorkingDirectoriesProvider(logger, abstractionsFileSystem);
+		ITemplateProvider templateProvider = new TemplateProvider(workingDirectoriesProvider, fileSystem);
+		ISolutionCreator solutionCreator = new SolutionCreator(fileSystem, logger, templateProvider);
+
+		IWorkspacePathBuilder pathBuilder = Substitute.For<IWorkspacePathBuilder>();
+		pathBuilder.IsWorkspace.Returns(true);
+		pathBuilder.RootPath.Returns(_tempDir);
+		pathBuilder.PackagesFolderPath.Returns(Path.Combine(_tempDir, "packages"));
+		pathBuilder.ProjectsFolderPath.Returns(Path.Combine(_tempDir, "projects"));
+		pathBuilder.MainSolutionFolderPath.Returns(_tempDir);
+		pathBuilder.MainSolutionPath.Returns(Path.Combine(_tempDir, "MainSolution.slnx"));
+
+		_creator = new UiProjectCreator(
+			new EnvironmentSettings(),
+			Substitute.For<IWorkspace>(),
+			Substitute.For<IApplicationPackageListProvider>(),
+			Substitute.For<IPackageCreator>(),
+			Substitute.For<IPackageDownloader>(),
+			pathBuilder,
+			templateProvider,
+			workingDirectoriesProvider,
+			fileSystem,
+			solutionCreator);
+	}
+
+	[TearDown]
+	public void TearDown() {
+		if (Directory.Exists(_tempDir)) {
+			Directory.Delete(_tempDir, true);
+		}
+	}
+
+	[Test]
+	[Description("Generates all four esproj-integration artifacts from the real shipped templates.")]
+	public void Create_Should_Produce_All_Esproj_Artifacts_From_Real_Templates() {
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert — 1. esproj wrapper
+		string esprojPath = Path.Combine(_tempDir, "projects", ProjectName, $"{ProjectName}.esproj");
+		File.Exists(esprojPath).Should().BeTrue("the .esproj wrapper must be written next to package.json");
+		string esprojContent = File.ReadAllText(esprojPath);
+		esprojContent.Should().NotContain("<%", "all template tokens must be substituted");
+		XmlDocument esprojDoc = new();
+		Action loadEsproj = () => esprojDoc.LoadXml(esprojContent);
+		loadEsproj.Should().NotThrow("the generated .esproj must be valid XML");
+		esprojDoc.DocumentElement.GetAttribute("Sdk").Should()
+			.Be("Microsoft.VisualStudio.JavaScript.Sdk", "the Sdk reference must be version-less (version lives in global.json)");
+		esprojContent.Should().Contain(
+			Path.Combine("..", "..", "packages", PackageName, "Files", "src", "js", ProjectName));
+
+		// Assert — 2. global.json pins the JavaScript SDK
+		string globalJsonPath = Path.Combine(_tempDir, "global.json");
+		File.Exists(globalJsonPath).Should().BeTrue();
+		JsonObject globalJson = JsonNode.Parse(File.ReadAllText(globalJsonPath)).AsObject();
+		globalJson["msbuild-sdks"]["Microsoft.VisualStudio.JavaScript.Sdk"].GetValue<string>()
+			.Should().Be("1.0.5581896");
+
+		// Assert — 3. MainSolution.slnx has the esproj with a <Build /> element
+		string solutionPath = Path.Combine(_tempDir, "MainSolution.slnx");
+		File.Exists(solutionPath).Should().BeTrue();
+		XmlDocument solutionDoc = new();
+		solutionDoc.Load(solutionPath);
+		XmlNode esprojNode = solutionDoc.SelectSingleNode(
+			"Solution/Project[@Path='projects\\rss_reader\\rss_reader.esproj']");
+		esprojNode.Should().NotBeNull("the esproj must be registered in the main solution");
+		esprojNode.SelectSingleNode("Build").Should()
+			.NotBeNull("the empty <Build /> element forces participation in every solution configuration");
+
+		// Assert — 4. package.json has a clean script with the substituted bundle path
+		string packageJsonPath = Path.Combine(_tempDir, "projects", ProjectName, "package.json");
+		File.Exists(packageJsonPath).Should().BeTrue();
+		JsonObject packageJson = JsonNode.Parse(File.ReadAllText(packageJsonPath)).AsObject();
+		string cleanScript = packageJson["scripts"]["clean"].GetValue<string>();
+		cleanScript.Should().NotContain("<%distPath%>", "the dist path token must be substituted");
+		cleanScript.Should().Contain("packages/UsrRssReader/Files/src/js/rss_reader");
+	}
+
+	#endregion
+
+}

--- a/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+++ b/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
@@ -97,8 +97,8 @@ public class UiProjectCreatorIntegrationTests {
 		loadEsproj.Should().NotThrow("the generated .esproj must be valid XML");
 		esprojDoc.DocumentElement.GetAttribute("Sdk").Should()
 			.Be("Microsoft.VisualStudio.JavaScript.Sdk", "the Sdk reference must be version-less (version lives in global.json)");
-		esprojContent.Should().Contain(
-			Path.Combine("..", "..", "packages", PackageName, "Files", "src", "js", ProjectName));
+		// Forward slashes are used on every platform (POSIX-native, normalized by MSBuild on Windows).
+		esprojContent.Should().Contain($"../../packages/{PackageName}/Files/src/js/{ProjectName}");
 
 		// Assert — 2. global.json pins the JavaScript SDK
 		string globalJsonPath = Path.Combine(_tempDir, "global.json");
@@ -112,8 +112,11 @@ public class UiProjectCreatorIntegrationTests {
 		File.Exists(solutionPath).Should().BeTrue();
 		XmlDocument solutionDoc = new();
 		solutionDoc.Load(solutionPath);
-		XmlNode esprojNode = solutionDoc.SelectSingleNode(
-			"Solution/Project[@Path='projects\\rss_reader\\rss_reader.esproj']");
+		// The .slnx stores the path produced by Path.GetRelativePath, which uses the OS separator
+		// (backslash on Windows, forward slash on POSIX). Compare in C# rather than embedding a fixed
+		// separator in an XPath predicate so the assertion holds on every platform.
+		string expectedRelativePath = Path.Combine("projects", ProjectName, $"{ProjectName}.esproj");
+		XmlNode esprojNode = FindProjectNode(solutionDoc, expectedRelativePath);
 		esprojNode.Should().NotBeNull("the esproj must be registered in the main solution");
 		esprojNode.SelectSingleNode("Build").Should()
 			.NotBeNull("the empty <Build /> element forces participation in every solution configuration");
@@ -125,6 +128,19 @@ public class UiProjectCreatorIntegrationTests {
 		string cleanScript = packageJson["scripts"]["clean"].GetValue<string>();
 		cleanScript.Should().NotContain("<%distPath%>", "the dist path token must be substituted");
 		cleanScript.Should().Contain("packages/UsrRssReader/Files/src/js/rss_reader");
+	}
+
+	#endregion
+
+	#region Methods: Private
+
+	private static XmlNode FindProjectNode(XmlDocument solutionDoc, string relativePath) {
+		foreach (XmlNode project in solutionDoc.SelectNodes("Solution/Project")) {
+			if (project.Attributes?["Path"]?.Value == relativePath) {
+				return project;
+			}
+		}
+		return null;
 	}
 
 	#endregion

--- a/clio.tests/Package/UiProjectCreatorTests.cs
+++ b/clio.tests/Package/UiProjectCreatorTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Clio.Common;
+using Clio.Package;
+using Clio.Workspace;
+using Clio.Workspaces;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Package;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Package")]
+public class UiProjectCreatorTests {
+
+	#region Constants: Private
+
+	private const string ProjectName = "rss_reader";
+	private const string PackageName = "UsrRssReader";
+	private const string VendorPrefix = "usr";
+	private const string RootPath = @"C:\ws";
+	private const string JavaScriptSdkName = "Microsoft.VisualStudio.JavaScript.Sdk";
+	private const string JavaScriptSdkVersion = "1.0.5581896";
+
+	private const string EsprojTemplate =
+		"<Project Sdk=\"Microsoft.VisualStudio.JavaScript.Sdk\">\n" +
+		"  <PropertyGroup>\n" +
+		"    <BuildOutputFolder>$(MSBuildProjectDirectory)\\<%distPath%></BuildOutputFolder>\n" +
+		"    <!-- <%projectName%> -->\n" +
+		"  </PropertyGroup>\n" +
+		"</Project>";
+
+	#endregion
+
+	#region Fields: Private
+
+	private IWorkspacePathBuilder _workspacePathBuilder;
+	private ITemplateProvider _templateProvider;
+	private IFileSystem _fileSystem;
+	private ISolutionCreator _solutionCreator;
+	private IWorkingDirectoriesProvider _workingDirectoriesProvider;
+	private Dictionary<string, string> _writtenFiles;
+	private UiProjectCreator _creator;
+
+	#endregion
+
+	#region Methods: Public
+
+	[SetUp]
+	public void SetUp() {
+		_writtenFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+		_workspacePathBuilder = Substitute.For<IWorkspacePathBuilder>();
+		_workspacePathBuilder.IsWorkspace.Returns(true);
+		_workspacePathBuilder.RootPath.Returns(RootPath);
+		_workspacePathBuilder.PackagesFolderPath.Returns(Path.Combine(RootPath, "packages"));
+		_workspacePathBuilder.ProjectsFolderPath.Returns(Path.Combine(RootPath, "projects"));
+		_workspacePathBuilder.MainSolutionFolderPath.Returns(RootPath);
+		_workspacePathBuilder.MainSolutionPath.Returns(Path.Combine(RootPath, "MainSolution.slnx"));
+
+		_templateProvider = Substitute.For<ITemplateProvider>();
+		_templateProvider.GetTemplate("esproj").Returns(EsprojTemplate);
+
+		_fileSystem = Substitute.For<IFileSystem>();
+		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<SearchOption>())
+			.Returns(Array.Empty<string>());
+		_fileSystem.ExistsFile(Arg.Any<string>()).Returns(false);
+		_fileSystem.WhenForAnyArgs(fs => fs.WriteAllTextToFile(default, default))
+			.Do(ci => _writtenFiles[ci.ArgAt<string>(0)] = ci.ArgAt<string>(1));
+
+		_solutionCreator = Substitute.For<ISolutionCreator>();
+
+		_workingDirectoriesProvider = Substitute.For<IWorkingDirectoriesProvider>();
+		_workingDirectoriesProvider.CurrentDirectory.Returns(RootPath);
+
+		_creator = new UiProjectCreator(
+			new EnvironmentSettings(),
+			Substitute.For<IWorkspace>(),
+			Substitute.For<IApplicationPackageListProvider>(),
+			Substitute.For<IPackageCreator>(),
+			Substitute.For<IPackageDownloader>(),
+			_workspacePathBuilder,
+			_templateProvider,
+			_workingDirectoriesProvider,
+			_fileSystem,
+			_solutionCreator);
+	}
+
+	[Test]
+	[Description("Writes a version-less .esproj wrapper next to the Angular project with the bundle " +
+		"output folder pointing into the Creatio package.")]
+	public void Create_Should_Write_Esproj_File() {
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert
+		string esprojPath = Path.Combine(RootPath, "projects", ProjectName, $"{ProjectName}.esproj");
+		_writtenFiles.Should().ContainKey(esprojPath);
+		string esproj = _writtenFiles[esprojPath];
+		esproj.Should().Contain("Sdk=\"Microsoft.VisualStudio.JavaScript.Sdk\"")
+			.And.NotContain("<%projectName%>")
+			.And.NotContain("<%distPath%>");
+		esproj.Should().Contain(Path.Combine("..", "..", "packages", PackageName, "Files", "src", "js", ProjectName));
+	}
+
+	[Test]
+	[Description("Creates a repo-root global.json pinning the JavaScript SDK version when none exists.")]
+	public void Create_Should_Pin_JavaScript_Sdk_In_New_GlobalJson() {
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert
+		string globalJsonPath = Path.Combine(RootPath, "global.json");
+		_writtenFiles.Should().ContainKey(globalJsonPath);
+		JsonObject root = JsonNode.Parse(_writtenFiles[globalJsonPath]).AsObject();
+		root["msbuild-sdks"][JavaScriptSdkName].GetValue<string>().Should().Be(JavaScriptSdkVersion);
+	}
+
+	[Test]
+	[Description("Merges the msbuild-sdks key into an existing global.json without clobbering the sdk node.")]
+	public void Create_Should_Merge_Into_Existing_GlobalJson() {
+		// Arrange
+		string globalJsonPath = Path.Combine(RootPath, "global.json");
+		_fileSystem.ExistsFile(globalJsonPath).Returns(true);
+		_fileSystem.ReadAllText(globalJsonPath).Returns(
+			"{ \"sdk\": { \"version\": \"10.0.100\", \"rollForward\": \"latestMinor\" } }");
+
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert
+		JsonObject root = JsonNode.Parse(_writtenFiles[globalJsonPath]).AsObject();
+		root["sdk"]["version"].GetValue<string>().Should().Be("10.0.100", "because the existing .NET SDK pin must be preserved");
+		root["msbuild-sdks"][JavaScriptSdkName].GetValue<string>().Should().Be(JavaScriptSdkVersion);
+	}
+
+	[Test]
+	[Description("Adds the .esproj to MainSolution.slnx with ForceBuild so a <Build /> element is emitted.")]
+	public void Create_Should_Add_Esproj_To_MainSolution_With_ForceBuild() {
+		// Arrange
+		List<SolutionProject> captured = [];
+		_solutionCreator.WhenForAnyArgs(sc => sc.AddProjectToSolution(default, default))
+			.Do(ci => captured.AddRange(ci.ArgAt<IEnumerable<SolutionProject>>(1)));
+
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert
+		_solutionCreator.Received(1)
+			.AddProjectToSolution(Path.Combine(RootPath, "MainSolution.slnx"), Arg.Any<IEnumerable<SolutionProject>>());
+		captured.Should().ContainSingle();
+		captured[0].ForceBuild.Should().BeTrue();
+		captured[0].Path.Should().Be(Path.Combine("projects", ProjectName, $"{ProjectName}.esproj"));
+	}
+
+	[Test]
+	[Description("Outside a workspace there is no main solution, so no esproj integration is performed.")]
+	public void Create_Should_Skip_Esproj_Integration_Outside_Workspace() {
+		// Arrange
+		_workspacePathBuilder.IsWorkspace.Returns(false);
+
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, false, string.Empty, _ => false);
+
+		// Assert
+		_writtenFiles.Keys.Should().NotContain(k => k.EndsWith(".esproj", StringComparison.OrdinalIgnoreCase));
+		_writtenFiles.Should().NotContainKey(Path.Combine(RootPath, "global.json"));
+		_solutionCreator.DidNotReceiveWithAnyArgs().AddProjectToSolution(default, default);
+	}
+
+	#endregion
+
+}

--- a/clio.tests/Package/UiProjectCreatorTests.cs
+++ b/clio.tests/Package/UiProjectCreatorTests.cs
@@ -104,7 +104,8 @@ public class UiProjectCreatorTests {
 		esproj.Should().Contain("Sdk=\"Microsoft.VisualStudio.JavaScript.Sdk\"")
 			.And.NotContain("<%projectName%>")
 			.And.NotContain("<%distPath%>");
-		esproj.Should().Contain(Path.Combine("..", "..", "packages", PackageName, "Files", "src", "js", ProjectName));
+		// Forward slashes are used on every platform (POSIX-native, normalized by MSBuild on Windows).
+		esproj.Should().Contain($"../../packages/{PackageName}/Files/src/js/{ProjectName}");
 	}
 
 	[Test]

--- a/clio.tests/Workspace/SolutionCreatorTests.cs
+++ b/clio.tests/Workspace/SolutionCreatorTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Xml;
+using Clio.Common;
+using Clio.Workspace;
+using Clio.Workspaces;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using AbstractionsFileSystem = System.IO.Abstractions.FileSystem;
+
+namespace Clio.Tests.Workspace;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Workspace")]
+public class SolutionCreatorTests {
+
+	#region Fields: Private
+
+	private string _tempDir;
+	private SolutionCreator _solutionCreator;
+
+	#endregion
+
+	#region Methods: Public
+
+	[SetUp]
+	public void SetUp() {
+		_tempDir = Path.Combine(Path.GetTempPath(), "clio-tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+		IFileSystem fileSystem = new FileSystem(new AbstractionsFileSystem());
+		ITemplateProvider templateProvider = Substitute.For<ITemplateProvider>();
+		templateProvider.GetTemplate("workspace/MainSolution.slnx").Returns(
+			"<Solution>\n  <Configurations>\n    <BuildType Name=\"Debug\" />\n    <BuildType Name=\"dev-n8\" />\n  </Configurations>\n</Solution>");
+		_solutionCreator = new SolutionCreator(fileSystem, Substitute.For<ILogger>(), templateProvider);
+	}
+
+	[TearDown]
+	public void TearDown() {
+		if (Directory.Exists(_tempDir)) {
+			Directory.Delete(_tempDir, true);
+		}
+	}
+
+	[Test]
+	[Description("Emits an empty <Build /> child for a project flagged with ForceBuild so the JS SDK " +
+		"project participates in every (custom) solution configuration.")]
+	public void AddProjectToSolution_Should_Emit_Build_Element_When_ForceBuild() {
+		// Arrange
+		string solutionPath = Path.Combine(_tempDir, "MainSolution.slnx");
+
+		// Act
+		_solutionCreator.AddProjectToSolution(solutionPath,
+			[new SolutionProject("rss_reader", @"projects\rss_reader\rss_reader.esproj") { ForceBuild = true }]);
+
+		// Assert
+		XmlNode projectNode = LoadProjectNode(solutionPath, @"projects\rss_reader\rss_reader.esproj");
+		projectNode.Should().NotBeNull();
+		projectNode.SelectSingleNode("Build").Should()
+			.NotBeNull("because the esproj must be forced into every solution configuration");
+	}
+
+	[Test]
+	[Description("A regular project (ForceBuild not set) is added without a <Build /> child.")]
+	public void AddProjectToSolution_Should_Not_Emit_Build_Element_By_Default() {
+		// Arrange
+		string solutionPath = Path.Combine(_tempDir, "MainSolution.slnx");
+
+		// Act
+		_solutionCreator.AddProjectToSolution(solutionPath,
+			[new SolutionProject("UsrPkg", @"packages\UsrPkg\Files\UsrPkg.csproj")]);
+
+		// Assert
+		XmlNode projectNode = LoadProjectNode(solutionPath, @"packages\UsrPkg\Files\UsrPkg.csproj");
+		projectNode.Should().NotBeNull();
+		projectNode.SelectSingleNode("Build").Should().BeNull();
+	}
+
+	[Test]
+	[Description("Re-adding the same ForceBuild project does not duplicate the project node or the " +
+		"<Build /> element (idempotent re-runs).")]
+	public void AddProjectToSolution_Should_Be_Idempotent_For_ForceBuild_Project() {
+		// Arrange
+		string solutionPath = Path.Combine(_tempDir, "MainSolution.slnx");
+		SolutionProject esproj =
+			new("rss_reader", @"projects\rss_reader\rss_reader.esproj") { ForceBuild = true };
+
+		// Act
+		_solutionCreator.AddProjectToSolution(solutionPath, [esproj]);
+		_solutionCreator.AddProjectToSolution(solutionPath, [esproj]);
+
+		// Assert
+		XmlDocument doc = new();
+		doc.Load(solutionPath);
+		XmlNodeList esprojNodes =
+			doc.SelectNodes("Solution/Project[@Path='projects\\rss_reader\\rss_reader.esproj']");
+		esprojNodes.Count.Should().Be(1, "because re-runs must not duplicate the project node");
+		esprojNodes[0].SelectNodes("Build").Count.Should().Be(1, "because the <Build /> element must not be duplicated");
+	}
+
+	#endregion
+
+	#region Methods: Private
+
+	private static XmlNode LoadProjectNode(string solutionPath, string projectPath) {
+		XmlDocument doc = new();
+		doc.Load(solutionPath);
+		return doc.SelectSingleNode($"Solution/Project[@Path='{projectPath}']");
+	}
+
+	#endregion
+
+}

--- a/clio/Command/CreateUiProjectCommand.cs
+++ b/clio/Command/CreateUiProjectCommand.cs
@@ -54,6 +54,12 @@ public class CreateUiProjectOptionsValidator : AbstractValidator<CreateUiProject
 				+ Environment.NewLine +
 				"See more: https://academy.creatio.com/docs/developer/front_end_development_freedom_ui/remote_module/implement_a_remote_module/overview");
 		RuleFor(x => x.PackageName).NotEmpty().WithMessage("Package name is required.");
+		RuleFor(x => x.PackageName).Matches("^[A-Za-z0-9_]+$")
+			.When(x => !string.IsNullOrEmpty(x.PackageName))
+			.WithMessage(
+				"'{PropertyName}' must contain only letters, digits and underscores. You entered: '{PropertyValue}'. "
+				+ "The package name is embedded into generated build scripts and folder paths, so path "
+				+ "separators, quotes and other special characters are rejected.");
 	}
 
 	#endregion

--- a/clio/Package/UiProjectCreator.cs
+++ b/clio/Package/UiProjectCreator.cs
@@ -7,8 +7,11 @@ namespace Clio.Package
 	using System.Collections.Generic;
 	using System.IO;
 	using System.Linq;
+	using System.Text.Json;
+	using System.Text.Json.Nodes;
 	using System.Text.RegularExpressions;
 	using Clio.Common;
+	using Clio.Workspace;
 	using Clio.Workspaces;
 
 	#region Interface: IUiProjectCreator
@@ -37,6 +40,18 @@ namespace Clio.Package
 		private const string packagesDirectoryName = "packages";
 		private const string projectsDirectoryName = "projects";
 
+		/// <summary>Name of the MSBuild project SDK that wraps the npm/Angular build.</summary>
+		private const string JavaScriptSdkName = "Microsoft.VisualStudio.JavaScript.Sdk";
+
+		/// <summary>
+		/// Pinned JavaScript SDK version written to the repo-root <c>global.json</c>. MSBuild project
+		/// SDKs do not support floating/latest versions, so this must be an exact version.
+		/// </summary>
+		private const string JavaScriptSdkVersion = "1.0.5581896";
+
+		private const string globalJsonFileName = "global.json";
+		private const string esprojTemplateName = "esproj";
+
 		#endregion
 
 		#region Fields: Private
@@ -54,6 +69,7 @@ namespace Clio.Package
 		private readonly ITemplateProvider _templateProvider;
 		private readonly IWorkingDirectoriesProvider _workingDirectoriesProvider;
 		private readonly IFileSystem _fileSystem;
+		private readonly ISolutionCreator _solutionCreator;
 
 		#endregion
 
@@ -63,7 +79,7 @@ namespace Clio.Package
 			IApplicationPackageListProvider applicationPackageListProvider, IPackageCreator packageCreator,
 			IPackageDownloader packageDownloader, IWorkspacePathBuilder workspacePathBuilder,
 			ITemplateProvider templateProvider, IWorkingDirectoriesProvider workingDirectoriesProvider,
-			IFileSystem fileSystem) {
+			IFileSystem fileSystem, ISolutionCreator solutionCreator) {
 			environmentSettings.CheckArgumentNull(nameof(environmentSettings));
 			workspace.CheckArgumentNull(nameof(workspace));
 			applicationPackageListProvider.CheckArgumentNull(nameof(applicationPackageListProvider));
@@ -72,6 +88,7 @@ namespace Clio.Package
 			templateProvider.CheckArgumentNull(nameof(templateProvider));
 			workingDirectoriesProvider.CheckArgumentNull(nameof(workingDirectoriesProvider));
 			fileSystem.CheckArgumentNull(nameof(fileSystem));
+			solutionCreator.CheckArgumentNull(nameof(solutionCreator));
 			_environmentSettings = environmentSettings;
 			_workspace = workspace;
 			_applicationPackageListProvider = applicationPackageListProvider;
@@ -81,6 +98,7 @@ namespace Clio.Package
 			_templateProvider = templateProvider;
 			_workingDirectoriesProvider = workingDirectoriesProvider;
 			_fileSystem = fileSystem;
+			_solutionCreator = solutionCreator;
 		}
 
 		#endregion
@@ -113,10 +131,18 @@ namespace Clio.Package
 				tplContent = tplContent.Replace("<%vendorPrefix%>", vendorPrefix, true, CultureInfo.InvariantCulture);
 				tplContent = tplContent.Replace("<%projectName%>", projectName,true, CultureInfo.InvariantCulture);
 				tplContent = tplContent.Replace("<%distPath%>",
-					$"{Path.Combine("../../", "packages/", packageName + "/", "Files/", "src/", "js/", projectName)}", true, CultureInfo.InvariantCulture);
+					BuildDistPath(packageName, projectName), true, CultureInfo.InvariantCulture);
 				_fileSystem.WriteAllTextToFile(filePath, tplContent);
 			}
 		}
+
+		/// <summary>
+		/// Bundle output folder (the <c>angular.json</c> <c>outputPath</c>), relative to the Angular
+		/// project directory and using forward slashes — e.g.
+		/// <c>../../packages/UsrRssReader/Files/src/js/rss_reader</c>.
+		/// </summary>
+		private static string BuildDistPath(string packageName, string projectName) =>
+			Path.Combine("../../", "packages/", packageName + "/", "Files/", "src/", "js/", projectName);
 		private void CreatePackage(string packageName) {
 			_packageCreator.Create(PackagesPath, packageName);
 		}
@@ -132,6 +158,61 @@ namespace Clio.Package
 				_templateProvider.CopyTemplateFolder(templateFolderName, projectPath, creatioVersion, "ui");
 			}
 			UpdateTemplateInfo(projectPath, projectName, packageName, vendorPrefix);
+		}
+
+		/// <summary>
+		/// Wires the generated Angular project into the .NET solution so that
+		/// <c>dotnet build MainSolution.slnx</c> also runs the npm build. Performs three coordinated
+		/// edits: writes an <c>.esproj</c> wrapper next to <c>package.json</c>, pins the JavaScript SDK
+		/// version in the repo-root <c>global.json</c>, and adds the <c>.esproj</c> to
+		/// <c>MainSolution.slnx</c> with a forced <c>&lt;Build /&gt;</c> element.
+		/// No-op outside a workspace, where there is no main solution to integrate with.
+		/// </summary>
+		private void IntegrateEsprojIntoSolution(string projectName, string packageName) {
+			if (!IsWorkspace) {
+				return;
+			}
+			CreateEsprojFile(projectName, packageName);
+			EnsureJavaScriptSdkPinnedInGlobalJson();
+			AddEsprojToMainSolution(projectName);
+		}
+
+		private void CreateEsprojFile(string projectName, string packageName) {
+			string esprojPath = Path.Combine(ProjectsPath, projectName, $"{projectName}.esproj");
+			// BuildOutputFolder is combined with $(MSBuildProjectDirectory); use OS separators so the
+			// path reads naturally on the host (MSBuild normalizes either way).
+			string buildOutputFolder = BuildDistPath(packageName, projectName)
+				.Replace('/', Path.DirectorySeparatorChar);
+			string content = _templateProvider.GetTemplate(esprojTemplateName)
+				.Replace("<%projectName%>", projectName)
+				.Replace("<%distPath%>", buildOutputFolder);
+			_fileSystem.WriteAllTextToFile(esprojPath, content);
+		}
+
+		/// <summary>
+		/// Ensures the repo-root <c>global.json</c> pins the JavaScript SDK version. Merges into an
+		/// existing file (preserving the <c>sdk</c> node and any other content) rather than overwriting.
+		/// </summary>
+		private void EnsureJavaScriptSdkPinnedInGlobalJson() {
+			string globalJsonPath = Path.Combine(_workspacePathBuilder.RootPath, globalJsonFileName);
+			JsonObject root = _fileSystem.ExistsFile(globalJsonPath)
+				? JsonNode.Parse(_fileSystem.ReadAllText(globalJsonPath)) as JsonObject ?? new JsonObject()
+				: new JsonObject();
+			if (root["msbuild-sdks"] is not JsonObject msbuildSdks) {
+				msbuildSdks = new JsonObject();
+				root["msbuild-sdks"] = msbuildSdks;
+			}
+			msbuildSdks[JavaScriptSdkName] = JavaScriptSdkVersion;
+			string serialized = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+			_fileSystem.WriteAllTextToFile(globalJsonPath, serialized);
+		}
+
+		private void AddEsprojToMainSolution(string projectName) {
+			string esprojPath = Path.Combine(ProjectsPath, projectName, $"{projectName}.esproj");
+			string relativeEsprojPath =
+				Path.GetRelativePath(_workspacePathBuilder.MainSolutionFolderPath, esprojPath);
+			SolutionProject esprojSolutionProject = new(projectName, relativeEsprojPath) { ForceBuild = true };
+			_solutionCreator.AddProjectToSolution(_workspacePathBuilder.MainSolutionPath, [esprojSolutionProject]);
 		}
 
 		private void CheckCorrectProjectName(string projectName) {
@@ -169,6 +250,7 @@ namespace Clio.Package
 				CreatePackage(packageName);
 			}
 			CreateProject(projectName, packageName, vendorPrefix, isEmpty, creatioVersion);
+			IntegrateEsprojIntoSolution(projectName, packageName);
 		}
 
 		#endregion

--- a/clio/Package/UiProjectCreator.cs
+++ b/clio/Package/UiProjectCreator.cs
@@ -179,13 +179,12 @@ namespace Clio.Package
 
 		private void CreateEsprojFile(string projectName, string packageName) {
 			string esprojPath = Path.Combine(ProjectsPath, projectName, $"{projectName}.esproj");
-			// BuildOutputFolder is combined with $(MSBuildProjectDirectory); use OS separators so the
-			// path reads naturally on the host (MSBuild normalizes either way).
-			string buildOutputFolder = BuildDistPath(packageName, projectName)
-				.Replace('/', Path.DirectorySeparatorChar);
+			// Keep forward slashes in BuildOutputFolder: they are POSIX-native and MSBuild normalizes
+			// them on Windows. A hard-coded backslash would be treated as a literal character on
+			// macOS/Linux and break the bundle path.
 			string content = _templateProvider.GetTemplate(esprojTemplateName)
 				.Replace("<%projectName%>", projectName)
-				.Replace("<%distPath%>", buildOutputFolder);
+				.Replace("<%distPath%>", BuildDistPath(packageName, projectName));
 			_fileSystem.WriteAllTextToFile(esprojPath, content);
 		}
 

--- a/clio/Workspace/SolutionCreator.cs
+++ b/clio/Workspace/SolutionCreator.cs
@@ -63,15 +63,35 @@ public class SolutionCreator : ISolutionCreator{
 			}
 		}
 		foreach (SolutionProject sp in solutionProjects) {
+			XmlElement projectNode;
 			if (!paths.Contains(sp.Path)) {
-				XmlElement projectNode = doc.CreateElement("Project");
+				projectNode = doc.CreateElement("Project");
 				projectNode.SetAttribute("Path", sp.Path);
 				solutionNode.AppendChild(projectNode);
 				paths.Add(sp.Path);
+			} else {
+				projectNode = FindProjectNode(solutionNode, sp.Path);
+			}
+			if (sp.ForceBuild && projectNode != null && projectNode.SelectSingleNode("Build") == null) {
+				projectNode.AppendChild(doc.CreateElement("Build"));
 			}
 		}
 
 		doc.Save(solutionPath);
+	}
+
+	private static XmlElement FindProjectNode(XmlNode solutionNode, string path) {
+		XmlNodeList existingProjects = solutionNode.SelectNodes("Project");
+		if (existingProjects == null) {
+			return null;
+		}
+		foreach (XmlNode existingProject in existingProjects) {
+			if (existingProject is XmlElement element
+				&& element.Attributes?["Path"]?.Value == path) {
+				return element;
+			}
+		}
+		return null;
 	}
 
 	private void CreateNewMainSolution(string solutionPath) {

--- a/clio/Workspace/SolutionProject.cs
+++ b/clio/Workspace/SolutionProject.cs
@@ -28,6 +28,15 @@ namespace Clio.Workspaces
 		public Guid Id { get; }
 		public Guid UId { get; }
 
+		/// <summary>
+		/// When <c>true</c>, an empty <c>&lt;Build /&gt;</c> element is emitted under the project's
+		/// node in the <c>.slnx</c>. This forces the project to participate in <b>every</b> solution
+		/// configuration — required for SDK-style projects (e.g. the JavaScript SDK <c>.esproj</c>)
+		/// that only understand Debug/Release and would otherwise be silently skipped under custom
+		/// configs such as <c>dev-n8</c>/<c>dev-nf</c>.
+		/// </summary>
+		public bool ForceBuild { get; init; }
+
 		#endregion
 
 	}

--- a/clio/docs/commands/new-ui-project.md
+++ b/clio/docs/commands/new-ui-project.md
@@ -11,7 +11,22 @@ clio new-ui-project <Name> [options]
 
 ## Description
 
-Create a new Freedom UI project.
+Create a new Freedom UI (Angular) project.
+
+When run inside a workspace, the command also wires the generated Angular project into
+`MainSolution.slnx` via an MSBuild `.esproj` wrapper, so that a single `dotnet build` produces
+both the C# package assembly and the Angular client bundle. Specifically it:
+
+- writes a version-less `projects/<name>/<name>.esproj` (Microsoft JavaScript SDK) next to
+  `package.json`, with its `BuildOutputFolder` pointing at the bundle location inside the package;
+- pins the JavaScript SDK version in a repo-root `global.json` (merged, never overwriting an
+  existing `sdk` node);
+- adds the `.esproj` to `MainSolution.slnx` with an empty `<Build />` element so it participates in
+  every solution configuration (including custom ones such as `dev-n8`/`dev-nf`);
+- adds a `clean` npm script so `dotnet clean` removes the generated bundle.
+
+> Building the bundle requires **Node.js + npm** on the machine; the JavaScript SDK shells out to
+> `npm` but does not install Node itself.
 
 ## Aliases
 

--- a/clio/tpl/esproj.tpl
+++ b/clio/tpl/esproj.tpl
@@ -27,7 +27,7 @@
       deleteOutputPath at its default (true), so every build recreates this folder. `dotnet clean`
       runs the npm `clean` script below to remove the bundle; the next build regenerates it.
     -->
-    <BuildOutputFolder>$(MSBuildProjectDirectory)\<%distPath%></BuildOutputFolder>
+    <BuildOutputFolder>$(MSBuildProjectDirectory)/<%distPath%></BuildOutputFolder>
     <CleanCommand>npm run clean</CleanCommand>
 
     <!-- Unit tests run through Jest (see jest.config.ts / `npm test`). -->

--- a/clio/tpl/esproj.tpl
+++ b/clio/tpl/esproj.tpl
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk">
+
+  <!--
+    Wraps the Angular "<%projectName%>" project so that building MainSolution.slnx (dotnet/msbuild,
+    or Visual Studio) also produces the client bundle. The JavaScript SDK runs `npm install`
+    (only when package.json / package-lock.json change) and then the build command below.
+
+    `ng build` emits straight into the Creatio package — see angular.json `outputPath` — so there
+    is no separate dist to copy. The SDK version is pinned centrally in the repo-root global.json,
+    so the Sdk attribute above is intentionally version-less.
+  -->
+  <PropertyGroup>
+    <!--
+      Declare the same build configurations the solution defines so the .slnx auto-maps and builds
+      this project under each of them. `ng build` is configuration-agnostic, so dev-n8 / dev-nf
+      behave the same as Debug here. NOTE: this alone is not enough for a custom solution config to
+      select the project — the empty <Build /> element in MainSolution.slnx is what forces it.
+    -->
+    <Configurations>Debug;Release;dev-n8;dev-nf</Configurations>
+
+    <BuildCommand>npm run build</BuildCommand>
+    <StartupCommand>npm start</StartupCommand>
+    <ShouldRunBuildScript>true</ShouldRunBuildScript>
+
+    <!--
+      Where `ng build` writes the bundle (angular.json outputPath). angular.json leaves
+      deleteOutputPath at its default (true), so every build recreates this folder. `dotnet clean`
+      runs the npm `clean` script below to remove the bundle; the next build regenerates it.
+    -->
+    <BuildOutputFolder>$(MSBuildProjectDirectory)\<%distPath%></BuildOutputFolder>
+    <CleanCommand>npm run clean</CleanCommand>
+
+    <!-- Unit tests run through Jest (see jest.config.ts / `npm test`). -->
+    <JavaScriptTestRoot>src\</JavaScriptTestRoot>
+    <JavaScriptTestFramework>Jest</JavaScriptTestFramework>
+  </PropertyGroup>
+
+</Project>

--- a/clio/tpl/ui-project-Empty/package.json
+++ b/clio/tpl/ui-project-Empty/package.json
@@ -11,6 +11,7 @@
     "build": "ng build",
     "build:dev": "ng build --configuration development",
     "watch": "ng build --watch --configuration development",
+    "clean": "node -e \"require('fs').rmSync('<%distPath%>', { recursive: true, force: true })\"",
     "test": "ng test"
   },
   "private": true,

--- a/clio/tpl/ui-project/package.json
+++ b/clio/tpl/ui-project/package.json
@@ -11,6 +11,7 @@
     "build": "ng build",
     "build:dev": "ng build --configuration development",
     "watch": "ng build --watch --configuration development",
+    "clean": "node -e \"require('fs').rmSync('<%distPath%>', { recursive: true, force: true })\"",
     "test": "ng test"
   },
   "private": true,

--- a/clio/tpl/workspace/AGENTS.md
+++ b/clio/tpl/workspace/AGENTS.md
@@ -2,88 +2,142 @@
 
 ## Repository structure
 
-This is a repository created by `clio` for `Creatio` CRM development. Use this file as a workspace-level template for any Clio-based project.
+This is a repository created by `clio` for `Creatio` CRM development. Use this file as a workspace-level template for any clio-based project.
+
+### /packages
+
+`packages` is the main **server-side** source root. Each Creatio package lives under `./packages/<PACKAGE_NAME>/`.
+
+Typical locations:
+- Backend C#: `./packages/<PACKAGE_NAME>/Files/src/cs/`
+- A package may build a standalone assembly via `./packages/<PACKAGE_NAME>/Files/<PACKAGE_NAME>.csproj` (output → `Files/Bin/...`).
+- Entry-point web services: `./packages/<PACKAGE_NAME>/Files/src/cs/EntryPoints/WebService/`
+- Configuration schemas (entities, pages, processes, source-code units): `./packages/<PACKAGE_NAME>/Schemas/<SCHEMA_NAME>/` (each is `metadata.json` + `properties.json` + optional `<Schema>.cs`).
+
+### /projects (Angular / Freedom UI clients)
+
+Custom Freedom UI components are Angular projects under `./projects/<NG_PROJECT>/`. They build into a package's
+file content (see each project's `angular.json` `outputPath`, e.g. `../../packages/<PACKAGE_NAME>/Files/src/js/<NG_PROJECT>`).
+
+**Only when an Angular project exists**, it is wired into `MainSolution.slnx` via a `.esproj` (next to its
+`package.json`). Because of that, **building the solution also builds the Angular bundle** — prefer:
+
+```bash
+dotnet build MainSolution.slnx -c dev-n8     # compiles C# AND runs the Angular (npm) build via the .esproj
+```
+
+over running `npm run build` by hand. Run `npm run build` directly only for a fast client-only iteration
+when you don't want the whole solution to build. If there is **no** Angular project, there is no `.esproj`
+and the solution is C#-only. Setup details (esproj + `global.json` + `<Build/>` in `.slnx`): see
+[docs/angular-esproj-solution-integration.md](./docs/angular-esproj-solution-integration.md).
+
+### /tests
+
+Unit/integration tests live under `./tests/<PACKAGE_NAME>/`.
 
 ### /.application
 
-`.application` contains reference binaries and configuration used for build/test in local workspaces.
+Reference binaries used for local build/test:
+- `./.application/net-framework/` for `net472` targets.
+- `./.application/net-core/` for `netstandard2.0` / modern targets.
 
-- [./.application/net-framework/](./.application/net-framework/) for `net472` based targets.
-- [./.application/net-core/](./.application/net-core/) for `netstandard2.0` and modern targets.
-
-Treat `.application` as dependency/reference input. Do not treat it as the primary place for product changes unless explicitly requested.
-
-use clio mcp server to download configuration from relevant environment
-
+Treat `.application` as read-only dependency input. **Only the frameworks present here are buildable** — if
+`net-framework` is missing, `-c dev-nf` will fail and you must build `-c dev-n8` (see "Building locally").
 
 ### /.clio
 
-`.clio` contains configuration files for `clio`.
+clio configuration: `clioignore` (packaging exclusions), `workspaceSettings.json` (packages list),
+`workspaceEnvironmentSettings.json` (environment settings).
 
-- [./.clio/clioignore](./.clio/clioignore) controls packaging exclusions.
-- [./.clio/workspaceSettings.json](./.clio/workspaceSettings.json) defines workspace packages and related settings.
-- [./.clio/workspaceEnvironmentSettings.json](./.clio/workspaceEnvironmentSettings.json) defines environment-level settings.
+---
 
-## packages
+## ⚠️ Deploying changes to Creatio — PICK THE RIGHT WORKFLOW FIRST
 
-`packages` is the main source root. Each Creatio package is under:
+> The clio MCP server's default guidance describes the **classic DB workflow** (`push-workspace` →
+> `compile-creatio` → `restart`). That guidance is **wrong for File System Mode (FSM)** environments and
+> will silently fail to apply your changes. **Always determine the mode before deploying.**
 
-- `./packages/<PACKAGE_NAME>/`
+### Step 0 — Detect the mode (do this once per environment, every session)
 
-Typical source locations:
+Call `get-fsm-mode` for the target environment. It returns `mode: "on" | "off"`.
 
-- Backend C#: `./packages/<PACKAGE_NAME>/Files/src/`
-- Entry point web services: `./packages/<PACKAGE_NAME>/Files/src/cs/EntryPoints/WebService/`
-- Frontend/client code: package-specific `Schemas` or frontend folders, depending on package structure.
+You can also infer FSM by checking whether the local workspace package folder is the **same files** as the
+Creatio install (e.g. on Windows a junction: `packages/<PKG>` ↔ `<creatio>/Terrasoft.Configuration/Pkg/<PKG>`
+share an inode). In FSM the workspace edits ARE the server's filesystem.
 
-Typical tests location:
+### If FSM is ON (file-system mode)
 
-- `./tests/<PACKAGE_NAME>/`
+The running app reads packages from the filesystem. Do **NOT** use `push-workspace` or `compile-creatio`
+— `compile-creatio` rebuilds from the **stale DB copy** and overwrites your good filesystem build.
 
-## Non negotiable rules
+| You changed… | Do this |
+|---|---|
+| **C# (`Files/src/cs`)** and/or **Angular (`projects/...`)** | `dotnet build MainSolution.slnx -c dev-n8` (one build covers both — the Angular `.esproj` runs the npm build), **then** `restart-by-environment-name`. Nothing else. (`npm run build` alone also works for a client-only iteration, but still restart afterwards.) |
+| **Schema via clio MCP** (`create/modify-entity-schema-column`, `update-entity-schema`, `*-user-task`, etc.) | After the MCP call, run `pkg-to-file-system` (**2fs**) to generate metadata and flush the DB changes to the filesystem (so they land in the workspace and persist). |
+| **Schema/metadata edited directly on the filesystem** | Run `pkg-to-db` (**2db**) to load the filesystem packages into the running database/runtime. |
 
-- Never throw for expected business/validation flow. Return error as value (for example, via `ErrorOr`) when that pattern exists in the workspace.
-- Always create or update unit tests for any new or changed production code unless explicitly instructed otherwise.
-- Always build and run tests for your changes unless explicitly instructed otherwise.
-- Follow path-level `AGENTS.md` files when present (they override this file for their subtree).
+Key FSM facts learned the hard way:
+- The package's compiled assembly comes from your local `dotnet build` (the workspace is the FS the app loads). **Build before you restart.** A restart is what loads the freshly built DLL.
+- Client (Angular) bundles are served from the filesystem; after building + restart, **hard-reload the browser (Ctrl+Shift+R)** to bust the cached AMD bundle.
+- DDL-style entity changes via MCP (`modify-entity-schema-column`) apply immediately to the DB/runtime; use **2fs** afterwards so they aren't lost from the workspace.
 
-## Build and test environment variables
+### If FSM is OFF (classic / database mode)
 
-Before running builds or unit tests, set the required environment variables.
+Use the clio MCP default flow:
+1. `push-workspace` — install local packages into the environment.
+2. `compile-creatio` — **only** if C# schemas / source-code / executable process code changed (or the runtime reports "schema missing in runtime").
+3. `restart-by-environment-name` — only if server assemblies were rebuilt or Redis was cleared.
 
-For net472:
+### Shared gotcha — clio auth dies after a restart
 
-```plain text
-dotnet build .\MainSolution.slnx -c dev-nf -v d
-```
+After `restart-by-environment-name`, clio's session to the configuration service often expires, so
+schema MCP calls (`modify-entity-schema-column`, `get-entity-schema-properties`, `compile-creatio`) start
+returning the HTML **login page** (parse error: `'<' is an invalid start of a value`). `get-fsm-mode` keeps
+working (different endpoint). Plan schema changes **before** a restart, or re-establish the clio session
+before retrying schema operations.
 
-For everything else:
+---
 
-```plain text
-dotnet build .\MainSolution.slnx -c dev-n8 -v d
-```
+## Building locally
+
+| Target framework                                       | Command                                    |
+|--------------------------------------------------------|--------------------------------------------|
+| `netstandard2.0` / modern (default)                    | `dotnet build MainSolution.slnx -c dev-n8` |
+| `net472` (only if `.application/net-framework` exists) | `dotnet build MainSolution.slnx -c dev-nf` |
+
+- Add `-v n`/`-v d` only when diagnosing; default minimal verbosity is fine.
+- On Windows, pass `MainSolution.slnx` without a leading `.\` — the leading backslash can be mangled by some shells.
+- The solution builds the C# package(s) **and** any Angular `.esproj` (so one `dotnet build` produces the client bundle too).
+
+## Data access (Freedom UI clients)
+
+Freedom UI Angular modules MUST read/write data through `@creatio-devkit/common` `Model` + datasources
+(`Model.create`, `model.load`/`insert`/`update`). **Never** use OData or raw DataService HTTP calls.
+Paging uses `options.pagingConfig { rowsOffset, rowCount }`; sorting uses
+`options.sortingConfig.columns[{ columnName, direction }]` where `direction` is the string `'asc'|'desc'|'none'`.
+
+## Non-negotiable rules
+
+- Never throw for expected business/validation flow. Return error-as-value (e.g. `ErrorOr`) where that pattern exists.
+- Create/update unit tests for new or changed production code unless explicitly told otherwise.
+- Build (and run tests, where they exist) for your changes unless explicitly told otherwise.
+- Path-level `AGENTS.md` files override this one for their subtree.
 
 ## Agent usage guidance
 
-- When working with custom configuration web services or their tests, use the `$creatio-config-webservice` skill.
-- Trigger this skill for changes under:
-  - `packages/<PACKAGE_NAME>/src/cs/EntryPoints/WebService`
-  - `packages/<PACKAGE_NAME>/Files/src/cs/EntryPoints/WebService`
-  - `tests/<PACKAGE_NAME>/EntryPoints/WebService`
+- For custom configuration web services or their tests, use the `$creatio-config-webservice` skill. Trigger it for changes under `packages/<PKG>/Files/src/cs/EntryPoints/WebService` or `tests/<PKG>/EntryPoints/WebService`.
+- If a `dbhub` (or equivalent) MCP database tool is configured, use it to **verify** data-layer outcomes directly (row counts, column types, stored content) instead of guessing.
 
 ## Workspace diary
 
 Keep a persistent engineering diary to speed up future tasks.
 
-Canonical diary file:
-- `./.codex/workspace-diary.md`
+Canonical diary file: `./.codex/workspace-diary.md`
 
-Mandatory agent behavior:
-- For any non-trivial task, read the latest relevant diary entries before implementing changes.
-- After completing non-trivial work, append a new diary entry.
-- Keep entries concise, factual, and path-referenced.
-- Do not rewrite history; append only.
-- If a task is exploratory and no code changes are made, still record key discoveries.
+Mandatory behavior:
+- Before non-trivial work, read the latest relevant diary entries.
+- After non-trivial work, append a new entry (append-only; never rewrite history).
+- Keep entries concise, factual, path-referenced. Record key discoveries even for exploratory, no-code tasks.
 
 Entry format:
 ```markdown
@@ -93,5 +147,4 @@ Decision: <important decision or approach>
 Discovery: <important behavior/constraint learned>
 Files: <path1>, <path2>
 Impact: <how this helps future tasks>
-
 ```

--- a/spec/esproj/angular-esproj-solution-integration.md
+++ b/spec/esproj/angular-esproj-solution-integration.md
@@ -1,0 +1,254 @@
+# Integrating an Angular (Freedom UI) project into the .NET solution via an `.esproj`
+
+> Reference for teaching the clio `new-ui-project` (and related) commands to wire a generated
+> Angular project into `MainSolution.slnx` so that `dotnet build` also builds the JavaScript bundle.
+>
+> Everything here was validated end‑to‑end on a Creatio **File System Mode (FSM)** workspace with
+> the Angular client output landing inside a Creatio package.
+
+---
+
+## 1. Goal / outcome
+
+After this wiring, a single command builds **both** the C# package assembly and the Angular client bundle:
+
+```bash
+dotnet build MainSolution.slnx -c dev-n8     # builds UsrRssReader.dll AND runs `npm run build`
+dotnet clean MainSolution.slnx -c dev-n8     # removes the bundle (npm run clean); next build regenerates it
+```
+
+This is achieved with **four** coordinated artifacts:
+
+| # | File                                | Change                                             | Owner tool                  |
+|---|-------------------------------------|----------------------------------------------------|-----------------------------|
+| 1 | `projects/<ngproj>/<ngproj>.esproj` | **new** – MSBuild wrapper around the npm build     | MSBuild / VS JavaScript SDK |
+| 2 | `global.json` (repo root)           | **new/updated** – pins the JavaScript SDK version  | MSBuild SDK resolver        |
+| 3 | `MainSolution.slnx` (repo root)     | **updated** – add the esproj + `<Build />` element | Solution build              |
+| 4 | `projects/<ngproj>/package.json`    | **updated** – add a `clean` npm script             | npm / esproj `CleanCommand` |
+
+---
+
+## 2. Template parameters
+
+When generating these files, substitute the following. Example values are from the reference project.
+
+| Placeholder               | Meaning                                                                                                               | Example                                               |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `{NgProjectName}`         | npm package name **and** project folder/file name                                                                     | `rss_reader`                                          |
+| `{NgProjectDir}`          | Angular project dir, relative to repo root                                                                            | `projects/rss_reader`                                 |
+| `{CreatioPackage}`        | Owning Creatio package                                                                                                | `UsrRssReader`                                        |
+| `{OutputPathFromNgProj}`  | `angular.json` `outputPath`, relative to the Angular project dir                                                      | `../../packages/UsrRssReader/Files/src/js/rss_reader` |
+| `{BundleDirFromRepoRoot}` | Same output folder, relative to repo root                                                                             | `packages/UsrRssReader/Files/src/js/rss_reader`       |
+| `{BundleDirFromEsproj}`   | Same output folder, relative to the esproj dir (== `{OutputPathFromNgProj}` since esproj sits next to `angular.json`) | `..\..\packages\UsrRssReader\Files\src\js\rss_reader` |
+| `{SolutionConfigs}`       | All solution build configs                                                                                            | `Debug;Release;dev-n8;dev-nf`                         |
+| `{NonStandardConfigs}`    | Configs that are **not** `Debug`/`Release` (these are the ones that need the `<Build />` workaround)                  | `dev-n8`, `dev-nf`                                    |
+| `{JsSdkVersion}`          | Pinned `Microsoft.VisualStudio.JavaScript.Sdk` version                                                                | `1.0.5581896`                                         |
+| `{TestFramework}`         | JS test framework, if any                                                                                             | `Jest`                                                |
+
+> **Key invariant:** the esproj lives **next to** `angular.json`/`package.json` (i.e. in `{NgProjectDir}`).
+> The JavaScript SDK runs `npm` with the esproj's directory as the working directory, so all npm
+> scripts and relative paths resolve from there.
+
+---
+
+## 3. File 1 — `{NgProjectDir}/{NgProjectName}.esproj`
+
+```xml
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk">
+
+  <PropertyGroup>
+    <!-- Declared so the project nominally knows the solution's configs. NOTE: this alone is NOT
+         enough for the .slnx to select it under custom configs — see the <Build /> note in the .slnx. -->
+    <Configurations>{SolutionConfigs}</Configurations>
+
+    <!-- The npm script run on `dotnet build`. The SDK also runs `npm install` first, but only when
+         package.json / package-lock.json changed since the last build. -->
+    <BuildCommand>npm run build</BuildCommand>
+    <StartupCommand>npm start</StartupCommand>
+    <ShouldRunBuildScript>true</ShouldRunBuildScript>
+
+    <!-- Where `ng build` writes the bundle (mirrors angular.json `outputPath`). Used by MSBuild/VS
+         for up-to-date checks and the project's output model. ng build leaves deleteOutputPath at
+         its default (true), so each build recreates this folder. -->
+    <BuildOutputFolder>$(MSBuildProjectDirectory)\{BundleDirFromEsproj}</BuildOutputFolder>
+
+    <!-- The JS SDK does NOT delete BuildOutputFolder on clean (npm outputs aren't MSBuild-tracked),
+         so we run an explicit npm clean script. Safe because the next build regenerates the bundle. -->
+    <CleanCommand>npm run clean</CleanCommand>
+
+    <!-- Optional: only if the project has JS unit tests. -->
+    <JavaScriptTestRoot>src\</JavaScriptTestRoot>
+    <JavaScriptTestFramework>{TestFramework}</JavaScriptTestFramework>
+  </PropertyGroup>
+
+</Project>
+```
+
+### Property reference
+
+| Property | Required? | Purpose |
+|---|---|---|
+| `Sdk` attr (no version) | yes | Loads the JavaScript SDK; version comes from `global.json` (File 2). |
+| `Configurations` | recommended | Lists valid project configs. Does **not** by itself fix custom-config selection in `.slnx`. |
+| `BuildCommand` | yes | npm script run on Build (default would be `npm run build`; set explicitly for clarity). |
+| `ShouldRunBuildScript` | yes | Must be `true` or Build does nothing. |
+| `StartupCommand` | optional | Used by VS "Run"/debug. |
+| `BuildOutputFolder` | recommended | Output location for MSBuild/VS tooling & incremental checks. Mirrors `angular.json` `outputPath`. |
+| `CleanCommand` | recommended | npm script run on `dotnet clean`. Needed because the SDK won't delete the bundle itself. |
+| `JavaScriptTestRoot` / `JavaScriptTestFramework` | optional | Enables `dotnet test` discovery for the JS project. Omit if no tests. |
+
+---
+
+## 4. File 2 — `global.json` (repo root)
+
+```json
+{
+  "msbuild-sdks": {
+    "Microsoft.VisualStudio.JavaScript.Sdk": "{JsSdkVersion}"
+  }
+}
+```
+
+- **Why centralize here instead of inline (`Sdk="...JavaScript.Sdk/{version}"`)?** It keeps the version
+  in one place, applies to *every* esproj added later, and avoids the multi-version warning (MSB4241/MSB3780).
+  The esproj's `Sdk` attribute is therefore version-less.
+- If a `global.json` already exists, **merge** the `msbuild-sdks` key (don't overwrite the `sdk` node or others).
+- **There is no "latest"/floating option** for MSBuild project SDKs — the version must be exact. The
+  `rollForward` feature only applies to the `.NET SDK` (`sdk` node), not to `msbuild-sdks`.
+
+---
+
+## 5. File 3 — `MainSolution.slnx` (repo root)
+
+Add the project reference **with an empty `<Build />` child**:
+
+```xml
+<Solution>
+  <Configurations>
+    <BuildType Name="Debug" />
+    <BuildType Name="Release" />
+    <BuildType Name="dev-n8" />
+    <BuildType Name="dev-nf" />
+  </Configurations>
+
+  <Project Path="packages\{CreatioPackage}\Files\{CreatioPackage}.csproj" />
+
+  <Project Path="{NgProjectDir-backslashes}\{NgProjectName}.esproj">
+    <!-- JS SDK project has no dev-n8/dev-nf configs; force it to participate in every solution config. -->
+    <Build />
+  </Project>
+</Solution>
+```
+
+### ⚠️ The single most important gotcha: `<Build />`
+
+The solution defines **non-standard** build configs (`dev-n8`, `dev-nf`). The JavaScript SDK project
+only understands `Debug`/`Release`, so under `dev-n8` the solution build prints:
+
+```
+The project "<ngproj>" is not selected for building in solution configuration "dev-n8|Any CPU".
+```
+
+…and **silently skips the npm build**. Things that were tried and **did NOT fix it**:
+
+- Adding `<Configurations>Debug;Release;dev-n8;dev-nf</Configurations>` to the esproj.
+- An explicit per-project mapping `<Configuration Solution="dev-n8|*" Project="Debug|Any CPU" />` in the `.slnx`.
+
+What **does** fix it: add an empty **`<Build />`** element under the `<Project>` in the `.slnx`
+(the same idiom Microsoft uses for `docker-compose.dcproj`). It forces the project to participate in
+**every** solution configuration. Because `ng build` is configuration-agnostic, all configs behave the same.
+
+> Rule of thumb for the clio command: **whenever the solution has any config other than `Debug`/`Release`,
+> emit `<Build />` for the esproj.** It's harmless to always include it.
+
+Path separators in `.slnx` use Windows backslashes (e.g. `projects\rss_reader\rss_reader.esproj`).
+
+---
+
+## 6. File 4 — `{NgProjectDir}/package.json` clean script
+
+Add a `clean` script so `dotnet clean` can remove the bundle (cross-platform, no extra dependency):
+
+```jsonc
+{
+  "scripts": {
+    "build": "ng build",
+    "clean": "node -e \"require('fs').rmSync('{OutputPathFromNgProj}', { recursive: true, force: true })\""
+  }
+}
+```
+
+- The path is **relative to the Angular project dir** (npm's working directory), i.e. the same value as
+  `angular.json` `outputPath` → `{OutputPathFromNgProj}`.
+- `force: true` makes it a no-op when the folder is already gone (idempotent).
+
+---
+
+## 7. How SDK install/restore actually works (no manual install needed)
+
+- The `Sdk` reference is resolved by MSBuild's **NuGet-based SDK resolver** at *evaluation time*. When a
+  version is present (here via `global.json`), it downloads the package from the configured NuGet feed
+  (nuget.org by default) into the global packages cache (`~/.nuget/packages`) automatically.
+- A fresh clone therefore needs **no separate install step** — the first `dotnet build`/`dotnet restore`
+  fetches it; subsequent builds are offline-fast from cache.
+- Failure mode if the version can't be fetched (offline / wrong feed): `MSB4236: The SDK '...' could not be found`.
+
+### Real prerequisites for a contributor (document these in a README)
+
+| Prerequisite | Auto-installed by build? |
+|---|---|
+| .NET SDK (`dotnet` CLI) | No — install once |
+| **Node.js + npm** (the esproj shells out to `npm`; the SDK does **not** install Node) | No — install once |
+| Network to nuget.org on first build (to fetch the JS SDK package) | Package: yes; feed access: no |
+
+> Tip: keep `engines` in `package.json` (e.g. `"node": ">=18.19.1"`) as a contributor hint.
+> For air-gapped/offline teams, host the SDK package on an internal feed or pre-populate the NuGet cache,
+> and add a `NuGet.config` pinning the feed.
+
+---
+
+## 8. Generation algorithm for the clio command
+
+1. Resolve parameters (Section 2). `{OutputPathFromNgProj}` comes from the generated `angular.json` `outputPath`.
+2. **Write** `{NgProjectDir}/{NgProjectName}.esproj` from the Section 3 template.
+3. **Ensure** `global.json` at repo root contains `msbuild-sdks["Microsoft.VisualStudio.JavaScript.Sdk"] = {JsSdkVersion}`
+   (create if missing; merge the key if present).
+4. **Add** the `<Project Path="...esproj">` entry to `MainSolution.slnx`. If the solution has any config
+   beyond `Debug`/`Release`, include the `<Build />` child (recommended: always include it).
+5. **Add** the `clean` script to `package.json` (and confirm a `build` script exists).
+6. Leave the esproj **version-less** (`Sdk="Microsoft.VisualStudio.JavaScript.Sdk"`) since the version is in `global.json`.
+
+---
+
+## 9. Verification
+
+```bash
+# Build: should run `npm run build` and regenerate the bundle under the package.
+dotnet build MainSolution.slnx -c dev-n8 -v n
+#   expect: "...esproj ... npm run build ... Browser application bundle generation complete"
+#   must NOT see: "is not selected for building in solution configuration"
+
+# Clean: should remove the bundle folder.
+dotnet clean MainSolution.slnx -c dev-n8
+#   then: the bundle directory ({BundleDirFromRepoRoot}) should be gone, and a rebuild restores it.
+```
+
+Confirm the bundle file (e.g. `{BundleDirFromRepoRoot}/remoteModuleEntry.js`) disappears after clean and
+reappears after build.
+
+---
+
+## 10. Gotchas summary (hard-won)
+
+1. **`<Build />` in `.slnx` is mandatory** when the solution has non-`Debug`/`Release` configs, or the
+   esproj is silently excluded ("not selected for building") and npm never runs.
+2. **No floating SDK versions** — `Sdk` references need an exact version; centralize it in `global.json`.
+3. **The SDK doesn't clean `BuildOutputFolder`** — npm outputs aren't MSBuild-tracked, so wire an explicit
+   `CleanCommand` → `npm run clean`.
+4. **Two output paths, two tools** — `angular.json` `outputPath` (for `ng build`) and `BuildOutputFolder`
+   (for MSBuild/VS) must be kept in sync; neither tool reads the other's file.
+5. **Node.js is a hard prerequisite** — the JS SDK runs `npm` but never installs Node.
+6. **esproj must sit next to `package.json`** — it defines the npm working directory.
+7. **FSM note (Creatio-specific):** with the Angular `outputPath` pointing into the package, `ng build`
+   deploys straight to the File-System-Mode location; a browser hard-reload (Ctrl+Shift+R) picks up the
+   new bundle. (Deployment/restart is orthogonal to this solution-build wiring.)


### PR DESCRIPTION
@
## What

Teaches the `new-ui-project` command (CLI `ui`/`new-ui`/`create-ui-project` and the MCP `new-ui-project` tool) to wire the generated Angular (Freedom UI) project into the workspace `MainSolution.slnx` via an MSBuild `.esproj`, so a single `dotnet build MainSolution.slnx` builds **both** the C# package assembly and the Angular client bundle.

Implements the spec in `spec/esproj/angular-esproj-solution-integration.md`.

## How

When run inside a workspace, the command now emits four coordinated artifacts:

| Artifact | Purpose |
|----------|---------|
| `projects/<name>/<name>.esproj` | Version-less Microsoft JavaScript SDK wrapper (new template `tpl/esproj.tpl`); `BuildCommand`/`CleanCommand` + `BuildOutputFolder` → bundle inside the package |
| repo-root `global.json` | Pins the JavaScript SDK version, **merged** into any existing file (preserves the `sdk` node) |
| `MainSolution.slnx` | esproj added with an empty `<Build />` element so it participates in **every** solution config, including custom ones (`dev-n8`/`dev-nf`) the JS SDK otherwise silently skips |
| `package.json` | `clean` npm script so `dotnet clean` removes the bundle |

Code:
- `UiProjectCreator` gains an `ISolutionCreator` dependency and an `IntegrateEsprojIntoSolution` step, **gated on `IsWorkspace`** (no main solution to integrate with outside a workspace).
- `SolutionProject` gains a `ForceBuild` flag; `SolutionCreator` emits the `<Build />` child for flagged projects and is idempotent on re-runs.
- The MCP `new-ui-project` tool inherits the behavior for free (routes through the same `UiProjectCreator.Create`).

## Tests

- `SolutionCreatorTests` — `<Build />` emission, default-off, idempotency.
- `UiProjectCreatorTests` — mocked orchestration (esproj write, global.json new + merge-preserve, `ForceBuild`, workspace gating).
- `UiProjectCreatorIntegrationTests` — drives the **real shipped templates** on a real filesystem in a temp workspace and asserts all four artifacts on disk (valid XML, version-less `Sdk`, merged `global.json`, `<Build />` in the slnx, substituted clean-script path).

21 related tests pass; `clio` builds clean.

## Not covered

A full `dotnet build MainSolution.slnx -c dev-n8` of the bundle was **not** run — it needs Node + npm + a live workspace and is not runnable in CI here. Coverage is unit + one real-template integration test, not an end-to-end npm build.

## Notes

- JS SDK version is pinned at `1.0.5581896` (matches the validated reference workspace) via the `JavaScriptSdkVersion` constant in `UiProjectCreator` — MSBuild project SDKs do not support floating versions.
- Building the bundle requires Node.js + npm on the machine (the JS SDK shells out to `npm`; it does not install Node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@