### PR TITLE
ENG-92149: render table log messages to string in MCP envelope

### DIFF
--- a/clio.tests/Command/McpServer/BaseToolTests.cs
+++ b/clio.tests/Command/McpServer/BaseToolTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using Clio.Command;
 using Clio.Command.McpServer.Tools;
 using Clio.Common;
+using ConsoleTables;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -259,6 +261,37 @@ public sealed class BaseToolTests {
 		ConsoleLogger.Instance.ClearMessages();
 	}
 
+	[Test]
+	[Category("Unit")]
+	[Description("Regression (ENG-92149): a command that prints a ConsoleTable (the experimental list-features path) "
+		+ "must yield a CommandExecutionResult that serializes through System.Text.Json without throwing, with the "
+		+ "table projected to its rendered string — the raw ConsoleTable graph reaches a ReadOnlySpan<byte> ref "
+		+ "struct that System.Text.Json cannot serialize, which the MCP SDK reports as IsError=true.")]
+	public void InternalExecute_ShouldProduceSerializableEnvelope_WhenCommandPrintsConsoleTable() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		ConsoleTable table = new() { Columns = { "Feature", "State" } };
+		table.Rows.Add(["sample-feature", "ENABLED"]);
+		var command = new FakeTablePrintingCommand(ConsoleLogger.Instance, exitCode: 0, table);
+		BaseToolHarness tool = new(command, ConsoleLogger.Instance);
+
+		// Act
+		CommandExecutionResult result = tool.Execute(new BaseToolHarnessOptions("table"));
+		Action serialize = () => JsonSerializer.Serialize(result);
+		LogMessage tableMessage = result.Output.Single(message => message.LogDecoratorType == LogDecoratorType.Table);
+
+		// Assert
+		serialize.Should().NotThrow(
+			because: "the MCP SDK serializes the returned envelope with System.Text.Json; a raw ConsoleTable in LogMessage.Value would throw and surface as IsError=true (ENG-92149)");
+		result.ExitCode.Should().Be(0,
+			because: "listing feature flags via a table is a successful read operation");
+		tableMessage.Value.Should().BeOfType<string>(
+			because: "the non-serializable ConsoleTable must be projected to its rendered string form before entering the MCP envelope");
+		tableMessage.Value!.ToString().Should().Contain("sample-feature",
+			because: "the human-readable table text (table.ToString()) must be preserved in the envelope, matching what the console renders");
+		ConsoleLogger.Instance.ClearMessages();
+	}
+
 	[RequiresPackage("cliogate", "2.0.0.0")]
 	private sealed class GatedToolHarnessOptions : EnvironmentOptions { }
 
@@ -303,6 +336,14 @@ public sealed class BaseToolTests {
 		public override int Execute(UngatedToolHarnessOptions options) {
 			WasExecuted = true;
 			logger.WriteInfo(messageToWrite);
+			return exitCode;
+		}
+	}
+
+	private sealed class FakeTablePrintingCommand(ILogger logger, int exitCode, ConsoleTable table)
+		: Command<BaseToolHarnessOptions> {
+		public override int Execute(BaseToolHarnessOptions options) {
+			logger.PrintTable(table);
 			return exitCode;
 		}
 	}

--- a/clio/Command/McpServer/Tools/BaseTool.cs
+++ b/clio/Command/McpServer/Tools/BaseTool.cs
@@ -150,7 +150,8 @@ public abstract class BaseTool<T>(
 			logger.PreserveMessages = true;
 			try {
 				int exitCode = command.Execute(options);
-				IReadOnlyList<LogMessage> flushedMessages = logger.FlushAndSnapshotMessages(clearMessages: true);
+				IReadOnlyList<LogMessage> flushedMessages = SanitizeForSerialization(
+					logger.FlushAndSnapshotMessages(clearMessages: true));
 				messagesToForward = flushedMessages;
 				executionResult = new CommandExecutionResult(
 					exitCode,
@@ -159,7 +160,8 @@ public abstract class BaseTool<T>(
 					CorrelationId: correlationId);
 			}
 			catch (Exception e) {
-				List<LogMessage> priorLogs = [.. logger.FlushAndSnapshotMessages(clearMessages: true)];
+				List<LogMessage> priorLogs = [.. SanitizeForSerialization(
+					logger.FlushAndSnapshotMessages(clearMessages: true))];
 				messagesToForward = priorLogs;
 				executionResult = CommandExecutionResult.FromException(e, priorLogs, correlationId);
 			}
@@ -171,5 +173,22 @@ public abstract class BaseTool<T>(
 		// tool invocations on stdio I/O performed by SendNotificationAsync.
 		McpLogNotifier.ForwardMessages(messagesToForward, correlationId);
 		return executionResult;
+	}
+
+	// The MCP SDK serializes the returned CommandExecutionResult with System.Text.Json, which walks
+	// LogMessage.Value (typed object). A TableMessage carries a raw ConsoleTable whose object graph
+	// reaches System.Text.Encoding.Preamble (a ReadOnlySpan<byte> ref struct) — System.Text.Json throws
+	// on that, and the SDK turns the throw into IsError=true (e.g. experimental list-features, ENG-92149).
+	// Project every non-string Value to its rendered string form (the same text the console writes via
+	// table.ToString()) before it enters the serialized envelope. This is general — any LogMessage with a
+	// non-serializable Value is made safe — and console rendering is untouched because the console reads
+	// from the live ConsoleLogger buffer, not this detached MCP snapshot.
+	private static IReadOnlyList<LogMessage> SanitizeForSerialization(IReadOnlyList<LogMessage> messages) {
+		foreach (LogMessage message in messages) {
+			if (message.Value is not (null or string)) {
+				message.Value = message.Value.ToString();
+			}
+		}
+		return messages;
 	}
 }


### PR DESCRIPTION
🔗 **Jira:** [ENG-92149](https://creatio.atlassian.net/browse/ENG-92149)

## Problem
`Tool_ShouldListFeatureFlags_WhenNoArgumentsSupplied` (clio.mcp.e2e) failed deterministically with `callResult.IsError == true`. Root cause (verified by local repro on master HEAD — **not** a parallelization race):

- `ExperimentalCommand.ListFeatures()` calls `_logger.PrintTable(table)` with a `ConsoleTable`.
- `ConsoleLogger` enqueues a `TableMessage` whose base `LogMessage.Value` (typed `object`) holds the raw `ConsoleTable`.
- `BaseTool.InternalExecute` flushes those `LogMessage`s into `CommandExecutionResult`; the MCP SDK serializes it with `System.Text.Json`, which walks the `ConsoleTable` graph and throws on `System.Text.Encoding.Preamble` (a `ReadOnlySpan<byte>` ref struct). The SDK turns the throw into `IsError=true`.
- Only the **list** path emits a table; the **toggle** path uses plain strings and serializes fine. The bug affects **any** MCP tool that prints a table.

## Fix
`BaseTool` now projects every non-`string` `LogMessage.Value` to its rendered string form (`Value.ToString()` — the same text the console writes) **before** the messages enter the serialized envelope. General fix (not experimental-specific). Console rendering is untouched — the console reads the live `ConsoleLogger` buffer, not the detached MCP snapshot.

## Tests
- New `clio.tests` unit test `InternalExecute_ShouldProduceSerializableEnvelope_WhenCommandPrintsConsoleTable` (Category Unit, Module McpServer): asserts the envelope serializes without throwing, `ExitCode == 0`, the table message `Value` is a string, and the rendered text is preserved. Fails without the fix, passes with it.
- `dotnet test --filter "Category=Unit&Module=McpServer"` (net10.0) → 1380 passed, 0 failed.
- `dotnet test --filter "FullyQualifiedName~ExperimentalTool"` (net10.0) → 2 passed, 0 failed.

MCP reviewed, no contract change — serialization-only fix (`value` was already typed as a string). Docs: N/A — no command/option/output contract changed.

Part of ENG-90640 (MCP e2e stabilization); targets the integration branch `feature/ENG-90640_mcp-e2e-stabilization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-92149]: https://creatio.atlassian.net/browse/ENG-92149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ