### PR TITLE
fix: align clio retry vocabulary with maxAttempts; publish with a single attempt

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageVersion Include="creatio.client" Version="1.0.37" />
+    <PackageVersion Include="creatio.client" Version="1.0.38" />
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.5" />
     <PackageVersion Include="ErrorOr" Version="2.1.1" />

--- a/clio.tests/Command/HealthCheckCommand.Tests.cs
+++ b/clio.tests/Command/HealthCheckCommand.Tests.cs
@@ -38,7 +38,7 @@ public class HealthCheckCommandTestCase
 		_applicationClient.Received(1).ExecuteGetRequest(
 			_environmentSettings.Uri + "/0/api/HealthCheck/Ping",
 			options.TimeOut,
-			options.RetryCount,
+			options.MaxAttempts,
 			options.RetryDelay);
 	}
 
@@ -51,7 +51,7 @@ public class HealthCheckCommandTestCase
 		_applicationClient.Received(1).ExecuteGetRequest(
 			_environmentSettings.Uri + "/api/HealthCheck/Ping",
 			options.TimeOut,
-			options.RetryCount,
+			options.MaxAttempts,
 			options.RetryDelay);
 	}
 
@@ -63,7 +63,7 @@ public class HealthCheckCommandTestCase
 		_applicationClient.Received(1).ExecuteGetRequest(
 			_environmentSettings.Uri + "/0/api/HealthCheck/Ping",
 			options.TimeOut,
-			options.RetryCount,
+			options.MaxAttempts,
 			options.RetryDelay);
 	}
 
@@ -77,7 +77,7 @@ public class HealthCheckCommandTestCase
 		_applicationClient.Received(1).ExecuteGetRequest(
 			_environmentSettings.Uri + "/api/HealthCheck/Ping",
 			options.TimeOut,
-			options.RetryCount,
+			options.MaxAttempts,
 			options.RetryDelay);
 	}
 

--- a/clio.tests/Command/PingAppCommandTests.cs
+++ b/clio.tests/Command/PingAppCommandTests.cs
@@ -36,7 +36,7 @@ internal class PingAppCommandTests : BaseCommandTests<PingAppOptions>{
 		EnvironmentSettings.IsNetCore = isNetCore;
 		PingAppOptions options = new () {
 			TimeOut = 1, 
-			RetryCount = 2, 
+			MaxAttempts = 2, 
 			RetryDelay = 3
 		};
 			
@@ -59,7 +59,7 @@ internal class PingAppCommandTests : BaseCommandTests<PingAppOptions>{
 		//Arrange
 		PingAppOptions options = new () {
 			TimeOut = 1,
-			RetryCount = 2,
+			MaxAttempts = 2,
 			RetryDelay = 3,
 			IsNetCore = isNetCore
 		};

--- a/clio.tests/Command/RemoteEntitySchemaDesignerClientTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaDesignerClientTests.cs
@@ -120,18 +120,18 @@ internal class RemoteEntitySchemaDesignerClientTests
 	}
 
 	[Test]
-	[Description("Publish uses the build-class timeout and retryCount=0 so a slow-but-successful legacy BuildWorkspace is not mistaken for a failure and not re-issued (ENG-90403).")]
-	public void PublishConfigurationChanges_UsesBuildClassTimeout_AndZeroRetries() {
+	[Description("Publish uses the build-class timeout and a single attempt (maxAttempts=1) so a slow-but-successful legacy BuildWorkspace is not mistaken for a failure and not re-issued (ENG-90403).")]
+	public void PublishConfigurationChanges_UsesBuildClassTimeout_AndSingleAttempt() {
 		// Arrange
 		_serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.SchemaDesignerRequest)
 			.Returns("http://local/DataService/json/SyncReply/SchemaDesignerRequest");
 		int capturedTimeout = 0;
-		int capturedRetryCount = -1;
+		int capturedMaxAttempts = -1;
 		_applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
 			Arg.Any<int>())
 			.Returns(callInfo => {
 				capturedTimeout = callInfo.ArgAt<int>(2);
-				capturedRetryCount = callInfo.ArgAt<int>(3);
+				capturedMaxAttempts = callInfo.ArgAt<int>(3);
 				return "{\"success\":true}";
 			});
 
@@ -141,8 +141,8 @@ internal class RemoteEntitySchemaDesignerClientTests
 		// Assert
 		capturedTimeout.Should().Be(RemoteEntitySchemaDesignerClient.PublishConfigurationTimeoutMs,
 			because: "a full server-side BuildWorkspace on a legacy instance can exceed 100s; publish must use the build-class timeout");
-		capturedRetryCount.Should().Be(0,
-			because: "the build POST is non-idempotent — retrying a timed-out build may stack concurrent compiles");
+		capturedMaxAttempts.Should().Be(1,
+			because: "publish must issue exactly one attempt and no retry — the build POST is non-idempotent and retrying a timed-out build may stack concurrent compiles");
 	}
 
 	private static bool ContainsJsonFlag(string body, string flagName) {

--- a/clio/Command/CreateUserTaskCommand.cs
+++ b/clio/Command/CreateUserTaskCommand.cs
@@ -128,7 +128,7 @@ public class CreateUserTaskCommand : RemoteCommand<CreateUserTaskOptions> {
 			PackageUId = packageUId
 		});
 		string createResponseJson = ApplicationClient.ExecutePostRequest(createNewSchemaUrl, createRequestBody,
-			RequestTimeout, RetryCount, DelaySec);
+			RequestTimeout, MaxAttempts, DelaySec);
 
 		DesignerResponse<ProcessUserTaskDesignSchemaDto> createResponse = UserTaskSchemaSupport
 			.Deserialize<DesignerResponse<ProcessUserTaskDesignSchemaDto>>(createResponseJson, "CreateNewSchema");
@@ -142,7 +142,7 @@ public class CreateUserTaskCommand : RemoteCommand<CreateUserTaskOptions> {
 		string saveSchemaUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.SaveUserTaskSchema);
 		string saveRequestBody = JsonSerializer.Serialize(schema);
 		string saveResponseJson = ApplicationClient.ExecutePostRequest(saveSchemaUrl, saveRequestBody, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 
 		SaveDesignItemDesignerResponse saveResponse = UserTaskSchemaSupport
 			.Deserialize<SaveDesignItemDesignerResponse>(saveResponseJson, "SaveSchema");
@@ -164,7 +164,7 @@ public class CreateUserTaskCommand : RemoteCommand<CreateUserTaskOptions> {
 			PackageName = packageName
 		});
 		Logger.WriteInfo($"Building package '{packageName}'...");
-		ApplicationClient.ExecutePostRequest(buildPackageUrl, buildRequestBody, RequestTimeout, RetryCount, DelaySec);
+		ApplicationClient.ExecutePostRequest(buildPackageUrl, buildRequestBody, RequestTimeout, MaxAttempts, DelaySec);
 	}
 
 	private void ApplyParameterDirectionMetadataIfNeeded(string packageName, string schemaName,

--- a/clio/Command/DeleteSchemaCommand.cs
+++ b/clio/Command/DeleteSchemaCommand.cs
@@ -87,7 +87,7 @@ public class DeleteSchemaCommand : RemoteCommand<DeleteSchemaOptions> {
 		string deleteUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.DeleteWorkspaceItem);
 		string deleteRequestBody = JsonSerializer.Serialize(new[] { schemaItem });
 		string deleteResponseJson = ApplicationClient.ExecutePostRequest(deleteUrl, deleteRequestBody, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 
 		DeleteWorkspaceItemsResponse deleteResponse =
 			Deserialize<DeleteWorkspaceItemsResponse>(deleteResponseJson, "Delete");
@@ -110,7 +110,7 @@ public class DeleteSchemaCommand : RemoteCommand<DeleteSchemaOptions> {
 			// silent success:true rowsAffected:0 — see clio.tests/Command/DeleteSchemaRemoteCommandTests.
 			string itemsUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.GetWorkspaceItems);
 			string itemsJson = ApplicationClient.ExecutePostRequest(
-				itemsUrl, string.Empty, RequestTimeout, RetryCount, DelaySec);
+				itemsUrl, string.Empty, RequestTimeout, MaxAttempts, DelaySec);
 			WorkspaceItemsResponse itemsResponse =
 				Deserialize<WorkspaceItemsResponse>(itemsJson, "GetWorkspaceItems");
 			WorkspaceExplorerItemDto item = (itemsResponse.Items ?? [])
@@ -125,7 +125,7 @@ public class DeleteSchemaCommand : RemoteCommand<DeleteSchemaOptions> {
 			string deleteUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.DeleteWorkspaceItem);
 			string requestBody = JsonSerializer.Serialize(new[] { item });
 			string responseJson = ApplicationClient.ExecutePostRequest(
-				deleteUrl, requestBody, RequestTimeout, RetryCount, DelaySec);
+				deleteUrl, requestBody, RequestTimeout, MaxAttempts, DelaySec);
 			DeleteWorkspaceItemsResponse deleteResponse =
 				Deserialize<DeleteWorkspaceItemsResponse>(responseJson, "Delete");
 			if (!deleteResponse.Success || deleteResponse.RowsAffected <= 0) {
@@ -196,7 +196,7 @@ public class DeleteSchemaCommand : RemoteCommand<DeleteSchemaOptions> {
 	private WorkspaceExplorerItemDto FindWorkspaceSchemaItem(string schemaName, HashSet<string> workspacePackages) {
 		string getWorkspaceItemsUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.GetWorkspaceItems);
 		string responseJson = ApplicationClient.ExecutePostRequest(getWorkspaceItemsUrl, string.Empty, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 
 		WorkspaceItemsResponse response = Deserialize<WorkspaceItemsResponse>(responseJson, "GetWorkspaceItems");
 		List<WorkspaceExplorerItemDto> matches = (response.Items ?? [])

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaDesignerClient.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaDesignerClient.cs
@@ -130,7 +130,8 @@ internal sealed class RemoteEntitySchemaDesignerClient : IRemoteEntitySchemaDesi
 
 	public BaseResponse PublishConfigurationChanges(RemoteCommandOptions options) {
 		// Build POST is non-idempotent: retrying a timed-out build may stack concurrent full compiles.
-		// Use the build-class timeout and retryCount=0 regardless of the command-level defaults.
+		// One attempt, no retries (maxAttempts: 1), regardless of the command-level defaults. The value is
+		// the total attempt count (minimum 1), so 1 issues exactly one request with no retry.
 		return PostToUrl<SchemaDesignerRequestDto, BaseResponse>(
 			_serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.SchemaDesignerRequest),
 			new SchemaDesignerRequestDto {
@@ -138,7 +139,7 @@ internal sealed class RemoteEntitySchemaDesignerClient : IRemoteEntitySchemaDesi
 				BuildChangedConfiguration = true
 			},
 			PublishConfigurationTimeoutMs,
-			retryCount: 0,
+			maxAttempts: 1,
 			options.RetryDelay,
 			"PublishConfigurationChanges");
 	}
@@ -232,16 +233,16 @@ internal sealed class RemoteEntitySchemaDesignerClient : IRemoteEntitySchemaDesi
 		string methodName)
 		where TRequest : class
 		where TResponse : BaseResponse {
-		return PostToUrl<TRequest, TResponse>(url, request, options.TimeOut, options.RetryCount, options.RetryDelay,
+		return PostToUrl<TRequest, TResponse>(url, request, options.TimeOut, options.MaxAttempts, options.RetryDelay,
 			methodName);
 	}
 
-	private TResponse PostToUrl<TRequest, TResponse>(string url, TRequest request, int timeoutMs, int retryCount,
+	private TResponse PostToUrl<TRequest, TResponse>(string url, TRequest request, int timeoutMs, int maxAttempts,
 		int retryDelay, string methodName)
 		where TRequest : class
 		where TResponse : BaseResponse {
 		string requestBody = request == null ? "{}" : _jsonConverter.SerializeObject(request);
-		string rawResponse = _applicationClient.ExecutePostRequest(url, requestBody, timeoutMs, retryCount, retryDelay);
+		string rawResponse = _applicationClient.ExecutePostRequest(url, requestBody, timeoutMs, maxAttempts, retryDelay);
 		TResponse response = DeserializeResponse<TResponse>(methodName, rawResponse);
 		return EnsureSuccess(response, methodName);
 	}
@@ -251,7 +252,7 @@ internal sealed class RemoteEntitySchemaDesignerClient : IRemoteEntitySchemaDesi
 		where TRequest : class
 		where TResponse : BaseResponse {
 		string requestBody = request == null ? "{}" : _jsonConverter.SerializeObject(request);
-		string rawResponse = _applicationClient.ExecutePostRequest(url, requestBody, options.TimeOut, options.RetryCount,
+		string rawResponse = _applicationClient.ExecutePostRequest(url, requestBody, options.TimeOut, options.MaxAttempts,
 			options.RetryDelay);
 		if (IsHtmlResponse(rawResponse)) {
 			return null;

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -97,7 +97,7 @@ namespace Clio.Command
 			try {
 				string url = RootPath + CreatioServicePaths.GetApplicationInfo;
 				string response = ApplicationClient.ExecutePostRequest(
-					url, "{}", options.TimeOut, options.RetryCount, options.RetryDelay);
+					url, "{}", options.TimeOut, options.MaxAttempts, options.RetryDelay);
 				JToken sysValues = JObject.Parse(response)["applicationInfo"]?["sysValues"];
 				if (sysValues is null){
 					Logger.WriteError(

--- a/clio/Command/HealthCheckCommand.cs
+++ b/clio/Command/HealthCheckCommand.cs
@@ -48,7 +48,7 @@ namespace Clio.Command
 			try
 			{
 				Logger.WriteInfo($"Checking {checkName} {requestUri} ...");
-				ApplicationClient.ExecuteGetRequest(requestUri, RequestTimeout, RetryCount, DelaySec);
+				ApplicationClient.ExecuteGetRequest(requestUri, RequestTimeout, MaxAttempts, DelaySec);
 				Logger.WriteInfo($"\t{checkName} - OK");
 			}
 			catch (WebException ex)
@@ -102,7 +102,7 @@ namespace Clio.Command
 			if (options.IsNetCore.HasValue)
 				EnvironmentSettings.IsNetCore = options.IsNetCore.Value;
 			RequestTimeout = options.TimeOut;
-			RetryCount = options.RetryCount;
+			MaxAttempts = options.MaxAttempts;
 			DelaySec = options.RetryDelay;
 			bool checkWebApp = IsEnabled(options.WebApp);
 			bool checkWebHost = IsEnabled(options.WebHost);

--- a/clio/Command/ModifyUserTaskParametersCommand.cs
+++ b/clio/Command/ModifyUserTaskParametersCommand.cs
@@ -134,7 +134,7 @@ public class ModifyUserTaskParametersCommand : RemoteCommand<ModifyUserTaskParam
 		string saveSchemaUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.SaveUserTaskSchema);
 		string saveRequestBody = JsonSerializer.Serialize(schema);
 		string saveResponseJson = ApplicationClient.ExecutePostRequest(saveSchemaUrl, saveRequestBody, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 		SaveDesignItemDesignerResponse saveResponse = UserTaskSchemaSupport
 			.Deserialize<SaveDesignItemDesignerResponse>(saveResponseJson, "SaveSchema");
 		UserTaskSchemaSupport.EnsureSaveSucceeded(saveResponse);
@@ -171,7 +171,7 @@ public class ModifyUserTaskParametersCommand : RemoteCommand<ModifyUserTaskParam
 	private WorkspaceExplorerItemDto FindWorkspaceUserTaskItem(string userTaskName, HashSet<string> workspacePackages) {
 		string getWorkspaceItemsUrl = _serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.GetWorkspaceItems);
 		string responseJson = ApplicationClient.ExecutePostRequest(getWorkspaceItemsUrl, string.Empty, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 		WorkspaceItemsResponse response =
 			UserTaskSchemaSupport.Deserialize<WorkspaceItemsResponse>(responseJson, "GetWorkspaceItems");
 
@@ -202,7 +202,7 @@ public class ModifyUserTaskParametersCommand : RemoteCommand<ModifyUserTaskParam
 			Cultures = []
 		});
 		string responseJson = ApplicationClient.ExecutePostRequest(getSchemaUrl, requestBody, RequestTimeout,
-			RetryCount, DelaySec);
+			MaxAttempts, DelaySec);
 		DesignerResponse<ProcessUserTaskDesignSchemaDto> response = UserTaskSchemaSupport
 			.Deserialize<DesignerResponse<ProcessUserTaskDesignSchemaDto>>(responseJson, "GetSchema");
 		UserTaskSchemaSupport.EnsureResponseSucceeded(response, "GetSchema");
@@ -336,6 +336,6 @@ public class ModifyUserTaskParametersCommand : RemoteCommand<ModifyUserTaskParam
 			PackageName = packageName
 		});
 		Logger.WriteInfo($"Building package '{packageName}'...");
-		ApplicationClient.ExecutePostRequest(buildPackageUrl, buildRequestBody, RequestTimeout, RetryCount, DelaySec);
+		ApplicationClient.ExecutePostRequest(buildPackageUrl, buildRequestBody, RequestTimeout, MaxAttempts, DelaySec);
 	}
 }

--- a/clio/Command/PingCommand.cs
+++ b/clio/Command/PingCommand.cs
@@ -27,7 +27,7 @@ namespace Clio.Command
 		}
 
 		private int ExecuteGetRequest() {
-			ApplicationClient.ExecuteGetRequest(RootPath, RequestTimeout, RetryCount, DelaySec);
+			ApplicationClient.ExecuteGetRequest(RootPath, RequestTimeout, MaxAttempts, DelaySec);
 			Logger.WriteInfo("Done");
 			return 0;
 		}
@@ -35,7 +35,7 @@ namespace Clio.Command
 		public override int Execute(PingAppOptions options) {
 			ServicePath = options.Endpoint;
 			RequestTimeout = options.TimeOut;
-			RetryCount = options.RetryCount;
+			MaxAttempts = options.MaxAttempts;
 			DelaySec = options.RetryDelay;
 			Logger.WriteInfo($"Ping {ServiceUri} ...");
 			return EnvironmentSettings.IsNetCore ? ExecuteGetRequest() : base.Execute(options);

--- a/clio/Command/RemoteCommand.cs
+++ b/clio/Command/RemoteCommand.cs
@@ -22,7 +22,7 @@ namespace Clio.Command
             internal set => _timeOut = value;
         }
 
-        public int RetryCount { get; internal set; } = 3;
+        public int MaxAttempts { get; internal set; } = 3;
         public int RetryDelay { get; internal set; } = 1;
 
 
@@ -98,7 +98,7 @@ namespace Clio.Command
 
         public virtual HttpMethod HttpMethod => HttpMethod.Post;
         public int RequestTimeout { get; set; }
-        public int RetryCount { get; set; }
+        public int MaxAttempts { get; set; }
         public int DelaySec { get; set; }
         public ILogger Logger { get; set; } = ConsoleLogger.Instance;
 
@@ -112,8 +112,8 @@ namespace Clio.Command
         protected virtual void ExecuteRemoteCommand(TEnvironmentOptions options)
         {
             string response = HttpMethod == HttpMethod.Post
-                ? ApplicationClient.ExecutePostRequest(ServiceUri, GetRequestData(options), RequestTimeout, RetryCount, DelaySec)
-                : ApplicationClient.ExecuteGetRequest(ServiceUri, RequestTimeout, RetryCount, DelaySec);
+                ? ApplicationClient.ExecutePostRequest(ServiceUri, GetRequestData(options), RequestTimeout, MaxAttempts, DelaySec)
+                : ApplicationClient.ExecuteGetRequest(ServiceUri, RequestTimeout, MaxAttempts, DelaySec);
             ProceedResponse(response, options);
         }
 
@@ -169,7 +169,7 @@ namespace Clio.Command
             try
             {
                 RequestTimeout = options.TimeOut;
-                RetryCount = options.RetryCount;
+                MaxAttempts = options.MaxAttempts;
                 DelaySec = options.RetryDelay;
                 ExecuteRemoteCommand(options);
                 string commandName = typeof(TEnvironmentOptions).GetCustomAttribute<VerbAttribute>()?.Name;

--- a/clio/Common/CreatioClientAdapter.cs
+++ b/clio/Common/CreatioClientAdapter.cs
@@ -115,33 +115,33 @@ public class CreatioClientAdapter : IApplicationClient{
 	}
 
 	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1) {
+		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, retryCount, delaySec),
+			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
-	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int retryCount = 1,
+	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int maxAttempts = 1,
 		int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecuteGetRequest(url, requestTimeout, retryCount, delaySec),
+			() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1) {
+		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec),
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public T ExecutePostRequest<T>(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1)
+		int maxAttempts = 1, int delaySec = 1)
 		where T : BaseResponse, new() {
 		// Re-auth detection runs against the raw body so an expired session cannot reach
 		// the JSON deserializer (which would throw on the HTML login page).
 		string response = _reauthExecutor.Execute(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, retryCount, delaySec),
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
 			ReauthExecutor.IsSessionExpiredResponse);
 		// If the retry also returned the session-expired HTML page, the JSON deserializer
 		// below would surface the same opaque "Invalid response format" symptom that
@@ -156,9 +156,9 @@ public class CreatioClientAdapter : IApplicationClient{
 	}
 
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1) {
+		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, retryCount, delaySec),
+			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -19,19 +19,19 @@ public interface IApplicationClient{
 	void DownloadFile(string url, string filePath, string requestData);
 
 	string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1);
+		int maxAttempts = 1, int delaySec = 1);
 
-	string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int retryCount = 1, int delaySec = 1);
+	string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1);
 
 	string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1);
+		int maxAttempts = 1, int delaySec = 1);
 
 	T ExecutePostRequest<T>(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1)
+		int maxAttempts = 1, int delaySec = 1)
 		where T : BaseResponse, new();
 
 	string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
-		int retryCount = 1, int delaySec = 1);
+		int maxAttempts = 1, int delaySec = 1);
 
 	void Listen(CancellationToken cancellationToken);
 	void Login();

--- a/clio/ModelBuilder/ModelBuilder.cs
+++ b/clio/ModelBuilder/ModelBuilder.cs
@@ -24,7 +24,7 @@ internal class ModelBuilder : IModelBuilder{
 	#region Constants: Private
 
 	private const string DefaultNamespace = "Models";
-	private const int SchemaRequestRetryCount = 3;
+	private const int SchemaRequestMaxAttempts = 3;
 	private const int SchemaRequestDelaySeconds = 2;
 
 	#endregion
@@ -345,7 +345,7 @@ internal class ModelBuilder : IModelBuilder{
 		string responseJson = _applicationClient.ExecutePostRequest(
 			EntitySchemaManagerRequestUrl,
 			string.Empty,
-			retryCount: SchemaRequestRetryCount,
+			maxAttempts: SchemaRequestMaxAttempts,
 			delaySec: SchemaRequestDelaySeconds);
 
 		JsonSerializerSettings settings = new() {
@@ -364,7 +364,7 @@ internal class ModelBuilder : IModelBuilder{
 		string definition
 			= _applicationClient.ExecutePostRequest(RuntimeEntitySchemaRequestUrl,
 				$"{{\"Name\" : \"{schema.Key}\"}}",
-				retryCount: SchemaRequestRetryCount,
+				maxAttempts: SchemaRequestMaxAttempts,
 				delaySec: SchemaRequestDelaySeconds);
 
 		JToken jt;

--- a/clio/Package/FileDesignModePackages.cs
+++ b/clio/Package/FileDesignModePackages.cs
@@ -53,7 +53,7 @@ namespace Clio.Package
 
 		// After restart the application may accept HTTP requests with a delay.
 		// Keep retries relatively generous to avoid flaky behavior in local/dev environments.
-		private const int retryRequestCount = 30;
+		private const int maxRequestAttempts = 30;
 
 		private const int delayBetweenRetryAttemptsSec = 3;
 
@@ -99,7 +99,7 @@ namespace Clio.Package
 		private bool IsFileDesignModeUrl {
 			get {
 				string responseFormServer
-					= _applicationClient.ExecutePostRequest(_getIsFileDesignModeUrl, string.Empty, Timeout.Infinite, retryRequestCount, delayBetweenRetryAttemptsSec);
+					= _applicationClient.ExecutePostRequest(_getIsFileDesignModeUrl, string.Empty, Timeout.Infinite, maxRequestAttempts, delayBetweenRetryAttemptsSec);
 				var response = _jsonConverter.DeserializeObject<BoolResponse>(responseFormServer);
 				if (response.Success) {
 					return response.Value;
@@ -126,7 +126,7 @@ namespace Clio.Package
 				return;
 			}
 			_logger.WriteLine($"Start load packages to {storageName} on a web application");
-			string responseFormServer = _applicationClient.ExecutePostRequest(endpoint, string.Empty,Timeout.Infinite, retryRequestCount, delayBetweenRetryAttemptsSec);
+			string responseFormServer = _applicationClient.ExecutePostRequest(endpoint, string.Empty,Timeout.Infinite, maxRequestAttempts, delayBetweenRetryAttemptsSec);
 			var response = _jsonConverter.DeserializeObject<BaseResponse>(responseFormServer);
 			if (response.Success) {
 				_logger.WriteLine($"Load packages to {storageName} on a web application completed");
@@ -149,7 +149,7 @@ namespace Clio.Package
 			string rawResponse;
 			try {
 				rawResponse = _applicationClient.ExecutePostRequest(_setFileDesignModeUrl, payload,
-					Timeout.Infinite, retryCount: 1, delaySec: delayBetweenRetryAttemptsSec);
+					Timeout.Infinite, maxAttempts: 1, delaySec: delayBetweenRetryAttemptsSec);
 			} catch (Exception ex) {
 				string message = ex.Message ?? string.Empty;
 				bool isNotFound = message.IndexOf("404", StringComparison.Ordinal) >= 0


### PR DESCRIPTION
## What & why

clio's schema-publish call passed `retryCount: 0` expecting **one request, no retries** — but **we expected 1 request and got 0**: the request was never sent. `Creatio.Client`'s retry helper treats the value as a *total attempt count* (not extra retries), so `0` meant *zero attempts* → it returned `null` → clio raised a `NullReferenceException` ("publishing the configuration failed: Object reference not set to an instance of an object"). That error tells the agent to run `compile-creatio`, which is the source of the repeated site compilations.

- Jira: https://creatio.atlassian.net/browse/ENG-91470
- Related client-side fix: [Advance-Technologies-Foundation/creatioclient#10](https://github.com/Advance-Technologies-Foundation/creatioclient/pull/10)

## Changes

- `PublishConfigurationChanges` now sends `maxAttempts: 1` — exactly one attempt, no retry of the non-idempotent build POST.
- Rename clio's own retry vocabulary to `maxAttempts` so it matches the renamed `Creatio.Client` API and nothing named `RetryCount` feeds a `maxAttempts` parameter: `IApplicationClient` + `CreatioClientAdapter` parameters, the `RemoteCommand(Options).RetryCount` property (default 3), and the `ModelBuilder` / `FileDesignModePackages` constants and call sites. No CLI flags change (these are not `[Option]`-bound).
- Bump `creatio.client` `1.0.37 → 1.0.38` in `Directory.Packages.props` — adopts the renamed `maxAttempts` parameter and clamps a `maxAttempts` value `< 1` to `1` (defense-in-depth).
- Update the affected unit tests.

## Compatibility & sequencing

- The fix works on the **current `creatio.client` 1.0.37** pin — clio calls the client positionally, and passing `1` is one attempt on the existing client. So the behavioral fix does not depend on the client release.
- The matching client change shipped as **`1.0.38`** — a **patch** release (not `1.1.0`). This PR now includes the `Directory.Packages.props` bump to `1.0.38`, which adopts the renamed API and adds the `< 1` clamp as defense-in-depth.

## Testing

- `dotnet build` clean; unit test suite green (`PublishConfigurationChanges_..._AndSingleAttempt` asserts `maxAttempts == 1`).
- Verified end-to-end against a Creatio stand: buggy clio → publish fails with the `null`/NRE and pushes `compile-creatio`; fixed build → `create-lookup` publishes in one request (~8s), lookup immediately usable, no extra compile.
