### PR TITLE
Guard Windows-only deploy-identity tests with [Platform("Win")]

### DIFF
--- a/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
+++ b/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 {
 	[Test]
 	[Description("Deploy uses the persisted registered environment so EnvironmentPath survives option filling and ConnectionStrings.config can be read.")]
+	[Platform("Win", Reason = "deploy-identity performs Windows-only IIS deployment (DeploymentStrategyFactory throws PlatformNotSupportedException off-Windows); skipped on non-Windows")]
 	public void Deploy_Should_Use_Persisted_Environment_When_Resolving_Identity_Path_And_Db_Connection()
 	{
 		// Arrange
@@ -99,6 +100,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 
 	[Test]
 	[Description("Deploy auto-discovers IdentityService.zip under the registered environment and auto-picks a free IIS port when both optional arguments are omitted.")]
+	[Platform("Win", Reason = "deploy-identity performs Windows-only IIS deployment (DeploymentStrategyFactory throws PlatformNotSupportedException off-Windows); skipped on non-Windows")]
 	public void Deploy_Should_Auto_Discover_Zip_And_Port_When_Optional_Arguments_Are_Omitted()
 	{
 		// Arrange
@@ -168,6 +170,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 
 	[Test]
 	[Description("Deploy creates and grants a new technical user only when create-tech-user is explicitly requested.")]
+	[Platform("Win", Reason = "deploy-identity performs Windows-only IIS deployment (DeploymentStrategyFactory throws PlatformNotSupportedException off-Windows); skipped on non-Windows")]
 	public void Deploy_Should_Create_Technical_User_Only_When_Requested()
 	{
 		// Arrange
@@ -219,6 +222,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 
 	[Test]
 	[Description("Deploy with no-app connects Creatio to IdentityService but skips OAuth app creation, credential verification, and local clio credential persistence.")]
+	[Platform("Win", Reason = "deploy-identity performs Windows-only IIS deployment (DeploymentStrategyFactory throws PlatformNotSupportedException off-Windows); skipped on non-Windows")]
 	public void Deploy_Should_Skip_OAuth_App_When_NoApp_Is_Requested()
 	{
 		// Arrange


### PR DESCRIPTION
## What

The 4 happy-path `Deploy_Should_*` tests in `IdentityServiceDeploymentServiceTests` drive `service.Deploy` → the Windows-only IIS path (`DeploymentStrategyFactory` throws `PlatformNotSupportedException` off-Windows), so a macOS/Linux `dotnet test --filter Category=Unit` saw **4 hard failures**, violating clio's cross-platform test policy.

Adds `[Platform("Win", Reason=...)]` to those 4 tests so they **skip** off-Windows and still **run** on Windows. The 2 `Deploy_Should_Reject_*` tests validate options before the platform path and stay cross-platform — left untouched.

## Verification

- Windows: `IdentityServiceDeploymentServiceTests` → 6 passed, 0 skipped (guarded tests still execute).
- macOS: full `Category=Unit` 4391/0/34 (the 4 now skip instead of failing).

Test-only change; production code untouched. Independent of (but complements) the min-Creatio-version gate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
