### PR TITLE
fix(test): isolate TurnFarmMode/MergeWorkspaces temp dirs per test run

### DIFF
--- a/clio.tests/Command/MergeWorkspacesCommandTest.cs
+++ b/clio.tests/Command/MergeWorkspacesCommandTest.cs
@@ -38,7 +38,8 @@ namespace Clio.Tests.Command
             _fileSystem = Substitute.For<IFileSystem>();
             _fileSystem.Directory.Exists(Arg.Any<string>()).Returns(true);
             _command = new MergeWorkspacesCommand(_workspaceMerger, _logger, _fileSystem);
-            _testOutputPath = Path.Combine(Path.GetTempPath(), "test-output");
+            // Unique per-test dir to avoid collisions across concurrent target frameworks
+            _testOutputPath = Path.Combine(Path.GetTempPath(), "test-output-" + Guid.NewGuid().ToString("N"));
             _testZipFileName = "TestMergedPackages";
             
             // Ensure test directory exists during test

--- a/clio.tests/Command/TurnFarmModeCommand.Tests.cs
+++ b/clio.tests/Command/TurnFarmModeCommand.Tests.cs
@@ -38,8 +38,8 @@ namespace Clio.Tests.Command
             _iisScanner = Substitute.For<IIisScanner>();
             _command = new TurnFarmModeCommand(_validator, _settingsRepository, _logger, _iisScanner);
 
-            // Set up test paths
-            _testSitePath = Path.Combine(Path.GetTempPath(), "TestSite");
+            // Unique per-test dir to avoid collisions across concurrent target frameworks
+            _testSitePath = Path.Combine(Path.GetTempPath(), "TestSite-" + Guid.NewGuid().ToString("N"));
             _testWebConfigPath = Path.Combine(_testSitePath, "Web.config");
             _testInternalWebConfigPath = Path.Combine(_testSitePath, "Terrasoft.WebApp", "Web.config");
 


### PR DESCRIPTION
## Problem

The `clio.tests` project began multi-targeting `net8.0;net10.0` (commit `66fc1769`), so `dotnet test` now runs both frameworks as **two concurrent processes**. `TurnFarmModeCommandTests` and `MergeWorkspacesCommandTest` each used a **fixed shared path** under `%TEMP%` (`TestSite` / `test-output`), created and recursively deleted in `SetUp`/`TearDown`. The two test hosts collided on the same files, producing flaky failures on CI:

- `being used by another process`
- `Access to the path 'Web.config' is denied`
- `Could not find a part of the path '...\TestSite\Web.config'`
- cascading `Expected result to be 0, but found 1` (the command-under-test hit the clobbered config and its `catch` returned 1)

The differing per-run counts (7 on net8.0, 5 on net10.0 in the same job) confirmed a timing race rather than a logic bug. The product code is fine — this is a test-isolation defect.

## Fix

Give each test a **unique per-run directory** (`Guid` suffix) so concurrent target frameworks can no longer resolve the same path. Root-cause fix only — no teardown guards added, so any future cleanup failure stays visible.

```diff
- _testSitePath   = Path.Combine(Path.GetTempPath(), "TestSite");
+ _testSitePath   = Path.Combine(Path.GetTempPath(), "TestSite-" + Guid.NewGuid().ToString("N"));
- _testOutputPath = Path.Combine(Path.GetTempPath(), "test-output");
+ _testOutputPath = Path.Combine(Path.GetTempPath(), "test-output-" + Guid.NewGuid().ToString("N"));
```

## Validation

- Reproduced locally with a 40× concurrent loop: **1/40 failures** on the broken code (5–7 per CI run), **0 failures** after the fix.
- 25× concurrent loop across both fixtures post-fix: **0 failures**.
- Build succeeds for both `net8.0` and `net10.0`.
- **Cleanup verified — no directory leak.** After thousands of test executions across the loop runs, `%TEMP%` contains **0** leftover `TestSite-*` and **0** leftover `test-output-*` directories. Each test's `TearDown` deletes its own unique directory cleanly; nothing accumulates. (This also confirms the unguarded delete succeeds — a silently failing teardown would leave a pile of orphaned `*-<guid>` dirs.)

`Validated: dotnet test --filter "Category=Unit&Module=Command"`

## Scope

Test-only change; no product code touched. `ClioRuntimePathsTests` (only builds a path string) and `DownloadConfigurationToolTests` (path passed as a validation arg) were checked and are not vulnerable.
