### PR TITLE
CLIO005 analyzer: flag DI services registered but never resolved; enable IDE0051/0052

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -3895,3 +3895,17 @@ Decision: Inject Clio.Common.ILogger; wrap extraction in BeginSpinner/try-finall
 Discovery: ConsoleLogger spinner only no-ops when Console.IsOutputRedirected; tests must inject NullLogger via AdditionalRegistrations (applied after base ILogger reg at BindingsModule.cs:643, last-wins) to stay deterministic cross-OS.
 Files: clio/Common/ScenarioHandlers/Unzip.cs, clio.tests/Requests/UnzipHandlerTests.cs
 Impact: Reference for migrating other hand-rolled Console spinners to the ILogger spinner; shows DI-override pattern to neutralize spinner in command/handler tests.
+
+## 2026-06-16 – CLIO005 false-positive reduction (broadened consumption)
+Context: CLIO005 (UnusedDiServiceAnalyzer) fired ~336 raw / ~168 unique on real clio build, mostly *Command/*Tool resolved indirectly via generic dispatch Resolve<T>() (type arg, not GetRequiredService<Concrete>).
+Decision: broadened consumption in UnusedDiServiceAnalyzer.cs — non-registration generic invocation type-args + generic object-creation type-args (new Bar<Foo>() → Foo) + typeof(Foo) all now count as consumption. Add* registrations excluded from self-consumption (registration branch returns early; typeof inside Add* skipped via IsTypeOfInsideRegistration). Unbound type params skipped naturally (not INamedTypeSymbol).
+Discovery: after fix, unique flagged services 168→71 (raw 336→284; clio multi-targets net8.0+net10.0 so raw doubles, 71 unique on either single or full build). Remaining 71 = 46 MCP *Tool (AddTransient<XTool>() in BindingsModule, instantiated by reflection/[McpServerToolAttribute] scan in McpToolSchemaCatalog — never a type-arg/typeof literal, so legitimately flagged), 11 *Validator, 14 other services. *Command flood gone (now seen via Resolve<T>() in Program.cs).
+Files: Clio.Analyzers/UnusedDiServiceAnalyzer.cs, Clio.Analyzers.Tests/UnusedDiServiceAnalyzerTests.cs
+Impact: analyzer no longer floods on indirect-generic-dispatch resolution; remaining list is the honest candidate set (reflection-resolved MCP tools dominate — would need [ResolvedDynamically] or a reflection-aware heuristic, deliberately NOT applied here).
+
+## 2026-06-16 – CLIO005 MCP reflection heuristic + triage evidence
+Context: CLIO005 flagged 71 services; 46 were MCP tools instantiated by reflection.
+Decision: Generalized the ResolvedDynamically attribute check into a name set {ResolvedDynamicallyAttribute, McpServerToolAttribute}; check type-level AND declared-method-level attributes (McpServerTool sits on a tool METHOD, mirroring McpToolSchemaCatalog's DeclaredOnly assembly scan).
+Discovery: BindingsModule.RegisterFluentValidators (typeof(IValidator<>) loop) and RegisterAssemblyInterfaceTypes (every Clio I* interface) auto-register interfaces reflectively — the analyzer cannot see these, so every explicit concrete AddTransient<XValidator>/<XAssertion>/<XService>() is REDUNDANT-CONCRETE when the type is consumed only via its interface. 71→25 after the MCP heuristic; the remaining 25 are all redundant-concrete (validators, assertions, interface-backed services) except IisScannerHandler concrete (used via static GetSites + alive via IIisScanner/IExternalLinkHandler).
+Files: Clio.Analyzers/UnusedDiServiceAnalyzer.cs, Clio.Analyzers.Tests/UnusedDiServiceAnalyzerTests.cs
+Impact: Heuristic suppresses all 46 MCP tools; triage table classifies the residual 25 for a future removal unit. No production removals in this unit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,12 @@ Treat custom `CLIO*` diagnostics as actionable and rely on `clio/.editorconfig` 
 - Favor DI resolution and constructor injection over manual construction.
 - Using `new`/`new()` for behavior classes should be a last resort, not normal practice.
 
+### CLIO005 specifics
+
+- Favor removing dead DI registrations over suppressing the diagnostic.
+- Use `[ResolvedDynamically]` only for services genuinely resolved via reflection or from another assembly (e.g. `clio.mcp.server`).
+- See the "Using [ResolvedDynamically]" callout in `project-context.md` for the full what/when/when-not guidance.
+
 # Workspace diary
 
 Keep a persistent engineering diary to speed up future tasks.

--- a/Clio.Analyzers.Tests/AnalyzerTestRunner.cs
+++ b/Clio.Analyzers.Tests/AnalyzerTestRunner.cs
@@ -33,8 +33,8 @@ internal static class AnalyzerTestRunner {
 			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
 		CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers([analyzer]);
-		ImmutableArray<Diagnostic> diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-		return diagnostics;
+		AnalysisResult result = await compilationWithAnalyzers.GetAnalysisResultAsync(System.Threading.CancellationToken.None);
+		return result.GetAllDiagnostics();
 	}
 
 	private static MetadataReference[] GetMetadataReferences() {

--- a/Clio.Analyzers.Tests/UnusedDiServiceAnalyzerTests.cs
+++ b/Clio.Analyzers.Tests/UnusedDiServiceAnalyzerTests.cs
@@ -1,0 +1,535 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Analyzers.Tests;
+
+/// <summary>
+/// Verifies <see cref="UnusedDiServiceAnalyzer"/> (CLIO005) diagnostics for DI-registered services
+/// that are never injected or resolved.
+/// </summary>
+public sealed class UnusedDiServiceAnalyzerTests {
+	private const string DiStubs = """
+	                    using Microsoft.Extensions.DependencyInjection;
+	                    namespace Microsoft.Extensions.DependencyInjection {
+	                    	public interface IServiceCollection { }
+	                    	public sealed class ServiceCollection : IServiceCollection { }
+	                    	public static class ServiceCollectionServiceExtensions {
+	                    		public static IServiceCollection AddTransient<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService { return services; }
+	                    		public static IServiceCollection AddTransient<TService>(this IServiceCollection services) { return services; }
+	                    		public static IServiceCollection AddTransient<TService>(this IServiceCollection services, System.Func<System.IServiceProvider, TService> factory) { return services; }
+	                    		public static IServiceCollection AddScoped<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService { return services; }
+	                    		public static IServiceCollection AddScoped<TService>(this IServiceCollection services) { return services; }
+	                    		public static IServiceCollection AddSingleton<TService, TImplementation>(this IServiceCollection services) where TImplementation : TService { return services; }
+	                    		public static IServiceCollection AddSingleton<TService>(this IServiceCollection services) { return services; }
+	                    		public static IServiceCollection AddTransient(this IServiceCollection services, System.Type serviceType, System.Type implementationType) { return services; }
+	                    	}
+	                    	public static class ServiceProviderServiceExtensions {
+	                    		public static T GetRequiredService<T>(this System.IServiceProvider provider) { return default; }
+	                    		public static T GetService<T>(this System.IServiceProvider provider) { return default; }
+	                    		public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this System.IServiceProvider provider) { return default; }
+	                    	}
+	                    }
+
+	                    """;
+
+	[Test]
+	[Description("Reports CLIO005 when a registered service and its implementation are never injected or resolved.")]
+	public async Task RunAnalyzerAsync_WhenRegisteredServiceIsNeverConsumed_ReturnsClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().ContainSingle(d => d.Id == "CLIO005",
+			because: "a service whose interface and implementation are never injected or resolved is dead code");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service is constructor-injected somewhere.")]
+	public async Task RunAnalyzerAsync_WhenServiceIsConstructorInjected_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(IFoo foo) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "constructor injection of the service type counts as consumption");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service is resolved via GetRequiredService<T>.")]
+	public async Task RunAnalyzerAsync_WhenServiceIsResolvedViaGetRequiredService_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public static class Program {
+		                    		public static void Run(System.IServiceProvider provider) {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    			IFoo foo = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<IFoo>(provider);
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "GetRequiredService<IFoo> resolves the service and counts as consumption");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service is resolved via GetServices<T>.")]
+	public async Task RunAnalyzerAsync_WhenServiceIsResolvedViaGetServices_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public static class Program {
+		                    		public static void Run(System.IServiceProvider provider) {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    			var all = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetServices<IFoo>(provider);
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "GetServices<IFoo> resolves the service collection and counts as consumption");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service is injected as IEnumerable<T>.")]
+	public async Task RunAnalyzerAsync_WhenServiceIsInjectedAsIEnumerable_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(System.Collections.Generic.IEnumerable<IFoo> foos) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "an IEnumerable<IFoo> constructor parameter consumes the element type IFoo");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 for a self-registered type that is resolved by its concrete type.")]
+	public async Task RunAnalyzerAsync_WhenSelfRegisteredTypeIsResolved_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public sealed class Foo { }
+		                    	public static class Program {
+		                    		public static void Run(System.IServiceProvider provider) {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<Foo>();
+		                    			Foo foo = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Foo>(provider);
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "a self-registered type resolved by its concrete type is consumed");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when only the concrete implementation is injected (service interface unconsumed).")]
+	public async Task RunAnalyzerAsync_WhenOnlyImplementationIsInjected_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(Foo foo) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "consumption of the implementation type means the registration is not dead even if the interface is unused");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service type is marked [ResolvedDynamically].")]
+	public async Task RunAnalyzerAsync_WhenServiceIsMarkedResolvedDynamically_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public sealed class ResolvedDynamicallyAttribute : System.Attribute { }
+		                    	[ResolvedDynamically]
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "[ResolvedDynamically] opts the service out of the dead-registration diagnostic");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the registered tool type has a method decorated with [McpServerTool] (reflection-scanned MCP tool).")]
+	public async Task RunAnalyzerAsync_WhenRegisteredTypeHasMcpServerToolMethod_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace ModelContextProtocol.Server {
+		                    	[System.AttributeUsage(System.AttributeTargets.Method)]
+		                    	public sealed class McpServerToolAttribute : System.Attribute {
+		                    		public string Name { get; set; }
+		                    	}
+		                    }
+		                    namespace SampleApp {
+		                    	public sealed class InstallGateTool {
+		                    		[ModelContextProtocol.Server.McpServerTool(Name = "install-gate")]
+		                    		public string InstallGate() => null;
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<InstallGateTool>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "a tool type whose method carries [McpServerTool] is instantiated by the MCP reflection scan and is not dead code");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service is resolved indirectly via a generic dispatch helper.")]
+	public async Task RunAnalyzerAsync_WhenServiceIsResolvedViaGenericDispatchHelper_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public sealed class Foo { }
+		                    	public static class Dispatcher {
+		                    		public static T Resolve<T>() => default;
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<Foo>();
+		                    			Foo foo = Dispatcher.Resolve<Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "Foo appears as a generic type argument of the custom Resolve<Foo>() dispatch helper, which counts as indirect resolution");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 when the service implementation is referenced via a typeof expression.")]
+	public async Task RunAnalyzerAsync_WhenImplementationIsReferencedViaTypeof_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IFoo, Foo>();
+		                    			System.Type fooType = typeof(Foo);
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "typeof(Foo) is a reflection-resolution signal that consumes the implementation type Foo");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 for AddSingleton and AddScoped registrations that are consumed.")]
+	public async Task RunAnalyzerAsync_WhenSingletonAndScopedAreConsumed_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface ISingletonService { }
+		                    	public sealed class SingletonService : ISingletonService { }
+		                    	public interface IScopedService { }
+		                    	public sealed class ScopedService : IScopedService { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(ISingletonService s, IScopedService sc) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddSingleton<ISingletonService, SingletonService>();
+		                    			services.AddScoped<IScopedService, ScopedService>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "AddSingleton and AddScoped registrations are tracked just like AddTransient and are consumed here");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 for a concrete type registered by itself that is alive via a consumed constructed generic interface.")]
+	public async Task RunAnalyzerAsync_WhenConcreteRegisteredTypeImplementsConsumedGenericInterface_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IValidator<T> { }
+		                    	public sealed class FooOptions { }
+		                    	public sealed class FooValidator : IValidator<FooOptions> { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(IValidator<FooOptions> validator) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<FooValidator>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "the concrete validator is alive via the consumed constructed interface IValidator<FooOptions> that consumers inject and the reflection registration loop wires");
+	}
+
+	[Test]
+	[Description("Does not report CLIO005 for a concrete type registered by itself that is alive via a consumed non-generic interface.")]
+	public async Task RunAnalyzerAsync_WhenConcreteRegisteredTypeImplementsConsumedInterface_ReturnsNoClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IFoo { }
+		                    	public sealed class Foo : IFoo { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(IFoo foo) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<Foo>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().NotContain(d => d.Id == "CLIO005",
+			because: "the concrete type Foo is alive via the consumed interface IFoo even though Foo itself is never injected directly");
+	}
+
+	[Test]
+	[Description("Reports CLIO005 for an interface+implementation registration whose interface is never consumed anywhere (the Unzip handler case).")]
+	public async Task RunAnalyzerAsync_WhenInterfaceImplementationRegistrationIsNeverConsumed_ReportsClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IBar { }
+		                    	public sealed class Bar : IBar { }
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<IBar, Bar>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().ContainSingle(d => d.Id == "CLIO005",
+			because: "Bar's only interface IBar is never injected anywhere, so the registration remains dead and interface-liveness must not suppress it");
+	}
+
+	[Test]
+	[Description("Reports CLIO005 for a dead validator whose constructed interface differs from the only consumed constructed interface (constructed-to-constructed matching, not open-generic).")]
+	public async Task RunAnalyzerAsync_WhenValidatorImplementsDifferentConstructedInterface_ReportsClio005Diagnostic() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface IValidator<T> { }
+		                    	public sealed class FooOptions { }
+		                    	public sealed class BarOptions { }
+		                    	public sealed class FooValidator : IValidator<FooOptions> { }
+		                    	public sealed class BarValidator : IValidator<BarOptions> { }
+		                    	public sealed class Consumer {
+		                    		public Consumer(IValidator<FooOptions> validator) { }
+		                    	}
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddTransient<FooValidator>();
+		                    			services.AddTransient<BarValidator>();
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Should().ContainSingle(d => d.Id == "CLIO005",
+			because: "only IValidator<FooOptions> is consumed; BarValidator implements IValidator<BarOptions> which is never consumed, so constructed-to-constructed matching must keep BarValidator flagged while FooValidator is suppressed");
+	}
+
+	[Test]
+	[Description("Reports CLIO005 for unconsumed AddSingleton, AddScoped, self-registration, factory and typeof registrations.")]
+	public async Task RunAnalyzerAsync_WhenAllRegistrationFormsAreUnconsumed_ReportsClio005PerRegistration() {
+		// Arrange
+		const string body = """
+		                    namespace SampleApp {
+		                    	public interface ISingletonService { }
+		                    	public sealed class SingletonService : ISingletonService { }
+		                    	public interface IScopedService { }
+		                    	public sealed class ScopedService : IScopedService { }
+		                    	public sealed class SelfRegistered { }
+		                    	public interface IFactoryService { }
+		                    	public sealed class FactoryService : IFactoryService { }
+		                    	public interface ITypeofService { }
+		                    	public sealed class TypeofService : ITypeofService { }
+		                    	public static class Program {
+		                    		public static void Run() {
+		                    			Microsoft.Extensions.DependencyInjection.IServiceCollection services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+		                    			services.AddSingleton<ISingletonService, SingletonService>();
+		                    			services.AddScoped<IScopedService, ScopedService>();
+		                    			services.AddTransient<SelfRegistered>();
+		                    			services.AddTransient<IFactoryService>(_ => new FactoryService());
+		                    			services.AddTransient(typeof(ITypeofService), typeof(TypeofService));
+		                    		}
+		                    	}
+		                    }
+		                    """;
+		UnusedDiServiceAnalyzer analyzer = new();
+
+		// Act
+		var diagnostics = await AnalyzerTestRunner.RunAnalyzerAsync(DiStubs + body, analyzer);
+
+		// Assert
+		diagnostics.Count(d => d.Id == "CLIO005")
+			.Should()
+			.Be(5, because: "each of the five unconsumed registration forms (Singleton, Scoped, self-reg, factory, typeof) is independently dead code");
+	}
+}

--- a/Clio.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Clio.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ CLIO001 | DependencyInjection | Warning | DependencyInjectionManualConstructionA
 CLIO002 | Logging | Warning | ConsoleOutputAnalyzer
 CLIO003 | Architecture | Warning | DirectSystemIoUsageAnalyzer
 CLIO004 | Architecture | Warning | DirectProcessUsageAnalyzer
+CLIO005 | DependencyInjection | Warning | UnusedDiServiceAnalyzer

--- a/Clio.Analyzers/UnusedDiServiceAnalyzer.cs
+++ b/Clio.Analyzers/UnusedDiServiceAnalyzer.cs
@@ -39,6 +39,8 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 
 	private const string ResolvedDynamicallyAttributeName = "ResolvedDynamicallyAttribute";
 
+	private const string McpServerToolAttributeName = "McpServerToolAttribute";
+
 	// Attribute simple names that signal a registered type is consumed by reflection rather than
 	// by an explicit inject/resolve the analyzer can observe. ResolvedDynamicallyAttribute is a
 	// type-level opt-out; McpServerToolAttribute is placed on the tool method (declared on the
@@ -46,7 +48,7 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 	private static readonly ImmutableHashSet<string> ReflectionConsumedAttributeNames = ImmutableHashSet.Create(
 		StringComparer.Ordinal,
 		ResolvedDynamicallyAttributeName,
-		"McpServerToolAttribute");
+		McpServerToolAttributeName);
 
 	private static readonly ImmutableHashSet<string> EnumerableWrapperMetadataNames = ImmutableHashSet.Create(
 		StringComparer.Ordinal,
@@ -68,7 +70,67 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 
 	private static bool IsTestAssembly(Compilation compilation) {
 		string assemblyName = compilation.AssemblyName ?? string.Empty;
-		return assemblyName.IndexOf("test", StringComparison.OrdinalIgnoreCase) >= 0;
+
+		// Precise match: only assemblies literally named "Test"/"Tests" or ending in ".Test"/".Tests"
+		// self-disable the analyzer. The previous broad Contains("test") check misclassified names
+		// such as "LatestThing" or "Attestation". (Out of scope: the other CLIO analyzers still use
+		// the broad check; this fix is intentionally limited to CLIO005.)
+		return assemblyName.Equals("Test", StringComparison.OrdinalIgnoreCase)
+			|| assemblyName.Equals("Tests", StringComparison.OrdinalIgnoreCase)
+			|| assemblyName.EndsWith(".Test", StringComparison.OrdinalIgnoreCase)
+			|| assemblyName.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase);
+	}
+
+	// Collects the concrete type-argument symbols of a generic invocation/name. Symbol-first via the
+	// bound method's substituted TypeArguments; syntax fallback via the GenericNameSyntax + GetTypeInfo
+	// when the symbol could not be bound. Unbound type parameters (e.g. a method/class type parameter T)
+	// surface as non-INamedTypeSymbol and are skipped by both AddConsumed (consumption call sites) and
+	// the `as INamedTypeSymbol` null-checks in CollectRegistration (registration call site), so callers
+	// get faithful, ordered results and apply their own filtering. Order is preserved (service stays [0]).
+	private static ImmutableArray<ITypeSymbol> CollectGenericTypeArgumentSymbols(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		IMethodSymbol? methodSymbol,
+		CancellationToken cancellationToken) {
+		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
+			return methodSymbol.TypeArguments;
+		}
+
+		GenericNameSyntax? genericName = invocation.Expression switch {
+			MemberAccessExpressionSyntax { Name: GenericNameSyntax memberGeneric } => memberGeneric,
+			GenericNameSyntax directGeneric => directGeneric,
+			_ => null
+		};
+
+		if (genericName is null) {
+			return ImmutableArray<ITypeSymbol>.Empty;
+		}
+
+		List<ITypeSymbol> syntaxTypes = [];
+		foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
+			if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
+				syntaxTypes.Add(t);
+			}
+		}
+
+		return syntaxTypes.Count > 0 ? [.. syntaxTypes] : ImmutableArray<ITypeSymbol>.Empty;
+	}
+
+	// Collects the type referenced by each typeof(...) argument of an invocation (e.g. the T in
+	// GetService(typeof(T)) or AddTransient(typeof(IFoo), typeof(Foo))). Order is preserved.
+	private static ImmutableArray<ITypeSymbol> CollectTypeOfArgumentTypes(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		CancellationToken cancellationToken) {
+		List<ITypeSymbol> typeOfTypes = [];
+		foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments) {
+			if (argument.Expression is TypeOfExpressionSyntax typeOf
+				&& semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeOfSymbol) {
+				typeOfTypes.Add(typeOfSymbol);
+			}
+		}
+
+		return typeOfTypes.Count > 0 ? [.. typeOfTypes] : ImmutableArray<ITypeSymbol>.Empty;
 	}
 
 	private static void AnalyzeInvocation(
@@ -77,11 +139,22 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 		ConcurrentDictionary<INamedTypeSymbol, Registration> registrations,
 		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
 		CancellationToken cancellationToken) {
+		string invokedName = GetInvokedMethodName(invocation);
+
+		// Cheap syntactic pre-check: only bind the symbol when this invocation could possibly be a
+		// registration, a resolution, or a generic call carrying concrete type arguments to consume.
+		// Plain non-generic calls (e.g. foo.Bar()) can never contribute and skip the (expensive) bind.
+		bool isRegistrationOrResolutionName = RegistrationMethodNames.Contains(invokedName)
+			|| ResolutionMethodNames.Contains(invokedName);
+		bool isSyntacticallyGeneric = invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax }
+			or GenericNameSyntax;
+		if (!isRegistrationOrResolutionName && !isSyntacticallyGeneric) {
+			return;
+		}
+
 		SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
 		IMethodSymbol? methodSymbol = symbolInfo.Symbol as IMethodSymbol
 			?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
-
-		string invokedName = GetInvokedMethodName(invocation);
 
 		if (RegistrationMethodNames.Contains(invokedName) && IsServiceCollectionRegistration(methodSymbol)) {
 			CollectRegistration(semanticModel, invocation, methodSymbol, registrations, cancellationToken);
@@ -106,24 +179,11 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 		IMethodSymbol? methodSymbol,
 		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
 		CancellationToken cancellationToken) {
-		// Bound symbol: use the substituted type arguments. Unbound type parameters
-		// (e.g. a method/class type parameter T) are not INamedTypeSymbol and are skipped
+		// Consume the concrete type arguments of the generic call. Unbound type parameters are skipped
 		// by AddConsumed, which is the desired behavior.
-		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
-			foreach (ITypeSymbol typeArgument in methodSymbol.TypeArguments) {
-				AddConsumed(consumed, typeArgument);
-			}
-			return;
-		}
-
-		// Syntax-level fallback when the symbol could not be bound.
-		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax memberGeneric }) {
-			CollectTypeArgumentSyntaxes(semanticModel, memberGeneric, consumed, cancellationToken);
-			return;
-		}
-
-		if (invocation.Expression is GenericNameSyntax directGeneric) {
-			CollectTypeArgumentSyntaxes(semanticModel, directGeneric, consumed, cancellationToken);
+		foreach (ITypeSymbol typeArgument in CollectGenericTypeArgumentSymbols(
+			semanticModel, invocation, methodSymbol, cancellationToken)) {
+			AddConsumed(consumed, typeArgument);
 		}
 	}
 
@@ -179,8 +239,9 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 			return false;
 		}
 
-		IMethodSymbol? methodSymbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol
-			?? semanticModel.GetSymbolInfo(invocation).CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+		SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+		IMethodSymbol? methodSymbol = symbolInfo.Symbol as IMethodSymbol
+			?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
 		return IsServiceCollectionRegistration(methodSymbol);
 	}
 
@@ -235,6 +296,12 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 
 		INamedTypeSymbol serviceKey = (INamedTypeSymbol)service.OriginalDefinition;
 		Registration registration = new(serviceKey, (INamedTypeSymbol)impl.OriginalDefinition, invocation.GetLocation());
+
+		// Accepted v1 under-reporting limitation (false-negative, intentional trade-off):
+		// registrations are keyed by service type, so a SECOND registration of the same service type
+		// (e.g. two different implementations of one interface, or the same closed generic registered
+		// twice) is not separately tracked — only the first registration's location is kept. A second,
+		// genuinely dead registration of the same service type is therefore missed.
 		registrations.TryAdd(serviceKey, registration);
 	}
 
@@ -243,34 +310,18 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 		InvocationExpressionSyntax invocation,
 		IMethodSymbol? methodSymbol,
 		CancellationToken cancellationToken) {
-		// Generic registration: Add*<TService>() or Add*<TService, TImpl>().
-		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
-			return methodSymbol.TypeArguments;
-		}
-
-		// Syntax-level fallback for generic args when the symbol could not be bound.
-		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax genericName }
-			&& genericName.TypeArgumentList.Arguments.Count > 0) {
-			List<ITypeSymbol> syntaxTypes = [];
-			foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
-				if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
-					syntaxTypes.Add(t);
-				}
-			}
-			if (syntaxTypes.Count > 0) {
-				return [.. syntaxTypes];
-			}
+		// Generic registration: Add*<TService>() or Add*<TService, TImpl>(). The shared helper returns
+		// the type arguments in order, so the [0]=service / [1]=impl indexing in CollectRegistration is
+		// preserved. Faithful, unfiltered results — CollectRegistration applies its own as-cast/null
+		// checks (so unbound type parameters there bail rather than shifting the service/impl indexes).
+		ImmutableArray<ITypeSymbol> genericTypeArguments = CollectGenericTypeArgumentSymbols(
+			semanticModel, invocation, methodSymbol, cancellationToken);
+		if (genericTypeArguments.Length > 0) {
+			return genericTypeArguments;
 		}
 
 		// Non-generic registration using typeof(...) arguments.
-		List<ITypeSymbol> typeOfTypes = [];
-		foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments) {
-			if (argument.Expression is TypeOfExpressionSyntax typeOf
-				&& semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeOfSymbol) {
-				typeOfTypes.Add(typeOfSymbol);
-			}
-		}
-		return typeOfTypes.Count > 0 ? [.. typeOfTypes] : ImmutableArray<ITypeSymbol>.Empty;
+		return CollectTypeOfArgumentTypes(semanticModel, invocation, cancellationToken);
 	}
 
 	private static void CollectResolution(
@@ -280,28 +331,18 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
 		CancellationToken cancellationToken) {
 		// Generic resolution: GetService<T>() / GetRequiredService<T>() / GetServices<T>().
-		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
-			foreach (ITypeSymbol typeArgument in methodSymbol.TypeArguments) {
+		ImmutableArray<ITypeSymbol> genericTypeArguments = CollectGenericTypeArgumentSymbols(
+			semanticModel, invocation, methodSymbol, cancellationToken);
+		if (genericTypeArguments.Length > 0) {
+			foreach (ITypeSymbol typeArgument in genericTypeArguments) {
 				AddConsumed(consumed, typeArgument);
 			}
 			return;
 		}
 
-		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax genericName }) {
-			foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
-				if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
-					AddConsumed(consumed, t);
-				}
-			}
-			return;
-		}
-
 		// Non-generic resolution: GetService(typeof(T)) / GetRequiredService(typeof(T)).
-		foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments) {
-			if (argument.Expression is TypeOfExpressionSyntax typeOf
-				&& semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeOfSymbol) {
-				AddConsumed(consumed, typeOfSymbol);
-			}
+		foreach (ITypeSymbol typeOfSymbol in CollectTypeOfArgumentTypes(semanticModel, invocation, cancellationToken)) {
+			AddConsumed(consumed, typeOfSymbol);
 		}
 	}
 
@@ -315,6 +356,13 @@ public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
 
 	private static void AddConsumed(ConcurrentDictionary<INamedTypeSymbol, byte> consumed, ITypeSymbol type) {
 		if (type is INamedTypeSymbol named) {
+			// Accepted v1 under-reporting limitation (false-negative, intentional trade-off):
+			// direct service/impl consumption is recorded at open-generic-definition granularity
+			// (OriginalDefinition). The direct-consumption check in CompilationEnd keys on this, so
+			// consuming any closed Foo<X> marks ALL Foo<…> registrations consumed — a dead Foo<Y>
+			// registration is missed when some Foo<X> is consumed. (Interface-liveness, in contrast,
+			// matches constructed-to-constructed via the entry added below; this note is specifically
+			// about the direct service/impl key.)
 			consumed.TryAdd((INamedTypeSymbol)named.OriginalDefinition, 0);
 
 			// Also record the constructed form (e.g. IValidator<ExternalLinkOptions>) so the

--- a/Clio.Analyzers/UnusedDiServiceAnalyzer.cs
+++ b/Clio.Analyzers/UnusedDiServiceAnalyzer.cs
@@ -1,0 +1,490 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Clio.Analyzers;
+
+/// <summary>
+///     Reports diagnostics when a service is registered through Microsoft DI but is never injected
+///     or resolved anywhere in the compilation, indicating possible dead code.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UnusedDiServiceAnalyzer : DiagnosticAnalyzer{
+	private static readonly DiagnosticDescriptor Rule = new(
+		"CLIO005",
+		"DI service is registered but never resolved",
+		"Service '{0}' is registered in DI but never injected or resolved; it may be dead code. Inject/resolve it, remove the registration, or mark it [ResolvedDynamically].",
+		"DependencyInjection",
+		DiagnosticSeverity.Warning,
+		true,
+		"Services registered in dependency injection that are never injected or resolved are likely dead code.",
+		customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
+	private static readonly ImmutableHashSet<string> RegistrationMethodNames = ImmutableHashSet.Create(
+		"AddSingleton",
+		"AddScoped",
+		"AddTransient");
+
+	private static readonly ImmutableHashSet<string> ResolutionMethodNames = ImmutableHashSet.Create(
+		"GetService",
+		"GetRequiredService",
+		"GetServices");
+
+	private const string ResolvedDynamicallyAttributeName = "ResolvedDynamicallyAttribute";
+
+	// Attribute simple names that signal a registered type is consumed by reflection rather than
+	// by an explicit inject/resolve the analyzer can observe. ResolvedDynamicallyAttribute is a
+	// type-level opt-out; McpServerToolAttribute is placed on the tool method (declared on the
+	// registered tool type) and is discovered by McpToolSchemaCatalog's assembly scan at runtime.
+	private static readonly ImmutableHashSet<string> ReflectionConsumedAttributeNames = ImmutableHashSet.Create(
+		StringComparer.Ordinal,
+		ResolvedDynamicallyAttributeName,
+		"McpServerToolAttribute");
+
+	private static readonly ImmutableHashSet<string> EnumerableWrapperMetadataNames = ImmutableHashSet.Create(
+		StringComparer.Ordinal,
+		"IEnumerable`1",
+		"IReadOnlyList`1",
+		"IReadOnlyCollection`1",
+		"ICollection`1",
+		"IList`1",
+		"List`1");
+
+	#region Properties: Public
+
+	/// <inheritdoc />
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+	#endregion
+
+	#region Methods: Private
+
+	private static bool IsTestAssembly(Compilation compilation) {
+		string assemblyName = compilation.AssemblyName ?? string.Empty;
+		return assemblyName.IndexOf("test", StringComparison.OrdinalIgnoreCase) >= 0;
+	}
+
+	private static void AnalyzeInvocation(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		ConcurrentDictionary<INamedTypeSymbol, Registration> registrations,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
+		IMethodSymbol? methodSymbol = symbolInfo.Symbol as IMethodSymbol
+			?? symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+
+		string invokedName = GetInvokedMethodName(invocation);
+
+		if (RegistrationMethodNames.Contains(invokedName) && IsServiceCollectionRegistration(methodSymbol)) {
+			CollectRegistration(semanticModel, invocation, methodSymbol, registrations, cancellationToken);
+			return;
+		}
+
+		if (ResolutionMethodNames.Contains(invokedName)) {
+			CollectResolution(semanticModel, invocation, methodSymbol, consumed, cancellationToken);
+			return;
+		}
+
+		// Any other generic method invocation (e.g. a custom dispatch helper such as
+		// Resolve<ExtractPackageCommand>() or LINQ's OfType<Foo>()) consumes its concrete
+		// type arguments. Service-collection Add* registrations are handled above and
+		// returned early, so they never reach here and cannot count as self-consumption.
+		CollectGenericInvocationTypeArguments(semanticModel, invocation, methodSymbol, consumed, cancellationToken);
+	}
+
+	private static void CollectGenericInvocationTypeArguments(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		IMethodSymbol? methodSymbol,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		// Bound symbol: use the substituted type arguments. Unbound type parameters
+		// (e.g. a method/class type parameter T) are not INamedTypeSymbol and are skipped
+		// by AddConsumed, which is the desired behavior.
+		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
+			foreach (ITypeSymbol typeArgument in methodSymbol.TypeArguments) {
+				AddConsumed(consumed, typeArgument);
+			}
+			return;
+		}
+
+		// Syntax-level fallback when the symbol could not be bound.
+		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax memberGeneric }) {
+			CollectTypeArgumentSyntaxes(semanticModel, memberGeneric, consumed, cancellationToken);
+			return;
+		}
+
+		if (invocation.Expression is GenericNameSyntax directGeneric) {
+			CollectTypeArgumentSyntaxes(semanticModel, directGeneric, consumed, cancellationToken);
+		}
+	}
+
+	private static void CollectTypeArgumentSyntaxes(
+		SemanticModel semanticModel,
+		GenericNameSyntax genericName,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
+			if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
+				AddConsumed(consumed, t);
+			}
+		}
+	}
+
+	private static void AnalyzeObjectCreation(
+		SemanticModel semanticModel,
+		ObjectCreationExpressionSyntax objectCreation,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		// Generic object creation new Bar<Foo>() consumes the type argument Foo, NOT Bar.
+		if (objectCreation.Type is not GenericNameSyntax genericName) {
+			return;
+		}
+
+		CollectTypeArgumentSyntaxes(semanticModel, genericName, consumed, cancellationToken);
+	}
+
+	private static void AnalyzeTypeOf(
+		SemanticModel semanticModel,
+		TypeOfExpressionSyntax typeOf,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		// A typeof(Foo) expression is a reflection-resolution signal and consumes Foo,
+		// EXCEPT when it is an argument to a service-collection Add* registration
+		// (that is the registration under test, not a consumption of it).
+		if (IsTypeOfInsideRegistration(semanticModel, typeOf)) {
+			return;
+		}
+
+		if (semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeSymbol) {
+			AddConsumed(consumed, typeSymbol);
+		}
+	}
+
+	private static bool IsTypeOfInsideRegistration(SemanticModel semanticModel, TypeOfExpressionSyntax typeOf) {
+		if (typeOf.Parent is not ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax invocation } }) {
+			return false;
+		}
+
+		string invokedName = GetInvokedMethodName(invocation);
+		if (!RegistrationMethodNames.Contains(invokedName)) {
+			return false;
+		}
+
+		IMethodSymbol? methodSymbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol
+			?? semanticModel.GetSymbolInfo(invocation).CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+		return IsServiceCollectionRegistration(methodSymbol);
+	}
+
+	private static string GetInvokedMethodName(InvocationExpressionSyntax invocation) {
+		return invocation.Expression switch {
+			MemberAccessExpressionSyntax memberAccess => memberAccess.Name switch {
+				IdentifierNameSyntax id => id.Identifier.ValueText,
+				GenericNameSyntax generic => generic.Identifier.ValueText,
+				_ => string.Empty
+			},
+			IdentifierNameSyntax id => id.Identifier.ValueText,
+			GenericNameSyntax generic => generic.Identifier.ValueText,
+			_ => string.Empty
+		};
+	}
+
+	private static bool IsServiceCollectionRegistration(IMethodSymbol? methodSymbol) {
+		if (methodSymbol is null) {
+			return false;
+		}
+
+		IMethodSymbol sourceMethod = methodSymbol.ReducedFrom ?? methodSymbol;
+		string ns = sourceMethod.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+		return ns.StartsWith("Microsoft.Extensions.DependencyInjection", StringComparison.Ordinal);
+	}
+
+	private static void CollectRegistration(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		IMethodSymbol? methodSymbol,
+		ConcurrentDictionary<INamedTypeSymbol, Registration> registrations,
+		CancellationToken cancellationToken) {
+		ImmutableArray<ITypeSymbol> typeArguments = ResolveRegistrationTypeArguments(
+			semanticModel, invocation, methodSymbol, cancellationToken);
+		if (typeArguments.Length == 0) {
+			return;
+		}
+
+		INamedTypeSymbol? service = typeArguments[0] as INamedTypeSymbol;
+		INamedTypeSymbol? impl = typeArguments.Length >= 2
+			? typeArguments[1] as INamedTypeSymbol
+			: service;
+
+		if (service is null || impl is null) {
+			return;
+		}
+
+		// Skip open generics for v1 (e.g. AddTransient(typeof(IFoo<>), typeof(Foo<>))).
+		if (service.IsUnboundGenericType || impl.IsUnboundGenericType) {
+			return;
+		}
+
+		INamedTypeSymbol serviceKey = (INamedTypeSymbol)service.OriginalDefinition;
+		Registration registration = new(serviceKey, (INamedTypeSymbol)impl.OriginalDefinition, invocation.GetLocation());
+		registrations.TryAdd(serviceKey, registration);
+	}
+
+	private static ImmutableArray<ITypeSymbol> ResolveRegistrationTypeArguments(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		IMethodSymbol? methodSymbol,
+		CancellationToken cancellationToken) {
+		// Generic registration: Add*<TService>() or Add*<TService, TImpl>().
+		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
+			return methodSymbol.TypeArguments;
+		}
+
+		// Syntax-level fallback for generic args when the symbol could not be bound.
+		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax genericName }
+			&& genericName.TypeArgumentList.Arguments.Count > 0) {
+			List<ITypeSymbol> syntaxTypes = [];
+			foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
+				if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
+					syntaxTypes.Add(t);
+				}
+			}
+			if (syntaxTypes.Count > 0) {
+				return [.. syntaxTypes];
+			}
+		}
+
+		// Non-generic registration using typeof(...) arguments.
+		List<ITypeSymbol> typeOfTypes = [];
+		foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments) {
+			if (argument.Expression is TypeOfExpressionSyntax typeOf
+				&& semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeOfSymbol) {
+				typeOfTypes.Add(typeOfSymbol);
+			}
+		}
+		return typeOfTypes.Count > 0 ? [.. typeOfTypes] : ImmutableArray<ITypeSymbol>.Empty;
+	}
+
+	private static void CollectResolution(
+		SemanticModel semanticModel,
+		InvocationExpressionSyntax invocation,
+		IMethodSymbol? methodSymbol,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed,
+		CancellationToken cancellationToken) {
+		// Generic resolution: GetService<T>() / GetRequiredService<T>() / GetServices<T>().
+		if (methodSymbol is not null && methodSymbol.TypeArguments.Length > 0) {
+			foreach (ITypeSymbol typeArgument in methodSymbol.TypeArguments) {
+				AddConsumed(consumed, typeArgument);
+			}
+			return;
+		}
+
+		if (invocation.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax genericName }) {
+			foreach (TypeSyntax arg in genericName.TypeArgumentList.Arguments) {
+				if (semanticModel.GetTypeInfo(arg, cancellationToken).Type is { } t) {
+					AddConsumed(consumed, t);
+				}
+			}
+			return;
+		}
+
+		// Non-generic resolution: GetService(typeof(T)) / GetRequiredService(typeof(T)).
+		foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments) {
+			if (argument.Expression is TypeOfExpressionSyntax typeOf
+				&& semanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type is { } typeOfSymbol) {
+				AddConsumed(consumed, typeOfSymbol);
+			}
+		}
+	}
+
+	private static void CollectConstructorParameters(
+		IMethodSymbol constructor,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed) {
+		foreach (IParameterSymbol parameter in constructor.Parameters) {
+			AddConsumed(consumed, parameter.Type);
+		}
+	}
+
+	private static void AddConsumed(ConcurrentDictionary<INamedTypeSymbol, byte> consumed, ITypeSymbol type) {
+		if (type is INamedTypeSymbol named) {
+			consumed.TryAdd((INamedTypeSymbol)named.OriginalDefinition, 0);
+
+			// Also record the constructed form (e.g. IValidator<ExternalLinkOptions>) so the
+			// CompilationEnd interface-liveness check can match it constructed-to-constructed against
+			// a registered type's AllInterfaces. The OriginalDefinition entry above keeps direct
+			// service/impl consumption lookups (which key on OriginalDefinition) working unchanged.
+			if (!SymbolEqualityComparer.Default.Equals(named, named.OriginalDefinition)) {
+				consumed.TryAdd(named, 0);
+			}
+
+			// IEnumerable<T> / IReadOnlyList<T> / List<T> etc. -> also consume the element type T.
+			if (named.IsGenericType
+				&& named.TypeArguments.Length == 1
+				&& EnumerableWrapperMetadataNames.Contains(named.OriginalDefinition.MetadataName)
+				&& named.TypeArguments[0] is INamedTypeSymbol elementType) {
+				consumed.TryAdd((INamedTypeSymbol)elementType.OriginalDefinition, 0);
+			}
+			return;
+		}
+
+		// T[] -> consume the element type T.
+		if (type is IArrayTypeSymbol arrayType && arrayType.ElementType is INamedTypeSymbol arrayElement) {
+			consumed.TryAdd((INamedTypeSymbol)arrayElement.OriginalDefinition, 0);
+		}
+	}
+
+	private static bool ImplementsConsumedInterface(
+		INamedTypeSymbol type,
+		ConcurrentDictionary<INamedTypeSymbol, byte> consumed) {
+		// AllInterfaces covers the type's own interfaces plus all transitively inherited ones,
+		// and yields constructed forms (e.g. IValidator<ExternalLinkOptions>). The consumed set
+		// is keyed with SymbolEqualityComparer.Default, so a constructed interface present in
+		// AllInterfaces matches the constructed interface recorded from a constructor parameter.
+		foreach (INamedTypeSymbol implementedInterface in type.AllInterfaces) {
+			if (consumed.ContainsKey(implementedInterface)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool IsReflectionConsumed(INamedTypeSymbol type) {
+		// Type-level signal (e.g. [ResolvedDynamically]).
+		if (HasReflectionConsumedAttribute(type)) {
+			return true;
+		}
+
+		// Member-level signal: the MCP tool attribute sits on a declared instance method of the
+		// registered tool type, mirroring McpToolSchemaCatalog's DeclaredOnly assembly scan.
+		// Declared members only (no base walk) keeps the analyzer's notion of "is a tool" identical
+		// to the runtime catalog.
+		foreach (ISymbol member in type.GetMembers()) {
+			if (member is IMethodSymbol && HasReflectionConsumedAttribute(member)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool HasReflectionConsumedAttribute(ISymbol symbol) {
+		return symbol.GetAttributes().Any(attr =>
+			attr.AttributeClass?.Name is { } name && ReflectionConsumedAttributeNames.Contains(name));
+	}
+
+	#endregion
+
+	#region Methods: Public
+
+	/// <inheritdoc />
+	public override void Initialize(AnalysisContext context) {
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.EnableConcurrentExecution();
+
+		context.RegisterCompilationStartAction(startContext => {
+			if (IsTestAssembly(startContext.Compilation)) {
+				return;
+			}
+
+			ConcurrentDictionary<INamedTypeSymbol, Registration> registrations
+				= new(SymbolEqualityComparer.Default);
+			ConcurrentDictionary<INamedTypeSymbol, byte> consumed
+				= new(SymbolEqualityComparer.Default);
+
+			startContext.RegisterSyntaxNodeAction(
+				syntaxContext => AnalyzeInvocation(
+					syntaxContext.SemanticModel,
+					(InvocationExpressionSyntax)syntaxContext.Node,
+					registrations,
+					consumed,
+					syntaxContext.CancellationToken),
+				SyntaxKind.InvocationExpression);
+
+			startContext.RegisterSyntaxNodeAction(
+				syntaxContext => AnalyzeObjectCreation(
+					syntaxContext.SemanticModel,
+					(ObjectCreationExpressionSyntax)syntaxContext.Node,
+					consumed,
+					syntaxContext.CancellationToken),
+				SyntaxKind.ObjectCreationExpression);
+
+			startContext.RegisterSyntaxNodeAction(
+				syntaxContext => AnalyzeTypeOf(
+					syntaxContext.SemanticModel,
+					(TypeOfExpressionSyntax)syntaxContext.Node,
+					consumed,
+					syntaxContext.CancellationToken),
+				SyntaxKind.TypeOfExpression);
+
+			startContext.RegisterSymbolAction(
+				symbolContext => {
+					if (symbolContext.Symbol is IMethodSymbol { MethodKind: MethodKind.Constructor } constructor) {
+						CollectConstructorParameters(constructor, consumed);
+					}
+				},
+				SymbolKind.Method);
+
+			startContext.RegisterCompilationEndAction(endContext => {
+				foreach (Registration registration in registrations.Values) {
+					bool serviceConsumed = consumed.ContainsKey(registration.Service);
+					bool implConsumed = consumed.ContainsKey(registration.Implementation);
+					if (serviceConsumed || implConsumed) {
+						continue;
+					}
+
+					if (IsReflectionConsumed(registration.Service)
+						|| IsReflectionConsumed(registration.Implementation)) {
+						continue;
+					}
+
+					// Interface-liveness: a concrete type registered explicitly (e.g.
+					// AddTransient<ExternalLinkOptionsValidator>()) is alive when consumers inject one
+					// of the interfaces it implements (e.g. IValidator<ExternalLinkOptions>) and the
+					// reflection registration loops (RegisterFluentValidators /
+					// RegisterAssemblyInterfaceTypes) wire the concrete to that interface at runtime.
+					// Match constructed-to-constructed (consumed holds the constructed interface; see
+					// AddConsumed) so IValidator<ExternalLinkOptions> matches exactly and the open
+					// IValidator<> alone does not over-suppress.
+					// Known, accepted limitation: a genuinely dead concrete type that merely implements
+					// a consumed interface (but is not the registered impl actually wired to it) is
+					// missed. This is an accepted trade-off to avoid false-flagging the legitimate
+					// concrete+interface pattern that clio's reflection registration loops create.
+					if (ImplementsConsumedInterface(registration.Implementation, consumed)
+						|| ImplementsConsumedInterface(registration.Service, consumed)) {
+						continue;
+					}
+
+					endContext.ReportDiagnostic(Diagnostic.Create(
+						Rule,
+						registration.Location,
+						registration.Service.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+				}
+			});
+		});
+	}
+
+	#endregion
+
+	private sealed class Registration{
+		public Registration(INamedTypeSymbol service, INamedTypeSymbol implementation, Location location) {
+			Service = service;
+			Implementation = implementation;
+			Location = location;
+		}
+
+		public INamedTypeSymbol Service { get; }
+
+		public INamedTypeSymbol Implementation { get; }
+
+		public Location Location { get; }
+	}
+}

--- a/clio/.editorconfig
+++ b/clio/.editorconfig
@@ -102,3 +102,11 @@ dotnet_diagnostic.CLIO096.severity = warning
 dotnet_diagnostic.CLIO097.severity = warning
 dotnet_diagnostic.CLIO098.severity = warning
 dotnet_diagnostic.CLIO099.severity = warning
+
+# Built-in dead-code style rules.
+# IDE0051: unused private member; IDE0052: unread private field.
+# These surface unused-private-member feedback in the IDE (Rider/VS) by default.
+# Command-line/CI build enforcement additionally requires
+# EnforceCodeStyleInBuild=true in the project (a separate, deliberate decision).
+dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.IDE0052.severity = warning

--- a/clio/Common/ResolvedDynamicallyAttribute.cs
+++ b/clio/Common/ResolvedDynamicallyAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Clio.Common;
+
+/// <summary>
+///     Marks a type that is registered in dependency injection but resolved dynamically
+///     (for example via reflection, the MCP server, or another assembly) rather than through
+///     direct constructor injection or a <c>GetService</c>/<c>GetRequiredService</c> call.
+/// </summary>
+/// <remarks>
+///     The CLIO005 analyzer treats a registered service as dead code when neither the service
+///     type nor its implementation is consumed within the compilation. Because a single-compilation
+///     analyzer cannot see cross-assembly or reflection-based resolution, apply this attribute to
+///     such types to opt out of the diagnostic.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, Inherited = false)]
+public sealed class ResolvedDynamicallyAttribute : Attribute{ }

--- a/project-context.md
+++ b/project-context.md
@@ -36,10 +36,26 @@
 - ~65 existing violations are tracked in `spec/cli-naming/camelcase-violations.md` — do not add new ones
 - When renaming a flag, add an alias for the old name (breaking change policy)
 
-### Roslyn analyzers (CLIO001-CLIO004)
+### Roslyn analyzers (CLIO001-CLIO005)
 - CLIO001: CLI option naming (kebab-case)
 - CLIO002-CLIO004: see `Clio.Analyzers/` for details
+- CLIO005: DI service registered but never injected/resolved (catches dead DI registrations)
 - All analyzer warnings are treated as errors in CI
+
+### Using [ResolvedDynamically]
+- **WHAT:** `Clio.Common.ResolvedDynamicallyAttribute` marks a class or interface that IS used
+  but is resolved by a mechanism CLIO005 (a single-compilation analyzer) cannot see — reflection /
+  assembly scanning, or resolution from another assembly (e.g. `clio.mcp.server`). It tells CLIO005
+  the registration is alive.
+- **WHEN to use:** ONLY when CLIO005 flags a registration that is genuinely consumed via
+  reflection / cross-assembly / dynamic resolution with no statically-visible injection or
+  `GetService` / `GetRequiredService` / `GetServices<T>` call. Apply `[ResolvedDynamically]` to the
+  service or the implementation type.
+- **WHEN NOT to use:** do NOT use it to silence CLIO005 on a genuinely-dead registration. If nothing
+  actually resolves the type, REMOVE the DI registration (and the dead type) instead. Prefer fixing
+  (inject/resolve, or delete) over suppressing.
+- CLIO005 already auto-exempts types reflection-instantiated via `[McpServerTool]` methods and types
+  that implement a consumed interface — so the attribute is only for cases outside those.
 
 ### MCP server
 - `clio.mcp.server/` exposes CLI commands over Model Context Protocol


### PR DESCRIPTION
## Summary

Prevents the "registered in DI but never resolved" dead-code class — the kind that left `UnzipRequestHandler` dead despite being DI-registered — from surviving review.

## CLIO005 — UnusedDiServiceAnalyzer

Flags a service registered via `IServiceCollection.Add*` whose **neither service nor implementation type** is ever consumed. "Consumed" = constructor parameter (incl. `IEnumerable<T>` element), `GetService`/`GetRequiredService`/`GetServices<T>`, any non-registration generic invocation's concrete type-args (so generic dispatch like `Resolve<T>()` counts), generic object-creation type-args, and `typeof(T)`.

Precision tuned to clio's actual DI reality so it has **0 false positives on the current codebase** while still flagging a genuinely registration-only type:
- generic dispatch (`Resolve<ExtractPackageCommand>()`) counts as consumption;
- types reflection-instantiated via `[McpServerTool]` methods are exempt (mirrors `McpToolSchemaCatalog`'s scan);
- a type implementing a **consumed interface** is treated as alive — models the `RegisterFluentValidators` / `RegisterAssemblyInterfaceTypes` reflection loops, so "register concrete + inject interface" is not falsely flagged.
- `[ResolvedDynamically]` opt-out provided for reflection/cross-assembly resolution a single-compilation analyzer can't see.

Tuning trail: 336 raw → after generic-dispatch fix → after `[McpServerTool]` heuristic (71) → after interface-liveness (25→**0**). Triage confirmed all intermediate flags were live-via-interface, not dead.

Two accepted v1 limitations are documented in-code (both under-reporting / never false-positive): duplicate registration of the same service type, and open-generic direct-consumption granularity.

## Also: enable IDE0051/IDE0052

`clio/.editorconfig` now enables the built-in unused-private-member / unread-private-field rules for IDE-time feedback. CLI/CI enforcement (`EnforceCodeStyleInBuild`) is left as a **separate decision** — measured at ~138 latent hits, some of which are injected-DI fields needing review before any cleanup. `CS0169/CS0649` (compiler-level) are already clean.

## Validation

- `dotnet test Clio.Analyzers.Tests` → **47 passed**. CLIO005 on the real clio build → **0**.
- Multi-lens review (bug / quality / performance): **0 Critical**. Performance review found CLIO005 better-shaped than the existing CLIO001 (per-node + `CompilationEnd`, no eager whole-tree semantic-model scan). The Important findings (two under-reporting edge cases + a collector dedup) are addressed or documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
