### PR TITLE
fix(settings): re-enable auto-update for users carrying a legacy Autoupdate=false

### DIFF
--- a/clio.tests/Command/SettingsBootstrapServiceTests.cs
+++ b/clio.tests/Command/SettingsBootstrapServiceTests.cs
@@ -172,4 +172,111 @@ public sealed class SettingsBootstrapServiceTests {
 		repairedResult.Report.ResolvedActiveEnvironmentKey.Should().Be("dev",
 			because: "the repaired bootstrap result should expose the newly valid active environment");
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Clears a legacy Autoupdate=false artifact (serialized when the field was a non-nullable bool) and stamps the settings version, restoring the enabled opt-out default.")]
+	public void GetResult_Should_Reset_Legacy_Autoupdate_False_And_Stamp_Version() {
+		// Arrange
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
+			{
+			  "Autoupdate": false,
+			  "Environments": {}
+			}
+			"""));
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+
+		// Assert
+		result.Settings.Autoupdate.Should().BeNull(
+			because: "the legacy false must be cleared so GetAutoupdate() falls back to the enabled opt-out default");
+		result.Report.RepairsApplied.Should().ContainSingle(repair => repair.Code == "autoupdate-legacy-default-reset",
+			because: "the migration must surface that auto-update was re-enabled so the user is informed");
+		persisted.Autoupdate.Should().BeNull(
+			because: "the cleared value must be persisted — NullValueHandling.Ignore drops the key entirely");
+		persisted.SettingsVersion.Should().Be(1,
+			because: "the settings version must be stamped so the one-time migration never runs again");
+		persistedContent.Should().NotContain("Autoupdate",
+			because: "a null Autoupdate is omitted from the file, restoring the pristine default state");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A deliberate Autoupdate=false on a file already at the current settings version is preserved across bootstrap and never reverted — proving the opt-out is not broken.")]
+	public void GetResult_Should_Preserve_Deliberate_Autoupdate_False_After_Migration() {
+		// Arrange: file already migrated (SettingsVersion=1) with a deliberate opt-out
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
+			{
+			  "Autoupdate": false,
+			  "SettingsVersion": 1,
+			  "Environments": {}
+			}
+			"""));
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+
+		// Assert
+		result.Settings.Autoupdate.Should().BeFalse(
+			because: "once the file is at the current settings version the migration must not touch a deliberate opt-out");
+		persisted.Autoupdate.Should().BeFalse(
+			because: "the deliberate --disable must survive bootstrap so 'clio autoupdate --disable' is not silently broken");
+		result.Report.RepairsApplied.Should().BeEmpty(
+			because: "no migration should run when the settings version is already current");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("With applyRepairs:false the legacy Autoupdate migration is neither applied nor reported, and the file is left untouched.")]
+	public void GetResult_Should_Not_Migrate_Autoupdate_When_ApplyRepairs_False() {
+		// Arrange
+		const string originalContent = """
+			{
+			  "Autoupdate": false,
+			  "Environments": {}
+			}
+			""";
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData(originalContent));
+		SettingsBootstrapService service = new(fileSystem, applyRepairs: false);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+
+		// Assert
+		result.Report.RepairsApplied.Should().BeEmpty(
+			because: "read-only bootstrap must not report a repair it did not persist");
+		persistedContent.Should().Be(originalContent,
+			because: "appsettings.json must not be modified when applyRepairs is false");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A freshly created appsettings.json is stamped with the current settings version so new installs are never treated as legacy.")]
+	public void GetResult_Should_Stamp_Version_On_Created_Empty_Settings_File() {
+		// Arrange
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+
+		// Assert
+		persisted.SettingsVersion.Should().Be(1,
+			because: "new installs must be born at the current settings version so the legacy migration never runs for them");
+		result.Settings.Autoupdate.Should().BeNull(
+			because: "a fresh file has no Autoupdate key, so auto-update stays at the enabled opt-out default");
+	}
 }

--- a/clio.tests/Examples/AppConfigs/appsettings-with-wrong-active-key.json
+++ b/clio.tests/Examples/AppConfigs/appsettings-with-wrong-active-key.json
@@ -4,6 +4,7 @@
   "$schema": "./schema.json",
   "ActiveEnvironmentKey": "wrong-dev",
   "Autoupdate": false,
+  "SettingsVersion": 1,
   "Environments": {
     "dev": {
       "Uri": "http://localhost",

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -333,6 +333,14 @@ namespace Clio
 			get; set;
 		}
 
+		/// <summary>
+		/// Settings schema version used to apply one-time settings migrations.
+		/// A null value denotes a legacy file written before migrations were introduced.
+		/// </summary>
+		public int? SettingsVersion {
+			get; set;
+		}
+
 		public Dictionary<string, EnvironmentSettings> Environments {
 			get; set;
 		}

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -42,6 +42,7 @@ public sealed record SettingsBootstrapResult(
 
 public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	private const string SettingsFileUnreadableCode = "settings-file-unreadable";
+	private const int CurrentSettingsVersion = 1;
 	private readonly IFileSystem _fileSystem;
 	private readonly bool _applyRepairs;
 
@@ -61,7 +62,7 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	private SettingsBootstrapResult Load() {
 		string settingsFilePath = SettingsRepository.AppSettingsFile;
 		if (!_fileSystem.File.Exists(settingsFilePath)) {
-			Settings emptySettings = new() { Environments = [] };
+			Settings emptySettings = new() { Environments = [], SettingsVersion = CurrentSettingsVersion };
 			if (_applyRepairs) {
 				SettingsRepository.SaveSettings(_fileSystem, emptySettings);
 			}
@@ -105,6 +106,9 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 				"Use 'clio set-active-environment <name>' to fix this."));
 		}
 		SettingsRepository.AttachDbServers(settingsModel);
+		if (_applyRepairs && ApplyMigrations(settingsModel, repairs)) {
+			SettingsRepository.SaveSettings(_fileSystem, settingsModel);
+		}
 		return BuildResult(
 			issues.Count > 0 ? "issues-detected" : "healthy",
 			settingsFilePath,
@@ -112,6 +116,29 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 			settingsModel,
 			issues,
 			repairs);
+	}
+
+	/// <summary>
+	/// Applies one-time settings migrations and returns true when the model was changed.
+	/// </summary>
+	private static bool ApplyMigrations(Settings settings, List<SettingsRepair> repairs) {
+		if ((settings.SettingsVersion ?? 0) >= CurrentSettingsVersion) {
+			return false;
+		}
+		// Migration 1: before #576 Autoupdate was a non-nullable bool, so the C# default
+		// 'false' was serialized into appsettings.json for every user who never opted in,
+		// silently disabling auto-update. Clear that legacy artifact so the opt-out default
+		// (enabled) applies again. Guarded by SettingsVersion, this runs once — a deliberate
+		// 'clio autoupdate --disable' made afterwards is preserved.
+		if (settings.Autoupdate == false) {
+			settings.Autoupdate = null;
+			repairs.Add(new SettingsRepair(
+				"autoupdate-legacy-default-reset",
+				"auto-update was disabled by a legacy default and has been re-enabled "
+				+ "(run 'clio autoupdate --disable' to opt out)"));
+		}
+		settings.SettingsVersion = CurrentSettingsVersion;
+		return true;
 	}
 
 	private static SettingsBootstrapResult BuildBroken(string settingsFilePath, string code, string message) {


### PR DESCRIPTION
## Problem

A large share of users have `"Autoupdate": false` in their `appsettings.json` even though they never ran `clio autoupdate --disable` and never knew the feature existed — confirmed on multiple independent machines.

**Root cause:** before #576, `Autoupdate` was a non-nullable `bool`. The C# default is `false`, and `SaveSettings` serializes with `NullValueHandling.Ignore` — which drops `null`, but **not** `false`. So any time clio wrote the settings file (registering an environment, switching the active one, …) it materialized `"Autoupdate": false` for everyone who hadn't explicitly opted in. After #576 changed the field to `bool?` with an opt-out default (`GetAutoupdate()` returns `?? true`), the stale `false` is read back as non-null, so it never reaches the default — **it sticks forever**, permanently disabling the background auto-updater.

## Fix

A one-time settings migration in `SettingsBootstrapService.Load()` (the single startup read path, which already has an `_applyRepairs`-gated repair-on-load precedent), guarded by a new `SettingsVersion` marker:

- **Pre-marker file with `Autoupdate == false`** → cleared to `null` so the enabled opt-out default applies again, and a bootstrap repair message is surfaced (existing `LogBootstrapDiagnostics` warns the user, telling them how to opt back out).
- **`SettingsVersion` stamped** so the migration runs **exactly once**. The marker's job is one-time-ness, not discrimination: a deliberate `clio autoupdate --disable` made *after* the migration is preserved — `--disable` is never silently re-enabled.
- **Only mutates when `applyRepairs` is true** → read-only / health-check paths leave the file untouched.
- **Freshly created settings files are stamped** so new installs are never treated as legacy.

### Why this lands on the *next manual update*
`appsettings.json` lives outside the dotnet-tool install dir, so `dotnet tool update clio -g` (or `clio update`) preserves it. The new binary's first bootstrap then clears the legacy `false` — exactly when the user upgrades.

## Tests
`SettingsBootstrapServiceTests` (mock `IFileSystem`):
- legacy `false` cleared + `SettingsVersion` stamped + repair reported;
- **deliberate `false` on an already-migrated file survives bootstrap** (proves opt-out isn't broken);
- `applyRepairs:false` neither mutates nor reports;
- new file born at current version.

All 10 bootstrap tests green. The pre-existing 5 `/tmp`↔`/private/tmp` macOS path failures are unrelated (verified failing on `master` without this change).

## Real-binary verification
Ran the built binary against a real legacy `appsettings.json` (many environments):
- `[WAR] clio settings bootstrap repaired auto-update was disabled by a legacy default and has been re-enabled (run 'clio autoupdate --disable' to opt out)` — notification shown;
- `Auto-update is currently enabled` afterwards (opt-out default applies);
- every other key (`$schema`, `container-image-cli`, environments, …) round-tripped identically — no data loss;
- a second run left the migrated file untouched (one-time).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)