### PR TITLE
docs(mcp): extend page-schema-handlers guide with missing built-in request catalog entries (ENG-89871)

### DIFF
--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -430,6 +430,40 @@ public sealed class McpGuidanceResourceTests {
 			because: "handler guidance should carry over the built-in copy-input request entry");
 		article.Text.Should().Contain("crt.GetSidebarStateRequest",
 			because: "handler guidance should carry over the built-in sidebar entries");
+		article.Text.Should().Contain("crt.PrintablesRequest",
+			because: "handler guidance should include the built-in printables request in the catalog");
+		article.Text.Should().Contain("crt.GoToPrintablesRequest",
+			because: "handler guidance should include the go-to-printables navigation request in the catalog");
+		article.Text.Should().Contain("crt.ExportDataGridToExcelRequest",
+			because: "handler guidance should include the Excel export request in the catalog");
+		article.Text.Should().Contain("crt.ImportDataRequest",
+			because: "handler guidance should include the import data request in the catalog");
+		article.Text.Should().Contain("crt.DeleteRecordsRequest",
+			because: "handler guidance should include the bulk delete request in the catalog");
+		article.Text.Should().Contain("crt.CopyRecordRequest",
+			because: "handler guidance should include the copy/duplicate record request in the catalog");
+		article.Text.Should().Contain("crt.ShowDialogRequest",
+			because: "handler guidance should include the show-dialog request in the built-in catalog");
+		article.Text.Should().Contain("| print the current or selected record(s) | `crt.PrintablesRequest` | button/menu `clicked.request` | no |",
+			because: "handler guidance should keep printables on direct request wiring instead of a custom handler");
+		article.Text.Should().Contain("| export list data to Excel | `crt.ExportDataGridToExcelRequest` | button/menu `clicked.request` | no |",
+			because: "handler guidance should keep Excel export on direct request wiring instead of a custom handler");
+		article.Text.Should().Contain("| import data for an entity | `crt.ImportDataRequest` | button/menu `clicked.request` | no |",
+			because: "handler guidance should keep import on direct request wiring instead of a custom handler");
+		article.Text.Should().Contain("| delete multiple selected records from a list | `crt.DeleteRecordsRequest` | button/menu `clicked.request` | no |",
+			because: "handler guidance should distinguish bulk list delete from single-record delete in the decision table");
+		article.Text.Should().Contain("| duplicate a record | `crt.CopyRecordRequest` | button/menu `clicked.request` | no |",
+			because: "handler guidance should keep record duplication on direct request wiring");
+		article.Text.Should().Contain("| `crt.PrintablesRequest` | config | `dataSourceName` required, `templateId?`, `printableCaption?`, `convertInPDF?`, `filters?` | generate printable document for current or selected record(s) |",
+			because: "handler guidance should expose the printables request contract with its required and optional fields");
+		article.Text.Should().Contain("| `crt.ExportDataGridToExcelRequest` | config | `viewName` required, `filters?` | export list data to Excel |",
+			because: "handler guidance should expose the Excel export request contract");
+		article.Text.Should().Contain("| `crt.ImportDataRequest` | config | `entitySchemaName` required | open import wizard for an entity |",
+			because: "handler guidance should expose the import data request contract");
+		article.Text.Should().Contain("| `crt.DeleteRecordsRequest` | config | `dataSourceName` required, `filters?`, `recordIds?`, `skipConfirmation?` | delete multiple records; prefer over `crt.DeleteRecordRequest` for list-based bulk delete |",
+			because: "handler guidance should expose the bulk delete request contract and clarify when to prefer it over the single-record variant");
+		article.Text.Should().Contain("| `crt.CopyRecordRequest` | config | `recordId` required, `itemsAttributeName?`, `entityName?` | duplicate a record |",
+			because: "handler guidance should expose the copy record request contract");
 		article.Text.Should().Contain("Standard handler parameter catalog",
 			because: "handler guidance should expose concrete payload contracts, not only the built-in request name list");
 		article.Text.Should().Contain("| Request | Kind | Params for AI authoring | Notes |",

--- a/clio/Command/McpServer/Resources/PageSchemaHandlersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageSchemaHandlersGuidanceResource.cs
@@ -61,6 +61,12 @@ public sealed class PageSchemaHandlersGuidanceResource {
 		         | compose an email from current context | `crt.CreateEmailRequest` | button/menu `clicked.request` | no |
 		         | copy a prepared literal value to clipboard | `crt.CopyClipboardRequest` | button/menu `clicked.request` | no |
 		         | copy a page attribute value to clipboard | `crt.CopyInputToClipboardRequest` | button/menu `clicked.request` | no |
+		         | print the current or selected record(s) | `crt.PrintablesRequest` | button/menu `clicked.request` | no |
+		         | open the printables management page | `crt.GoToPrintablesRequest` | button/menu `clicked.request` | no |
+		         | export list data to Excel | `crt.ExportDataGridToExcelRequest` | button/menu `clicked.request` | no |
+		         | import data for an entity | `crt.ImportDataRequest` | button/menu `clicked.request` | no |
+		         | delete multiple selected records from a list | `crt.DeleteRecordsRequest` | button/menu `clicked.request` | no |
+		         | duplicate a record | `crt.CopyRecordRequest` | button/menu `clicked.request` | no |
 		         | page init, destroy, attribute-change orchestration, editor interaction, or domain-specific workflow | handler in `SCHEMA_HANDLERS` | handlers runtime | yes |
 
 		       Request shape quick reference
@@ -350,6 +356,12 @@ public sealed class PageSchemaHandlersGuidanceResource {
 		       - Use `crt.HandleViewModelAttributeChangeRequest` when one field should update dependent page state.
 		       - Use `crt.LoadDataRequest` when the handler must prepare or refresh backing collections/data.
 		       - Use `crt.CancelRecordChangesRequest` when the page must discard unsaved edits and return to the clean state.
+		       - Use `crt.PrintablesRequest` when a button should generate a printable document for the current record or selected records from a data source.
+		       - Use `crt.GoToPrintablesRequest` when a button should navigate to the printables management page.
+		       - Use `crt.ExportDataGridToExcelRequest` when a button should export list data to an Excel file.
+		       - Use `crt.ImportDataRequest` when a button should open the import wizard for a given entity.
+		       - Use `crt.DeleteRecordsRequest` for bulk deletion of multiple selected records from a list (with optional filter or recordIds).
+		       - Use `crt.CopyRecordRequest` to duplicate an existing record.
 		       - When dispatching another request imperatively from a handler, pass both `$context: request.$context` and `scopes: [...request.scopes]` unless the target request intentionally changes scope.
 		       - Use a custom `usr.*Request` only when no built-in request type matches the domain workflow.
 
@@ -380,6 +392,13 @@ public sealed class PageSchemaHandlersGuidanceResource {
 		         - `crt.OpenSidebarRequest`
 		         - `crt.CloseSidebarRequest`
 		         - `crt.GetSidebarStateRequest`
+		         - `crt.PrintablesRequest`
+		         - `crt.GoToPrintablesRequest`
+		         - `crt.ExportDataGridToExcelRequest`
+		         - `crt.ImportDataRequest`
+		         - `crt.DeleteRecordsRequest`
+		         - `crt.CopyRecordRequest`
+		         - `crt.ShowDialogRequest`
 		       - Treat this catalog as the first place to look before inventing custom `usr.*Request` names.
 		       - Prefer the exact built-in request name from this catalog when the requirement matches it directly.
 
@@ -403,6 +422,12 @@ public sealed class PageSchemaHandlersGuidanceResource {
 		         | `crt.CopyClipboardRequest` | config | `value` required | copy a prepared literal value |
 		         | `crt.CopyInputToClipboardRequest` | config | `attribute` required, `successMessageArea?` | copy the value of a page attribute |
 		         | `crt.ClosePageRequest` | config | `none` | close current page |
+		         | `crt.PrintablesRequest` | config | `dataSourceName` required, `templateId?`, `printableCaption?`, `convertInPDF?`, `filters?` | generate printable document for current or selected record(s) |
+		         | `crt.GoToPrintablesRequest` | config | `none` | open printables management page in a new tab |
+		         | `crt.ExportDataGridToExcelRequest` | config | `viewName` required, `filters?` | export list data to Excel |
+		         | `crt.ImportDataRequest` | config | `entitySchemaName` required | open import wizard for an entity |
+		         | `crt.DeleteRecordsRequest` | config | `dataSourceName` required, `filters?`, `recordIds?`, `skipConfirmation?` | delete multiple records; prefer over `crt.DeleteRecordRequest` for list-based bulk delete |
+		         | `crt.CopyRecordRequest` | config | `recordId` required, `itemsAttributeName?`, `entityName?` | duplicate a record |
 		       - Lifecycle and attribute-change requests:
 		         | Request | Kind | Params visible in handler | Notes |
 		         | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary

- Added 7 missing `crt.*` requests to the **Standard built-in handler catalog**: `crt.PrintablesRequest`, `crt.GoToPrintablesRequest`, `crt.ExportDataGridToExcelRequest`, `crt.ImportDataRequest`, `crt.DeleteRecordsRequest`, `crt.CopyRecordRequest`, `crt.ShowDialogRequest`
- Extended the **Direct request decision table** with 6 new rows so AI callers know these actions can be wired directly without a custom handler
- Added 6 new rows to the **Core page/action requests** parameter table with full field contracts (required vs optional)
- Added 6 new **Request selection hints** with usage conditions for each new request

## Motivation

The catalog was missing common built-in requests that developers and AI agents encounter regularly. `crt.PrintablesRequest` was a concrete example — its handler exists in `studio-enterprise/feature/schema-view` but it was absent from the guide, causing AI to potentially invent custom handlers for standard platform actions.

All new entries were sourced from `@CrtRequestHandler` usages in `creatio-ui/libs/studio-enterprise/feature/schema-view/src/lib/handlers/` and their corresponding request model files in `util/model/src/lib/requests/`.

## Test plan

- [ ] `dotnet test clio.tests/clio.tests.csproj --filter "PageSchemaHandlersGuidanceResource"` — passes (1/1)
- [ ] New test assertions verify each added catalog entry, decision table row, and parameter contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)