### PR TITLE
fix(mcp): re-authenticate and retry on expired Creatio session

### DIFF
--- a/clio.tests/Common/CreatioAuthResponseGuardTests.cs
+++ b/clio.tests/Common/CreatioAuthResponseGuardTests.cs
@@ -81,12 +81,18 @@ public class CreatioAuthResponseGuardTests {
 	}
 
 	[Test]
-	[Description("Documented bounded false positive: a valid JSON body that legitimately contains 'Authentication failed' is reported as an auth failure. Pinning it guards the real JSON-401 case against a refactor that 'fixes' it and regresses detection.")]
-	public void IsLikelyAuthRedirect_JsonContainingAuthFailedText_ReturnsTrue_DocumentedFalsePositive() {
-		// The content-first check fires before the JSON short-circuit. Cost of this false positive is
-		// one redundant re-login; the retry-once contract guarantees it cannot loop.
+	[Description("A valid JSON body that merely mentions 'Authentication failed' in a non-Message field is NOT an auth failure (structural match prevents re-running an executed write).")]
+	public void IsLikelyAuthRedirect_JsonMentioningAuthFailedInOtherField_ReturnsFalse() {
 		string body = "{\"description\":\"Authentication failed for impersonated user\",\"success\":false}";
 		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
-			.Should().BeTrue("known, documented false positive — see CreatioAuthResponseGuard.IsLikelyAuthRedirect remarks");
+			.Should().BeFalse("because only a top-level Message equal to the 401 value is an auth failure");
+	}
+
+	[Test]
+	[Description("Exact-match discriminator: a fault envelope whose top-level Message merely STARTS WITH 'Authentication failed' but is not equal to it is a real error, not the 401 envelope. This is the case a substring match would wrongly retry — a write duplication.")]
+	public void IsLikelyAuthRedirect_FaultEnvelopeWithDifferentMessage_ReturnsFalse() {
+		string body = "{\"Message\":\"Authentication failed for the linked account.\",\"StackTrace\":null,\"ExceptionType\":\"System.InvalidOperationException\"}";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
+			.Should().BeFalse("because the top-level Message must EQUAL 'Authentication failed.', not just contain the phrase");
 	}
 }

--- a/clio.tests/Common/CreatioAuthResponseGuardTests.cs
+++ b/clio.tests/Common/CreatioAuthResponseGuardTests.cs
@@ -95,4 +95,18 @@ public class CreatioAuthResponseGuardTests {
 		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
 			.Should().BeFalse("because the top-level Message must EQUAL 'Authentication failed.', not just contain the phrase");
 	}
+
+	[Test]
+	[Description("Regression guard pinning the Creatio login-failure signatures the detector depends on. If a Creatio upgrade or localization renames these tokens, this test fails as a prompt to re-capture against the live login contract.")]
+	public void IsLikelyAuthRedirect_PinsKnownCreatioLoginContract() {
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(
+				"{\"Message\":\"Authentication failed.\",\"StackTrace\":null,\"ExceptionType\":\"System.InvalidOperationException\"}")
+			.Should().BeTrue("the JSON-401 'Authentication failed.' envelope is a pinned login-failure signature");
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(
+				"<!DOCTYPE html><html><head><title>Creatio</title></head><body>NuiLogin</body></html>")
+			.Should().BeTrue("the NuiLogin login page is a pinned login-failure signature");
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(
+				"<!DOCTYPE html><html><a href=\"/Login/NuiLogin.aspx\">login</a></html>")
+			.Should().BeTrue("the /Login/ path marker is a pinned login-failure signature");
+	}
 }

--- a/clio.tests/Common/CreatioAuthResponseGuardTests.cs
+++ b/clio.tests/Common/CreatioAuthResponseGuardTests.cs
@@ -79,4 +79,14 @@ public class CreatioAuthResponseGuardTests {
 		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
 			.Should().BeFalse("because re-login must not be triggered by ordinary service errors");
 	}
+
+	[Test]
+	[Description("Documented bounded false positive: a valid JSON body that legitimately contains 'Authentication failed' is reported as an auth failure. Pinning it guards the real JSON-401 case against a refactor that 'fixes' it and regresses detection.")]
+	public void IsLikelyAuthRedirect_JsonContainingAuthFailedText_ReturnsTrue_DocumentedFalsePositive() {
+		// The content-first check fires before the JSON short-circuit. Cost of this false positive is
+		// one redundant re-login; the retry-once contract guarantees it cannot loop.
+		string body = "{\"description\":\"Authentication failed for impersonated user\",\"success\":false}";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
+			.Should().BeTrue("known, documented false positive — see CreatioAuthResponseGuard.IsLikelyAuthRedirect remarks");
+	}
 }

--- a/clio.tests/Common/CreatioAuthResponseGuardTests.cs
+++ b/clio.tests/Common/CreatioAuthResponseGuardTests.cs
@@ -1,0 +1,82 @@
+using Clio.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[TestFixture]
+[Property("Module", "Common")]
+[Category("Unit")]
+public class CreatioAuthResponseGuardTests {
+
+	[Test]
+	[Description("A valid JSON object response is treated as a real service response, never an auth redirect.")]
+	public void IsLikelyAuthRedirect_JsonObject_ReturnsFalse() {
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect("{\"success\":true,\"schema\":{}}")
+			.Should().BeFalse("because a JSON body is a real service response");
+	}
+
+	[Test]
+	[Description("A valid JSON array response is treated as a real service response.")]
+	public void IsLikelyAuthRedirect_JsonArray_ReturnsFalse() {
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect("[{\"id\":1}]")
+			.Should().BeFalse("because a JSON array is a real service response");
+	}
+
+	[Test]
+	[Description("Leading whitespace before JSON does not trip the non-JSON heuristic.")]
+	public void IsLikelyAuthRedirect_JsonWithLeadingWhitespace_ReturnsFalse() {
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect("\r\n\t  {\"ok\":1}")
+			.Should().BeFalse("because the first non-whitespace character is '{'");
+	}
+
+	[Test]
+	[Description("The empirically captured NuiLogin.aspx body is detected as an auth redirect.")]
+	public void IsLikelyAuthRedirect_NuiLoginPage_ReturnsTrue() {
+		// Shape captured from a real .NET Framework target: XHTML starting with <!DOCTYPE,
+		// <title>Creatio</title>, and a NuiLogin reference.
+		string loginHtml =
+			"\n\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n" +
+			"<html xmlns=\"http://www.w3.org/1999/xhtml\" dir=\"ltr\" culture=\"en-US\">\n" +
+			"<head><title>\n\tCreatio\n</title>" +
+			"<script src=\"../Login/NuiLogin.aspx?ReturnUrl=%2f\"></script></head><body></body></html>";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(loginHtml)
+			.Should().BeTrue("because the body is the NuiLogin login page, not a service response");
+	}
+
+	[Test]
+	[Description("A generic IIS / 5xx HTML error page is NOT treated as an auth redirect so the original error surfaces.")]
+	public void IsLikelyAuthRedirect_GenericHtmlError_ReturnsFalse() {
+		string iisError =
+			"<!DOCTYPE html><html><head><title>500 - Internal Server Error</title></head>" +
+			"<body><h1>Server Error</h1></body></html>";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(iisError)
+			.Should().BeFalse("because relogin cannot fix a 500 and the real error must surface");
+	}
+
+	[TestCase(null)]
+	[TestCase("")]
+	[TestCase("   \r\n ")]
+	[Description("Null, empty, or whitespace responses are not auth redirects (e.g. an empty ResetScriptCache reply).")]
+	public void IsLikelyAuthRedirect_NullOrWhitespace_ReturnsFalse(string response) {
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(response)
+			.Should().BeFalse("because there is no login marker to act on");
+	}
+
+	[Test]
+	[Description("The JSON 401 auth-failure body returned by ServiceModel endpoints is detected even though it is valid JSON.")]
+	public void IsLikelyAuthRedirect_Json401AuthenticationFailed_ReturnsTrue() {
+		// Exact body captured from a real .NET Framework target for an expired/invalid session.
+		string body = "{\"Message\":\"Authentication failed.\",\"StackTrace\":null,\"ExceptionType\":\"System.InvalidOperationException\"}";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
+			.Should().BeTrue("because a 401 'Authentication failed' payload means the session must be renewed");
+	}
+
+	[Test]
+	[Description("A genuine JSON service error (not an auth failure) is left alone so the original error surfaces.")]
+	public void IsLikelyAuthRedirect_JsonServiceError_ReturnsFalse() {
+		string body = "{\"success\":false,\"errorInfo\":{\"message\":\"Schema with UId not found\"}}";
+		CreatioAuthResponseGuard.IsLikelyAuthRedirect(body)
+			.Should().BeFalse("because re-login must not be triggered by ordinary service errors");
+	}
+}

--- a/clio.tests/Common/CreatioClientAdapterReauthTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterReauthTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Clio.Common;
+using Creatio.Client;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -68,4 +69,48 @@ public class CreatioClientAdapterReauthTests {
 		act.Should().Throw<UnauthorizedAccessException>("because wrong credentials are not an expiry to retry");
 		calls.Should().Be(1, "because the retry must not run when re-auth itself fails");
 	}
+
+	[Test]
+	[Description("Version gate: an observed version that is already stale (renewed by another caller) skips the redundant login and leaves the version unchanged.")]
+	public void ReauthenticateOnce_StaleObservedVersion_SkipsLogin() {
+		CreatioClientAdapter adapter = NewAdapterWithoutClient();
+		int logins = 0;
+		int baseline = adapter.SessionVersion;
+
+		adapter.ReauthenticateOnce(baseline, () => logins++);   // matches → renews, version = baseline + 1
+		adapter.ReauthenticateOnce(baseline, () => logins++);   // now stale → must skip
+
+		logins.Should().Be(1, "because the second caller observed a stale version and must skip the redundant login");
+		adapter.SessionVersion.Should().Be(baseline + 1, "because only the first re-login advanced the version");
+	}
+
+	[Test]
+	[Description("Version gate: a matching observed version triggers exactly one login and advances the version by one.")]
+	public void ReauthenticateOnce_MatchingObservedVersion_LogsInOnceAndBumps() {
+		CreatioClientAdapter adapter = NewAdapterWithoutClient();
+		int logins = 0;
+		int observed = adapter.SessionVersion;
+
+		adapter.ReauthenticateOnce(observed, () => logins++);
+
+		logins.Should().Be(1, "because the observed version matched the current generation");
+		adapter.SessionVersion.Should().Be(observed + 1, "because a successful re-login advances the generation");
+	}
+
+	[Test]
+	[Description("Version gate ordering: a failing login must NOT advance the version (the bump happens only after login succeeds), so the next caller still re-authenticates. This guards against reordering the increment before the login.")]
+	public void ReauthenticateOnce_LoginThrows_DoesNotAdvanceVersionAndPropagates() {
+		CreatioClientAdapter adapter = NewAdapterWithoutClient();
+		int observed = adapter.SessionVersion;
+
+		Action act = () => adapter.ReauthenticateOnce(observed, () => throw new UnauthorizedAccessException("bad creds"));
+
+		act.Should().Throw<UnauthorizedAccessException>("because a failed re-login must surface");
+		adapter.SessionVersion.Should().Be(observed, "because the version must not advance when login fails");
+	}
+
+	// The version gate never touches the live client (login is injected), so a never-resolved
+	// Lazy is enough to construct the adapter under test.
+	private static CreatioClientAdapter NewAdapterWithoutClient() =>
+		new(new Lazy<CreatioClient>(() => null));
 }

--- a/clio.tests/Common/CreatioClientAdapterReauthTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterReauthTests.cs
@@ -42,18 +42,18 @@ public class CreatioClientAdapterReauthTests {
 	}
 
 	[Test]
-	[Description("A persistent login redirect does not loop: the call runs at most twice and the second body is returned as-is.")]
-	public void ExecuteWithReauthRetry_PersistentRedirect_DoesNotLoop() {
+	[Description("A persistent auth failure (re-auth did not restore the session) does not loop: the call runs exactly twice, then a typed auth error is thrown instead of returning the login/401 body to a deserializer.")]
+	public void ExecuteWithReauthRetry_PersistentAuthFailure_ThrowsTypedAuthError() {
 		int calls = 0;
 		int reauths = 0;
 		const string login = "<!DOCTYPE html><html>NuiLogin</html>";
 
-		string result = CreatioClientAdapter.ExecuteWithReauthRetry(
+		Action act = () => CreatioClientAdapter.ExecuteWithReauthRetry(
 			() => { calls++; return login; },
 			() => reauths++);
 
-		result.Should().Be(login, "because the second result is returned without further detection");
-		calls.Should().Be(2, "because there is exactly one retry");
+		act.Should().Throw<UnauthorizedAccessException>("because re-auth did not restore the session");
+		calls.Should().Be(2, "because there is exactly one retry — no third attempt");
 		reauths.Should().Be(1, "because re-auth is attempted once");
 	}
 

--- a/clio.tests/Common/CreatioClientAdapterReauthTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterReauthTests.cs
@@ -1,0 +1,71 @@
+using System;
+using Clio.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[TestFixture]
+[Property("Module", "Common")]
+[Category("Unit")]
+public class CreatioClientAdapterReauthTests {
+
+	[Test]
+	[Description("When the first response is valid, the service call runs once and re-auth is not invoked.")]
+	public void ExecuteWithReauthRetry_ValidResponse_DoesNotReauthenticate() {
+		int calls = 0;
+		int reauths = 0;
+
+		string result = CreatioClientAdapter.ExecuteWithReauthRetry(
+			() => { calls++; return "{\"success\":true}"; },
+			() => reauths++);
+
+		result.Should().Be("{\"success\":true}");
+		calls.Should().Be(1, "because a valid response needs no retry");
+		reauths.Should().Be(0, "because the session was alive");
+	}
+
+	[Test]
+	[Description("On a login redirect, re-auth runs once and the call is retried exactly once, returning the recovered response.")]
+	public void ExecuteWithReauthRetry_ExpiredSession_RelogsInAndRetriesOnce() {
+		int calls = 0;
+		int reauths = 0;
+
+		string result = CreatioClientAdapter.ExecuteWithReauthRetry(
+			() => { calls++; return calls == 1 ? "<!DOCTYPE html><html>NuiLogin</html>" : "{\"success\":true}"; },
+			() => reauths++);
+
+		result.Should().Be("{\"success\":true}", "because the retry after re-login succeeds");
+		calls.Should().Be(2, "because the call runs once, hits the login page, then runs once more");
+		reauths.Should().Be(1, "because re-auth happens exactly once");
+	}
+
+	[Test]
+	[Description("A persistent login redirect does not loop: the call runs at most twice and the second body is returned as-is.")]
+	public void ExecuteWithReauthRetry_PersistentRedirect_DoesNotLoop() {
+		int calls = 0;
+		int reauths = 0;
+		const string login = "<!DOCTYPE html><html>NuiLogin</html>";
+
+		string result = CreatioClientAdapter.ExecuteWithReauthRetry(
+			() => { calls++; return login; },
+			() => reauths++);
+
+		result.Should().Be(login, "because the second result is returned without further detection");
+		calls.Should().Be(2, "because there is exactly one retry");
+		reauths.Should().Be(1, "because re-auth is attempted once");
+	}
+
+	[Test]
+	[Description("A wrong-credentials UnauthorizedAccessException from re-auth propagates and the call is not retried.")]
+	public void ExecuteWithReauthRetry_BadCredentials_PropagatesWithoutRetry() {
+		int calls = 0;
+
+		Action act = () => CreatioClientAdapter.ExecuteWithReauthRetry(
+			() => { calls++; return "<!DOCTYPE html><html>NuiLogin</html>"; },
+			() => throw new UnauthorizedAccessException("bad creds"));
+
+		act.Should().Throw<UnauthorizedAccessException>("because wrong credentials are not an expiry to retry");
+		calls.Should().Be(1, "because the retry must not run when re-auth itself fails");
+	}
+}

--- a/clio/Common/CreatioAuthResponseGuard.cs
+++ b/clio/Common/CreatioAuthResponseGuard.cs
@@ -1,18 +1,18 @@
 using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Clio.Common;
 
 /// <summary>
 /// Detects Creatio authentication failures in raw service responses.
 /// When a Forms-auth session expires (or the auth cookie is missing/invalid), Creatio rejects
-/// a protected service call in one of two observed shapes, both of which the underlying HTTP
-/// stack surfaces to the caller as a plain response body — the HTTP status and final URL are
-/// hidden by the client, so the body is the only signal available:
+/// a protected service call in one of two observed shapes, both surfaced to the caller as a plain
+/// response body — the HTTP status and final URL are hidden by the client:
 /// <list type="bullet">
 /// <item><description>
-/// A JSON 401 payload <c>{"Message":"Authentication failed.",...}</c> returned by
-/// <c>*.svc</c> ServiceModel endpoints — verified against .NET Framework targets with both a
-/// missing and an invalid auth cookie.
+/// A JSON 401 fault envelope <c>{"Message":"Authentication failed.","StackTrace":null,"ExceptionType":"..."}</c>
+/// returned by <c>*.svc</c> ServiceModel endpoints — verified against .NET Framework targets.
 /// </description></item>
 /// <item><description>
 /// A <c>302</c> redirect to <c>/Login/NuiLogin.aspx</c> that the HTTP stack auto-follows,
@@ -20,53 +20,67 @@ namespace Clio.Common;
 /// <c>NuiLogin</c>) as a 200 body.
 /// </description></item>
 /// </list>
-/// This guard reports either shape so the caller can re-authenticate and retry. The NetCore
-/// login route may differ; the heuristic targets Forms-auth (.NET Framework) — see the scope
-/// note on <c>CreatioClientAdapter.ExecuteWithReauthRetry</c>.
+/// Both shapes are produced <i>before</i> the request reaches the service handler, so a caller that
+/// re-authenticates and retries on this signal cannot duplicate a side effect. The NetCore login
+/// route may differ; the heuristic targets Forms-auth (.NET Framework) — see the scope note on
+/// <c>CreatioClientAdapter.ExecuteWithReauthRetry</c>.
 /// </summary>
 internal static class CreatioAuthResponseGuard {
 
-	// JSON 401 body marker. Canonical Creatio ServiceModel auth-failure message.
-	private const string AuthFailedMarker = "Authentication failed";
+	// Cheap pre-filter: present in the 401 envelope and in any other fault that mentions auth.
+	private const string AuthFailedSubstring = "Authentication failed";
+
+	// Exact value of the top-level "Message" field in the auth-failure 401 envelope. Matched by
+	// equality (NOT substring): the same envelope shape carries every server exception, so a
+	// mid-call 500 with a different Message — or a valid payload that merely mentions the phrase —
+	// must NOT be treated as an expired session, otherwise re-auth would re-run an executed write.
+	private const string AuthFailedMessage = "Authentication failed.";
 
 	// Login-page (HTML) markers, unique to the Creatio Forms-auth login redirect.
 	private const string LoginPageMarker = "NuiLogin";
 	private const string LoginPathMarker = "/Login/";
 
 	/// <summary>
-	/// Returns <c>true</c> when <paramref name="response"/> indicates an expired or missing
-	/// Creatio session (JSON 401 auth-failure body or a login-page redirect) rather than a real
+	/// Returns <c>true</c> when <paramref name="response"/> indicates an expired or missing Creatio
+	/// session (the JSON 401 auth-failure envelope or a login-page redirect) rather than a real
 	/// service response.
 	/// </summary>
 	/// <remarks>
-	/// The JSON 401 auth-failure body is valid JSON, so it is matched by content first. Otherwise,
-	/// every Creatio configuration-service and OData response is JSON: a body whose first
-	/// non-whitespace character is '{' or '[' is a real response (zero false positives on the hot
-	/// path), while a non-JSON body is treated as an auth redirect only when it carries a login
-	/// marker — so a generic IIS / 5xx HTML error page is NOT mistaken for an expired session
-	/// (re-login would not fix it, and the original error should surface unchanged).
-	/// Known bounded false positive: a payload that legitimately contains the text
-	/// "Authentication failed" (e.g. a get-page body carrying such a caption) triggers one extra
-	/// re-login; the retried call returns the correct body and cannot loop, so the cost is a single
-	/// wasted re-authentication. This is accepted deliberately — a false negative would make the
-	/// fix inert, which is worse than one redundant login.
+	/// A JSON body (first non-whitespace char '{' or '[') is an auth failure only when it is the 401
+	/// envelope, identified structurally: the top-level <c>Message</c> must <i>equal</i>
+	/// <see cref="AuthFailedMessage"/>. Equality, not substring, is essential on write paths — a
+	/// substring match would fire on a valid, already-executed response that merely contains the
+	/// phrase and would re-run the write. A cheap substring pre-filter skips JSON parsing for the
+	/// overwhelming majority of payloads that never mention auth. A non-JSON body is an auth failure
+	/// only when it carries a login marker, so a generic IIS / 5xx HTML error page is left alone
+	/// (re-login could not fix it, and the original error should surface unchanged).
 	/// </remarks>
 	public static bool IsLikelyAuthRedirect(string response) {
 		if (string.IsNullOrWhiteSpace(response)) {
 			return false;
-		}
-		if (response.IndexOf(AuthFailedMarker, StringComparison.OrdinalIgnoreCase) >= 0) {
-			return true;
 		}
 		ReadOnlySpan<char> trimmed = response.AsSpan().TrimStart();
 		if (trimmed.Length == 0) {
 			return false;
 		}
 		char first = trimmed[0];
-		if (first == '{' || first == '[') {
+		if (first == '[') {
 			return false;
+		}
+		if (first == '{') {
+			return response.IndexOf(AuthFailedSubstring, StringComparison.OrdinalIgnoreCase) >= 0
+				&& IsAuthFailureFaultEnvelope(response);
 		}
 		return response.IndexOf(LoginPageMarker, StringComparison.OrdinalIgnoreCase) >= 0
 			|| response.IndexOf(LoginPathMarker, StringComparison.OrdinalIgnoreCase) >= 0;
+	}
+
+	private static bool IsAuthFailureFaultEnvelope(string response) {
+		try {
+			JObject envelope = JObject.Parse(response);
+			return string.Equals((string)envelope["Message"], AuthFailedMessage, StringComparison.OrdinalIgnoreCase);
+		} catch (JsonException) {
+			return false;
+		}
 	}
 }

--- a/clio/Common/CreatioAuthResponseGuard.cs
+++ b/clio/Common/CreatioAuthResponseGuard.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Clio.Common;
+
+/// <summary>
+/// Detects Creatio authentication failures in raw service responses.
+/// When a Forms-auth session expires (or the auth cookie is missing/invalid), Creatio rejects
+/// a protected service call in one of two observed shapes, both of which the underlying HTTP
+/// stack surfaces to the caller as a plain response body — the HTTP status and final URL are
+/// hidden by the client, so the body is the only signal available:
+/// <list type="bullet">
+/// <item><description>
+/// A JSON 401 payload <c>{"Message":"Authentication failed.",...}</c> returned by
+/// <c>*.svc</c> ServiceModel endpoints — verified against .NET Framework targets with both a
+/// missing and an invalid auth cookie.
+/// </description></item>
+/// <item><description>
+/// A <c>302</c> redirect to <c>/Login/NuiLogin.aspx</c> that the HTTP stack auto-follows,
+/// yielding the login-page HTML (XHTML beginning with <c>&lt;!DOCTYPE</c> and containing
+/// <c>NuiLogin</c>) as a 200 body.
+/// </description></item>
+/// </list>
+/// This guard reports either shape so the caller can re-authenticate and retry. The NetCore
+/// login route may differ; the heuristic targets Forms-auth (.NET Framework) — see the scope
+/// note on <c>CreatioClientAdapter.ExecuteWithReauthRetry</c>.
+/// </summary>
+internal static class CreatioAuthResponseGuard {
+
+	// JSON 401 body marker. Canonical Creatio ServiceModel auth-failure message.
+	private const string AuthFailedMarker = "Authentication failed";
+
+	// Login-page (HTML) markers, unique to the Creatio Forms-auth login redirect.
+	private const string LoginPageMarker = "NuiLogin";
+	private const string LoginPathMarker = "/Login/";
+
+	/// <summary>
+	/// Returns <c>true</c> when <paramref name="response"/> indicates an expired or missing
+	/// Creatio session (JSON 401 auth-failure body or a login-page redirect) rather than a real
+	/// service response.
+	/// </summary>
+	/// <remarks>
+	/// The JSON 401 auth-failure body is valid JSON, so it is matched by content first. Otherwise,
+	/// every Creatio configuration-service and OData response is JSON: a body whose first
+	/// non-whitespace character is '{' or '[' is a real response (zero false positives on the hot
+	/// path), while a non-JSON body is treated as an auth redirect only when it carries a login
+	/// marker — so a generic IIS / 5xx HTML error page is NOT mistaken for an expired session
+	/// (re-login would not fix it, and the original error should surface unchanged).
+	/// Known bounded false positive: a payload that legitimately contains the text
+	/// "Authentication failed" (e.g. a get-page body carrying such a caption) triggers one extra
+	/// re-login; the retried call returns the correct body and cannot loop, so the cost is a single
+	/// wasted re-authentication. This is accepted deliberately — a false negative would make the
+	/// fix inert, which is worse than one redundant login.
+	/// </remarks>
+	public static bool IsLikelyAuthRedirect(string response) {
+		if (string.IsNullOrWhiteSpace(response)) {
+			return false;
+		}
+		if (response.IndexOf(AuthFailedMarker, StringComparison.OrdinalIgnoreCase) >= 0) {
+			return true;
+		}
+		ReadOnlySpan<char> trimmed = response.AsSpan().TrimStart();
+		if (trimmed.Length == 0) {
+			return false;
+		}
+		char first = trimmed[0];
+		if (first == '{' || first == '[') {
+			return false;
+		}
+		return response.IndexOf(LoginPageMarker, StringComparison.OrdinalIgnoreCase) >= 0
+			|| response.IndexOf(LoginPathMarker, StringComparison.OrdinalIgnoreCase) >= 0;
+	}
+}

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -145,13 +145,15 @@ public class CreatioClientAdapter : IApplicationClient{
 
 	/// <summary>
 	/// Core re-auth-and-retry logic, separated from the live client so it can be unit tested.
-	/// Runs <paramref name="serviceCall"/>; if the response is a Creatio login redirect, invokes
-	/// <paramref name="reauthenticate"/> once and runs the call again exactly once. The second
-	/// result is returned as-is (no further detection) to guarantee termination. A login redirect
-	/// proves the request never reached the service (Forms auth bounces it before the handler), so
-	/// the retry is side-effect-safe even for non-idempotent writes; an
-	/// <see cref="UnauthorizedAccessException"/> raised by <paramref name="reauthenticate"/> (wrong
-	/// credentials, not expiry) propagates and is never retried.
+	/// Runs <paramref name="serviceCall"/>; if the response is a Creatio auth failure, invokes
+	/// <paramref name="reauthenticate"/> once and runs the call again exactly once (termination is
+	/// guaranteed — there is no third attempt). An auth failure proves the request never reached the
+	/// service (Forms auth / 401 rejects it before the handler), so the retry is side-effect-safe even
+	/// for non-idempotent writes. If re-auth did not restore the session — the retry still returns an
+	/// auth-failure body — a typed <see cref="UnauthorizedAccessException"/> is thrown instead of
+	/// letting the login/401 body reach a JSON deserializer as an opaque "unexpected '&lt;'" error.
+	/// A wrong-credentials <see cref="UnauthorizedAccessException"/> raised by
+	/// <paramref name="reauthenticate"/> propagates and is never retried.
 	/// </summary>
 	internal static string ExecuteWithReauthRetry(Func<string> serviceCall, Action reauthenticate) {
 		string response = serviceCall();
@@ -159,7 +161,12 @@ public class CreatioClientAdapter : IApplicationClient{
 			return response;
 		}
 		reauthenticate();
-		return serviceCall();
+		response = serviceCall();
+		if (CreatioAuthResponseGuard.IsLikelyAuthRedirect(response)) {
+			throw new UnauthorizedAccessException(
+				"Creatio re-authentication did not restore the session; the service still returned a login/401 response.");
+		}
+		return response;
 	}
 
 	public string CallConfigurationService(string serviceName, string serviceMethod, string requestData,

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -51,6 +51,7 @@ public class CreatioClientAdapter : IApplicationClient{
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
 	private readonly JsonConverter _jsonConverter;
 	private readonly object _reauthSyncRoot = new();
+	private volatile int _sessionVersion;
 
 	private CreatioClient Client => _lazyClient.Value;
 
@@ -99,22 +100,41 @@ public class CreatioClientAdapter : IApplicationClient{
 
 	/// <summary>
 	/// Executes a Creatio service call and, when the response is a login redirect caused by an
-	/// expired Forms-auth session, re-authenticates once via <see cref="CreatioClient.Login()"/>
-	/// and retries the call exactly once. The re-login is serialized through
-	/// <see cref="_reauthSyncRoot"/> because the adapter is a DI singleton shared across calls.
+	/// expired Forms-auth session, re-authenticates once and retries the call exactly once. Re-login
+	/// is serialized through <see cref="_reauthSyncRoot"/> and gated by <see cref="_sessionVersion"/>
+	/// (the adapter is a DI singleton), so a burst of concurrent stale calls triggers a single
+	/// <see cref="CreatioClient.Login()"/> rather than one login per thread.
 	/// </summary>
 	/// <remarks>
 	/// Scope: this recovers Forms-auth (cookie) sessions only. OAuth bearer expiry returns a 401
 	/// (not a login-page redirect) and has no public token-refresh entry point on the client, so it
 	/// is not covered here. Sessions held by <c>RemoteDataProvider</c> (ATF.Repository) are separate
 	/// and are likewise not covered by this adapter.
+	/// Call budget: the wrapped methods also forward <c>retryCount</c> to the underlying client's own
+	/// HTTP retry loop, so on the worst path a single logical call issues up to <c>2 × retryCount</c>
+	/// HTTP requests (inner transport retries followed by one outer re-auth retry).
 	/// </remarks>
-	private string ExecuteWithReauthRetry(Func<string> serviceCall) =>
-		ExecuteWithReauthRetry(serviceCall, () => {
-			lock (_reauthSyncRoot) {
-				Client.Login();
+	private string ExecuteWithReauthRetry(Func<string> serviceCall) {
+		int observedSessionVersion = _sessionVersion;
+		return ExecuteWithReauthRetry(serviceCall, () => ReauthenticateOnce(observedSessionVersion));
+	}
+
+	/// <summary>
+	/// Re-authenticates under <see cref="_reauthSyncRoot"/>, but only if no other thread has already
+	/// renewed the session since the caller observed <paramref name="observedSessionVersion"/>. Under a
+	/// burst of concurrent calls that all hit the same expired session this collapses N would-be logins
+	/// into one: the first thread logs in and bumps the version; the others see the new version and skip,
+	/// their retry reusing the freshly renewed session.
+	/// </summary>
+	private void ReauthenticateOnce(int observedSessionVersion) {
+		lock (_reauthSyncRoot) {
+			if (_sessionVersion != observedSessionVersion) {
+				return;
 			}
-		});
+			Client.Login();
+			_sessionVersion++;
+		}
+	}
 
 	/// <summary>
 	/// Core re-auth-and-retry logic, separated from the live client so it can be unit tested.

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -119,22 +119,29 @@ public class CreatioClientAdapter : IApplicationClient{
 		return ExecuteWithReauthRetry(serviceCall, () => ReauthenticateOnce(observedSessionVersion));
 	}
 
+	private void ReauthenticateOnce(int observedSessionVersion) =>
+		ReauthenticateOnce(observedSessionVersion, () => Client.Login());
+
 	/// <summary>
-	/// Re-authenticates under <see cref="_reauthSyncRoot"/>, but only if no other thread has already
-	/// renewed the session since the caller observed <paramref name="observedSessionVersion"/>. Under a
-	/// burst of concurrent calls that all hit the same expired session this collapses N would-be logins
-	/// into one: the first thread logs in and bumps the version; the others see the new version and skip,
-	/// their retry reusing the freshly renewed session.
+	/// Version-gated single re-login, separated from the live client so it can be unit tested.
+	/// Under <see cref="_reauthSyncRoot"/>, re-authenticates only if no other thread has renewed the
+	/// session since <paramref name="observedSessionVersion"/> was read — collapsing a burst of
+	/// concurrent stale calls into one login. The version is bumped only AFTER <paramref name="login"/>
+	/// returns, so a failed login leaves <see cref="_sessionVersion"/> untouched and the next caller
+	/// still re-authenticates.
 	/// </summary>
-	private void ReauthenticateOnce(int observedSessionVersion) {
+	internal void ReauthenticateOnce(int observedSessionVersion, Action login) {
 		lock (_reauthSyncRoot) {
 			if (_sessionVersion != observedSessionVersion) {
 				return;
 			}
-			Client.Login();
+			login();
 			_sessionVersion++;
 		}
 	}
+
+	/// <summary>Current re-authentication generation. Test seam for the version gate.</summary>
+	internal int SessionVersion => _sessionVersion;
 
 	/// <summary>
 	/// Core re-auth-and-retry logic, separated from the live client so it can be unit tested.

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -50,6 +50,7 @@ public class CreatioClientAdapter : IApplicationClient{
 	private readonly Lazy<CreatioClient> _lazyClient;
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
 	private readonly JsonConverter _jsonConverter;
+	private readonly object _reauthSyncRoot = new();
 
 	private CreatioClient Client => _lazyClient.Value;
 
@@ -96,9 +97,48 @@ public class CreatioClientAdapter : IApplicationClient{
 
 	#region Methods: Public
 
+	/// <summary>
+	/// Executes a Creatio service call and, when the response is a login redirect caused by an
+	/// expired Forms-auth session, re-authenticates once via <see cref="CreatioClient.Login()"/>
+	/// and retries the call exactly once. The re-login is serialized through
+	/// <see cref="_reauthSyncRoot"/> because the adapter is a DI singleton shared across calls.
+	/// </summary>
+	/// <remarks>
+	/// Scope: this recovers Forms-auth (cookie) sessions only. OAuth bearer expiry returns a 401
+	/// (not a login-page redirect) and has no public token-refresh entry point on the client, so it
+	/// is not covered here. Sessions held by <c>RemoteDataProvider</c> (ATF.Repository) are separate
+	/// and are likewise not covered by this adapter.
+	/// </remarks>
+	private string ExecuteWithReauthRetry(Func<string> serviceCall) =>
+		ExecuteWithReauthRetry(serviceCall, () => {
+			lock (_reauthSyncRoot) {
+				Client.Login();
+			}
+		});
+
+	/// <summary>
+	/// Core re-auth-and-retry logic, separated from the live client so it can be unit tested.
+	/// Runs <paramref name="serviceCall"/>; if the response is a Creatio login redirect, invokes
+	/// <paramref name="reauthenticate"/> once and runs the call again exactly once. The second
+	/// result is returned as-is (no further detection) to guarantee termination. A login redirect
+	/// proves the request never reached the service (Forms auth bounces it before the handler), so
+	/// the retry is side-effect-safe even for non-idempotent writes; an
+	/// <see cref="UnauthorizedAccessException"/> raised by <paramref name="reauthenticate"/> (wrong
+	/// credentials, not expiry) propagates and is never retried.
+	/// </summary>
+	internal static string ExecuteWithReauthRetry(Func<string> serviceCall, Action reauthenticate) {
+		string response = serviceCall();
+		if (!CreatioAuthResponseGuard.IsLikelyAuthRedirect(response)) {
+			return response;
+		}
+		reauthenticate();
+		return serviceCall();
+	}
+
 	public string CallConfigurationService(string serviceName, string serviceMethod, string requestData,
 		int requestTimeout = Timeout.Infinite) {
-		return Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout);
+		return ExecuteWithReauthRetry(() =>
+			Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout));
 	}
 
 	public void DownloadFile(string url, string filePath, string requestData) {
@@ -112,29 +152,36 @@ public class CreatioClientAdapter : IApplicationClient{
 
 	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int retryCount = 1, int delaySec = 1) {
-		return Client.ExecuteDeleteRequest(url, requestData, requestTimeout, retryCount, delaySec);
+		return ExecuteWithReauthRetry(() =>
+			Client.ExecuteDeleteRequest(url, requestData, requestTimeout, retryCount, delaySec));
 	}
 
 	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int retryCount = 1,
 		int delaySec = 1) {
-		return Client.ExecuteGetRequest(url, requestTimeout, retryCount, delaySec);
+		return ExecuteWithReauthRetry(() =>
+			Client.ExecuteGetRequest(url, requestTimeout, retryCount, delaySec));
 	}
 
 	public string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int retryCount = 1, int delaySec = 1) {
-		return Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec);
+		return ExecuteWithReauthRetry(() =>
+			Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec));
 	}
 
 	public T ExecutePostRequest<T>(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int retryCount = 1, int delaySec = 1)
 		where T : BaseResponse, new() {
-		string response = Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec);
+		// Re-auth on the raw string boundary so an expired session is recovered BEFORE
+		// deserialization runs on the (now valid) response rather than throwing on login HTML.
+		string response = ExecuteWithReauthRetry(() =>
+			Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec));
 		return _jsonConverter.DeserializeObject<T>(response);
 	}
 
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int retryCount = 1, int delaySec = 1) {
-		return Client.ExecutePatchRequest(url, requestData, requestTimeout, retryCount, delaySec);
+		return ExecuteWithReauthRetry(() =>
+			Client.ExecutePatchRequest(url, requestData, requestTimeout, retryCount, delaySec));
 	}
 
 	public void Listen(CancellationToken cancellationToken) {


### PR DESCRIPTION
## Problem

`clio mcp-server` caches the authenticated `CreatioClient` process-wide (`ToolCommandResolver.ContainerCache` + `AddSingleton<IApplicationClient>`), and `CreatioClient` logs in only once (`InitAuthCookie` calls `Login()` only when the cookie is null). After a long idle pause the server session expires; the cached cookie is dead and subsequent service calls fail. In the reported incident `update-page`/`get-page` failed with `Unexpected character ... <` — the client silently returned the login response and clio parsed it as JSON. A fresh CLI process works because it re-logs-in from scratch.

This is **Opt 2** (containment in the clio adapter). The deeper defect — `creatio.client` auto-following the auth redirect and returning it as a success body — lives in the NuGet and is intentionally out of scope here.

## Change

`CreatioClientAdapter` wraps all text service methods (`ExecutePostRequest`/`<T>`, `ExecuteGetRequest`, `ExecutePatchRequest`, `ExecuteDeleteRequest`, `CallConfigurationService`) in `ExecuteWithReauthRetry`:

1. run the call;
2. if the response is a Creatio auth failure, call `Login()` once and retry **exactly once**.

Re-auth is serialized through a lock (the adapter is a DI singleton). The retry sits on the raw-string boundary so the generic `ExecutePostRequest<T>` recovers before deserialization.

### Why retry is safe
An auth failure proves the request never reached the service (Forms auth bounces it before the handler), so no side effect occurred — safe even for non-idempotent writes. A wrong-credentials `UnauthorizedAccessException` from `Login()` propagates without retry.

### Detection (`CreatioAuthResponseGuard`)
Two failure shapes, **both confirmed empirically against .NET Framework stands**:
- **JSON 401** `{"Message":"Authentication failed."}` — what `.svc` endpoints actually return for an expired/invalid session (matched by the `"Authentication failed"` substring);
- **HTML login redirect** — `302 → /Login/NuiLogin.aspx` auto-followed into the NuiLogin page (matched by a non-JSON body + `NuiLogin`/`/Login/`).

Valid JSON service/OData responses are never matched; a generic IIS/5xx HTML page is deliberately left alone (relogin cannot fix it). Known bounded false positive: a payload legitimately containing "Authentication failed" costs one redundant relogin, never a loop — documented in code.

## Not confirmed (open follow-up)

The transcript symptom was an **HTML `<` body**; the local repro only reproduced the **JSON-401** shape on the same endpoints/stand. The exact `<` body was not reproduced — it is consistent with, but not confirmed as, the covered login-redirect path (it could also have been a server-side IIS/app-pool error during that instance's instability that day). **Confirming step:** run e2e against a genuinely expired MCP session and capture the actual `<` body to verify it trips a marker. This requires restarting the MCP process and was not done in-session.

## Out of scope (documented in XML-doc)

- **OAuth** bearer expiry — returns 401, no public token-refresh entry point on the client.
- **`RemoteDataProvider` / ATF.Repository** — a separate authenticated session (odata-read, dataforge), not routed through this adapter.
- **`DownloadFile`/`UploadFile`** — binary/file paths.

## Testing

- 14 unit tests: `CreatioAuthResponseGuardTests` (both failure shapes + valid JSON + IIS-500 + null/empty) and `CreatioClientAdapterReauthTests` (happy path → no relogin, expiry → relogin + retry once, persistent redirect → no loop, bad-creds → propagate without retry).
- Full `Common` test namespace: 445/445 (no regression).
- Release build green on net10.0 + net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
