### PR TITLE
fix(mcp): bind get-component-info via args record so component-type engages detail mode (#664)

### DIFF
--- a/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
@@ -63,7 +63,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse detailResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["componentType"] = "crt.MenuItem" });
+			new Dictionary<string, object?> { ["component-type"] ="crt.MenuItem" });
 
 		// Assert
 		tabListResponse.Success.Should().BeTrue(
@@ -135,7 +135,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse mobileListResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["schemaType"] = "mobile" });
+			new Dictionary<string, object?> { ["schema-type"] = "mobile" });
 
 		// Assert
 		mobileListResponse.Success.Should().BeTrue(
@@ -170,7 +170,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse response = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["componentType"] = "crt.DoesNotExist" });
+			new Dictionary<string, object?> { ["component-type"] ="crt.DoesNotExist" });
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -179,6 +179,8 @@ public sealed class ComponentInfoToolE2ETests {
 			because: "the failure should identify the missing component type");
 		response.Items.Should().NotBeNullOrEmpty(
 			because: "the fallback response should still expose available types for discovery in the flat item list");
+		response.Items!.Count.Should().BeLessThan(20,
+			because: "an unknown type must return a bounded closest-match shortlist, not the full ~199-item catalog (acceptance #2)");
 	}
 
 	[Test]
@@ -196,11 +198,11 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse fieldResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["componentType"] = "crt.NumberInput" });
+			new Dictionary<string, object?> { ["component-type"] ="crt.NumberInput" });
 		ComponentInfoResponse containerResponse = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["componentType"] = "crt.TabContainer" });
+			new Dictionary<string, object?> { ["component-type"] ="crt.TabContainer" });
 
 		// Assert
 		fieldResponse.Success.Should().BeTrue(
@@ -236,7 +238,7 @@ public sealed class ComponentInfoToolE2ETests {
 		ComponentInfoResponse response = await CallComponentInfoAsync(
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["componentType"] = "crt.TabContainer" });
+			new Dictionary<string, object?> { ["component-type"] ="crt.TabContainer" });
 
 		// Assert
 		response.ResolvedFrom.Should().Be("latest-fallback",
@@ -261,9 +263,9 @@ public sealed class ComponentInfoToolE2ETests {
 			arrangeContext.Session,
 			arrangeContext.CancellationTokenSource.Token,
 			new Dictionary<string, object?> {
-				["componentType"] = "crt.TabContainer",
+				["component-type"] ="crt.TabContainer",
 				["version"] = "8.3.3",
-				["environmentName"] = "any-env"
+				["environment-name"] = "any-env"
 			});
 
 		// Assert
@@ -283,9 +285,12 @@ public sealed class ComponentInfoToolE2ETests {
 		McpServerSession session,
 		CancellationToken cancellationToken,
 		IReadOnlyDictionary<string, object?> arguments) {
+		// get-component-info binds a single `args` record (kebab-case fields), like every other
+		// clio MCP tool — wrap the per-call fields so the real binding engages instead of dropping
+		// them as unknown top-level keys.
 		CallToolResult callResult = await session.CallToolAsync(
 			ToolName,
-			new Dictionary<string, object?>(arguments),
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?>(arguments) },
 			cancellationToken);
 		callResult.IsError.Should().NotBeTrue(
 			because: "get-component-info should return structured responses instead of top-level MCP failures");

--- a/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
+++ b/clio.tests/Command/McpServer/ComponentInfoToolTests.cs
@@ -217,13 +217,41 @@ public sealed class ComponentInfoToolTests {
 	}
 
 	[Test]
+	[Description("Binds the get-component-info argument record from kebab-case JSON using the real MCP serializer options, and routes camelCase spellings into the overflow bag. This is the exact JSON->record binding the MCP host performs (the layer the camelCase-vs-kebab bug lived in); direct method calls in the other tests bypass it.")]
+	public void ComponentInfoArgs_Should_Bind_KebabCase_And_Route_CamelCase_To_ExtensionData() {
+		// Arrange — the very options the MCP host feeds WithToolsFromAssembly for argument binding.
+		JsonSerializerOptions options = Clio.BindingsModule.CreateMcpSerializerOptions();
+
+		// Act — canonical kebab payload (what get-tool-contract advertises and the schema now emits)
+		// vs the camelCase payload an LLM trusting the old flat schema would send.
+		ComponentInfoArgs kebab = JsonSerializer.Deserialize<ComponentInfoArgs>(
+			"""{"component-type":"crt.NumberInput","schema-type":"mobile","environment-name":"local"}""", options)!;
+		ComponentInfoArgs camel = JsonSerializer.Deserialize<ComponentInfoArgs>(
+			"""{"componentType":"crt.NumberInput"}""", options)!;
+
+		// Assert — kebab binds to the typed parameters; nothing overflows.
+		kebab.ComponentType.Should().Be("crt.NumberInput",
+			because: "the kebab 'component-type' field must bind so detail mode engages — the bug was this never happening");
+		kebab.SchemaType.Should().Be("mobile");
+		kebab.EnvironmentName.Should().Be("local");
+		(kebab.ExtensionData is null || kebab.ExtensionData.Count == 0).Should().BeTrue(
+			because: "every kebab field binds to a declared parameter, so nothing overflows");
+
+		// camelCase does NOT bind to ComponentType; it lands in ExtensionData where GetLegacyAliasError rejects it.
+		camel.ComponentType.Should().BeNull(
+			because: "componentType is not a declared parameter name, so it must not bind — silently binding it is exactly what produced the 199-item list");
+		camel.ExtensionData.Should().ContainKey("componentType",
+			because: "the unbound camelCase spelling must surface in the overflow bag so the tool can return a rename hint");
+	}
+
+	[Test]
 	[Description("Returns grouped component summaries when component-type is omitted.")]
 	public async Task ComponentInfoTool_Should_Return_Grouped_List_When_Component_Type_Is_Omitted() {
 		// Arrange
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo();
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs());
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -249,7 +277,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.TabContainer");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.TabContainer"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -275,7 +303,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(search: "tab");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(Search: "tab"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -296,7 +324,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(search: "bulkActions");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(Search: "bulkActions"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -317,7 +345,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.MenuItem");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.MenuItem"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -341,7 +369,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.Unknown");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.Unknown"));
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -349,11 +377,77 @@ public sealed class ComponentInfoToolTests {
 		response.Error.Should().Contain("crt.Unknown",
 			because: "the failure should identify the missing component type");
 		response.Items.Should().NotBeNull(
-			because: "the tool should still return available types for discovery");
-		response.Count.Should().Be(6,
-			because: "the fallback list should expose the full catalog when no search filter is applied");
+			because: "the tool should still return closest available types for discovery");
+		response.Count.Should().BeLessThanOrEqualTo(6,
+			because: "a not-found response returns a bounded closest-match shortlist, never more than the catalog holds");
 		response.ResolvedFrom.Should().Be("latest-fallback",
 			because: "the resolver tier marker should still ship with error responses to help diagnosis");
+	}
+
+	[Test]
+	[Description("An unknown component-type returns a bounded closest-match shortlist, never the full catalog — even against a registry much larger than the suggestion cap with no search filter applied.")]
+	public async Task ComponentInfoTool_Should_Return_Bounded_Suggestions_For_Unknown_Type() {
+		// Arrange — a registry far larger than MaxNotFoundSuggestions so the bound is observable
+		// (the shared TestRegistryJson has only 6 entries, fewer than the cap, so it cannot prove it).
+		const string largeRegistryJson = """
+		[
+		  {"componentType":"crt.Widget01","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget02","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget03","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget04","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget05","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget06","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget07","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget08","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget09","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget10","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget11","category":"c","description":"d","container":false,"properties":{}},
+		  {"componentType":"crt.Widget12","category":"c","description":"d","container":false,"properties":{}}
+		]
+		""";
+		ComponentInfoTool tool = BuildTool(
+			new ComponentInfoCatalog(new InMemoryRegistryClient(largeRegistryJson)),
+			new InMemoryMobileCatalog(TestMobileRegistryJson));
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.DoesNotExist"));
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "an unknown component type must not pretend a detail lookup succeeded");
+		response.Error.Should().Contain("crt.DoesNotExist",
+			because: "the failure should identify the missing component type");
+		response.Count.Should().BeGreaterThan(0,
+			because: "a not-found response should still offer the closest known types for discovery");
+		response.Count.Should().BeLessThan(12,
+			because: "suggestions must be a bounded shortlist, never the entire 12-entry catalog (acceptance #2)");
+		response.Items.Should().NotBeNull();
+		response.Items!.Count.Should().Be(response.Count,
+			because: "the item list and the reported count must agree");
+	}
+
+	[Test]
+	[Description("A camelCase parameter spelling captured by the args overflow bag is rejected with a rename hint, instead of silently dropping the value and degrading a detail request into the full catalog — this is the exact failure get-tool-contract advertises as a rejected alias.")]
+	public async Task ComponentInfoTool_Should_Reject_CamelCase_Parameter_Alias() {
+		// Arrange — simulate the deserializer routing a camelCase field into ExtensionData
+		// (the canonical bound parameter is the kebab-case 'component-type').
+		ComponentInfoTool tool = CreateTool();
+		ComponentInfoArgs args = new() {
+			ExtensionData = new Dictionary<string, JsonElement> {
+				["componentType"] = JsonSerializer.SerializeToElement("crt.TabContainer")
+			}
+		};
+
+		// Act
+		ComponentInfoResponse response = await tool.GetComponentInfo(args);
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "a mis-spelled componentType must not silently fall through to list mode");
+		response.Error.Should().Contain("componentType",
+			because: "the rename hint must name the offending field");
+		response.Error.Should().Contain("component-type",
+			because: "the rename hint must point at the canonical kebab-case parameter");
 	}
 
 	[Test]
@@ -365,7 +459,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
 
 		// Act — passing environment-name routes resolution through the cliogate probe stub.
-		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(EnvironmentName: "test-stand"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -387,7 +481,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
 
 		// Act — probe resolves 8.1.5 but the client only has "latest" published.
-		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(EnvironmentName: "test-stand"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -405,7 +499,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo();
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs());
 
 		// Assert
 		response.ResolvedFrom.Should().Be("latest-fallback",
@@ -423,7 +517,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog, environmentVersion: "8.1.5");
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "test-stand");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(EnvironmentName: "test-stand"));
 
 		// Assert
 		response.ResolvedFrom.Should().Be("environment",
@@ -473,7 +567,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = new(catalog, mobileCatalog, new FakeDocsClient(), factory, settingsRepository);
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(environmentName: "prod-stand");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(EnvironmentName: "prod-stand"));
 
 		// Assert
 		response.ResolvedTargetVersion.Should().Be("8.2.1",
@@ -491,7 +585,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = CreateTool();
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(version: "not-a-version");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(Version: "not-a-version"));
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -508,7 +602,7 @@ public sealed class ComponentInfoToolTests {
 
 		// Act
 		ComponentInfoResponse response = await tool.GetComponentInfo(
-			environmentName: "test-stand", version: "8.3.3");
+			new ComponentInfoArgs(EnvironmentName: "test-stand", Version: "8.3.3"));
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -548,7 +642,7 @@ public sealed class ComponentInfoToolTests {
 		ComponentInfoTool tool = BuildTool(catalog, mobileCatalog);
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo();
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs());
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -596,7 +690,7 @@ public sealed class ComponentInfoToolTests {
 	public async Task ComponentInfoTool_Should_Return_Mobile_Catalog_When_SchemaType_Is_Mobile() {
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(schemaType: "mobile");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(SchemaType: "mobile"));
 
 		response.Success.Should().BeTrue(
 			because: "listing mobile components should succeed when the mobile registry is available");
@@ -615,7 +709,7 @@ public sealed class ComponentInfoToolTests {
 	public async Task ComponentInfoTool_Should_Return_Mobile_Detail_When_SchemaType_Is_Mobile_And_Type_Is_Known() {
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.Toggle", schemaType: "mobile");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.Toggle", SchemaType: "mobile"));
 
 		response.Success.Should().BeTrue(
 			because: "crt.Toggle exists in the mobile registry");
@@ -630,7 +724,7 @@ public sealed class ComponentInfoToolTests {
 	public async Task ComponentInfoTool_Should_Return_Error_When_Web_Only_Type_Is_Requested_From_Mobile_Catalog() {
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.Label", schemaType: "mobile");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.Label", SchemaType: "mobile"));
 
 		response.Success.Should().BeFalse(
 			because: "crt.Label is a web component and should not appear in the mobile catalog");
@@ -671,7 +765,7 @@ public sealed class ComponentInfoToolTests {
 			docs);
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.WithDocs");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.WithDocs"));
 
 		// Assert
 		response.Success.Should().BeTrue();
@@ -689,7 +783,7 @@ public sealed class ComponentInfoToolTests {
 	public async Task ComponentInfoTool_Should_Omit_Documentation_When_No_Docs_Are_Listed() {
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.TabContainer");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.TabContainer"));
 
 		response.Documentation.Should().BeNull(
 			because: "the curated registry entry has no references.docs[] so the docs client must not be called");
@@ -700,7 +794,7 @@ public sealed class ComponentInfoToolTests {
 	public async Task ComponentInfoTool_Should_Default_To_Web_Catalog_When_SchemaType_Is_Omitted() {
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.TabContainer");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.TabContainer"));
 
 		response.Success.Should().BeTrue(
 			because: "crt.TabContainer exists in the web registry — omitting schema-type should use the web catalog");
@@ -747,7 +841,7 @@ public sealed class ComponentInfoToolTests {
 			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.SimpleButton");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.SimpleButton"));
 
 		// Assert
 		response.Success.Should().BeTrue();
@@ -788,7 +882,7 @@ public sealed class ComponentInfoToolTests {
 			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.Persistent");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.Persistent"));
 		GC.Collect();
 		GC.WaitForPendingFinalizers();
 
@@ -834,7 +928,7 @@ public sealed class ComponentInfoToolTests {
 			new ComponentInfoCatalog(new InMemoryRegistryClient(registryJson)),
 			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.WithTypes");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.WithTypes"));
 
 		response.Success.Should().BeTrue();
 		response.Mode.Should().Be("detail");
@@ -859,7 +953,7 @@ public sealed class ComponentInfoToolTests {
 		// crt.TabContainer in TestRegistryJson has no content block at all.
 		ComponentInfoTool tool = CreateTool();
 
-		ComponentInfoResponse response = await tool.GetComponentInfo(componentType: "crt.TabContainer");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs("crt.TabContainer"));
 
 		response.References.Should().BeNull(
 			because: "components without producer-side type definitions must not carry an empty content node");
@@ -894,7 +988,7 @@ public sealed class ComponentInfoToolTests {
 			new InMemoryMobileCatalog(TestMobileRegistryJson));
 
 		// Act
-		ComponentInfoResponse response = await tool.GetComponentInfo(search: "selection");
+		ComponentInfoResponse response = await tool.GetComponentInfo(new ComponentInfoArgs(Search: "selection"));
 
 		// Assert
 		response.Success.Should().BeTrue();

--- a/clio/Command/McpServer/Tools/ComponentInfoGrouping.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoGrouping.cs
@@ -21,6 +21,60 @@ public static class ComponentInfoGrouping {
 	}
 
 	/// <summary>
+	/// Returns a bounded "did you mean" shortlist for an unknown component type, ordered by
+	/// closeness to the requested type (case-insensitive Levenshtein distance, ties broken
+	/// alphabetically). When <paramref name="search"/> is supplied the candidate pool is first
+	/// narrowed by the same keyword filter as list mode; otherwise every known entry is a
+	/// candidate. Either way the result is capped at <paramref name="max"/> so a not-found
+	/// response never echoes the full catalog as "suggestions".
+	/// </summary>
+	public static IReadOnlyList<ComponentRegistryEntry> SuggestForUnknown(
+		IReadOnlyList<ComponentRegistryEntry> entries, string? componentType, string? search, int max) {
+		IReadOnlyList<ComponentRegistryEntry> pool = string.IsNullOrWhiteSpace(search)
+			? entries
+			: FilterEntries(entries, search);
+		string target = (componentType ?? string.Empty).Trim();
+		return pool
+			.OrderBy(entry => Distance(entry.ComponentType, target))
+			.ThenBy(entry => entry.ComponentType, StringComparer.OrdinalIgnoreCase)
+			.Take(Math.Max(0, max))
+			.ToArray();
+	}
+
+	/// <summary>
+	/// Case-insensitive Levenshtein edit distance between two component type names. Drives the
+	/// not-found suggestion ranking so the closest spellings to a mistyped <c>component-type</c>
+	/// surface first. Mirrors the ranking <see cref="ToolContractCatalog"/> uses for unknown tool
+	/// names.
+	/// </summary>
+	private static int Distance(string? source, string? target) {
+		string left = (source ?? string.Empty).ToLowerInvariant();
+		string right = (target ?? string.Empty).ToLowerInvariant();
+		if (left.Length == 0) {
+			return right.Length;
+		}
+		if (right.Length == 0) {
+			return left.Length;
+		}
+		int[,] matrix = new int[left.Length + 1, right.Length + 1];
+		for (int i = 0; i <= left.Length; i++) {
+			matrix[i, 0] = i;
+		}
+		for (int j = 0; j <= right.Length; j++) {
+			matrix[0, j] = j;
+		}
+		for (int i = 1; i <= left.Length; i++) {
+			for (int j = 1; j <= right.Length; j++) {
+				int cost = left[i - 1] == right[j - 1] ? 0 : 1;
+				matrix[i, j] = Math.Min(
+					Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
+					matrix[i - 1, j - 1] + cost);
+			}
+		}
+		return matrix[left.Length, right.Length];
+	}
+
+	/// <summary>
 	/// Projects entries to compact list items ordered alphabetically by component type.
 	/// Description is null-coalesced so the response omits empty strings from the new
 	/// payload shape (which does not carry per-component descriptions).

--- a/clio/Command/McpServer/Tools/ComponentInfoGrouping.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoGrouping.cs
@@ -35,43 +35,10 @@ public static class ComponentInfoGrouping {
 			: FilterEntries(entries, search);
 		string target = (componentType ?? string.Empty).Trim();
 		return pool
-			.OrderBy(entry => Distance(entry.ComponentType, target))
+			.OrderBy(entry => McpToolArgumentSupport.LevenshteinDistance(entry.ComponentType, target))
 			.ThenBy(entry => entry.ComponentType, StringComparer.OrdinalIgnoreCase)
 			.Take(Math.Max(0, max))
 			.ToArray();
-	}
-
-	/// <summary>
-	/// Case-insensitive Levenshtein edit distance between two component type names. Drives the
-	/// not-found suggestion ranking so the closest spellings to a mistyped <c>component-type</c>
-	/// surface first. Mirrors the ranking <see cref="ToolContractCatalog"/> uses for unknown tool
-	/// names.
-	/// </summary>
-	private static int Distance(string? source, string? target) {
-		string left = (source ?? string.Empty).ToLowerInvariant();
-		string right = (target ?? string.Empty).ToLowerInvariant();
-		if (left.Length == 0) {
-			return right.Length;
-		}
-		if (right.Length == 0) {
-			return left.Length;
-		}
-		int[,] matrix = new int[left.Length + 1, right.Length + 1];
-		for (int i = 0; i <= left.Length; i++) {
-			matrix[i, 0] = i;
-		}
-		for (int j = 0; j <= right.Length; j++) {
-			matrix[0, j] = j;
-		}
-		for (int i = 1; i <= left.Length; i++) {
-			for (int j = 1; j <= right.Length; j++) {
-				int cost = left[i - 1] == right[j - 1] ? 0 : 1;
-				matrix[i, j] = Math.Min(
-					Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
-					matrix[i - 1, j - 1] + cost);
-			}
-		}
-		return matrix[left.Length, right.Length];
 	}
 
 	/// <summary>

--- a/clio/Command/McpServer/Tools/ComponentInfoTool.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoTool.cs
@@ -77,7 +77,9 @@ public sealed class ComponentInfoTool(
 			"version: explicit 3-part semver. uri/login/password: emergency fallback only.")]
 		[Required] ComponentInfoArgs args,
 		CancellationToken cancellationToken = default) {
-		string? legacyAliasError = GetLegacyAliasError(args);
+		string? legacyAliasError = McpToolArgumentSupport.BuildLegacyAliasError(
+			args.ExtensionData, LegacyAliases, ".",
+			"Valid: component-type, search, schema-type, environment-name, version, uri, login, password.");
 		if (!string.IsNullOrWhiteSpace(legacyAliasError)) {
 			return new ComponentInfoResponse {
 				Success = false,
@@ -117,38 +119,6 @@ public sealed class ComponentInfoTool(
 		["environmentName"] = "environment-name",
 		["environment_name"] = "environment-name"
 	};
-
-	/// <summary>
-	/// Rejects camelCase / snake_case parameter spellings and unknown fields captured by the
-	/// <see cref="ComponentInfoArgs.ExtensionData"/> overflow bag, returning a single actionable
-	/// rename hint. Because <c>component-type</c> is optional, a mis-spelled
-	/// <c>componentType</c> would otherwise bind to nothing and silently fall through to the full
-	/// catalog (the bug this tool is fixing), so the rejection has to happen before
-	/// <see cref="BuildResponseAsync"/> ever runs.
-	/// </summary>
-	private static string? GetLegacyAliasError(ComponentInfoArgs args) {
-		if (args.ExtensionData is null || args.ExtensionData.Count == 0) {
-			return null;
-		}
-		List<string> mapped = [];
-		List<string> unknown = [];
-		foreach (string key in args.ExtensionData.Keys) {
-			if (LegacyAliases.TryGetValue(key, out string? canonical)) {
-				mapped.Add($"'{key}' -> '{canonical}'");
-			} else {
-				unknown.Add($"'{key}'");
-			}
-		}
-		List<string> parts = [];
-		if (mapped.Count > 0) {
-			parts.Add("Rename: " + string.Join(", ", mapped) + ".");
-		}
-		if (unknown.Count > 0) {
-			parts.Add("Unknown args: " + string.Join(", ", unknown)
-				+ ". Valid: component-type, search, schema-type, environment-name, version, uri, login, password.");
-		}
-		return parts.Count > 0 ? string.Join(" ", parts) : null;
-	}
 
 	/// <summary>
 	/// Single async pipeline that backs both the web and mobile flavors. The branch

--- a/clio/Command/McpServer/Tools/ComponentInfoTool.cs
+++ b/clio/Command/McpServer/Tools/ComponentInfoTool.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -37,6 +38,13 @@ public sealed class ComponentInfoTool(
 	internal const string DocumentationSeparator = ComponentDocumentationLoader.DocumentationSeparator;
 
 	/// <summary>
+	/// Upper bound on the "did you mean" entries returned when a requested <c>component-type</c>
+	/// is unknown. Keeps the not-found envelope a small, actionable shortlist instead of echoing
+	/// the full ~199-item catalog as "suggestions".
+	/// </summary>
+	private const int MaxNotFoundSuggestions = 8;
+
+	/// <summary>
 	/// Canonical contract text returned for every data-source-bound field component type
 	/// (members of <see cref="SchemaValidationService.StandardFieldComponentTypes"/>).
 	/// Surfaced as <c>dataSourceBindingContract</c> in the tool response so agents see the
@@ -64,24 +72,21 @@ public sealed class ComponentInfoTool(
 		"If schema-type is omitted, defaults to the web component catalog (excludes mobile-only components such as crt.Toggle and crt.BarcodeScanner). " +
 		"Use schema-type: 'mobile' to retrieve mobile-specific components — the mobile registry is separate and excludes web-only types.")]
 	public async Task<ComponentInfoResponse> GetComponentInfo(
-		[Description("Freedom UI component type, for example 'crt.TabContainer'. Omit or use 'list' to return the catalog.")]
-		string? componentType = null,
-		[Description("Optional keyword filter applied in list mode and in not-found suggestions, for example 'tab'.")]
-		string? search = null,
-		[Description("Component registry to query: 'web' (default) for standard Freedom UI pages, or 'mobile' for mobile page components (crt.Toggle, crt.BarcodeScanner, crt.Sort, etc.).")]
-		string? schemaType = null,
-		[Description("Registered environment name to scope the catalog to its real platform version (probed via cliogate GetSysInfo). PREFER this — pass the same environment you edit pages on. Mutually exclusive with 'version'.")]
-		string? environmentName = null,
-		[Description("Explicit catalog version (3-part semver, e.g. '8.3.3') when the platform version is already known. Mutually exclusive with 'environment-name'.")]
-		string? version = null,
-		[Description("Emergency fallback only: direct application URI when no environment is registered. Prefer 'environment-name'.")]
-		string? uri = null,
-		[Description("Emergency fallback only: login paired with 'uri'. Prefer 'environment-name'.")]
-		string? login = null,
-		[Description("Emergency fallback only: password paired with 'uri'. Prefer 'environment-name'.")]
-		string? password = null,
+		[Description("Parameters: component-type (optional; omit or use 'list' to return the catalog), search (optional keyword filter). " +
+			"schema-type: 'web' (default) or 'mobile'. environment-name: PREFERRED — scopes the catalog to the target platform version (mutually exclusive with version). " +
+			"version: explicit 3-part semver. uri/login/password: emergency fallback only.")]
+		[Required] ComponentInfoArgs args,
 		CancellationToken cancellationToken = default) {
-		ComponentInfoArgs args = new(componentType, search, schemaType, environmentName, version, uri, login, password);
+		string? legacyAliasError = GetLegacyAliasError(args);
+		if (!string.IsNullOrWhiteSpace(legacyAliasError)) {
+			return new ComponentInfoResponse {
+				Success = false,
+				Mode = "list",
+				Error = legacyAliasError,
+				Count = 0,
+				Items = []
+			};
+		}
 		try {
 			return await BuildResponseAsync(args, cancellationToken).ConfigureAwait(false);
 		}
@@ -94,6 +99,55 @@ public sealed class ComponentInfoTool(
 				Items = []
 			};
 		}
+	}
+
+	/// <summary>
+	/// Canonical kebab-case parameter names paired with the camelCase / snake_case spellings an
+	/// LLM is most likely to emit. Mirrors <see cref="PageListTool"/>'s alias handling so the
+	/// reality (the bound <see cref="ComponentInfoArgs"/> shape) and the advertised
+	/// <c>get-tool-contract</c> aliases stay in lockstep — the rejection here is exactly what the
+	/// contract's <c>componentType -&gt; component-type</c> alias promises, instead of silently
+	/// dropping an unbound camelCase value and degrading a detail request to a 199-item list.
+	/// </summary>
+	private static readonly Dictionary<string, string> LegacyAliases = new(StringComparer.Ordinal) {
+		["componentType"] = "component-type",
+		["component_type"] = "component-type",
+		["schemaType"] = "schema-type",
+		["schema_type"] = "schema-type",
+		["environmentName"] = "environment-name",
+		["environment_name"] = "environment-name"
+	};
+
+	/// <summary>
+	/// Rejects camelCase / snake_case parameter spellings and unknown fields captured by the
+	/// <see cref="ComponentInfoArgs.ExtensionData"/> overflow bag, returning a single actionable
+	/// rename hint. Because <c>component-type</c> is optional, a mis-spelled
+	/// <c>componentType</c> would otherwise bind to nothing and silently fall through to the full
+	/// catalog (the bug this tool is fixing), so the rejection has to happen before
+	/// <see cref="BuildResponseAsync"/> ever runs.
+	/// </summary>
+	private static string? GetLegacyAliasError(ComponentInfoArgs args) {
+		if (args.ExtensionData is null || args.ExtensionData.Count == 0) {
+			return null;
+		}
+		List<string> mapped = [];
+		List<string> unknown = [];
+		foreach (string key in args.ExtensionData.Keys) {
+			if (LegacyAliases.TryGetValue(key, out string? canonical)) {
+				mapped.Add($"'{key}' -> '{canonical}'");
+			} else {
+				unknown.Add($"'{key}'");
+			}
+		}
+		List<string> parts = [];
+		if (mapped.Count > 0) {
+			parts.Add("Rename: " + string.Join(", ", mapped) + ".");
+		}
+		if (unknown.Count > 0) {
+			parts.Add("Unknown args: " + string.Join(", ", unknown)
+				+ ". Valid: component-type, search, schema-type, environment-name, version, uri, login, password.");
+		}
+		return parts.Count > 0 ? string.Join(" ", parts) : null;
 	}
 
 	/// <summary>
@@ -147,11 +201,15 @@ public sealed class ComponentInfoTool(
 			return CreateDetailResponse(entry, state.ResolvedVersion, resolvedFrom, documentation, state.GlobalReferences);
 		}
 
-		IReadOnlyList<ComponentRegistryEntry> suggestions = ComponentInfoGrouping.FilterEntries(state.Entries, args.Search);
+		string requestedType = args.ComponentType.Trim();
+		IReadOnlyList<ComponentRegistryEntry> suggestions =
+			ComponentInfoGrouping.SuggestForUnknown(state.Entries, requestedType, args.Search, MaxNotFoundSuggestions);
 		return new ComponentInfoResponse {
 			Success = false,
 			Mode = "list",
-			Error = $"Component type '{args.ComponentType}' was not found.",
+			Error = $"Component type '{requestedType}' was not found. "
+				+ $"Showing the {suggestions.Count} closest known type(s) — pass one of these as 'component-type', "
+				+ "or omit 'component-type' to list the full catalog.",
 			Count = suggestions.Count,
 			Items = ComponentInfoGrouping.CreateItems(suggestions),
 			ResolvedTargetVersion = state.ResolvedVersion,
@@ -338,25 +396,35 @@ public sealed record ComponentInfoArgs(
 	string? SchemaType = null,
 
 	[property: JsonPropertyName("environment-name")]
-	[property: Description("Registered environment name to scope the catalog to its real platform version. Mutually exclusive with 'version'.")]
+	[property: Description("Registered environment name to scope the catalog to its real platform version (probed via cliogate GetSysInfo). PREFER this — pass the same environment you edit pages on. Mutually exclusive with 'version'.")]
 	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("version")]
-	[property: Description("Explicit catalog version (3-part semver). Mutually exclusive with 'environment-name'.")]
+	[property: Description("Explicit catalog version (3-part semver, e.g. '8.3.3') when the platform version is already known. Mutually exclusive with 'environment-name'.")]
 	string? Version = null,
 
 	[property: JsonPropertyName("uri")]
-	[property: Description("Emergency fallback only: direct application URI. Prefer 'environment-name'.")]
+	[property: Description("Emergency fallback only: direct application URI when no environment is registered. Prefer 'environment-name'.")]
 	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
-	[property: Description("Emergency fallback only: login paired with 'uri'.")]
+	[property: Description("Emergency fallback only: login paired with 'uri'. Prefer 'environment-name'.")]
 	string? Login = null,
 
 	[property: JsonPropertyName("password")]
-	[property: Description("Emergency fallback only: password paired with 'uri'.")]
+	[property: Description("Emergency fallback only: password paired with 'uri'. Prefer 'environment-name'.")]
 	string? Password = null
-);
+) {
+	/// <summary>
+	/// Overflow bag for any request field that does not bind to a declared kebab-case parameter —
+	/// most importantly the camelCase / snake_case spellings (<c>componentType</c>,
+	/// <c>schemaType</c>, <c>environmentName</c>) an LLM tends to emit. The tool inspects this in
+	/// <c>GetComponentInfo</c> and rejects mis-spelled fields with a rename hint instead of letting
+	/// an unbound <c>component-type</c> silently degrade a detail request into a full catalog dump.
+	/// </summary>
+	[JsonExtensionData]
+	public Dictionary<string, JsonElement>? ExtensionData { get; init; }
+}
 
 /// <summary>
 /// Structured response from the <c>get-component-info</c> MCP tool.

--- a/clio/Command/McpServer/Tools/McpToolArgumentSupport.cs
+++ b/clio/Command/McpServer/Tools/McpToolArgumentSupport.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Clio.Command.McpServer.Tools;
+
+/// <summary>
+/// Shared helpers for MCP tools that bind a single <c>args</c> record with kebab-case fields.
+/// Centralizes two pieces of logic several tools used to copy verbatim — legacy-alias rejection
+/// over the <c>[JsonExtensionData]</c> overflow bag, and the edit-distance ranking used for
+/// "did you mean" suggestions — so the behavior (and the SonarCloud duplication budget) stays in
+/// one place. Each caller keeps its own canonical alias map and wording via the parameters.
+/// </summary>
+internal static class McpToolArgumentSupport {
+	/// <summary>
+	/// Builds a single actionable rename hint from the fields an MCP arg record could not bind
+	/// (captured in its <c>[JsonExtensionData]</c> bag). Known camelCase/snake_case spellings are
+	/// reported as <c>'alias' -&gt; 'canonical'</c> renames; everything else is listed as unknown
+	/// with the caller-supplied valid-field hint. Returns <c>null</c> when there is nothing to
+	/// flag (no overflow), so a clean call passes straight through.
+	/// </summary>
+	/// <param name="extensionData">The arg record's overflow bag (unbound JSON fields).</param>
+	/// <param name="aliases">Canonical map of known mis-spelling -&gt; canonical kebab-case name.</param>
+	/// <param name="renameSuffix">Trailing text appended after the rename list (e.g. <c>"."</c> or a type reminder); use <c>""</c> for none.</param>
+	/// <param name="unknownHint">Sentence appended after the unknown-args list, e.g. <c>"Valid: a, b, c."</c>.</param>
+	public static string? BuildLegacyAliasError(
+		IReadOnlyDictionary<string, JsonElement>? extensionData,
+		IReadOnlyDictionary<string, string> aliases,
+		string renameSuffix,
+		string unknownHint) {
+		if (extensionData is null || extensionData.Count == 0) {
+			return null;
+		}
+		List<string> mapped = [];
+		List<string> unknown = [];
+		foreach (string key in extensionData.Keys) {
+			if (aliases.TryGetValue(key, out string? canonical)) {
+				mapped.Add($"'{key}' -> '{canonical}'");
+			} else {
+				unknown.Add($"'{key}'");
+			}
+		}
+		List<string> parts = [];
+		if (mapped.Count > 0) {
+			parts.Add("Rename: " + string.Join(", ", mapped) + renameSuffix);
+		}
+		if (unknown.Count > 0) {
+			parts.Add("Unknown args: " + string.Join(", ", unknown) + ". " + unknownHint);
+		}
+		return parts.Count > 0 ? string.Join(" ", parts) : null;
+	}
+
+	/// <summary>
+	/// Case-insensitive Levenshtein edit distance between two identifiers. Drives the "closest
+	/// match" ranking for unknown tool names and unknown component types. Equal strings score 0.
+	/// </summary>
+	public static int LevenshteinDistance(string? source, string? target) {
+		string left = (source ?? string.Empty).ToLowerInvariant();
+		string right = (target ?? string.Empty).ToLowerInvariant();
+		if (left.Length == 0) {
+			return right.Length;
+		}
+		if (right.Length == 0) {
+			return left.Length;
+		}
+		int[,] matrix = new int[left.Length + 1, right.Length + 1];
+		for (int i = 0; i <= left.Length; i++) {
+			matrix[i, 0] = i;
+		}
+		for (int j = 0; j <= right.Length; j++) {
+			matrix[0, j] = j;
+		}
+		for (int i = 1; i <= left.Length; i++) {
+			for (int j = 1; j <= right.Length; j++) {
+				int cost = left[i - 1] == right[j - 1] ? 0 : 1;
+				matrix[i, j] = Math.Min(
+					Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
+					matrix[i - 1, j - 1] + cost);
+			}
+		}
+		return matrix[left.Length, right.Length];
+	}
+}

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -72,30 +72,9 @@ public sealed class PageListTool(
 	}
 
 	private static string? GetLegacyAliasError(PageListArgs args) {
-		if (args.ExtensionData is null || args.ExtensionData.Count == 0) {
-			return null;
-		}
-		List<string> mapped = [];
-		List<string> unknown = [];
-		foreach (string key in args.ExtensionData.Keys) {
-			if (LegacyAliases.TryGetValue(key, out string? canonical)) {
-				mapped.Add($"'{key}' -> '{canonical}'");
-			} else {
-				unknown.Add($"'{key}'");
-			}
-		}
-		if (mapped.Count == 0 && unknown.Count == 0) {
-			return null;
-		}
-		List<string> parts = [];
-		if (mapped.Count > 0) {
-			parts.Add("Rename: " + string.Join(", ", mapped));
-		}
-		if (unknown.Count > 0) {
-			parts.Add("Unknown args: " + string.Join(", ", unknown)
-				+ ". Valid: package-name, code, search-pattern, limit, environment-name, uri, login, password.");
-		}
-		return string.Join(" ", parts);
+		return McpToolArgumentSupport.BuildLegacyAliasError(
+			args.ExtensionData, LegacyAliases, string.Empty,
+			"Valid: package-name, code, search-pattern, limit, environment-name, uri, login, password.");
 	}
 }
 

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -218,6 +218,7 @@ internal static class ToolContractCatalog {
 	private const string LoginFieldName = "login";
 	private const string NumberType = "number";
 	private const string ObjectType = "object";
+	private const string ComponentTypeFieldName = "component-type";
 	private const string OperationsFieldName = "operations";
 	private const string PackageNameFieldName = "package-name";
 	private const string PasswordFieldName = "password";
@@ -2967,7 +2968,7 @@ internal static class ToolContractCatalog {
 			new ToolInputSchemaContract(
 				[],
 				[
-					Field("component-type", StringType, "Freedom UI component type, e.g. 'crt.TabContainer'. Omit or use 'list' to return the catalog (list mode); a known type returns that one component's full contract (detail mode); an unknown type returns a bounded suggestion shortlist."),
+					Field(ComponentTypeFieldName, StringType, "Freedom UI component type, e.g. 'crt.TabContainer'. Omit or use 'list' to return the catalog (list mode); a known type returns that one component's full contract (detail mode); an unknown type returns a bounded suggestion shortlist."),
 					Field("search", StringType, "Optional keyword filter applied in list mode and to not-found suggestions, e.g. 'tab'."),
 					Field("schema-type", StringType, "Component registry to query: 'web' (default) or 'mobile'. The mobile registry is separate (crt.Toggle, crt.BarcodeScanner, crt.Sort, ...) and excludes web-only types."),
 					Field(EnvironmentNameFieldName, StringType, "PREFERRED. Registered environment name; scopes the catalog to its real platform version. Mutually exclusive with 'version'."),
@@ -2992,18 +2993,18 @@ internal static class ToolContractCatalog {
 			),
 			CommonErrorContract,
 			[
-				Alias(ParameterScope, "component-type", "componentType", RejectedStatus, "Use 'component-type' instead of 'componentType'."),
+				Alias(ParameterScope, ComponentTypeFieldName, "componentType", RejectedStatus, "Use 'component-type' instead of 'componentType'."),
 				Alias(ParameterScope, "schema-type", "schemaType", RejectedStatus, "Use 'schema-type' instead of 'schemaType'."),
 				Alias(ParameterScope, EnvironmentNameFieldName, "environmentName", RejectedStatus, "Use 'environment-name' instead of 'environmentName'.")
 			],
 			[],
 			[
 				Example("Inspect one component contract", new Dictionary<string, object?> {
-					["component-type"] = "crt.TabContainer"
+					[ComponentTypeFieldName] = "crt.TabContainer"
 				}),
 				Example("List the full component catalog", new Dictionary<string, object?>()),
 				Example("Inspect a mobile component contract", new Dictionary<string, object?> {
-					["component-type"] = "crt.Toggle",
+					[ComponentTypeFieldName] = "crt.Toggle",
 					["schema-type"] = "mobile"
 				})
 			],

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -3005,12 +3005,18 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildComponentInfo() {
 		return new ToolContractDefinition(
 			ComponentInfoTool.ToolName,
-			"Returns grouped Freedom UI component summaries or a full component contract for one component type.",
+			"Returns a flat list of Freedom UI component summaries or the full contract for one component type.",
 			new ToolInputSchemaContract(
 				[],
 				[
-					Field("component-type", StringType, "Optional component type. Omit or use list to return the grouped catalog."),
-					Field("search", StringType, "Optional keyword filter for list mode.")
+					Field("component-type", StringType, "Freedom UI component type, e.g. 'crt.TabContainer'. Omit or use 'list' to return the catalog (list mode); a known type returns that one component's full contract (detail mode); an unknown type returns a bounded suggestion shortlist."),
+					Field("search", StringType, "Optional keyword filter applied in list mode and to not-found suggestions, e.g. 'tab'."),
+					Field("schema-type", StringType, "Component registry to query: 'web' (default) or 'mobile'. The mobile registry is separate (crt.Toggle, crt.BarcodeScanner, crt.Sort, ...) and excludes web-only types."),
+					Field(EnvironmentNameFieldName, StringType, "PREFERRED. Registered environment name; scopes the catalog to its real platform version. Mutually exclusive with 'version'."),
+					Field("version", StringType, "Explicit catalog version (3-part semver, e.g. '8.3.3'). Mutually exclusive with 'environment-name'."),
+					Field("uri", StringType, "Emergency fallback only: direct application URI. Prefer 'environment-name'."),
+					Field(LoginFieldName, StringType, "Emergency fallback only: login paired with 'uri'."),
+					Field(PasswordFieldName, StringType, "Emergency fallback only: password paired with 'uri'.")
 				]),
 			EnvelopeOutput(
 				SuccessFieldName,
@@ -3020,18 +3026,27 @@ internal static class ToolContractCatalog {
 				Field(SuccessFieldName, BooleanType, ToolSucceededDescription),
 				Field("mode", StringType, "detail or list."),
 				Field("count", NumberType, "Number of matching components."),
-				Field("groups", ArrayType, "Grouped list-mode results."),
-				Field("componentType", StringType, "Component type for detail mode."),
+				Field("items", ArrayType, "Flat list-mode component summaries, each with componentType and an optional description."),
+				Field("componentType", StringType, "Component type echoed back in detail mode."),
+				Field("resolvedTargetVersion", StringType, "Catalog version the response was filtered against."),
+				Field("resolvedFrom", StringType, "Resolver tier that produced the version: 'environment' or 'latest-fallback'."),
 				Field(ErrorFieldName, StringType, FailureMessageDescription)
 			),
 			CommonErrorContract,
 			[
-				Alias(ParameterScope, "component-type", "componentType", RejectedStatus, "Use 'component-type' instead of 'componentType'.")
+				Alias(ParameterScope, "component-type", "componentType", RejectedStatus, "Use 'component-type' instead of 'componentType'."),
+				Alias(ParameterScope, "schema-type", "schemaType", RejectedStatus, "Use 'schema-type' instead of 'schemaType'."),
+				Alias(ParameterScope, EnvironmentNameFieldName, "environmentName", RejectedStatus, "Use 'environment-name' instead of 'environmentName'.")
 			],
 			[],
 			[
 				Example("Inspect one component contract", new Dictionary<string, object?> {
 					["component-type"] = "crt.TabContainer"
+				}),
+				Example("List the full component catalog", new Dictionary<string, object?>()),
+				Example("Inspect a mobile component contract", new Dictionary<string, object?> {
+					["component-type"] = "crt.Toggle",
+					["schema-type"] = "mobile"
 				})
 			],
 			Flow([ComponentInfoTool.ToolName], "Use after get-page when bundle.viewConfig contains unfamiliar crt.* component types."),

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -50,27 +50,9 @@ public sealed class ToolContractGetTool {
 	private const string ToolNamesParam = "tool-names";
 
 	private static string? CollectLegacyAliasError(ToolContractGetArgs args) {
-		if (args.ExtensionData is null || args.ExtensionData.Count == 0) {
-			return null;
-		}
-		List<string> mapped = [];
-		List<string> unknown = [];
-		foreach (string key in args.ExtensionData.Keys) {
-			if (LegacyAliases.TryGetValue(key, out string? canonical)) {
-				mapped.Add($"'{key}' -> '{canonical}'");
-			} else {
-				unknown.Add($"'{key}'");
-			}
-		}
-		List<string> parts = [];
-		if (mapped.Count > 0) {
-			parts.Add("Rename: " + string.Join(", ", mapped) + ". tool-names must be an array of strings.");
-		}
-		if (unknown.Count > 0) {
-			parts.Add("Unknown args: " + string.Join(", ", unknown)
-				+ ". Valid: tool-names (array of strings). Omit args to list all tools.");
-		}
-		return parts.Count > 0 ? string.Join(" ", parts) : null;
+		return McpToolArgumentSupport.BuildLegacyAliasError(
+			args.ExtensionData, LegacyAliases, ". tool-names must be an array of strings.",
+			"Valid: tool-names (array of strings). Omit args to list all tools.");
 	}
 }
 
@@ -464,34 +446,10 @@ internal static class ToolContractCatalog {
 		return Contracts.Keys
 			.Concat(McpToolSchemaCatalog.RegisteredToolNames)
 			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.OrderBy(name => ComputeDistance(requestedName, name))
+			.OrderBy(name => McpToolArgumentSupport.LevenshteinDistance(requestedName, name))
 			.ThenBy(name => name, StringComparer.OrdinalIgnoreCase)
 			.Take(3)
 			.ToArray();
-	}
-
-	private static int ComputeDistance(string source, string target) {
-		if (string.Equals(source, target, StringComparison.OrdinalIgnoreCase)) {
-			return 0;
-		}
-		string left = source.ToLowerInvariant();
-		string right = target.ToLowerInvariant();
-		int[,] matrix = new int[left.Length + 1, right.Length + 1];
-		for (int i = 0; i <= left.Length; i++) {
-			matrix[i, 0] = i;
-		}
-		for (int j = 0; j <= right.Length; j++) {
-			matrix[0, j] = j;
-		}
-		for (int i = 1; i <= left.Length; i++) {
-			for (int j = 1; j <= right.Length; j++) {
-				int cost = left[i - 1] == right[j - 1] ? 0 : 1;
-				matrix[i, j] = Math.Min(
-					Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
-					matrix[i - 1, j - 1] + cost);
-			}
-		}
-		return matrix[left.Length, right.Length];
 	}
 
 	private static ToolContractDefinition BuildToolContractGet() {


### PR DESCRIPTION
## Problem

`get-component-info` ([#664](https://github.com/Advance-Technologies-Foundation/clio/issues/664)) ignored a concrete `component-type` and never engaged detail mode — every call returned the full 199-item `mode: "list"` catalog, so an agent could not confirm a component's exact contract and every call was token-heavy.

**Root cause:** `get-component-info` was the *only* clio MCP tool that took flat camelCase method parameters (`componentType`, `schemaType`, …) instead of the shared single-`args`-record shape every other tool uses. The MCP SDK binds arguments by parameter name, so:

- the real `tools/list` schema advertised flat `componentType` (camelCase);
- `get-tool-contract` advertised `component-type` (kebab) and listed `componentType` as a `rejected` alias;
- an agent trusting the contract sent `component-type`, the binding ignored it (the optional parameter stayed null), and the response degraded to the full list.

The `ComponentInfoArgs` record already carried the correct `[JsonPropertyName("component-type")]` attributes but was never wired as the binding surface — this PR completes that intent.

## Changes

- **`ComponentInfoTool`** — `GetComponentInfo` now takes `[Required] ComponentInfoArgs args`. Added `[JsonExtensionData]` + `GetLegacyAliasError` (mirrors `PageListTool`) so camelCase/snake_case spellings are rejected with a rename hint instead of silently dropping to a catalog dump (`component-type` is optional, so a misbound value would otherwise vanish). The real schema now emits `{"args":{"component-type", …}}` (kebab), matching the rest of the fleet and `get-tool-contract`.
- **Acceptance #2 fix** — the not-found path returned the entire catalog as "suggestions" when no `search` was set (`FilterEntries(null)` returns everything). It now returns a bounded closest-match shortlist (Levenshtein top-8) via `ComponentInfoGrouping.SuggestForUnknown`.
- **`get-tool-contract`** — `BuildComponentInfo` now lists the previously-missing `schema-type` / `environment-name` / `version` / `uri` / `login` / `password` fields and their aliases; fixed the bogus output field `groups` → `items`.
- **Tests** — all unit calls moved to `new ComponentInfoArgs(...)`; added a deserialization binding proof (using the real `BindingsModule.CreateMcpSerializerOptions()`), plus bounded-suggestions and reject-alias tests; e2e calls wrapped in `args` + kebab with a bounded not-found assertion.

## Acceptance criteria

- ✅ `get-component-info {"args":{"component-type":"crt.NumberInput"}}` → `mode: "detail"` (single contract), not the 199-item list.
- ✅ Unknown `component-type` → actionable error with a bounded suggestion shortlist, not the full catalog.
- ✅ Unit tests cover detail-mode hit, unknown-type bounded error, and list mode (no `component-type`).

> **Note on the call shape:** the fix moves `get-component-info` to the universal `args` wrapper, so calls are now `{"args":{"component-type":"…"}}`, consistent with every other clio tool. The issue's literal example showed a flat `{"component-type":…}`; no clio tool supports flat kebab, so this is the "or equivalent" form the acceptance allows.

## Verification

- Build (clio + clio.tests + clio.mcp.e2e): 0 errors. `ComponentInfoToolTests`: 32/32 green.
- **`clio.mcp.e2e` is not run by CI** (only `clio.tests` + analyzers), so the real arg-binding is not covered by an automated pipeline. Verified manually against a live MCP server built from this branch: `tools/list` now emits `{"args":{component-type, search, schema-type, environment-name, version, uri, login, password}}` (kebab, wrapped), and the deserialization unit test proves kebab binds while camelCase routes to the overflow bag.
- 7 unrelated `McpServer` failures (cwd / workspace / products-path tests) are pre-existing on `origin/master` (confirmed via stash comparison) — caused by worktree temp-path aliasing, not this change.

Resolves #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
