### PR TITLE
refactor(paths): consolidate local clio directories under a single home root

### DIFF
--- a/clio.tests/Common/ClioRuntimePathsTests.cs
+++ b/clio.tests/Common/ClioRuntimePathsTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using Clio;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Common")]
+[NonParallelizable] // mutates the CLIO_HOME process environment variable
+[Description("Unit tests for ClioRuntimePaths home/cache resolution and the CLIO_HOME override")]
+public sealed class ClioRuntimePathsTests {
+
+	private string? _originalClioHome;
+
+	[SetUp]
+	public void SetUp() => _originalClioHome = System.Environment.GetEnvironmentVariable("CLIO_HOME");
+
+	[TearDown]
+	public void TearDown() => System.Environment.SetEnvironmentVariable("CLIO_HOME", _originalClioHome);
+
+	[Test]
+	[Description("CLIO_HOME overrides the home root verbatim and CacheRoot nests directly under it.")]
+	public void CacheRoot_Honors_ClioHome_Override() {
+		// Arrange
+		string home = Path.Combine(Path.GetTempPath(), "clio-home-override-test");
+		System.Environment.SetEnvironmentVariable("CLIO_HOME", home);
+
+		// Act / Assert
+		ClioRuntimePaths.Home.Should().Be(home,
+			because: "CLIO_HOME must override the resolved home root verbatim");
+		ClioRuntimePaths.CacheRoot.Should().Be(Path.Combine(home, "cache"),
+			because: "the cache root must nest directly under the home root");
+	}
+
+	[Test]
+	[Description("A blank CLIO_HOME is ignored so the default Company/Product path is used.")]
+	public void Home_Falls_Back_When_ClioHome_Blank() {
+		// Arrange
+		System.Environment.SetEnvironmentVariable("CLIO_HOME", "   ");
+
+		// Act
+		string home = ClioRuntimePaths.Home;
+
+		// Assert
+		home.Should().NotBeNullOrWhiteSpace(
+			because: "a blank override must be ignored so the default Company/Product path is resolved instead");
+		home.Trim().Should().NotBe("",
+			because: "a whitespace-only CLIO_HOME must not leak through as the home root");
+	}
+}

--- a/clio.tests/Common/ClioRuntimePathsTests.cs
+++ b/clio.tests/Common/ClioRuntimePathsTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Reflection;
 using Clio;
 using FluentAssertions;
 using NUnit.Framework;
@@ -40,13 +41,38 @@ public sealed class ClioRuntimePathsTests {
 		// Arrange
 		System.Environment.SetEnvironmentVariable("CLIO_HOME", "   ");
 
-		// Act
-		string home = ClioRuntimePaths.Home;
+		// Act / Assert
+		AssertFallbackHome(ClioRuntimePaths.Home);
+	}
 
-		// Assert
+	[Test]
+	[Description("An unset CLIO_HOME falls back to the default Company/Product path.")]
+	public void Home_Falls_Back_When_ClioHome_Not_Set() {
+		// Arrange
+		System.Environment.SetEnvironmentVariable("CLIO_HOME", null);
+
+		// Act / Assert
+		AssertFallbackHome(ClioRuntimePaths.Home);
+	}
+
+	// The fallback path is AppSettingsFolderPath = <userRoot>/<Company>/<Product>. We assert that
+	// structure (absolute + ends with the entry assembly's Company/Product segments) rather than a
+	// hardcoded "creatio/clio": under `dotnet test` the entry assembly is the test host, so the
+	// segments resolve to "Microsoft Corporation/testhost", not the clio assembly's values. This
+	// still guards against the real regression — the fallback silently resolving to an unrelated
+	// location (e.g. temp) or an empty string.
+	private static void AssertFallbackHome(string home) {
 		home.Should().NotBeNullOrWhiteSpace(
-			because: "a blank override must be ignored so the default Company/Product path is resolved instead");
-		home.Trim().Should().NotBe("",
-			because: "a whitespace-only CLIO_HOME must not leak through as the home root");
+			because: "a missing/blank CLIO_HOME must resolve to the default Company/Product path, not an empty string");
+		Path.IsPathRooted(home).Should().BeTrue(
+			because: "the fallback must be an absolute path under the user's home/local-app-data root");
+
+		Assembly entryAssembly = Assembly.GetEntryAssembly();
+		string? company = entryAssembly?.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
+		string? product = entryAssembly?.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
+		if (!string.IsNullOrEmpty(company) && !string.IsNullOrEmpty(product)) {
+			home.Should().EndWith(Path.Combine(company, product),
+				because: "the fallback path is composed as <userRoot>/<Company>/<Product>");
+		}
 	}
 }

--- a/clio/Command/ComponentRegistryRefreshCommand.cs
+++ b/clio/Command/ComponentRegistryRefreshCommand.cs
@@ -131,7 +131,6 @@ public sealed class ComponentRegistryRefreshCommand {
 	}
 
 	private static string GetCacheDirectory() {
-		string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		return Path.Combine(profile, ".clio", "cache", ComponentRegistryCacheStore.CacheDirectoryName);
+		return Path.Combine(ClioRuntimePaths.CacheRoot, ComponentRegistryCacheStore.CacheDirectoryName);
 	}
 }

--- a/clio/Command/McpServer/Tools/ComponentRegistryCacheStore.cs
+++ b/clio/Command/McpServer/Tools/ComponentRegistryCacheStore.cs
@@ -14,7 +14,7 @@ namespace Clio.Command.McpServer.Tools;
 /// <summary>
 /// Stores fetched component-registry payloads on disk so that AI requests survive a
 /// transient CDN outage and so that warm starts do not always hit the network.
-/// Lives at <c>~/.clio/cache/component-registry/</c>; one <c>{version}.json</c> file per
+/// Lives at <c><clio-home>/cache/component-registry/</c>; one <c>{version}.json</c> file per
 /// resolved platform version plus a sidecar <c>{version}.meta.json</c>.
 /// </summary>
 public interface IComponentRegistryCacheStore {
@@ -61,7 +61,7 @@ public sealed class ComponentRegistryCacheStore : IComponentRegistryCacheStore {
 
 	/// <summary>
 	/// Flavor-aware factory. The <paramref name="subdirectory"/> isolates payloads
-	/// per flavor (e.g. <c>"mobile"</c> → <c>~/.clio/cache/component-registry/mobile/</c>)
+	/// per flavor (e.g. <c>"mobile"</c> → <c><clio-home>/cache/component-registry/mobile/</c>)
 	/// so web and mobile cannot collide on the same <c>latest.json</c> key. Pass an
 	/// empty string for the web flavor — keeps the cache layout that pre-mobile builds
 	/// already populated on user disks.
@@ -198,8 +198,7 @@ public sealed class ComponentRegistryCacheStore : IComponentRegistryCacheStore {
 	}
 
 	private static string DefaultRoot(IFileSystem fileSystem) {
-		string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		return fileSystem.Path.Combine(profile, ".clio", "cache", CacheDirectoryName);
+		return fileSystem.Path.Combine(ClioRuntimePaths.CacheRoot, CacheDirectoryName);
 	}
 
 	private static string ComposeRoot(IFileSystem fileSystem, string subdirectory) {

--- a/clio/Command/McpServer/Tools/ComponentRegistryClient.cs
+++ b/clio/Command/McpServer/Tools/ComponentRegistryClient.cs
@@ -16,7 +16,7 @@ namespace Clio.Command.McpServer.Tools;
 
 /// <summary>
 /// Orchestrates the layered fallback chain that backs <c>get-component-info</c>:
-/// CDN → file cache (<c>~/.clio/cache/component-registry/</c>) → embedded snapshot
+/// CDN → file cache (<c><clio-home>/cache/component-registry/</c>) → embedded snapshot
 /// in <c>clio.dll</c>. AI requests never block on the network: stale cache is returned
 /// synchronously while a background refresh runs.
 /// </summary>
@@ -70,7 +70,7 @@ public enum ComponentRegistrySource {
 /// <param name="CdnRegistryFileName">Bare filename served by the academy CDN; e.g. <c>"ComponentRegistry.json"</c>.</param>
 /// <param name="LocalFileEnvironmentVariable">Name of the env var that forces a local override of the entire chain.</param>
 /// <param name="CacheSubdirectoryName">
-/// Optional sub-folder under <c>~/.clio/cache/component-registry/</c> isolating this
+/// Optional sub-folder under <c><clio-home>/cache/component-registry/</c> isolating this
 /// flavor's payloads. Empty for the web flavor (back-compat with cache files written
 /// before the mobile flavor existed).
 /// </param>

--- a/clio/Command/McpServer/Tools/ComponentRegistryDocsCacheStore.cs
+++ b/clio/Command/McpServer/Tools/ComponentRegistryDocsCacheStore.cs
@@ -52,9 +52,9 @@ public sealed record ComponentRegistryDocsCacheReadResult(byte[] Content, bool I
 
 /// <summary>
 /// Disk-backed implementation of <see cref="IComponentRegistryDocsCacheStore"/>. Files
-/// live under <c>~/.clio/cache/component-registry/{version}/{docPath}</c> with a
+/// live under <c><clio-home>/cache/component-registry/{version}/{docPath}</c> with a
 /// <c>.meta.json</c> sidecar of the same name. The cache root and TTL are shared with
-/// the registry-payload store so a single <c>~/.clio/cache/component-registry/</c>
+/// the registry-payload store so a single <c><clio-home>/cache/component-registry/</c>
 /// delete resets every layer in one go.
 /// </summary>
 public sealed class ComponentRegistryDocsCacheStore : IComponentRegistryDocsCacheStore {
@@ -246,8 +246,7 @@ public sealed class ComponentRegistryDocsCacheStore : IComponentRegistryDocsCach
 	}
 
 	private static string DefaultRoot(IFileSystem fileSystem) {
-		string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		return fileSystem.Path.Combine(profile, ".clio", "cache", ComponentRegistryCacheStore.CacheDirectoryName);
+		return fileSystem.Path.Combine(ClioRuntimePaths.CacheRoot, ComponentRegistryCacheStore.CacheDirectoryName);
 	}
 
 	private static readonly JsonSerializerOptions MetadataSerializerOptions = new() {

--- a/clio/Environment/ClioRuntimePaths.cs
+++ b/clio/Environment/ClioRuntimePaths.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace Clio;
+
+/// <summary>
+/// Central resolver for clio's per-user local directories. Every on-disk location for
+/// configuration, cache, and state derives from a single home root, so the layout stays
+/// consistent across platforms and can be relocated wholesale via the <c>CLIO_HOME</c>
+/// environment variable. See <c>docs/architecture/clio-home-consolidation.md</c>.
+/// </summary>
+public static class ClioRuntimePaths {
+
+	/// <summary>
+	/// The single home root for clio's per-user state. Equals
+	/// <see cref="SettingsRepository.AppSettingsFolderPath"/> (which honors <c>CLIO_HOME</c>):
+	/// <c>~/creatio/clio</c> on macOS/Linux, <c>%LOCALAPPDATA%\creatio\clio</c> on Windows.
+	/// </summary>
+	public static string Home => SettingsRepository.AppSettingsFolderPath;
+
+	/// <summary>
+	/// Root for disposable cached artifacts (component registry, docker assets). Safe to
+	/// delete at any time: entries re-populate from their source (CDN, bundled assets) on
+	/// next use. A cache-clear operation must never reach outside this subtree.
+	/// </summary>
+	public static string CacheRoot => Path.Combine(Home, "cache");
+}

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -352,6 +352,13 @@ namespace Clio
 		private Settings _settings = new ();
 		public static string AppSettingsFolderPath {
 			get {
+				// CLIO_HOME, when set, overrides the entire root verbatim. This is the single
+				// source of truth for clio's home directory; see ClioRuntimePaths and
+				// docs/architecture/clio-home-consolidation.md.
+				var clioHome = Environment.GetEnvironmentVariable("CLIO_HOME");
+				if (!string.IsNullOrWhiteSpace(clioHome)) {
+					return clioHome;
+				}
 				var userPath = Environment.GetEnvironmentVariable(
 					RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
 						"LOCALAPPDATA" : "HOME");

--- a/docs/architecture/clio-home-consolidation.md
+++ b/docs/architecture/clio-home-consolidation.md
@@ -1,0 +1,141 @@
+# ADR: Consolidate clio local directories under a single home root
+
+**Status:** Accepted
+**Date:** 2026-06-01
+**Scope:** Where clio stores per-user state, cache, and configuration on the local machine.
+
+## Context
+
+clio currently scatters its local state across several unrelated roots. A full audit of
+the codebase found four independent "global" roots plus a couple of per-workspace paths.
+
+### Audit — global per-user state
+
+| Root (macOS/Linux) | Root (Windows) | Contents | Source |
+|---|---|---|---|
+| `$HOME/creatio/clio/` *(visible)* | `%LOCALAPPDATA%\creatio\clio\` | `appsettings.json` (environments + secrets), `schema.json`, `update-check.json`, `docker-assets/code-server/`, docker-templates, `infrastructure/` | `SettingsRepository.AppSettingsFolderPath` (`Company`/`Product`) |
+| `~/.clio/` | `%USERPROFILE%\.clio\` | `cache/component-registry/`, `iis-root/` (default) | `ComponentRegistryCacheStore`, `Settings.GetDefaultIisRootPath` |
+| `$TMPDIR/clio/` (+ `clio_restore_*`) | `%TEMP%\clio\` | temporary working directories | `WorkingDirectoriesProvider.BaseTempDirectory` (env `CLIO_WORKING_DIRECTORY`) |
+| — | `%APPDATA%\clio\` | context-menu icons (Windows only) | `RegisterCommand` |
+
+The root cause: **two parallel hierarchies** (`creatio/clio` via the .NET `Company/Product`
+convention, and `~/.clio` via hardcoded literals). `code-server` cache and docker-templates
+live under the first; component-registry cache lives under the second. The split is also
+inconsistent across platforms (on Windows the config sits in `LOCALAPPDATA` while the cache
+sits in `USERPROFILE`).
+
+The `appsettings.json` file under `~/creatio/clio` holds every registered environment
+**and its credentials** (passwords, `ClientSecret`).
+
+### Per-workspace / per-cwd paths (intentionally NOT global)
+
+- `.clio-pages/{schema}/` in the current working directory (`PageGetTool`, `PageSyncTool`) —
+  by design, output sits next to the user's project. The observed `~/.clio-pages` is a
+  symptom of the MCP server starting with `$HOME` as cwd, not of this consolidation.
+- `.clio/workspaceSettings.json` — the workspace marker (`WorkspacePathBuilder`). Correct.
+- `workspace/.application` — downloaded configuration. Correct.
+
+## Decision
+
+**Use the existing `~/creatio/clio` root (`SettingsRepository.AppSettingsFolderPath`) as the
+single home for clio's per-user state**, and move the component-registry cache under it.
+Introduce an explicit `CLIO_HOME` environment override.
+
+This **inverts the direction of migration**: instead of moving the precious config into a
+new root (and risking the loss of environments/credentials), we redirect the *disposable*
+cache into the root the config already lives in. `appsettings.json` does not move a single
+byte, so the regression risk that motivated this work disappears rather than being mitigated.
+
+### Why not `~/.clio`?
+
+`~/.clio` is the more conventional hidden dotfolder, but choosing it would require migrating
+the credential-bearing `appsettings.json` — an atomic/locked/idempotent migration with real
+failure modes (read-only FS, concurrent CLI + MCP processes). The `~/creatio/clio` option
+avoids all of it. The only downside is cosmetic: the root is visible on macOS/Linux. That is
+accepted as a conscious trade-off, and `CLIO_HOME` provides the escape hatch for anyone who
+prefers a hidden root.
+
+### What is intentionally kept OUT of the single root
+
+These are not clio "state" and must not be folded into the config root:
+
+- **`iis-root` (default)** — a deployment target (like `C:\inetpub\wwwroot`), potentially
+  gigabytes of local Creatio deployments. Changing its default would orphan existing
+  deployments. Default left unchanged.
+- **temp** (`$TMPDIR/clio`) — ephemeral by definition; belongs in the OS temp area.
+- **Windows context-menu icons** (`%APPDATA%\clio`) — the `.reg` files hardcode
+  `%APPDATA%\\clio\\creatio_favicon.ico`; moving the icons without re-importing the registry
+  would break the context menu. Out of scope here.
+
+## Target layout
+
+```
+~/creatio/clio/              ($CLIO_HOME override)   |  Windows: %LOCALAPPDATA%\creatio\clio\
+├── appsettings.json         config: NOT moved   [never auto-cleaned: secrets]
+├── schema.json              config
+├── update-check.json        state
+├── cache/                   [disposable: a future "clear-cache" may safely wipe this subtree]
+│   └── component-registry/     (redirected from ~/.clio/cache — re-downloaded from CDN)
+├── docker-assets/
+│   └── code-server/            (already under this root today — unchanged)
+├── docker-templates/           (already under this root today — unchanged)
+└── infrastructure/             (already under this root today — unchanged)
+
+Deliberately OUTSIDE the root: iis-root (default), temp, Windows icons.
+```
+
+The subfolders encode a **deletion-safety boundary**: a cache-clear operation must be unable
+to touch `appsettings.json` or `iis-root`.
+
+This change redirects only the component-registry cache under `cache/`. `docker-assets/`
+(code-server) and `docker-templates/` already live under the root, but are not yet regrouped
+under `cache/`; regrouping them is deferred future work (it would touch
+`CodeServerArchiveCache` and `DockerTemplatePathProvider` plus their tests).
+
+## Implementation
+
+1. **`ClioRuntimePaths`** — a central resolver over `AppSettingsFolderPath` exposing `Home`
+   and `CacheRoot`. The component-registry cache now composes its path through it; the other
+   roots (code-server, docker-templates, infrastructure, config) still derive from
+   `AppSettingsFolderPath` directly and can be routed through `ClioRuntimePaths` incrementally.
+2. **`CLIO_HOME` override** — added at the single source of truth
+   (`SettingsRepository.AppSettingsFolderPath`). When set, it is returned verbatim as the
+   root. `CLIO_WORKING_DIRECTORY` is left untouched (already in circulation; renaming it
+   would itself be a breaking change).
+3. **Redirect the three cache hardcodes** to `ClioRuntimePaths.CacheRoot`:
+   `ComponentRegistryCacheStore.DefaultRoot`, `ComponentRegistryDocsCacheStore.DefaultRoot`,
+   `ComponentRegistryRefreshCommand.GetCacheDirectory`.
+
+**Completeness test:** after the change, `grep` for `SpecialFolder.UserProfile` and the
+`".clio"` literal must resolve only to (a) the central resolver and (b) the legitimate
+workspace marker `.clio/workspaceSettings.json`.
+
+## Backward compatibility
+
+- **Config:** zero action. `appsettings.json` is not moved → registered environments keep
+  working with no user intervention. No locks, no atomic-rename, no migration code needed.
+- **Cache:** the old `~/.clio/cache` is simply orphaned; the new location re-populates from
+  the CDN on first use (the embedded snapshot in `clio.dll` covers even a simultaneous CDN
+  outage, so the first cold call still succeeds). clio does not auto-clean the old folder;
+  `~/.clio` can be deleted manually. The cache is never migrated (it is disposable by
+  construction).
+- **`CLIO_HOME`:** new, additive. It is also the future path to a hidden root — a later
+  change can move the config under `~/.clio` via `CLIO_HOME` without re-opening this decision.
+- **iis-root default:** unchanged → existing deployments are not orphaned.
+
+## Out of scope (tracked separately)
+
+- **`.clio-pages` in `$HOME`:** bind `get-page` / `sync-page` output to the workspace root
+  (the directory containing `.clio/workspaceSettings.json`) instead of the raw
+  `GetCurrentDirectory()`, so an MCP server started from `$HOME` no longer writes there.
+- **Windows icons + `.reg`:** if ever consolidated, update the `.reg` files and re-import
+  them in `RegisterCommand` in the same change.
+
+## Consequences
+
+- **Positive:** one root per platform; zero risk to environments/credentials; minimal code;
+  on Windows the cache moves from `%USERPROFILE%\.clio` to `%LOCALAPPDATA%\creatio\clio`,
+  which is the more correct location for a cache.
+- **Negative:** the root remains visible on macOS/Linux (`~/creatio/clio`). Mitigated by
+  `CLIO_HOME`. The name `~/creatio` reads like a "Creatio projects" folder; however, clio
+  already owns `~/creatio/clio` today, so no new namespace conflict is introduced.

--- a/docs/architecture/clio-pages-workspace-binding.md
+++ b/docs/architecture/clio-pages-workspace-binding.md
@@ -1,0 +1,66 @@
+# Plan: bind `.clio-pages` output to the workspace root
+
+**Status:** Proposed (not yet implemented)
+**Related:** `docs/architecture/clio-home-consolidation.md` (explicitly out of scope there)
+
+## Problem
+
+`get-page` and `sync-page` write their output (`body.js`, `bundle.json`, `meta.json`) to
+`.clio-pages/{schema}/` resolved against the **raw current working directory**:
+
+- `PageGetTool.WriteFilesAndCompact` — `Path.Combine(fileSystem.Directory.GetCurrentDirectory(), ".clio-pages")`
+  (`clio/Command/McpServer/Tools/PageGetTool.cs:62`)
+- `PageSyncTool` verification write — `Path.Combine(fileSystem.Directory.GetCurrentDirectory(), ".clio-pages", schemaName)`
+  (`clio/Command/McpServer/Tools/PageSyncTool.cs:183`)
+
+When the MCP server is launched with `$HOME` as its working directory (a common host
+default), this produces `~/.clio-pages/` — page artifacts dumped straight into the user's
+home folder, with a `.gitignore` entry written there too.
+
+This is **not** the same problem as home-directory consolidation: `.clio-pages` is meant to
+sit next to the user's project so they can edit `body.js` in place. The bug is the *anchor*,
+not the location concept. It must therefore stay workspace/project-relative — never folded
+into the global `CLIO_HOME` root (that would make multiple workspaces collide).
+
+## Proposed fix
+
+Anchor the output at the **workspace root** — the nearest ancestor directory containing
+`.clio/workspaceSettings.json` (the existing workspace marker used by `WorkspacePathBuilder`)
+— instead of the raw cwd.
+
+Resolution order for the output base directory:
+
+1. The workspace root found by walking up from the current directory until
+   `.clio/workspaceSettings.json` is found.
+2. If no workspace marker is found before reaching the filesystem root, fall back to the
+   current directory **only when it is not the user's home directory**; otherwise fail with a
+   clear, actionable error:
+   *"get-page must run inside a clio workspace (a directory whose tree contains
+   `.clio/workspaceSettings.json`) or in a project directory; refusing to write `.clio-pages`
+   into the home directory. Pass an explicit workspace/output directory."*
+
+This keeps the "files next to my project" model intact while making it impossible to silently
+litter `$HOME`.
+
+## Implementation sketch
+
+- Add a small resolver (e.g. `PageOutputDirectoryResolver`) that takes the current directory
+  and returns the output base, using the upward `.clio/workspaceSettings.json` walk that
+  `WorkspacePathBuilder` already implements — reuse it rather than re-deriving the walk.
+- Replace the two `GetCurrentDirectory()` call sites above with the resolver.
+- Consider an explicit `outputDirectory` argument on `get-page` / `sync-page` so callers
+  (and the MCP host) can pin the location deterministically; the home-directory guard then
+  only applies to the implicit path.
+
+## Tests
+
+- Workspace marker in an ancestor → output lands under that workspace root, not cwd.
+- cwd is a plain project dir (no marker, not home) → output under cwd (current behavior).
+- cwd is the home directory and no marker found → tool fails with the guard error rather than
+  writing `~/.clio-pages`.
+- Explicit `outputDirectory` argument → honored regardless of cwd.
+
+## Out of scope
+
+Moving `.clio-pages` under `CLIO_HOME`. It is intentionally project-relative; see the
+consolidation ADR.


### PR DESCRIPTION
## What

Consolidates clio's scattered per-user local directories under a single home root.

## Why

An audit found four independent global roots (`~/creatio/clio`, `~/.clio`, `$TMPDIR/clio`, `%APPDATA%\clio`). The component-registry cache lived under `~/.clio` while config, code-server cache and docker templates lived under `~/creatio/clio` — two parallel hierarchies, inconsistent across platforms (on Windows the config sits in `LOCALAPPDATA` while the cache sat in `USERPROFILE`).

## Decision

Use the existing `AppSettingsFolderPath` (`~/creatio/clio` | `%LOCALAPPDATA%\creatio\clio`) as the single home root and redirect the disposable component-registry cache under it. This **inverts the migration direction**: instead of moving the credential-bearing `appsettings.json` into a new root, we redirect the throwaway cache into the root the config already lives in. Result: **zero risk to registered environments — nothing to reconfigure after upgrade.**

See [docs/architecture/clio-home-consolidation.md](docs/architecture/clio-home-consolidation.md) for the full rationale and audit.

## Changes

- `ClioRuntimePaths` — central resolver (`Home`, `CacheRoot`)
- `CLIO_HOME` env override at the single source of truth (`AppSettingsFolderPath`)
- Redirect three `~/.clio/cache` hardcodes (`ComponentRegistryCacheStore` / `ComponentRegistryDocsCacheStore` / `ComponentRegistryRefreshCommand`) to `ClioRuntimePaths.CacheRoot`
- Refresh stale doc comments (`~/.clio/cache/...` → `<clio-home>/cache/...`)
- ADR + follow-up plan for `.clio-pages` workspace binding
- Unit tests for the `CLIO_HOME` contract

## Backward compatibility

- `appsettings.json` is **not** moved → registered environments keep working, no reconfiguration needed.
- Only behavioral change: after upgrade the first MCP call sees a cold cache (old `~/.clio/cache` is orphaned; ~1.9 MB, safe to delete manually). The embedded snapshot in `clio.dll` covers even a simultaneous CDN outage, so the first cold call still succeeds.
- `CLIO_WORKING_DIRECTORY` untouched; `CLIO_HOME` is new and additive.

## Out of scope (documented as follow-ups)

- Regroup `docker-assets` / `docker-templates` under `cache/`
- Bind `.clio-pages` output to the workspace root (fixes MCP-started-from-`$HOME` writing to `~/.clio-pages`) — see [docs/architecture/clio-pages-workspace-binding.md](docs/architecture/clio-pages-workspace-binding.md)
- Windows context-menu icons + `.reg`; default `iis-root` deliberately kept outside the root

## Testing

- `dotnet build` clean (0 errors / 0 warnings)
- Ran adjacent unit tests (`ComponentRegistry*`, `DockerTemplatePathProvider`, `InfrastructurePathProvider`) + new `ClioRuntimePaths` tests — all green (69 tests). Not the full suite, as changes are local.
- Completeness check: `grep` for `SpecialFolder.UserProfile` / `".clio"` resolves only to the central resolver, the legitimate workspace marker, and the deliberately-retained `iis-root` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
