### PR TITLE
feat(mcp): actionable cliogate remediation + install-gate MCP tool (#658)

### DIFF
--- a/clio.tests/Command/McpServer/InstallGateToolTests.cs
+++ b/clio.tests/Command/McpServer/InstallGateToolTests.cs
@@ -1,0 +1,109 @@
+using System.Linq;
+using Clio.Command;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using Clio.Package;
+using Clio.WebApplication;
+using FluentAssertions;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Property("Module", "McpServer")]
+public sealed class InstallGateToolTests {
+	[Test]
+	[Category("Unit")]
+	[Description("Advertises a stable install-gate MCP tool name so clients and tests share one contract identifier.")]
+	public void InstallGate_Should_Advertise_Stable_Tool_Name() {
+		// Act
+		string toolName = InstallGateTool.InstallGateToolName;
+
+		// Assert
+		toolName.Should().Be("install-gate",
+			because: "the MCP contract should keep a stable install-gate tool name");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Resolves InstallGateCommand for the requested environment and returns the real command exit code.")]
+	public void InstallGate_Should_Resolve_Command_For_Environment_And_Return_Exit_Code() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		FakeInstallGateCommand resolvedCommand = new(exitCode: 0);
+		commandResolver.Resolve<InstallGateCommand>(Arg.Any<EnvironmentOptions>())
+			.Returns(resolvedCommand);
+		InstallGateTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		try {
+			// Act
+			CommandExecutionResult result = tool.InstallGate(new InstallGateArgs("sandbox"));
+
+			// Assert
+			result.ExitCode.Should().Be(0,
+				because: "the MCP tool should return the real install-gate command exit code");
+			commandResolver.Received(1).Resolve<InstallGateCommand>(Arg.Is<EnvironmentOptions>(options =>
+				options.Environment == "sandbox"));
+			resolvedCommand.CapturedOptions.Should().NotBeNull(
+				because: "the resolved install-gate command should receive the forwarded options");
+			resolvedCommand.CapturedOptions!.Environment.Should().Be("sandbox",
+				because: "the environment-name argument should map into InstallGateOptions");
+		} finally {
+			ConsoleLogger.Instance.ClearMessages();
+		}
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Exposes non-destructive, idempotent MCP metadata and remediation-oriented description for install-gate.")]
+	public void InstallGate_Should_Expose_Expected_Mcp_Metadata() {
+		// Arrange
+		McpServerToolAttribute attribute = (McpServerToolAttribute)typeof(InstallGateTool)
+			.GetMethod(nameof(InstallGateTool.InstallGate))!
+			.GetCustomAttributes(typeof(McpServerToolAttribute), false)
+			.Single();
+		System.ComponentModel.DescriptionAttribute description =
+			(System.ComponentModel.DescriptionAttribute)typeof(InstallGateTool)
+				.GetMethod(nameof(InstallGateTool.InstallGate))!
+				.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+				.Single();
+
+		// Assert
+		attribute.Name.Should().Be(InstallGateTool.InstallGateToolName,
+			because: "the metadata should reuse the production tool-name constant");
+		attribute.ReadOnly.Should().BeFalse(
+			because: "installing cliogate changes the target environment package state");
+		attribute.Destructive.Should().BeFalse(
+			because: "installing or updating cliogate is an additive, non-destructive provisioning step");
+		attribute.Idempotent.Should().BeTrue(
+			because: "re-running install-gate on an already-gated environment is safe");
+		description.Description.Should().Contain("cliogate",
+			because: "the description should name the package the tool installs");
+		description.Description.Should().Contain("restore-workspace",
+			because: "the description should point at the gate-dependent flow that motivates this tool");
+	}
+
+	private sealed class FakeInstallGateCommand : InstallGateCommand {
+		private readonly int _exitCode;
+
+		public FakeInstallGateCommand(int exitCode)
+			: base(
+				new EnvironmentSettings(),
+				Substitute.For<IPackageInstaller>(),
+				Substitute.For<IApplication>(),
+				Substitute.For<IWorkingDirectoriesProvider>(),
+				Substitute.For<ILogger>()) {
+			_exitCode = exitCode;
+		}
+
+		public InstallGateOptions? CapturedOptions { get; private set; }
+
+		public override int Execute(InstallGateOptions options) {
+			CapturedOptions = options;
+			return _exitCode;
+		}
+	}
+}

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -1375,4 +1375,34 @@ public sealed class ToolContractGetToolTests {
 		contract.Description.Should().Contain("excluded",
 			because: "the description must clarify Binary is not just hidden, but unsupported through this tool set");
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Returns the canonical install-gate contract so an MCP-only agent can discover the cliogate remediation tool.")]
+	public void ToolContractGet_Should_Return_InstallGate_Contract() {
+		// Arrange
+		ToolContractGetTool tool = new();
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs([
+			InstallGateTool.InstallGateToolName
+		]));
+
+		// Assert
+		result.Success.Should().BeTrue(
+			because: "install-gate must be discoverable through get-tool-contract so gate-dependent flows are completable from MCP");
+		ToolContractDefinition contract = result.Tools!.Single();
+		contract.Name.Should().Be(InstallGateTool.InstallGateToolName,
+			because: "the requested tool contract should be returned verbatim");
+		contract.InputSchema.Required.Should().ContainSingle(required => required == "environment-name",
+			because: "install-gate targets one registered environment");
+		contract.OutputContract.Kind.Should().Be("command-execution-result",
+			because: "install-gate returns the standard command execution result payload");
+		contract.PreferredFlow.Tools.Should().Equal(
+			new[] {
+				InstallGateTool.InstallGateToolName,
+				RestoreWorkspaceTool.RestoreWorkspaceToolName
+			},
+			because: "the contract should advertise installing the gate before retrying the gate-dependent flow");
+	}
 }

--- a/clio.tests/Common/ClioGateway.Tests.cs
+++ b/clio.tests/Common/ClioGateway.Tests.cs
@@ -195,7 +195,7 @@ public class ClioGatewayTests : BaseClioModuleTests
 		actualPackageInfo.Should().Be(expectedResult);
 	}
 	
-	[TestCase("1.0.0", "2.0.0", false, "To use this command, you need to install the cliogate package version 2.0.0 or higher.")]
+	[TestCase("1.0.0", "2.0.0", false, "To use this command, you need to install the cliogate package version 2.0.0 or higher. Run 'clio install-gate -e <environment>' (or call the install-gate MCP tool) and retry.")]
 	[TestCase("2.0.0", "1.0.0", true, null)]
 	[TestCase("2.0.0", "2.0.0", true, null)]
 	public void CheckCompatibleVersion_Should_BehaveAsExpected(string installedVersion, string requiredVersion, bool shouldNotThrow, string expectedMessage){

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -331,6 +331,7 @@ public class BindingsModule {
 		services.AddTransient<SysSettingsListTool>();
 		services.AddTransient<SysSettingCreateTool>();
 		services.AddTransient<SysSettingUpdateTool>();
+		services.AddTransient<InstallGateTool>();
 		services.AddTransient<IDataForgeEnrichmentBuilder, DataForgeEnrichmentBuilder>();
 		services.AddTransient<IApplicationCreateEnrichmentService, ApplicationCreateEnrichmentService>();
 		services.AddTransient<ISchemaEnrichmentService, SchemaEnrichmentService>();

--- a/clio/Command/McpServer/Tools/InstallGateTool.cs
+++ b/clio/Command/McpServer/Tools/InstallGateTool.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Clio.Common;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Tools;
+
+/// <summary>
+/// MCP tool surface for the <c>install-gate</c> command.
+/// </summary>
+public sealed class InstallGateTool(
+	ILogger logger,
+	IToolCommandResolver commandResolver)
+	: BaseTool<InstallGateOptions>(null, logger, commandResolver) {
+
+	/// <summary>
+	/// Stable MCP tool name for installing the cliogate package.
+	/// </summary>
+	internal const string InstallGateToolName = "install-gate";
+
+	/// <summary>
+	/// Installs (or updates) the bundled cliogate package into a registered Creatio environment.
+	/// </summary>
+	[McpServerTool(Name = InstallGateToolName, ReadOnly = false, Destructive = false, Idempotent = true,
+		OpenWorld = false)]
+	[Description("""
+				 Installs (or updates) the bundled cliogate package into a registered Creatio environment.
+
+				 Run this when a gate-dependent tool (for example `restore-workspace`, `unlock-package`, or
+				 `lock-package`) fails with "you need to install the cliogate package version ... or higher".
+				 cliogate exposes the server-side API that workspace and package tooling depends on, so install
+				 it once per freshly deployed instance before using those flows.
+				 """)]
+	public CommandExecutionResult InstallGate(
+		[Description("Install-gate parameters")] [Required] InstallGateArgs args) {
+		InstallGateOptions options = new() {
+			Environment = args.EnvironmentName
+		};
+		return InternalExecute<InstallGateCommand>(options);
+	}
+}
+
+/// <summary>
+/// MCP arguments for the <c>install-gate</c> tool.
+/// </summary>
+public sealed record InstallGateArgs(
+	[property: JsonPropertyName("environment-name")]
+	[property: Description("Registered clio environment name")]
+	[property: Required]
+	string EnvironmentName
+);

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -353,7 +353,8 @@ internal static class ToolContractCatalog {
 			[SysSettingGetTool.GetSysSettingToolName] = BuildGetSysSetting(),
 			[SysSettingsListTool.ListSysSettingsToolName] = BuildListSysSettings(),
 			[SysSettingCreateTool.CreateSysSettingToolName] = BuildCreateSysSetting(),
-			[SysSettingUpdateTool.UpdateSysSettingToolName] = BuildUpdateSysSetting()
+			[SysSettingUpdateTool.UpdateSysSettingToolName] = BuildUpdateSysSetting(),
+			[InstallGateTool.InstallGateToolName] = BuildInstallGate()
 		};
 
 	private static readonly string[] CanonicalToolNames = [
@@ -3529,6 +3530,38 @@ internal static class ToolContractCatalog {
 				"C# schemas were added or modified in the targeted package.",
 				"The runtime reported a missing-in-runtime or schema-not-found error that maps to a compilation gap.",
 				"Caller must NOT call this tool after `create-app`, `update-page`, `sync-pages`, `update-entity-schema`, `create-page`, `create-entity-business-rule`, or `create-page-business-rule`."
+			]);
+	}
+
+	private static ToolContractDefinition BuildInstallGate() {
+		return new ToolContractDefinition(
+			InstallGateTool.InstallGateToolName,
+			"Installs (or updates) the bundled cliogate package into a registered Creatio environment. cliogate exposes the server-side API that workspace and package tooling depends on. Run this once per freshly deployed instance, or whenever a gate-dependent tool fails with \"you need to install the cliogate package version ... or higher\".",
+			new ToolInputSchemaContract(
+				[EnvironmentNameFieldName],
+				[
+					Field(EnvironmentNameFieldName, StringType, RegisteredEnvironmentNameDescription)
+				]),
+			CommandExecutionOutput(),
+			CommonErrorContract,
+			[],
+			[],
+			[
+				Example("Install cliogate into a freshly deployed environment", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName
+				})
+			],
+			Flow(
+				[
+					InstallGateTool.InstallGateToolName,
+					RestoreWorkspaceTool.RestoreWorkspaceToolName
+				],
+				"Install cliogate first, then retry the gate-dependent tool (for example restore-workspace) that reported the missing-cliogate error."),
+			[],
+			[],
+			Preconditions: [
+				"The target environment is registered (see list-environments / reg-web-app).",
+				"A gate-dependent tool reported \"you need to install the cliogate package version ... or higher\", or this is a freshly deployed instance that has not yet had cliogate installed."
 			]);
 	}
 

--- a/clio/Common/ClioGateway.cs
+++ b/clio/Common/ClioGateway.cs
@@ -77,7 +77,9 @@ public class ClioGateway : IClioGateway
 
 	public void CheckCompatibleVersion(string version){
 		if (!IsCompatibleWith(version)) {
-			throw new NotSupportedException($"To use this command, you need to install the cliogate package version {version} or higher.");
+			throw new NotSupportedException(
+				$"To use this command, you need to install the cliogate package version {version} or higher. " +
+				"Run 'clio install-gate -e <environment>' (or call the install-gate MCP tool) and retry.");
 		}
 	}
 


### PR DESCRIPTION
## What & why

Sub-issue of #656 (item 3). On a freshly deployed instance, gate-dependent tools (`restore-workspace`, `unlock-package`, `lock-package`, …) fail with:

> To use this command, you need to install the cliogate package version 2.0.0.0 or higher.

The message stated the requirement but not **how** to satisfy it, and `install-gate` was only a CLI verb — not an MCP tool — so an MCP-only agent was stuck.

## Changes

- **Actionable error**: [`ClioGateway.CheckCompatibleVersion`](clio/Common/ClioGateway.cs) now appends the remediation: *"Run `clio install-gate -e <environment>` (or call the install-gate MCP tool) and retry."* Single chokepoint, so every gate-dependent command/tool benefits.
- **`install-gate` MCP tool** ([`InstallGateTool`](clio/Command/McpServer/Tools/InstallGateTool.cs)) wrapping the existing `InstallGateCommand` via the environment-aware command resolver. Marked non-destructive + idempotent.
- **Discoverable contract**: curated `get-tool-contract` entry for `install-gate` with the `install-gate → restore-workspace` preferred flow.
- Updated the pinned `ClioGateway` message assertion; added tool + contract unit tests.

Out of scope (deferred per #656): having `deploy-creatio` auto-install cliogate during provisioning.

## Testing

Full unit gate (`Category!=Integration`) green locally: **3479 passed, 0 failed, 17 skipped**.

Closes #658
Refs #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)
