### PR TITLE
fix(mcp): add Step 0 channel-resolution routing to page-modification guide

### DIFF
--- a/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
+++ b/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
@@ -192,6 +192,8 @@ public sealed class GuidanceGetToolTests {
 			because: "the guidance tool should return the canonical page modification article text");
 		result.Article.Text.Should().Contain("page-schema-resources",
 			because: "the page modification guide should route localizable string edits to the resources guide");
+		result.Article.Text.Should().Contain("RESOLVE CHANNEL",
+			because: "Step 0 must make the agent resolve the web/mobile channel before editing a page");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
+++ b/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
@@ -192,8 +192,8 @@ public sealed class GuidanceGetToolTests {
 			because: "the guidance tool should return the canonical page modification article text");
 		result.Article.Text.Should().Contain("page-schema-resources",
 			because: "the page modification guide should route localizable string edits to the resources guide");
-		result.Article.Text.Should().Contain("RESOLVE CHANNEL",
-			because: "Step 0 must make the agent resolve the web/mobile channel before editing a page");
+		result.Article.Text.Should().Contain("WEB, MOBILE, OR BOTH",
+			because: "Step 0 must make the agent resolve web vs mobile before editing a page");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
+++ b/clio.tests/Command/McpServer/GuidanceGetToolTests.cs
@@ -194,6 +194,8 @@ public sealed class GuidanceGetToolTests {
 			because: "the page modification guide should route localizable string edits to the resources guide");
 		result.Article.Text.Should().Contain("WEB, MOBILE, OR BOTH",
 			because: "Step 0 must make the agent resolve web vs mobile before editing a page");
+		result.Article.Text.Should().Contain("default to web",
+			because: "Step 0 must default to web when the requirement does not name a surface");
 	}
 
 	[Test]

--- a/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
@@ -23,6 +23,8 @@ public sealed class PageModificationGuidanceResource {
 		       clio MCP page modification guide
 
 		       PRE-EDIT GUIDANCE CHECKLIST — MANDATORY before writing any body
+		       STEP 0 — RESOLVE CHANNEL (before list-pages/get-page): web and mobile are SEPARATE page schemas (e.g., `<Entity>_FormPage`/`_ListPage` vs `<Entity>_MobileFormPage`/`_MobileListPage`) — editing one never affects its counterpart. Decide which channel(s) the requirement targets and, for every page it touches, edit the variant for each targeted channel (mobile pass: read `mobile-page-modification` first).
+
 		       MOBILE CHECK: If `get-page` returned `schema-type: "mobile"`, STOP — call `get-guidance` with name `mobile-page-modification` instead. Mobile pages use plain JSON (NOT AMD), draw from a separate component catalog (different list of components, same wrapped registry envelope and same `get-component-info` response shape — pass `schema-type: "mobile"` to query it), and must NOT contain handlers, validators, or converters. The rules below apply ONLY to web pages (schema-type: "web"). NOTE: even on mobile, a subset of the checklist below still applies (notably `page-schema-resources` and entity-level `business-rules`) — the mobile guide lists which items carry over.
 
 		       GATE: if ANY row in the table below matches your change, you MUST call the listed guide before producing the body. Skipping a matching row is treated as a defect, not a shortcut.
@@ -56,6 +58,7 @@ public sealed class PageModificationGuidanceResource {
 		       - If no replacing schema exists, `hierarchy[0]` is the original schema and the design package is the original package.
 
 		       Canonical page modification flow
+		       0. RESOLVE CHANNEL (see Step 0): decide which channel(s) the requirement targets; edit each affected page in every targeted channel (web and mobile variants are separate schemas).
 		       1. `list-pages` — discover the page schema name.
 		       2. `get-page` — read `raw.body` (the editable replacing schema body) and `page` metadata.
 		       3. Edit `raw.body` as needed.

--- a/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
@@ -23,7 +23,7 @@ public sealed class PageModificationGuidanceResource {
 		       clio MCP page modification guide
 
 		       PRE-EDIT GUIDANCE CHECKLIST — MANDATORY before writing any body
-		       STEP 0 — WEB, MOBILE, OR BOTH (before list-pages/get-page): web and mobile are SEPARATE page schemas (e.g., `<Entity>_FormPage`/`_ListPage` vs `<Entity>_MobileFormPage`/`_MobileListPage`) — editing one never affects its counterpart. Decide whether the requirement targets web, mobile, or both, then for every page it touches edit each targeted variant (mobile pass: read `mobile-page-modification` first).
+		       STEP 0 — WEB, MOBILE, OR BOTH (before list-pages/get-page): web and mobile are SEPARATE page schemas (e.g., `<Entity>_FormPage`/`_ListPage` vs `<Entity>_MobileFormPage`/`_MobileListPage`) — editing one never affects its counterpart. Decide whether the requirement targets web, mobile, or both; if it does not say, default to web (mobile is an explicit opt-in). Then for every page it touches edit each targeted variant (mobile pass: read `mobile-page-modification` first).
 
 		       MOBILE CHECK: If `get-page` returned `schema-type: "mobile"`, STOP — call `get-guidance` with name `mobile-page-modification` instead. Mobile pages use plain JSON (NOT AMD), draw from a separate component catalog (different list of components, same wrapped registry envelope and same `get-component-info` response shape — pass `schema-type: "mobile"` to query it), and must NOT contain handlers, validators, or converters. The rules below apply ONLY to web pages (schema-type: "web"). NOTE: even on mobile, a subset of the checklist below still applies (notably `page-schema-resources` and entity-level `business-rules`) — the mobile guide lists which items carry over.
 
@@ -58,7 +58,7 @@ public sealed class PageModificationGuidanceResource {
 		       - If no replacing schema exists, `hierarchy[0]` is the original schema and the design package is the original package.
 
 		       Canonical page modification flow
-		       0. WEB, MOBILE, OR BOTH (see Step 0): decide whether the requirement targets web, mobile, or both; edit each affected page's web and/or mobile variant accordingly.
+		       0. WEB, MOBILE, OR BOTH (see Step 0): decide whether the requirement targets web, mobile, or both (default to web if unspecified); edit each affected page's web and/or mobile variant accordingly.
 		       1. `list-pages` — discover the page schema name.
 		       2. `get-page` — read `raw.body` (the editable replacing schema body) and `page` metadata.
 		       3. Edit `raw.body` as needed.

--- a/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/PageModificationGuidanceResource.cs
@@ -23,7 +23,7 @@ public sealed class PageModificationGuidanceResource {
 		       clio MCP page modification guide
 
 		       PRE-EDIT GUIDANCE CHECKLIST — MANDATORY before writing any body
-		       STEP 0 — RESOLVE CHANNEL (before list-pages/get-page): web and mobile are SEPARATE page schemas (e.g., `<Entity>_FormPage`/`_ListPage` vs `<Entity>_MobileFormPage`/`_MobileListPage`) — editing one never affects its counterpart. Decide which channel(s) the requirement targets and, for every page it touches, edit the variant for each targeted channel (mobile pass: read `mobile-page-modification` first).
+		       STEP 0 — WEB, MOBILE, OR BOTH (before list-pages/get-page): web and mobile are SEPARATE page schemas (e.g., `<Entity>_FormPage`/`_ListPage` vs `<Entity>_MobileFormPage`/`_MobileListPage`) — editing one never affects its counterpart. Decide whether the requirement targets web, mobile, or both, then for every page it touches edit each targeted variant (mobile pass: read `mobile-page-modification` first).
 
 		       MOBILE CHECK: If `get-page` returned `schema-type: "mobile"`, STOP — call `get-guidance` with name `mobile-page-modification` instead. Mobile pages use plain JSON (NOT AMD), draw from a separate component catalog (different list of components, same wrapped registry envelope and same `get-component-info` response shape — pass `schema-type: "mobile"` to query it), and must NOT contain handlers, validators, or converters. The rules below apply ONLY to web pages (schema-type: "web"). NOTE: even on mobile, a subset of the checklist below still applies (notably `page-schema-resources` and entity-level `business-rules`) — the mobile guide lists which items carry over.
 
@@ -58,7 +58,7 @@ public sealed class PageModificationGuidanceResource {
 		       - If no replacing schema exists, `hierarchy[0]` is the original schema and the design package is the original package.
 
 		       Canonical page modification flow
-		       0. RESOLVE CHANNEL (see Step 0): decide which channel(s) the requirement targets; edit each affected page in every targeted channel (web and mobile variants are separate schemas).
+		       0. WEB, MOBILE, OR BOTH (see Step 0): decide whether the requirement targets web, mobile, or both; edit each affected page's web and/or mobile variant accordingly.
 		       1. `list-pages` — discover the page schema name.
 		       2. `get-page` — read `raw.body` (the editable replacing schema body) and `page` metadata.
 		       3. Edit `raw.body` as needed.


### PR DESCRIPTION
Adds a STEP 0 to the page-modification pre-edit checklist and canonical flow: resolve which UI channel(s) the requirement targets (web / mobile / both) and edit the matching page variant for each, before choosing a schema. Prevents an agent from editing the web _FormPage when the requirement targets the mobile _MobileFormPage (and vice versa).