### PR TITLE
Multi-target test projects to net8.0 and net10.0

### DIFF
--- a/Clio.Analyzers.Tests/Clio.Analyzers.Tests.csproj
+++ b/Clio.Analyzers.Tests/Clio.Analyzers.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/clio.mcp.e2e/clio.mcp.e2e.csproj
+++ b/clio.mcp.e2e/clio.mcp.e2e.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net10.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/clio.tests/clio.tests.csproj
+++ b/clio.tests/clio.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Clio.Tests</RootNamespace>


### PR DESCRIPTION
## What

Multi-target the test projects so they can also build/run under **.NET 8** (in addition to .NET 10).

| Project | Before | After |
|---|---|---|
| `clio.tests` | `net10.0` | `net10.0;net8.0` |
| `Clio.Analyzers.Tests` | `net10.0` | `net10.0;net8.0` |
| `clio.mcp.e2e` | `net10.0` | `net10.0;net8.0` |

`cliogate.tests` stays at `net472` (.NET Framework gate package).

## Scope / what this does NOT fix

⚠️ This does **not** fix the `CLIO Unit Tests` CI failure on agents that have only **.NET SDK 9.x**.
Verified by reproducing the agent condition locally (pinned SDK `9.0.311` via global.json):

- `restore` always evaluates **every** TFM, so as long as `net10.0` is in the chain
  (`clio.tests` **and** the referenced `clio.csproj`), SDK 9 fails with `NETSDK1045`
  *before* the net8 target matters.
- `--framework net8.0`, `-f net8.0`, and `-p:TargetFramework=net8.0` all still hit
  `NETSDK1045` during restore — they filter the test run, not the restore.

The real CI fix is to install the **.NET 10 SDK on the agents** (tracked separately, INFR-11943).

This PR is therefore an **orthogonal capability**: it lets the test suite build/run under the
net8 runtime on a machine that has the .NET 10 SDK. It is not a substitute for SDK 10 on CI.

## Verification (on a machine with SDK 10)

- `clio.tests` net8 full Unit run: **4172 passed, 0 failed**, 20 skipped.
- `Clio.Analyzers.Tests` net8: 47 passed. net10: 47 passed (no regression).
- `clio.mcp.e2e` net8 build: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)