### PR TITLE
#ENG-91912 Fix MCP e2e transport: drop hardcoded dev ClioProcessPath + TFM

### DIFF
--- a/clio.mcp.e2e/Support/Configuration/TestConfiguration.cs
+++ b/clio.mcp.e2e/Support/Configuration/TestConfiguration.cs
@@ -111,7 +111,8 @@ internal static class TestConfiguration {
 	}
 
 	private static string? ResolveRepositoryProcessPath(string repositoryRoot) {
-		string repositoryOutputDirectory = Path.Combine(repositoryRoot, "clio", "bin", "Debug", "net10.0");
+		(string configuration, string targetFramework) = ResolveCurrentBuildOutputLayout();
+		string repositoryOutputDirectory = Path.Combine(repositoryRoot, "clio", "bin", configuration, targetFramework);
 		string repositoryExecutablePath = Path.Combine(
 			repositoryOutputDirectory,
 			OperatingSystem.IsWindows() ? "clio.exe" : "clio.dll");
@@ -121,6 +122,23 @@ internal static class TestConfiguration {
 
 		string repositoryAssemblyPath = Path.Combine(repositoryOutputDirectory, "clio.dll");
 		return File.Exists(repositoryAssemblyPath) ? repositoryAssemblyPath : null;
+	}
+
+	/// <summary>
+	/// Derives the build configuration and target framework moniker from the running test
+	/// assembly directory (for example <c>.../clio.mcp.e2e/bin/Debug/net8.0</c>) so the sibling
+	/// clio output directory is resolved for the framework actually under test. Hardcoding a single
+	/// moniker (previously <c>net10.0</c>) broke the multi-targeted suite when CI runs net8.0.
+	/// </summary>
+	private static (string Configuration, string TargetFramework) ResolveCurrentBuildOutputLayout() {
+		string assemblyDirectory = Path.GetDirectoryName(typeof(TestConfiguration).Assembly.Location) ?? string.Empty;
+		DirectoryInfo? targetFrameworkDirectory = string.IsNullOrWhiteSpace(assemblyDirectory)
+			? null
+			: new DirectoryInfo(assemblyDirectory);
+
+		string targetFramework = targetFrameworkDirectory?.Name is { Length: > 0 } tfm ? tfm : "net8.0";
+		string configuration = targetFrameworkDirectory?.Parent?.Name is { Length: > 0 } cfg ? cfg : "Debug";
+		return (configuration, targetFramework);
 	}
 
 	private static bool IsRepositoryRoot(string directoryPath) {

--- a/clio.mcp.e2e/appsettings.json
+++ b/clio.mcp.e2e/appsettings.json
@@ -1,7 +1,7 @@
 {
   "McpE2E": {
     "AllowDestructiveMcpTests": true,
-    "ClioProcessPath": "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.exe",
+    "ClioProcessPath": "",
     "Sandbox": {
       "EnvironmentName": "d2",
       "ProcessCode": "UpdateConfigurationActivityLogRetentionPeriod",


### PR DESCRIPTION
🔗 **Jira:** [ENG-91912](https://creatio.atlassian.net/browse/ENG-91912)

## What

Fixes the dominant `clio.mcp.e2e` CI failure: **`System.IO.IOException: Failed to connect transport`** (24 tests across 10 fixtures) — the stdio MCP server was launched from a non-existent directory.

## Root cause

`clio.mcp.e2e/appsettings.json` committed an absolute developer path as `ClioProcessPath`:

```
C:\Projects\clio\clio\bin\Debug\net10.0\clio.exe
```

(added in the .NET 10 migration #545). Fixtures that do **not** override it via `ResolveFreshClioProcessPath()` launch the MCP server from that path, which does not exist on CI (real checkout `C:\CI\work\Acc\`) → transport connect fails at arrange.

Affected fixtures: `AddPackageDependency`, `AssertInfrastructure`, `CompileCreatio`, `DeployCreatio`, `DownloadConfiguration`, `Experimental`, `FindEmptyIisPort`, `FsmMode`, `LinkFromRepository`, `PackageHotfix`.

Compounding: `TestConfiguration.ResolveRepositoryProcessPath` hardcoded `net10.0`, but after #726 the suite is multi-targeted `net8.0;net10.0` and CI runs **net8.0**, so the repository-output path never resolved either.

## Fix

- `appsettings.json`: `ClioProcessPath` → `""` so `ClioExecutableResolver` falls back to the loaded clio assembly location (correct on every machine and TFM) — matching `appsettings.example.json`.
- `TestConfiguration`: derive the configuration + target-framework folder from the running test-assembly directory instead of hardcoded `Debug/net10.0`.

## Validation

- Builds clean (`clio.mcp.e2e`, net8.0 + net10.0).
- Locally reproduced and confirmed: `AddPackageDependency_Should_Be_Advertised_By_McpServer` now **passes** (previously `Failed to connect transport`).
- Full TeamCity re-run on the integration branch in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-91912]: https://creatio.atlassian.net/browse/ENG-91912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ