### PR TITLE
Modernize UnzipRequestHandler: fix directory bug, IFileSystem, logger spinner

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -3881,3 +3881,17 @@ Decision: (1) Deleted clio/Requests/ValidationBehaviour.cs (IPipelineBehavior �
 Discovery: BindingsModule had no `using MediatR;` import — `AddMediatR` resolved via MediatR's extension in the MS DI namespace, so removing the call + package was sufficient (no using to strip there). clio.tests had ZERO MediatR references after prior units — nothing to clean. OneOf is a SEPARATE package and stays (used elsewhere). Clean build with 0 warnings/0 errors WITHOUT the MediatR package is the compile-time proof that no reference remains.
 Files: clio/Requests/ValidationBehaviour.cs (deleted), clio/Common/ScenarioHandlers/BaseHandlerRequest.cs, clio/BindingsModule.cs, clio/Requests/IExternalLinkHandler.cs, clio/clio.csproj, Directory.Packages.props, CONTRIBUTING.md, CLAUDE.md, AGENTS.md, project-context.md
 Impact: MediatR is fully GONE from clio/ and clio.tests/ (package uninstalled). Docs/instructions updated from "deprecated/being removed" to "removed". Full unit suite: 4031 passed / 0 failed / 20 skipped. New commands: Command<TOptions> + DI services only.
+
+## 2026-06-16 – Modernization pilot: UnzipRequestHandler
+Context: Pilot for "modernize while we touch a file" playbook on clio/Common/ScenarioHandlers/Unzip.cs.
+Decision: Fixed inverted dir-creation (line 88 created dir only when it already existed); injected System.IO.Abstractions.IFileSystem into handler (aliased as IAbstractionsFileSystem to avoid clash with Clio.Common.IFileSystem in same namespace); routed Directory/Path ops + zip File.OpenRead through it; kept entry.ExtractToFile concrete (integration-tested); justified both CLIO002 pragmas with comments; kept ValidateAndThrow sync.
+Discovery: Unqualified IFileSystem in Clio.Common.* resolves to Clio.Common.IFileSystem, NOT System.IO.Abstractions — must alias (neighbors use IAbstractionsFileSystem). System.IO.Abstractions.IFileSystem already registered unconditionally (BindingsModule.cs:198). Validator still uses concrete System.IO.File.Exists, so handler tests need the source zip BOTH as a real temp touch (validator) AND seeded into MockFileSystem (handler). Bug-fix test must use an EMPTY zip so the extraction loop's else-branch CreateDirectory can't mask the inverted line-88 bug.
+Files: clio/Common/ScenarioHandlers/Unzip.cs, clio.tests/Requests/UnzipHandlerTests.cs
+Impact: Establishes the modernize-on-touch pattern; UnzipRequestValidator IFileSystem conversion left as follow-up.
+
+## 2026-06-16 – Unzip handler: replace hand-rolled spinner with ILogger spinner
+Context: Amends in-progress modernize-unzip pilot; replace custom Console spinner in UnzipRequestHandler.
+Decision: Inject Clio.Common.ILogger; wrap extraction in BeginSpinner/try-finally(EndSpinner(success))/EndSpinner. Dropped async -> Task.FromResult (no await left). Removed Turn(), _sequence, _counter, all Console.* and both CLIO002 pragmas; removed now-unused `using System;`.
+Discovery: ConsoleLogger spinner only no-ops when Console.IsOutputRedirected; tests must inject NullLogger via AdditionalRegistrations (applied after base ILogger reg at BindingsModule.cs:643, last-wins) to stay deterministic cross-OS.
+Files: clio/Common/ScenarioHandlers/Unzip.cs, clio.tests/Requests/UnzipHandlerTests.cs
+Impact: Reference for migrating other hand-rolled Console spinners to the ILogger spinner; shows DI-override pattern to neutralize spinner in command/handler tests.

--- a/clio.tests/Requests/UnzipHandlerTests.cs
+++ b/clio.tests/Requests/UnzipHandlerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using System.IO.Compression;
 using System.Threading.Tasks;
 using Clio.Common.ScenarioHandlers;
@@ -13,6 +14,40 @@ namespace Clio.Tests.Requests;
 [TestFixture]
 [Property("Module", "Requests")]
 internal class UnzipHandlerTests : BaseClioModuleTests {
+
+	// Replace the production ConsoleLogger with a NullLogger so the handler's spinner is a
+	// deterministic no-op. Otherwise BeginSpinner would animate via Console.SetCursorPosition on
+	// any runner where stdout is not redirected, making the tests OS/terminal-dependent.
+	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
+		base.AdditionalRegistrations(containerBuilder);
+		containerBuilder.AddSingleton<Clio.Common.ILogger>(new Clio.Common.NullLogger());
+	}
+
+	#region Methods: Private
+
+	private static byte[] CreateZipBytes(Action<ZipArchive> build) {
+		using MemoryStream memoryStream = new();
+		using (ZipArchive archive = new(memoryStream, ZipArchiveMode.Create, leaveOpen: true)) {
+			build(archive);
+		}
+		return memoryStream.ToArray();
+	}
+
+	private static byte[] CreateEmptyZipBytes() {
+		return CreateZipBytes(_ => { });
+	}
+
+	// The validator (out of scope for this pilot) still calls the concrete System.IO.File.Exists,
+	// so the source archive must exist on the real disk as well as in the injected MockFileSystem.
+	private static string CreateRealSourceTouch(string workingDirectory, string fileName) {
+		Directory.CreateDirectory(workingDirectory);
+		string realPath = Path.Combine(workingDirectory, fileName);
+		File.WriteAllBytes(realPath, Array.Empty<byte>());
+		return realPath;
+	}
+
+	#endregion
+
 	[Test]
 	[Description("Validates the unzip request explicitly and rejects invalid scenario handler input before extraction runs.")]
 	public async Task Handle_ShouldThrowValidationException_WhenUnzipRequestIsInvalid() {
@@ -31,34 +66,68 @@ internal class UnzipHandlerTests : BaseClioModuleTests {
 	}
 
 	[Test]
+	[Description("Creates the destination directory when it does not exist before extracting, proving the corrected directory-creation logic.")]
+	public async Task Handle_ShouldCreateDestinationDirectory_WhenDestinationDoesNotExist() {
+		// Arrange
+		IUnzipHandler handler = Container.GetRequiredService<IUnzipHandler>();
+		string workingDirectory = Path.Combine(Path.GetTempPath(), $"clio-unzip-{Guid.NewGuid():N}");
+		// Empty zip: the extraction loop body never runs, so ONLY the corrected line-88 logic can
+		// create the destination directory. The previous inverted logic created it only when it
+		// already existed, so this test fails against the bug and passes against the fix.
+		byte[] zipBytes = CreateEmptyZipBytes();
+		string archivePath = CreateRealSourceTouch(workingDirectory, "archive.zip");
+		string destinationDirectory = Path.Combine(workingDirectory, "out");
+		FileSystem.AddFile(archivePath, new MockFileData(zipBytes));
+
+		try {
+			// Act
+			var result = await handler.Handle(new UnzipRequest {
+				Arguments = new() {
+					["from"] = archivePath,
+					["to"] = destinationDirectory
+				}
+			});
+
+			// Assert
+			FileSystem.Directory.Exists(destinationDirectory).Should().BeTrue(
+				because: "the handler must create the destination directory when it is missing");
+			result.Value.Should().NotBeNull(
+				because: "a valid request with a readable archive should return a success response");
+		}
+		finally {
+			if (Directory.Exists(workingDirectory)) {
+				Directory.Delete(workingDirectory, true);
+			}
+		}
+	}
+
+	[Test]
 	[Description("Extracts a valid archive to the target directory when the unzip request passes validation.")]
 	public async Task Handle_ShouldExtractArchive_WhenUnzipRequestIsValid() {
 		// Arrange
 		IUnzipHandler handler = Container.GetRequiredService<IUnzipHandler>();
 		string workingDirectory = Path.Combine(Path.GetTempPath(), $"clio-unzip-{Guid.NewGuid():N}");
-		string archivePath = Path.Combine(workingDirectory, "archive.zip");
 		string destinationDirectory = Path.Combine(workingDirectory, "out");
 		string extractedDirectory = Path.Combine(destinationDirectory, "nested");
-		Directory.CreateDirectory(workingDirectory);
-		Directory.CreateDirectory(destinationDirectory);
-		await using (FileStream archiveStream = File.Create(archivePath))
-		using (ZipArchive archive = new(archiveStream, ZipArchiveMode.Create)) {
-			archive.CreateEntry("nested/");
-		}
-		UnzipRequest request = new() {
-			Arguments = new() {
-				["from"] = archivePath,
-				["to"] = destinationDirectory
-			}
-		};
+		// The handler now reads the archive through the injected MockFileSystem, so the zip is seeded
+		// in-memory; a real touch satisfies the (out-of-scope) validator's concrete File.Exists check.
+		byte[] zipBytes = CreateZipBytes(archive => archive.CreateEntry("nested/"));
+		string archivePath = CreateRealSourceTouch(workingDirectory, "archive.zip");
+		FileSystem.AddFile(archivePath, new MockFileData(zipBytes));
+		FileSystem.Directory.CreateDirectory(destinationDirectory);
 
 		try {
 			// Act
-			var result = await handler.Handle(request);
+			var result = await handler.Handle(new UnzipRequest {
+				Arguments = new() {
+					["from"] = archivePath,
+					["to"] = destinationDirectory
+				}
+			});
 
 			// Assert
-			Directory.Exists(extractedDirectory).Should().BeTrue(
-				because: "a valid request should pass validation and execute the unzip handler");
+			FileSystem.Directory.Exists(extractedDirectory).Should().BeTrue(
+				because: "a valid request should pass validation and execute the unzip handler against the mocked file system");
 			result.Value.Should().NotBeNull(because: "the handler should return a success response");
 		}
 		finally {

--- a/clio.tests/Requests/UnzipHandlerTests.cs
+++ b/clio.tests/Requests/UnzipHandlerTests.cs
@@ -91,8 +91,10 @@ internal class UnzipHandlerTests : BaseClioModuleTests {
 			// Assert
 			FileSystem.Directory.Exists(destinationDirectory).Should().BeTrue(
 				because: "the handler must create the destination directory when it is missing");
-			result.Value.Should().NotBeNull(
-				because: "a valid request with a readable archive should return a success response");
+			result.IsT0.Should().BeTrue(
+				because: "a readable archive yields an UnzipResponse, not a HandlerError");
+			result.AsT0.Status.Should().Be(BaseHandlerResponse.CompletionStatus.Success,
+				because: "a valid request with a readable archive should complete successfully");
 		}
 		finally {
 			if (Directory.Exists(workingDirectory)) {
@@ -128,7 +130,60 @@ internal class UnzipHandlerTests : BaseClioModuleTests {
 			// Assert
 			FileSystem.Directory.Exists(extractedDirectory).Should().BeTrue(
 				because: "a valid request should pass validation and execute the unzip handler against the mocked file system");
-			result.Value.Should().NotBeNull(because: "the handler should return a success response");
+			result.IsT0.Should().BeTrue(
+				because: "a readable archive yields an UnzipResponse, not a HandlerError");
+			result.AsT0.Status.Should().Be(BaseHandlerResponse.CompletionStatus.Success,
+				because: "the handler should complete extraction successfully");
+		}
+		finally {
+			if (Directory.Exists(workingDirectory)) {
+				Directory.Delete(workingDirectory, true);
+			}
+		}
+	}
+
+	[Test]
+	[Category("Integration")]
+	[Description("Extracts a real file entry from a zip archive to disk and verifies its contents, exercising the per-entry ExtractToFile byte-write path that MockFileSystem cannot cover.")]
+	public async Task Handle_ShouldExtractFileEntry_WhenArchiveContainsFile() {
+		// Arrange
+		// This test uses the REAL filesystem: entry.ExtractToFile writes bytes via concrete
+		// System.IO, so MockFileSystem (used by the Unit tests) cannot exercise this path.
+		string workingDirectory = Path.Combine(Path.GetTempPath(), $"clio-unzip-int-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(workingDirectory);
+		try {
+			const string entryName = "hello.txt";
+			byte[] expectedBytes = System.Text.Encoding.UTF8.GetBytes("Hello, clio!");
+			string archivePath = Path.Combine(workingDirectory, "archive.zip");
+			using (FileStream zipStream = File.Create(archivePath))
+			using (ZipArchive archive = new(zipStream, ZipArchiveMode.Create)) {
+				ZipArchiveEntry entry = archive.CreateEntry(entryName);
+				using Stream entryStream = entry.Open();
+				entryStream.Write(expectedBytes, 0, expectedBytes.Length);
+			}
+			string destinationDirectory = Path.Combine(workingDirectory, "out");
+
+			IUnzipHandler handler = new UnzipRequestHandler(
+				new UnzipRequestValidator(),
+				new System.IO.Abstractions.FileSystem(),
+				new Clio.Common.NullLogger());
+
+			// Act
+			var result = await handler.Handle(new UnzipRequest {
+				Arguments = new() {
+					["from"] = archivePath,
+					["to"] = destinationDirectory
+				}
+			});
+
+			// Assert
+			result.IsT0.Should().BeTrue(
+				because: "a readable archive yields an UnzipResponse, not a HandlerError");
+			string extractedFile = Path.Combine(destinationDirectory, entryName);
+			File.Exists(extractedFile).Should().BeTrue(
+				because: "the file entry must be written to disk via the ExtractToFile byte-write path");
+			File.ReadAllBytes(extractedFile).Should().Equal(expectedBytes,
+				because: "the extracted file must contain exactly the bytes stored in the archive entry");
 		}
 		finally {
 			if (Directory.Exists(workingDirectory)) {

--- a/clio/Common/ScenarioHandlers/Unzip.cs
+++ b/clio/Common/ScenarioHandlers/Unzip.cs
@@ -94,7 +94,8 @@ namespace Clio.Common.ScenarioHandlers {
             bool success = false;
             try {
                 // Open the archive through IFileSystem so the file-open is mockable; the per-entry
-                // ExtractToFile below writes bytes via concrete System.IO and is integration-tested.
+                // ExtractToFile below writes bytes via concrete System.IO and is covered by the
+                // [Category("Integration")] test Handle_ShouldExtractFileEntry_WhenArchiveContainsFile.
                 using var stream = _fileSystem.File.OpenRead(zipFileName);
                 using var archive = new ZipArchive(stream);
                 foreach (var entry in archive.Entries) {

--- a/clio/Common/ScenarioHandlers/Unzip.cs
+++ b/clio/Common/ScenarioHandlers/Unzip.cs
@@ -1,9 +1,9 @@
 ﻿using FluentValidation;
 using OneOf;
-using System;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using IAbstractionsFileSystem = System.IO.Abstractions.IFileSystem;
 
 namespace Clio.Common.ScenarioHandlers {
 
@@ -68,57 +68,56 @@ namespace Clio.Common.ScenarioHandlers {
     internal class UnzipRequestHandler : IUnzipHandler {
 
         private readonly IValidator<UnzipRequest> _validator;
-        private readonly char[] _sequence;
-        private int _counter;
-        public UnzipRequestHandler(IValidator<UnzipRequest> validator)
+        private readonly IAbstractionsFileSystem _fileSystem;
+        private readonly ILogger _logger;
+        public UnzipRequestHandler(IValidator<UnzipRequest> validator, IAbstractionsFileSystem fileSystem, ILogger logger)
         {
             _validator = validator;
-            _sequence = new[] { '/', '-', '\\', '|' };
-            _counter = 0;
+            _fileSystem = fileSystem;
+            _logger = logger;
         }
 
         /// <inheritdoc />
-        public async Task<OneOf<UnzipResponse, HandlerError>> Handle(UnzipRequest request) {
+        public Task<OneOf<UnzipResponse, HandlerError>> Handle(UnzipRequest request) {
 
             _validator.ValidateAndThrow(request);
 
             string zipFileName = request.Arguments["from"];
             string destinationDirectory = request.Arguments["to"];
 
-            _ = !Directory.Exists(destinationDirectory) ? null : Directory.CreateDirectory(destinationDirectory);
-
-            using var archive = ZipFile.OpenRead(zipFileName);
-#pragma warning disable CLIO002
-            await Console.Out.WriteAsync("Extracting files: ");
-#pragma warning restore CLIO002
-            foreach (var entry in archive.Entries) {
-                // Skip directories (entries ending with '/')
-                if (!entry.FullName.EndsWith("/")) {
-                    entry.ExtractToFile(Path.Combine(destinationDirectory, entry.FullName), true);
-                    Turn();
-                }
-                else {
-                    var dir = Path.GetDirectoryName(Path.Combine(destinationDirectory, entry.FullName));
-                    Directory.CreateDirectory(dir);
-                }
+            // Ensure the destination directory exists (create it when it does NOT exist).
+            if (!_fileSystem.Directory.Exists(destinationDirectory)) {
+                _fileSystem.Directory.CreateDirectory(destinationDirectory);
             }
-            return new UnzipResponse() {
+
+            _logger.BeginSpinner("Extracting files");
+            bool success = false;
+            try {
+                // Open the archive through IFileSystem so the file-open is mockable; the per-entry
+                // ExtractToFile below writes bytes via concrete System.IO and is integration-tested.
+                using var stream = _fileSystem.File.OpenRead(zipFileName);
+                using var archive = new ZipArchive(stream);
+                foreach (var entry in archive.Entries) {
+                    // Skip directories (entries ending with '/')
+                    if (!entry.FullName.EndsWith("/")) {
+                        entry.ExtractToFile(_fileSystem.Path.Combine(destinationDirectory, entry.FullName), true);
+                    }
+                    else {
+                        var dir = _fileSystem.Path.GetDirectoryName(_fileSystem.Path.Combine(destinationDirectory, entry.FullName));
+                        _fileSystem.Directory.CreateDirectory(dir);
+                    }
+                }
+                success = true;
+            }
+            finally {
+                _logger.EndSpinner(success);
+            }
+
+            return Task.FromResult<OneOf<UnzipResponse, HandlerError>>(new UnzipResponse() {
                 Status = BaseHandlerResponse.CompletionStatus.Success,
                 Description = $"Finished extracting files to {destinationDirectory}"
-            };
+            });
 
-        }
-
-        private void Turn() {
-            _counter++;
-            if (_counter >= _sequence.Length) {
-                _counter = 0;
-            }
-            var position = Console.GetCursorPosition();
-#pragma warning disable CLIO002
-            Console.Write(_sequence[_counter]);
-#pragma warning restore CLIO002
-            Console.SetCursorPosition(position.Left, position.Top);
         }
     }
 }


### PR DESCRIPTION
## Summary

Modernization pilot for `UnzipRequestHandler` (the "boy-scout while we touch a file" playbook). Three improvements, plus the agreed review fixes.

## What changed

- **Bug fix:** the destination-directory creation was inverted (`_ = !Directory.Exists(d) ? null : Directory.CreateDirectory(d)` created the dir only when it *already* existed). Now creates it when missing — covered by a discriminating unit test (empty zip, so only the corrected branch can create the destination).
- **Testability:** inject `System.IO.Abstractions.IFileSystem`; route `Directory`/`Path` ops and the zip file-open through it (`new ZipArchive(_fileSystem.File.OpenRead(...))`). Per-entry `ExtractToFile` stays on concrete `System.IO` (it writes bytes) and is covered by a new **integration** test that extracts a real file entry and asserts on-disk contents.
- **Spinner:** replace the hand-rolled `Console` spinner (`Turn()` + cursor writes) with the existing `ILogger.BeginSpinner`/`EndSpinner`, wrapped in `try/finally` so the background thread always stops. This **removes both CLIO002 suppressions and all direct `Console` usage** from the file, and is MCP-safe by construction (the logger no-ops the animation under `IsMcpServerMode`/redirected output).
- **Async:** dropped (no `await` remained) → `Task.FromResult`; `ValidateAndThrow` kept synchronous (matches the validator's sync rules).

## Validation

- `dotnet test --filter "Category=Unit&(Module=Common|Module=Requests)"` → **566 passed**.
- New `Category=Integration` extraction test passes.
- Multi-lens review (bug / quality / testing): **0 Critical**. The two Important findings — a misleading "integration-tested" comment and weak `OneOf.Value` success assertions — are **fixed in this PR** (real integration test added; assertions strengthened to `IsT0`/`AsT0.Status`).

## Notes / deliberately out of scope

- `UnzipRequestValidator.File.Exists` still uses concrete `System.IO` (converting a FluentValidation validator to `IFileSystem` is a separate pattern) — noted as a follow-up.
- Spectre.Console spinner standardization was considered and **deferred** — clio's existing logger spinner already covers the functional + MCP-safety need; Spectre would be a separate, deliberate initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
