### PR TITLE
Gate net10.0 behind SDK >= 10 so SDK 9.x CI agents can build/test

### DIFF
--- a/Clio.Analyzers.Tests/Clio.Analyzers.Tests.csproj
+++ b/Clio.Analyzers.Tests/Clio.Analyzers.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <!-- net10.0 is only restored/built when the SDK supports it; SDK 9.x agents (CI) restore net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/clio.mcp.e2e/clio.mcp.e2e.csproj
+++ b/clio.mcp.e2e/clio.mcp.e2e.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+		<!-- net10.0 is only restored/built when the SDK supports it; SDK 9.x agents (CI) restore net8.0 only. -->
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/clio.tests/clio.tests.csproj
+++ b/clio.tests/clio.tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <!-- net10.0 is only restored/built when the SDK supports it; SDK 9.x agents (CI) restore net8.0 only. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Clio.Tests</RootNamespace>

--- a/clio/clio.csproj
+++ b/clio/clio.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+		<!-- net10.0 is only restored/built when the SDK supports it; SDK 9.x agents (CI) restore net8.0 only. -->
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
 		<PackAsTool>true</PackAsTool>
 		<PackageId>clio</PackageId>
 		<Company>creatio</Company>


### PR DESCRIPTION
## Problem

CI agents run **.NET SDK 9.x**, but every project targets `net10.0;net8.0`.
`dotnet test --framework net8.0` still fails with `NETSDK1045: ... does not support targeting .NET 10.0`, because the implicit **restore** evaluates **all** target frameworks (net10.0 from the test project *and* from the referenced `clio.csproj`), and SDK 9 cannot target net10. `--framework` filters the test run, not the restore.

## Fix

Make `net10.0` conditional on the SDK version:

```xml
<TargetFrameworks>net8.0</TargetFrameworks>
<TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
```

- **SDK 9.x** → restores/builds/tests **net8.0 only** → CI goes green.
- **SDK 10+** → `net10.0;net8.0` as before → no change to shipped/dev builds.

Applied to `clio.csproj`, `clio.tests`, `Clio.Analyzers.Tests`, `clio.mcp.e2e`.

## Verification (local)

| SDK | Resolved `TargetFrameworks` (all 4 projects) | `dotnet test --framework net8.0` |
|---|---|---|
| Default **10** | `net10.0;net8.0` | n/a (unchanged path) |
| Pinned **9.0.311** (`global.json`) | `net8.0` | ✅ **606 passed, 0 failed**, no NETSDK1045 |

> Verified with `dotnet msbuild <proj> -getProperty:TargetFrameworks` under each SDK.

## Notes

- Runtime: SDK 9.x ships the net9 runtime; the net8 test host runs on it. No separate `net9.0` target is needed.
- Alternative with zero code change: install the **.NET 10 SDK** on the agents (INFR-11943) — then the conditional simply keeps the full `net10.0;net8.0` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)