### PR TITLE
fix: large MSSQL backup (>=2GB) k8s restore — correct WSL copy path (backslashes + missing /mnt/data segment)

### DIFF
--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -413,7 +413,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	}
 
 	bool useFs = false;
-	string dest = _msFileSystem.Path.Join("\\\\\\\\wsl.localhost", "rancher-desktop", "mnt", "clio-infrastructure",
+	string dest = _msFileSystem.Path.Join("\\\\wsl.localhost", "rancher-desktop", "mnt", "clio-infrastructure",
 		"mssql", "data",
 		$"{siteName}.bak");
 	if (_msFileSystem.FileInfo.New(src).Length < int.MaxValue) {

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -413,7 +413,12 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	}
 
 	bool useFs = false;
-	string dest = _msFileSystem.Path.Join("\\\\wsl.localhost", "rancher-desktop", "mnt", "data", "clio-infrastructure",
+	// Won't-fix (SonarCloud S1075): the \\wsl.localhost UNC is an environment-fixed path for the
+	// local Rancher Desktop k8s setup, not a configurable deployment target. Eliminating the
+	// hardcode requires streaming the backup into the pod via the k8s API and dropping the
+	// >= 2 GB WSL fallback entirely — tracked as a separate refactor. The trailing NOSONAR
+	// suppresses S1075 for this line only.
+	string dest = _msFileSystem.Path.Join("\\\\wsl.localhost", "rancher-desktop", "mnt", "data", "clio-infrastructure", // NOSONAR
 		"mssql", "data",
 		$"{siteName}.bak");
 	if (_msFileSystem.FileInfo.New(src).Length < int.MaxValue) {

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -413,7 +413,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	}
 
 	bool useFs = false;
-	string dest = _msFileSystem.Path.Join("\\\\wsl.localhost", "rancher-desktop", "mnt", "clio-infrastructure",
+	string dest = _msFileSystem.Path.Join("\\\\wsl.localhost", "rancher-desktop", "mnt", "data", "clio-infrastructure",
 		"mssql", "data",
 		$"{siteName}.bak");
 	if (_msFileSystem.FileInfo.New(src).Length < int.MaxValue) {


### PR DESCRIPTION
## Problem

`clio deploy-creatio` (Kubernetes restore mode) creates the IIS site and registers the environment but leaves it with **no database** when the MSSQL `.bak` is **>= 2 GB**. `clio ping` still reports `Done ping-app` (the `/0/ping` endpoint never touches the DB), so the failure is silent — the app only fails later at runtime with `Cannot open database "<env>" ... Login failed for user 'sa'`.

Backups under `int.MaxValue` (~2 GB) use `CopyBackupFileToPod` (kubectl cp into the pod, reads the real mountPath) and are unaffected. Only the large-file branch — which copies via the WSL `hostPath` share — was broken, by **two independent regressions** in its hardcoded path.

### Regression 1 — extra backslashes in the UNC prefix
Introduced in PR #549 (IFileSystem migration, `cd5ca8e`, 2026-04-24): the literal `"\\\\wsl.localhost"` (4 chars = 2 real backslashes) was doubled to 8 chars (4 real backslashes), producing an invalid UNC path, so `File.Copy` throws `The specified path is invalid` for every `.bak >= 2 GB`. (`RestoreDb.Tests.cs` already used the correct verbatim literal — source and test were inconsistent after #549.)

### Regression 2 — missing `/mnt/data` path segment
The copy target was hardcoded as `\\wsl.localhost\rancher-desktop\mnt\clio-infrastructure\mssql\data\<env>.bak`, but `CreateInfrastructure.cs` provisions **every** PV under `persistentInfrastructureRoot = "/mnt/data/clio-infrastructure"`. With the `data` segment missing, the `.bak` lands in a directory the MSSQL container never mounts, so `RESTORE FROM DISK = /var/opt/mssql/data/<env>.bak` fails with `Cannot open backup device ... operating system error 2 (file not found)` → `RESTORE DATABASE is terminating abnormally`.

History of regression 2:
- The hardcoded path was added in `c64665d1` (Kirill Krylov — *"Added option to copy large files through FS"*, 2025-03-09). It was **correct at the time** — the generator also used `/mnt/clio-infrastructure`.
- It was **broken by `d1cf2036` (Vladimir — *"feat: default help output to console instead of browser"*, 2026-03-17)**, which changed the generator root to `/mnt/data/clio-infrastructure` but did not update the deploy-side copy path. The two hardcoded roots drifted apart.

## Fix

- `01f471f1` — restore the correct 2-backslash UNC literal (reverts the #549 doubling).
- `018800f9` — add the missing `data` segment so the copy target matches the generator root and the in-container restore path: `\\wsl.localhost\rancher-desktop\mnt\data\clio-infrastructure\mssql\data\<env>.bak`.

## Validation

Built locally, installed as a global tool, wiped the local k8s infra, recreated it from the **stock** `create-k8-files` manifest (PV hostPath `/mnt/data/clio-infrastructure/mssql`, mount `/var/opt/mssql`), then deployed a fresh environment from a 7 GB MSSQL build. Result: `.bak` copied to `...\mnt\data\clio-infrastructure\mssql\data\<env>.bak`, `RESTORE` succeeded, the database exists (`SELECT name FROM sys.databases`), and the login page returns `200 OK` — **with no manifest changes**.

## Follow-up (out of scope for this PR)

The copy target is still a hardcoded absolute path (SonarCloud S1075) and now duplicates the infrastructure root in two places — the very drift that caused regression 2. A sturdier fix would either share a single `CLIO_INFRA_ROOT` constant between `CreateInfrastructure` and the deploy path, or stream the tar directly to the pod's stdin in `Cp.CopyFileToPodAsync` (it currently buffers the whole file in a `MemoryStream`, which is the only reason the >= 2 GB WSL fallback exists) and drop the WSL/large-file branch entirely.
