### PR TITLE
fix(mcp): anchor .clio-pages output at workspace root, not raw cwd

### DIFF
--- a/clio.tests/Command/McpServer/PageOutputDirectoryResolverTests.cs
+++ b/clio.tests/Command/McpServer/PageOutputDirectoryResolverTests.cs
@@ -1,0 +1,111 @@
+using System.IO.Abstractions.TestingHelpers;
+using Clio.Command.McpServer.Tools;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public class PageOutputDirectoryResolverTests {
+
+	private static string Resolve(
+		MockFileSystem fs, string cwd, string home, string fallback, string? explicitDir) =>
+		PageOutputDirectoryResolver.ResolveAnchor(fs, cwd, home, fallback, explicitDir);
+
+	[Test]
+	[Description("An explicit output-directory wins over every fallback, even when cwd is the home directory.")]
+	public void ResolveAnchor_WhenExplicitDirectoryGiven_HonorsItRegardlessOfCwd() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string home = fs.Path.Combine(baseDir, "home");
+		string explicitDir = fs.Path.Combine(baseDir, "explicit-out");
+
+		string anchor = Resolve(fs, cwd: home, home: home,
+			fallback: fs.Path.Combine(baseDir, "cliohome"), explicitDir: explicitDir);
+
+		anchor.Should().Be(fs.Path.GetFullPath(explicitDir),
+			because: "an explicit output-directory must be honored regardless of the current directory");
+	}
+
+	[Test]
+	[Description("Walks up from a nested cwd to the workspace root identified by .clio/workspaceSettings.json.")]
+	public void ResolveAnchor_WhenWorkspaceMarkerInAncestor_ReturnsWorkspaceRoot() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string wsRoot = fs.Path.Combine(baseDir, "ws");
+		fs.AddFile(fs.Path.Combine(wsRoot, ".clio", "workspaceSettings.json"), new MockFileData("{}"));
+		string cwd = fs.Path.Combine(wsRoot, "packages", "UsrPkg");
+		fs.AddDirectory(cwd);
+
+		string anchor = Resolve(fs, cwd, home: fs.Path.Combine(baseDir, "home"),
+			fallback: fs.Path.Combine(baseDir, "cliohome"), explicitDir: null);
+
+		anchor.Should().Be(fs.Path.GetFullPath(wsRoot),
+			because: "output must anchor at the workspace root, not the raw nested cwd");
+	}
+
+	[Test]
+	[Description("A plain project directory (no workspace marker, not home) keeps the cwd-relative behavior.")]
+	public void ResolveAnchor_WhenPlainProjectDir_ReturnsCwd() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string cwd = fs.Path.Combine(baseDir, "proj");
+		fs.AddDirectory(cwd);
+
+		string anchor = Resolve(fs, cwd, home: fs.Path.Combine(baseDir, "home"),
+			fallback: fs.Path.Combine(baseDir, "cliohome"), explicitDir: null);
+
+		anchor.Should().Be(cwd,
+			because: "a non-home project directory with no workspace marker keeps the current cwd-relative behavior");
+	}
+
+	[Test]
+	[Description("When cwd is the home directory and no workspace is found, anchors at the managed clio home fallback, never the bare $HOME.")]
+	public void ResolveAnchor_WhenCwdIsHomeAndNoWorkspace_ReturnsFallbackNotHome() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string home = fs.Path.Combine(baseDir, "home");
+		string fallback = fs.Path.Combine(baseDir, "cliohome");
+
+		string anchor = Resolve(fs, cwd: home, home: home, fallback: fallback, explicitDir: null);
+
+		anchor.Should().Be(fallback,
+			because: "output must fall back to the managed home root and never litter the bare home directory");
+		anchor.Should().NotBe(home);
+	}
+
+	[Test]
+	[Description("An orphaned .clio directory without workspaceSettings.json (e.g. a pre-consolidation ~/.clio cache) above a project dir is NOT treated as a workspace root.")]
+	public void ResolveAnchor_WhenOrphanedClioDirAboveProjectDir_DoesNotTreatAsWorkspace() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string outer = fs.Path.Combine(baseDir, "outer");
+		// Orphaned .clio directory WITHOUT the workspaceSettings.json marker file.
+		fs.AddDirectory(fs.Path.Combine(outer, ".clio"));
+		string cwd = fs.Path.Combine(outer, "proj");
+		fs.AddDirectory(cwd);
+
+		string anchor = Resolve(fs, cwd, home: fs.Path.Combine(baseDir, "home"),
+			fallback: fs.Path.Combine(baseDir, "cliohome"), explicitDir: null);
+
+		anchor.Should().Be(cwd,
+			because: "a bare .clio directory without workspaceSettings.json must not masquerade as a workspace root");
+	}
+
+	[Test]
+	[Description("The workspace marker directly in the cwd anchors at the cwd.")]
+	public void ResolveAnchor_WhenWorkspaceMarkerInCwd_ReturnsCwd() {
+		MockFileSystem fs = new();
+		string baseDir = fs.Directory.GetCurrentDirectory();
+		string wsRoot = fs.Path.Combine(baseDir, "ws");
+		fs.AddFile(fs.Path.Combine(wsRoot, ".clio", "workspaceSettings.json"), new MockFileData("{}"));
+
+		string anchor = Resolve(fs, cwd: wsRoot, home: fs.Path.Combine(baseDir, "home"),
+			fallback: fs.Path.Combine(baseDir, "cliohome"), explicitDir: null);
+
+		anchor.Should().Be(fs.Path.GetFullPath(wsRoot),
+			because: "a cwd that is itself the workspace root anchors there");
+	}
+}

--- a/clio/Command/McpServer/Tools/PageGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageGetTool.cs
@@ -20,7 +20,9 @@ public sealed class PageGetTool(
 
 	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = false, Idempotent = true, OpenWorld = false)]
 	[Description(
-		"Get a Freedom UI page. Writes body.js / bundle.json / meta.json to .clio-pages/{schema-name}/ in the working directory and returns file paths. " +
+		"Get a Freedom UI page. Writes body.js / bundle.json / meta.json to .clio-pages/{schema-name}/ and returns file paths. " +
+		"Output is anchored at the clio workspace root (the nearest ancestor containing .clio/workspaceSettings.json), or at an explicit `output-directory` when supplied. " +
+		"When the server runs from the home directory and no workspace is found, output falls back to the managed clio home root instead of littering $HOME — pass `output-directory` (your project root) to keep page files next to your code. " +
 		"body.js contains the EDITABLE own-body of the replacing schema in the design package (empty template when no replacing schema exists yet) — this is what update-page should receive. " +
 		"bundle.json contains the full merged view of the entire hierarchy and is the correct source for reading what components are on the page. " +
 		"IMPORTANT: bundle.json is a JSON document. Use a JSON parsing tool (jq, PowerShell ConvertFrom-Json, Python json.load) to navigate it; do NOT rely on grep or line-oriented text search — it is typically minified to a single line. " +
@@ -53,15 +55,20 @@ public sealed class PageGetTool(
 			}
 			resolvedCommand.TryGetPage(options, out PageGetResponse response);
 			if (response.Success) {
-				return WriteFilesAndCompact(response, args.SchemaName);
+				return WriteFilesAndCompact(response, args.SchemaName, args.OutputDirectory);
 			}
 			return response;
 		});
 	}
 
-	private PageGetResponse WriteFilesAndCompact(PageGetResponse response, string schemaName) {
-		string rootDir = fileSystem.Path.Combine(
-			fileSystem.Directory.GetCurrentDirectory(), ".clio-pages");
+	private PageGetResponse WriteFilesAndCompact(PageGetResponse response, string schemaName, string? outputDirectory) {
+		string anchor = PageOutputDirectoryResolver.ResolveAnchor(
+			fileSystem,
+			fileSystem.Directory.GetCurrentDirectory(),
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+			ClioRuntimePaths.Home,
+			outputDirectory);
+		string rootDir = fileSystem.Path.Combine(anchor, ".clio-pages");
 		string schemaDir = fileSystem.Path.Combine(rootDir, schemaName);
 		try {
 			if (fileSystem.Directory.Exists(schemaDir)) {
@@ -134,5 +141,9 @@ public sealed record PageGetArgs(
 	string? Login,
 	[property: JsonPropertyName("password")]
 	[property: Description("Direct Creatio password paired with `uri`. Emergency fallback only.")]
-	string? Password
+	string? Password,
+
+	[property: JsonPropertyName("output-directory")]
+	[property: Description("Optional. Directory to anchor .clio-pages output under — typically your project/workspace root. When omitted, the workspace root is auto-detected by walking up for .clio/workspaceSettings.json; if the server runs from the home directory with no workspace found, output falls back to the clio home root rather than $HOME.")]
+	string? OutputDirectory = null
 );

--- a/clio/Command/McpServer/Tools/PageOutputDirectoryResolver.cs
+++ b/clio/Command/McpServer/Tools/PageOutputDirectoryResolver.cs
@@ -1,0 +1,91 @@
+using System;
+using IFileSystem = System.IO.Abstractions.IFileSystem;
+
+namespace Clio.Command.McpServer.Tools;
+
+/// <summary>
+/// Resolves the anchor directory under which <c>get-page</c> / <c>sync-pages</c> write their
+/// <c>.clio-pages/{schema}/</c> output.
+/// <para>
+/// The MCP server is frequently launched with <c>$HOME</c> as its working directory (a common
+/// host default — Claude Code starts <c>clio mcp-server</c> without an explicit cwd). Anchoring
+/// the output at the raw current directory therefore dumps page artifacts straight into the
+/// user's home folder. This resolver binds the output to the workspace root instead, and falls
+/// back to the managed clio home root (never the bare home directory) when no workspace is found.
+/// </para>
+/// <para>See <c>docs/architecture/clio-pages-workspace-binding.md</c>.</para>
+/// </summary>
+internal static class PageOutputDirectoryResolver {
+
+	private const string ClioDirectoryName = ".clio";
+	private const string WorkspaceSettingsFileName = "workspaceSettings.json";
+
+	/// <summary>
+	/// Resolves the base directory under which the <c>.clio-pages</c> tree is created.
+	/// Resolution order:
+	/// <list type="number">
+	/// <item>an explicit caller-supplied directory — honored regardless of cwd;</item>
+	/// <item>the nearest ancestor of <paramref name="currentDirectory"/> containing
+	/// <c>.clio/workspaceSettings.json</c> (the workspace marker);</item>
+	/// <item><paramref name="currentDirectory"/> itself, when it is not the user's home directory;</item>
+	/// <item><paramref name="homeFallbackAnchor"/> (the managed clio home root) when the current
+	/// directory is the bare home directory — so output never litters <c>$HOME</c> and the tool
+	/// never fails for lack of a workspace.</item>
+	/// </list>
+	/// </summary>
+	/// <param name="fileSystem">File-system abstraction used to probe for the workspace marker.</param>
+	/// <param name="currentDirectory">The process current working directory.</param>
+	/// <param name="homeDirectory">The user's home directory (<c>SpecialFolder.UserProfile</c>).</param>
+	/// <param name="homeFallbackAnchor">Anchor used instead of the bare home directory (clio home root).</param>
+	/// <param name="explicitDirectory">Optional caller-pinned output directory.</param>
+	public static string ResolveAnchor(
+		IFileSystem fileSystem,
+		string currentDirectory,
+		string homeDirectory,
+		string homeFallbackAnchor,
+		string? explicitDirectory) {
+		if (!string.IsNullOrWhiteSpace(explicitDirectory)) {
+			return fileSystem.Path.GetFullPath(explicitDirectory);
+		}
+		string? workspaceRoot = FindWorkspaceRoot(fileSystem, currentDirectory);
+		if (workspaceRoot is not null) {
+			return workspaceRoot;
+		}
+		return IsSameDirectory(fileSystem, currentDirectory, homeDirectory)
+			? homeFallbackAnchor
+			: currentDirectory;
+	}
+
+	/// <summary>
+	/// Walks up from <paramref name="startDirectory"/> looking for a directory that contains
+	/// <c>.clio/workspaceSettings.json</c>. Matches the workspace marker <em>file</em> — not the
+	/// bare <c>.clio</c> directory — so an orphaned <c>~/.clio</c> (e.g. a pre-consolidation cache
+	/// folder) above a plain project directory does not masquerade as a workspace root.
+	/// </summary>
+	private static string? FindWorkspaceRoot(IFileSystem fileSystem, string startDirectory) {
+		var directory = fileSystem.DirectoryInfo.New(startDirectory);
+		while (directory is not null) {
+			string marker = fileSystem.Path.Combine(directory.FullName, ClioDirectoryName, WorkspaceSettingsFileName);
+			if (fileSystem.File.Exists(marker)) {
+				return directory.FullName;
+			}
+			directory = directory.Parent;
+		}
+		return null;
+	}
+
+	private static bool IsSameDirectory(IFileSystem fileSystem, string left, string right) {
+		if (string.IsNullOrEmpty(left) || string.IsNullOrEmpty(right)) {
+			return false;
+		}
+		string normalizedLeft = Normalize(fileSystem, left);
+		string normalizedRight = Normalize(fileSystem, right);
+		// macOS and Windows file systems are case-insensitive; OrdinalIgnoreCase is the safe
+		// comparison for the home-directory guard across the platforms clio runs on.
+		return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static string Normalize(IFileSystem fileSystem, string path) =>
+		fileSystem.Path.GetFullPath(path)
+			.TrimEnd(fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar);
+}

--- a/clio/Command/McpServer/Tools/PageSyncTool.cs
+++ b/clio/Command/McpServer/Tools/PageSyncTool.cs
@@ -31,6 +31,7 @@ public sealed class PageSyncTool(
 	[Description("Updates multiple Freedom UI page schemas in a single call. " +
 	             "For each page: validates body client-side (optional), runs AI semantic review (optional), saves to Creatio, " +
 	             "and verifies the update (optional). Continues processing remaining pages on failure. " +
+		             "When verify=true, the read-back body is written to .clio-pages/{schema-name}/body.js, anchored at the workspace root (or the `output-directory` argument); see get-page for the anchoring rules. " +
 	             "Client-side validation, when enabled, also enforces VendorPrefix.Name format " +
 	             "(SCHEMA_CONVERTERS and SCHEMA_VALIDATORS keys; SCHEMA_HANDLERS entry `request` values). " +
 	             "Before editing page bodies or resource payloads, call get-guidance with name `page-modification` and use its pre-edit checklist to select specialized page-authoring guides. " +
@@ -66,7 +67,7 @@ public sealed class PageSyncTool(
 				foreach (PageSyncPageInput page in args.Pages) {
 					samplingResults.TryGetValue(page.SchemaName, out PageSamplingReview samplingReview);
 					PageSyncPageResult pageResult = SyncSinglePage(
-						page, updateCommand, getCommand, validate, verify, samplingReview);
+						page, updateCommand, getCommand, validate, verify, samplingReview, args.OutputDirectory);
 					results.Add(pageResult);
 				}
 				Thread.Sleep(500);
@@ -132,7 +133,8 @@ public sealed class PageSyncTool(
 		PageGetCommand getCommand,
 		bool validate,
 		bool verify,
-		PageSamplingReview samplingReview) {
+		PageSamplingReview samplingReview,
+		string? outputDirectory) {
 		try {
 			PageSyncValidationResult validationResult = null;
 			if (validate) {
@@ -180,8 +182,14 @@ public sealed class PageSyncTool(
 				}
 				string? verifiedBodyFile = null;
 				if (getResponse.Raw?.Body is not null) {
+					string anchor = PageOutputDirectoryResolver.ResolveAnchor(
+						fileSystem,
+						fileSystem.Directory.GetCurrentDirectory(),
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+						ClioRuntimePaths.Home,
+						outputDirectory);
 					string schemaDir = fileSystem.Path.Combine(
-						fileSystem.Directory.GetCurrentDirectory(), ".clio-pages", page.SchemaName);
+						anchor, ".clio-pages", page.SchemaName);
 					fileSystem.Directory.CreateDirectory(schemaDir);
 					string bodyFile = fileSystem.Path.Combine(schemaDir, "body.js");
 					fileSystem.File.WriteAllText(bodyFile, getResponse.Raw.Body);
@@ -385,7 +393,11 @@ public sealed record PageSyncArgs(
 
 	[property: JsonPropertyName("skip-sampling")]
 	[property: Description("Reserved escape hatch. Omit by default. Pre-condition for setting true: the immediately preceding user message in this turn contains an explicit instruction to skip the AI semantic review for this batch, OR the MCP host has reported sampling as unavailable in this session. Absent that evidence, omit this field. Default: false")]
-	bool? SkipSampling = null
+	bool? SkipSampling = null,
+
+	[property: JsonPropertyName("output-directory")]
+	[property: Description("Optional. Directory to anchor verified-page .clio-pages output under — typically your project/workspace root. When omitted, the workspace root is auto-detected by walking up for .clio/workspaceSettings.json; if running from the home directory with no workspace found, output falls back to the clio home root rather than $HOME. Only relevant when verify=true.")]
+	string? OutputDirectory = null
 );
 
 /// <summary>

--- a/docs/architecture/clio-pages-workspace-binding.md
+++ b/docs/architecture/clio-pages-workspace-binding.md
@@ -1,6 +1,6 @@
 # Plan: bind `.clio-pages` output to the workspace root
 
-**Status:** Proposed (not yet implemented)
+**Status:** Implemented
 **Related:** `docs/architecture/clio-home-consolidation.md` (explicitly out of scope there)
 
 ## Problem
@@ -22,45 +22,69 @@ sit next to the user's project so they can edit `body.js` in place. The bug is t
 not the location concept. It must therefore stay workspace/project-relative — never folded
 into the global `CLIO_HOME` root (that would make multiple workspaces collide).
 
-## Proposed fix
+## Fix
 
 Anchor the output at the **workspace root** — the nearest ancestor directory containing
-`.clio/workspaceSettings.json` (the existing workspace marker used by `WorkspacePathBuilder`)
-— instead of the raw cwd.
+`.clio/workspaceSettings.json` (the workspace marker) — instead of the raw cwd.
 
-Resolution order for the output base directory:
+Resolution order for the output base directory (`PageOutputDirectoryResolver.ResolveAnchor`):
 
-1. The workspace root found by walking up from the current directory until
-   `.clio/workspaceSettings.json` is found.
-2. If no workspace marker is found before reaching the filesystem root, fall back to the
-   current directory **only when it is not the user's home directory**; otherwise fail with a
-   clear, actionable error:
-   *"get-page must run inside a clio workspace (a directory whose tree contains
-   `.clio/workspaceSettings.json`) or in a project directory; refusing to write `.clio-pages`
-   into the home directory. Pass an explicit workspace/output directory."*
+1. An explicit caller-supplied `output-directory` argument — honored regardless of cwd. This is
+   the deterministic escape hatch for the common case where the MCP server runs from `$HOME`
+   (Claude Code starts `clio mcp-server` without an explicit cwd): the agent passes its project
+   root and page files land next to the code.
+2. The workspace root found by walking up from the current directory until a directory
+   containing the `.clio/workspaceSettings.json` **file** is found. Matching the marker *file*
+   (not the bare `.clio` *directory*) is deliberate: an orphaned `~/.clio` — e.g. a
+   pre-consolidation cache folder left behind by the home-consolidation refactor — must not
+   masquerade as a workspace root and re-route output back to `$HOME`.
+3. The current directory itself, **when it is not the user's home directory** (preserves the
+   existing "files next to my plain project" behavior).
+4. When the current directory *is* the bare home directory and no workspace is found, fall back
+   to the **managed clio home root** (`ClioRuntimePaths.Home` — `~/creatio/clio` |
+   `%LOCALAPPDATA%\creatio\clio`, honoring `CLIO_HOME`) rather than failing. This keeps the tool
+   working out of the box while making it impossible to silently litter the bare `$HOME`.
 
-This keeps the "files next to my project" model intact while making it impossible to silently
-litter `$HOME`.
+The home-root fallback is the one deliberate departure from a strict "workspace-only" model: it
+is **not** a per-workspace location, so it is acceptable only for the "no workspace at all" case
+(a single shared scratch area), never as a substitute for a real workspace anchor. The general
+prohibition on folding `.clio-pages` under `CLIO_HOME` for *multi-workspace* use still stands
+(see Out of scope).
 
-## Implementation sketch
+## Implementation
 
-- Add a small resolver (e.g. `PageOutputDirectoryResolver`) that takes the current directory
-  and returns the output base, using the upward `.clio/workspaceSettings.json` walk that
-  `WorkspacePathBuilder` already implements — reuse it rather than re-deriving the walk.
-- Replace the two `GetCurrentDirectory()` call sites above with the resolver.
-- Consider an explicit `outputDirectory` argument on `get-page` / `sync-page` so callers
-  (and the MCP host) can pin the location deterministically; the home-directory guard then
-  only applies to the implicit path.
+- `PageOutputDirectoryResolver.ResolveAnchor(fileSystem, currentDirectory, homeDirectory,
+  homeFallbackAnchor, explicitDirectory)` (`clio/Command/McpServer/Tools/PageOutputDirectoryResolver.cs`)
+  — a pure static resolver returning the base directory under which the unchanged `.clio-pages/{schema}`
+  suffix is created. It implements the upward `.clio/workspaceSettings.json` *file* walk directly
+  rather than reusing `WorkspacePathBuilder.RootPath` — the latter walks to the `.clio`
+  *directory* and would resolve an orphaned `~/.clio` to `$HOME`.
+- Both `GetCurrentDirectory()` call sites now route through the resolver:
+  `PageGetTool.WriteFilesAndCompact` and `PageSyncTool.SyncSinglePage` (the verify read-back write).
+  Each passes `Environment.GetFolderPath(SpecialFolder.UserProfile)` as the home directory and
+  `ClioRuntimePaths.Home` as the fallback anchor.
+- An optional `output-directory` argument was added to both `get-page` (`PageGetArgs`) and
+  `sync-pages` (`PageSyncArgs`), with tool `[Description]` text updated to document the anchoring
+  contract for the MCP host.
 
 ## Tests
 
-- Workspace marker in an ancestor → output lands under that workspace root, not cwd.
-- cwd is a plain project dir (no marker, not home) → output under cwd (current behavior).
-- cwd is the home directory and no marker found → tool fails with the guard error rather than
-  writing `~/.clio-pages`.
-- Explicit `outputDirectory` argument → honored regardless of cwd.
+`clio.tests/Command/McpServer/PageOutputDirectoryResolverTests.cs`:
+
+- Explicit `output-directory` → honored regardless of cwd (even when cwd is home).
+- Workspace marker in an ancestor → output anchors at that workspace root, not the nested cwd.
+- cwd is a plain project dir (no marker, not home) → anchors at cwd (current behavior preserved).
+- cwd is the home directory and no marker found → anchors at the managed home fallback, never the
+  bare `$HOME`.
+- Orphaned `.clio` directory (no `workspaceSettings.json`) above a project dir → **not** treated
+  as a workspace root (proves the file marker, not the `.clio` dir, is matched).
+- Workspace marker directly in the cwd → anchors at cwd.
+
+The existing `PageToolsTests` keep the cwd-relative behavior green because `MockFileSystem`'s
+current directory is never the real home directory, so the home fallback stays dormant.
 
 ## Out of scope
 
-Moving `.clio-pages` under `CLIO_HOME`. It is intentionally project-relative; see the
-consolidation ADR.
+Folding `.clio-pages` under `CLIO_HOME` for *multi-workspace* use. It is intentionally
+project-relative; the home-root fallback above is only the single-shared-scratch case when no
+workspace exists. See the consolidation ADR.


### PR DESCRIPTION
## What

`get-page` / `sync-pages` no longer dump page artifacts into the user's home folder. Output is now anchored at the workspace root (or an explicit directory), with a safe non-home fallback.

## Why

The MCP server is launched as `clio mcp-server` **without an explicit cwd**, so it inherits `$HOME`. Both tools resolved `.clio-pages/{schema}/` against the raw `Directory.GetCurrentDirectory()`, so `body.js` / `bundle.json` / `meta.json` (and a `.gitignore`) were written straight into `~/.clio-pages/` — e.g. `~/.clio-pages/UsrEng90846Test_FormPage/`.

This is the follow-up **deliberately deferred** by #650 and documented in [`docs/architecture/clio-pages-workspace-binding.md`](docs/architecture/clio-pages-workspace-binding.md) (out of scope there). It is a fix of the *anchor*, not the location concept.

## Decision

New `PageOutputDirectoryResolver.ResolveAnchor` resolves the base directory under which the unchanged `.clio-pages/{schema}` suffix is created, in order:

1. an explicit `output-directory` argument — honored regardless of cwd (the deterministic escape hatch for the agent to pin its project root);
2. the nearest ancestor containing the `.clio/workspaceSettings.json` **file** marker — matching the *file*, not the bare `.clio` *directory*, so an orphaned `~/.clio` (a pre-consolidation cache folder) cannot masquerade as a workspace and re-route output back to `$HOME`;
3. the current directory when it is **not** the home directory (preserves the existing project-relative behavior);
4. the managed clio home root (`ClioRuntimePaths.Home`, honoring `CLIO_HOME`) when cwd **is** the bare home directory — a soft fallback so the tool never litters `$HOME` and never fails for lack of a workspace.

> Note on default behavior: because the server runs from `$HOME` in the common setup, branch (4) is what fires by default — pages land under `<clio-home>/.clio-pages/` (e.g. `~/creatio/clio/.clio-pages/`). To get files next to your project, pass `output-directory` or start the server inside a workspace.

## Changes

- `PageOutputDirectoryResolver` — central anchor resolver (pure, static, file-system-abstracted).
- `PageGetTool.WriteFilesAndCompact` and the `PageSyncTool` verify read-back now route through the resolver.
- New optional `output-directory` argument on `get-page` (`PageGetArgs`) and `sync-pages` (`PageSyncArgs`); tool `[Description]` text updated to document the anchoring contract.
- ADR marked **Implemented** and rewritten to match the shipped soft-fallback behavior.

## Testing

- `dotnet build` clean (0 errors).
- New `PageOutputDirectoryResolverTests` — 6 cases incl. explicit-arg, workspace-in-ancestor, plain-project-dir, home→fallback, **orphaned-`.clio`-above-project-dir** (proves the file marker, not the `.clio` dir, is matched), and marker-in-cwd. All green.
- Existing `PageToolsTests` / `PageSyncToolTests` — 50/50 green (the home fallback stays dormant under `MockFileSystem`, whose cwd is never the real home).
- Full `Module=McpServer` run: 432 passed; the only 5 failures are pre-existing, environment-dependent tests unrelated to this change (`CreateUiProject*`, `DownloadConfiguration*`, `ListCreatioBuilds*`) — verified identical on clean `master` via `git stash`.

Verification is unit-level + wiring-by-inspection; not exercised against a live MCP host in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)