### PR TITLE
#ENG-91829 cliogate probe-first arrange: skip per-test reg/install when already serving

### DIFF
--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -145,6 +145,18 @@ internal static class ClioCliCommandRunner {
 		McpE2ESettings settings,
 		string environmentName,
 		CancellationToken cancellationToken = default) {
+		// Probe-first: when cliogate is already serving on the registered environment — e.g. a CI
+		// site-prep step ran reg-web-app + install-gate once before the test run (ENG-91829) — skip the
+		// per-test re-register, login-readiness gate, and install-gate entirely. A single cheap HTTP GET
+		// against a real /rest/CreatioApiGateway/* route replaces tens of seconds of per-test arrange.
+		// Any negative result (env not registered, route 404/warming up, stand unreachable) falls through
+		// to the full self-install path below, which local/manual runs without a prep step still rely on.
+		if (await IsCliogateAlreadyServingAsync(environmentName, cancellationToken)) {
+			TestContext.Out.WriteLine(
+				$"[cliogate] '{environmentName}' is already serving cliogate routes; skipping per-test reg-web-app/install-gate (site prep handled it).");
+			return;
+		}
+
 		// Re-register the sandbox env at the freshly-deployed URL FIRST, before we ping/login it. In CI
 		// the env name ("dev") is registered ahead of time but its stored URL is stale (the build's
 		// real URL is only known at runtime, exposed as the TeamCity param DeployedUrl). Correcting the
@@ -363,6 +375,52 @@ internal static class ClioCliCommandRunner {
 	/// <c>/rest/CreatioApiGateway/*</c> handlers do, so this closes the readiness race that causes
 	/// MCP tools calling cliogate routes to fail with (404) Not Found.
 	/// </summary>
+	/// <summary>
+	/// One-shot, short-budget check of whether cliogate is already serving its HTTP handlers on the
+	/// registered <paramref name="environmentName"/>. Used by <see cref="EnsureCliogateInstalledAsync"/>
+	/// to skip the expensive per-test reg-web-app/login/install path when a CI site-prep step has
+	/// already installed cliogate once (ENG-91829). Returns <c>false</c> on any negative or error
+	/// outcome (env not registered, route still 404/warming up, stand unreachable) so the caller falls
+	/// back to the full self-install path; caller cancellation is propagated.
+	/// </summary>
+	private static async Task<bool> IsCliogateAlreadyServingAsync(
+		string environmentName,
+		CancellationToken cancellationToken) {
+		try {
+			EnvironmentSettings environment = RegisteredClioEnvironmentSettingsResolver.Resolve(environmentName);
+			string probeUrl = new ServiceUrlBuilder(environment).Build(CliogateProbeRoute);
+			using HttpClientHandler handler = new() {
+				// Same read-only, unauthenticated GET rationale as WaitForCliogateHttpHandlersAsync:
+				// dev/CI stands serve over HTTPS with self-signed certs and a not-yet-warm route can
+				// 3xx-redirect, so accept any cert and do not follow redirects.
+				ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+				AllowAutoRedirect = false
+			};
+			using HttpClient httpClient = new(handler) {
+				Timeout = CliogateHttpRequestTimeout
+			};
+			// Single attempt bounded by one request timeout: a serving route returns immediately; a
+			// not-yet-serving or unreachable route throws CliogateReadinessTimeoutException, which we
+			// translate to "not ready" rather than waiting out the full install-readiness budget here.
+			ICliogateHttpReadinessProbe probe = new CliogateHttpReadinessProbe(
+				httpClient,
+				maxAttempts: 1,
+				delayBetweenAttempts: TimeSpan.Zero,
+				overallTimeout: CliogateHttpRequestTimeout);
+			await probe.WaitUntilServingAsync(probeUrl, cancellationToken);
+			return true;
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+			throw;
+		}
+		catch (Exception exception) {
+			TestContext.Out.WriteLine(
+				$"[cliogate] readiness probe for '{environmentName}' did not confirm a serving route " +
+				$"({exception.GetType().Name}: {exception.Message}); falling back to reg-web-app + install-gate.");
+			return false;
+		}
+	}
+
 	private static async Task WaitForCliogateHttpHandlersAsync(
 		string environmentName,
 		CancellationToken cancellationToken) {

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -370,12 +370,6 @@ internal static class ClioCliCommandRunner {
 	}
 
 	/// <summary>
-	/// After <c>list-packages</c> (DataService) reports ready, polls a read-only cliogate HTTP route
-	/// until it stops returning 404. The DataService layer can come up before the
-	/// <c>/rest/CreatioApiGateway/*</c> handlers do, so this closes the readiness race that causes
-	/// MCP tools calling cliogate routes to fail with (404) Not Found.
-	/// </summary>
-	/// <summary>
 	/// One-shot, short-budget check of whether cliogate is already serving its HTTP handlers on the
 	/// registered <paramref name="environmentName"/>. Used by <see cref="EnsureCliogateInstalledAsync"/>
 	/// to skip the expensive per-test reg-web-app/login/install path when a CI site-prep step has
@@ -387,27 +381,15 @@ internal static class ClioCliCommandRunner {
 		string environmentName,
 		CancellationToken cancellationToken) {
 		try {
-			EnvironmentSettings environment = RegisteredClioEnvironmentSettingsResolver.Resolve(environmentName);
-			string probeUrl = new ServiceUrlBuilder(environment).Build(CliogateProbeRoute);
-			using HttpClientHandler handler = new() {
-				// Same read-only, unauthenticated GET rationale as WaitForCliogateHttpHandlersAsync:
-				// dev/CI stands serve over HTTPS with self-signed certs and a not-yet-warm route can
-				// 3xx-redirect, so accept any cert and do not follow redirects.
-				ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-				AllowAutoRedirect = false
-			};
-			using HttpClient httpClient = new(handler) {
-				Timeout = CliogateHttpRequestTimeout
-			};
 			// Single attempt bounded by one request timeout: a serving route returns immediately; a
 			// not-yet-serving or unreachable route throws CliogateReadinessTimeoutException, which we
 			// translate to "not ready" rather than waiting out the full install-readiness budget here.
-			ICliogateHttpReadinessProbe probe = new CliogateHttpReadinessProbe(
-				httpClient,
+			await ProbeCliogateServingAsync(
+				environmentName,
 				maxAttempts: 1,
 				delayBetweenAttempts: TimeSpan.Zero,
-				overallTimeout: CliogateHttpRequestTimeout);
-			await probe.WaitUntilServingAsync(probeUrl, cancellationToken);
+				overallTimeout: CliogateHttpRequestTimeout,
+				cancellationToken: cancellationToken);
 			return true;
 		}
 		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
@@ -421,8 +403,35 @@ internal static class ClioCliCommandRunner {
 		}
 	}
 
-	private static async Task WaitForCliogateHttpHandlersAsync(
+	/// <summary>
+	/// After <c>list-packages</c> (DataService) reports ready, polls a read-only cliogate HTTP route
+	/// until it stops returning 404. The DataService layer can come up before the
+	/// <c>/rest/CreatioApiGateway/*</c> handlers do, so this closes the readiness race that causes
+	/// MCP tools calling cliogate routes to fail with (404) Not Found.
+	/// </summary>
+	private static Task WaitForCliogateHttpHandlersAsync(
 		string environmentName,
+		CancellationToken cancellationToken) =>
+		ProbeCliogateServingAsync(
+			environmentName,
+			CliogateHttpReadinessAttempts,
+			CliogateHttpReadinessDelay,
+			CliogateHttpReadinessOverallTimeout,
+			cancellationToken);
+
+	/// <summary>
+	/// Shared cliogate HTTP-probe setup for both the one-shot skip check
+	/// (<see cref="IsCliogateAlreadyServingAsync"/>) and the post-install readiness poll
+	/// (<see cref="WaitForCliogateHttpHandlersAsync"/>). Resolves the env, composes the probe URL,
+	/// and wires the HttpClient/probe with the cert-accept + no-redirect rationale once, so the two
+	/// call sites differ only in their attempt/delay/timeout budget and the non-obvious TLS/redirect
+	/// rationale cannot drift between them.
+	/// </summary>
+	private static async Task ProbeCliogateServingAsync(
+		string environmentName,
+		int maxAttempts,
+		TimeSpan delayBetweenAttempts,
+		TimeSpan overallTimeout,
 		CancellationToken cancellationToken) {
 		EnvironmentSettings environment = RegisteredClioEnvironmentSettingsResolver.Resolve(environmentName);
 		// Compose the probe URL through ServiceUrlBuilder so the .NET-Framework `0/` alias is applied
@@ -445,9 +454,9 @@ internal static class ClioCliCommandRunner {
 		};
 		ICliogateHttpReadinessProbe probe = new CliogateHttpReadinessProbe(
 			httpClient,
-			CliogateHttpReadinessAttempts,
-			CliogateHttpReadinessDelay,
-			CliogateHttpReadinessOverallTimeout);
+			maxAttempts,
+			delayBetweenAttempts,
+			overallTimeout);
 		await probe.WaitUntilServingAsync(probeUrl, cancellationToken);
 	}
 


### PR DESCRIPTION
🔗 **Jira:** [ENG-91829](https://creatio.atlassian.net/browse/ENG-91829)

> Targets the umbrella branch `feature/ENG-90640_mcp-e2e-stabilization-2` (not master).

## Problem
Every Sandbox MCP e2e test's arrange called `ClioCliCommandRunner.EnsureCliogateInstalledAsync`, which ran `reg-web-app` + a login-readiness gate + `install-gate` + cliogate readiness polling **on every test**. That per-test round-trip dominates slow fixtures (e.g. `AddItemModel_Should_Generate_Model_Files` ~126s) — the cost was the arrange, not the operation under test.

## Change
Add a **probe-first** fast path to `EnsureCliogateInstalledAsync`: a single cheap unauthenticated GET against a real `/rest/CreatioApiGateway/*` route (reusing the existing `CliogateHttpReadinessProbe`). When cliogate is already serving on the registered environment — e.g. a CI **site-prep step** ran `reg-web-app` + `install-gate` once before the test run — arrange returns immediately, skipping the re-register / login / install entirely. Any negative result (env not registered, route 404 / warming up, stand unreachable) falls through to the existing full self-install path that local/manual runs without a prep step still rely on.

Beneficial even **without** a prep step: the first destructive test installs cliogate, then every subsequent test probe-skips (the `dev` env is now registered at the real URL and cliogate serves), collapsing N per-test installs into one per run. On a probe miss the GET returns fast (immediate 404 / connection-refused), so the fall-through path adds no meaningful latency.

This is the harness half of the ENG-91829 plan; the matching CI **site-prep step** (register the env + install cliogate once, after Deploy, before `dotnet test`) is a TeamCity job-config change applied separately.

## Validation
- `dotnet build clio.mcp.e2e` — clean (the two pre-existing nullable warnings are unrelated).
- The probe-first path is exercised end-to-end on the deploy-backed TeamCity run (no local Creatio stand); behavior with cliogate absent is unchanged (full fall-through), so this is safe to land ahead of the prep step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-91829]: https://creatio.atlassian.net/browse/ENG-91829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ