### PR TITLE
#ENG-90640 fix MCP e2e: sync residual guidance asserts + mobile validation Errors

### DIFF
--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -546,8 +546,8 @@ public sealed class McpGuidanceResourceE2ETests {
 			because: "the handler guide should give AI a predictable ordering heuristic for multi-handler arrays");
 		article.Text.Should().Contain("Orchestration patterns",
 			because: "the handler guide should distinguish page-body dispatch, handler-chain dispatch, and direct SDK service orchestration");
-		article.Text.Should().Contain("Use `await request.$context.executeRequest(...)` when a deployed page-body handler forwards into another page-scoped request.",
-			because: "the handler guide should keep executeRequest as the default page-body orchestration path");
+		article.Text.Should().Contain("Use `await sdk.HandlerChainService.instance.process({ type, $context, scopes })` when a deployed page-body handler forwards into another page-scoped request.",
+			because: "the handler guide should keep HandlerChainService.instance.process as the canonical page-body orchestration path");
 		article.Text.Should().Contain("Use SDK/domain services such as `sdk.ProcessEngineService` when the task is direct service orchestration rather than request forwarding.",
 			because: "the handler guide should mention the direct service-orchestration path seen in product code");
 		article.Text.Should().MatchRegex(@"type: ""crt\.RunBusinessProcessRequest"",\s+processName: ""<ProcessName>"",\s+\$context(: request\.\$context|),\s+scopes: \[\.\.\.request\.scopes\]",
@@ -729,7 +729,7 @@ public sealed class McpGuidanceResourceE2ETests {
 			because: "fragment-only sdk snippets should say they are not standalone schema modules");
 		article.Text.Should().Contain("Inner handler/body snippet only: DialogService from SDK code:",
 			because: "fragment-only dialog snippets should say they are not standalone schema modules");
-		article.Text.Should().Contain("Inner handler/body snippet only: HandlerChainService from advanced SDK-oriented schema code:",
+		article.Text.Should().Contain("Inner handler/body snippet: canonical HandlerChainService dispatch from page-body handler code (per Creatio Academy SCHEMA_HANDLERS examples):",
 			because: "fragment-only handler-chain snippets should say they are not standalone schema modules");
 		article.Text.Should().Contain("Rule: in deployed page-body handlers, use `await sdk.HandlerChainService.instance.process({ type, $context, scopes })` for imperative request dispatch.",
 			because: "the guide should use HandlerChainService as the documented dispatch path for schema handlers");

--- a/clio/Command/McpServer/Tools/MobilePageValidation.cs
+++ b/clio/Command/McpServer/Tools/MobilePageValidation.cs
@@ -43,7 +43,11 @@ internal static class MobilePageValidation {
 			MarkersOk = true,
 			JsSyntaxOk = true,
 			ContentOk = valid,
-			Errors = valid ? null : errors,
+			// A valid mobile body must still surface a non-null (empty) error
+			// collection: clients assert against Validation.Errors directly, and a
+			// null here surfaces as a missing "errors" field that breaks
+			// not-contains assertions (ENG-90640 mobile AMD-marker case).
+			Errors = valid ? [] : errors,
 			Warnings = warnings.Count > 0 ? warnings : null
 		};
 	}


### PR DESCRIPTION
🔗 **Jira:** [ENG-90640](https://creatio.atlassian.net/browse/ENG-90640)

Closes three residual MCP e2e failures surfaced by the ENG-90640 suite work.

## What

**Guidance contract drift (verified locally, net10.0 — both green)**

The `executeRequest` → `sdk.HandlerChainService.instance.process` migration landed in the page-schema **resources** (06-12) and the asserts were only *partially* synced by ENG-91828, leaving two stale `Contain(...)` asserts pointing at text the resource no longer emits:

- `McpServer_Should_Return_Page_Schema_Handlers_Guidance` — orchestration line still expected `request.$context.executeRequest(...)`.
- `McpServer_Should_Return_Page_Schema_Sdk_Common_Guidance` — expected the old `Inner handler/body snippet only: HandlerChainService …` header.

Both asserts are now aligned with the canonical (already-shipped) resource text. **No resource/guidance content changed — tests only.**

**Mobile page-sync null collection**

`MobilePageValidation` returned `Validation.Errors = null` for a *valid* mobile body. With `[JsonIgnore(WhenWritingNull)]` that serialises to a missing `errors` field, so the client's `Errors.Should().NotContain(...)` saw `<null>` and threw. Now returns an empty collection.

- Fixes `PageSyncTool_Should_Accept_Valid_Mobile_Body_Without_AMD_Marker_Errors` (sandbox-gated → CI-verified).

## Not included (deferred — need a live stand to reproduce)

Two further PageSync residuals require new validation logic plus a reachable sandbox to reproduce (deploy is currently failing on the agent with `LoadLicResponse`), so they are intentionally **out of scope** here:

- `…_Reject_Obvious_Custom_MaxLength_Validators_Before_Save` — needs textual detection of custom `usr.*MaxLength` validators in the content-chain (the AST cannot parse the marker-delimited body, so the JS-syntax error wins first).
- `…_Reject_Proxy_Field_Bindings_Before_Save` — needs the nesting-validator message to also name the expected `$PDS_` datasource binding.

## MCP & docs

MCP reviewed: resource text, tool args, descriptions and destructive flags unchanged; only test asserts + an internal response-shape null were corrected. Docs reviewed, no update required.

**Validated:** `dotnet test --filter "Category=Unit&Module=McpServer"` (1323 passed) + both guidance e2e tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-90640]: https://creatio.atlassian.net/browse/ENG-90640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ