### PR TITLE
Rename adac command name to toolkit (branding change)

### DIFF
--- a/clio.tests/Command/McpServer/SkillManagementToolTests.cs
+++ b/clio.tests/Command/McpServer/SkillManagementToolTests.cs
@@ -17,7 +17,7 @@ namespace Clio.Tests.Command.McpServer;
 public sealed class SkillManagementToolTests {
 	[Test]
 	[Category("Unit")]
-	[Description("Advertises stable MCP tool names for install-adac, update-adac, and delete-adac so callers and tests share the same identifiers.")]
+	[Description("Advertises stable MCP tool names for install-toolkit, update-toolkit, and delete-toolkit so callers and tests share the same identifiers.")]
 	public void SkillManagementTools_ShouldAdvertiseStableToolNames() {
 		// Arrange & Act
 		string installToolName = InstallSkillsTool.ToolName;
@@ -25,14 +25,14 @@ public sealed class SkillManagementToolTests {
 		string deleteToolName = DeleteSkillTool.ToolName;
 
 		// Assert
-		installToolName.Should().Be("install-adac", because: "the install MCP tool name must remain stable");
-		updateToolName.Should().Be("update-adac", because: "the update MCP tool name must remain stable");
-		deleteToolName.Should().Be("delete-adac", because: "the delete MCP tool name must remain stable");
+		installToolName.Should().Be("install-toolkit", because: "the install MCP tool name must remain stable");
+		updateToolName.Should().Be("update-toolkit", because: "the update MCP tool name must remain stable");
+		deleteToolName.Should().Be("delete-toolkit", because: "the delete MCP tool name must remain stable");
 	}
 
 	[Test]
 	[Category("Unit")]
-	[Description("Maps install-adac MCP arguments (target, repo) into install-adac command options.")]
+	[Description("Maps install-toolkit MCP arguments (target, repo) into install-toolkit command options.")]
 	public void InstallSkills_ShouldMapTargetAndRepoArguments() {
 		// Arrange
 		FakeInstallSkillsCommand command = new();
@@ -50,7 +50,7 @@ public sealed class SkillManagementToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Maps update-adac MCP arguments (target, repo) into update-adac command options.")]
+	[Description("Maps update-toolkit MCP arguments (target, repo) into update-toolkit command options.")]
 	public void UpdateSkill_ShouldMapTargetAndRepoArguments() {
 		// Arrange
 		FakeUpdateSkillCommand command = new();
@@ -67,7 +67,7 @@ public sealed class SkillManagementToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Maps delete-adac MCP argument (target) into delete-adac command options.")]
+	[Description("Maps delete-toolkit MCP argument (target) into delete-toolkit command options.")]
 	public void DeleteSkill_ShouldMapTargetArgument() {
 		// Arrange
 		FakeDeleteSkillCommand command = new();

--- a/clio/Command/McpServer/Prompts/SkillManagementPrompt.cs
+++ b/clio/Command/McpServer/Prompts/SkillManagementPrompt.cs
@@ -12,7 +12,7 @@ public static class SkillManagementPrompt {
 	/// <summary>
 	/// Builds guidance for installing the toolkit skill through MCP.
 	/// </summary>
-	[McpServerPrompt(Name = "install-adac-guidance"), Description("Prompt to install the Creatio toolkit skill")]
+	[McpServerPrompt(Name = "install-toolkit-guidance"), Description("Prompt to install the Creatio toolkit skill")]
 	public static string InstallSkills(
 		[Description("Optional agent to limit to: claude | codex | cursor | copilot")] string target = null,
 		[Description("Optional source override (marketplace git URL, or path/URL for cursor)")] string repo = null) =>
@@ -27,7 +27,7 @@ public static class SkillManagementPrompt {
 	/// <summary>
 	/// Builds guidance for updating the toolkit skill through MCP.
 	/// </summary>
-	[McpServerPrompt(Name = "update-adac-guidance"), Description("Prompt to update the Creatio toolkit skill")]
+	[McpServerPrompt(Name = "update-toolkit-guidance"), Description("Prompt to update the Creatio toolkit skill")]
 	public static string UpdateSkill(
 		[Description("Optional agent to limit to: claude | codex | cursor | copilot")] string target = null,
 		[Description("Optional source override (marketplace git URL, or path/URL for cursor)")] string repo = null) =>
@@ -41,7 +41,7 @@ public static class SkillManagementPrompt {
 	/// <summary>
 	/// Builds guidance for uninstalling the toolkit skill through MCP.
 	/// </summary>
-	[McpServerPrompt(Name = "delete-adac-guidance"), Description("Prompt to uninstall the Creatio toolkit skill")]
+	[McpServerPrompt(Name = "delete-toolkit-guidance"), Description("Prompt to uninstall the Creatio toolkit skill")]
 	public static string DeleteSkill(
 		[Description("Optional agent to limit to: claude | codex | cursor | copilot")] string target = null) =>
 		$"""

--- a/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DataForgeOrchestrationGuidanceResource.cs
@@ -25,7 +25,7 @@ public sealed class DataForgeOrchestrationGuidanceResource {
 
 			       Architecture split
 			       - clio (passive): DataForge enrichment is built into selected write tools. It runs automatically before the mutation, returns a `dataforge` section alongside the result, and degrades gracefully when DataForge is unavailable. The mutation is never blocked.
-			       - ADAC / AI consumer (active): explicit orchestration — the AI agent calls DataForge tools at the right points in a workflow to gather context it cannot derive from the requirement alone.
+			       - Toolkit / AI consumer (active): explicit orchestration — the AI agent calls DataForge tools at the right points in a workflow to gather context it cannot derive from the requirement alone.
 			       - Do not duplicate passive enrichment: tools that already enrich internally (`create-app`, `sync-schemas`, `create-entity-schema`, `create-lookup`, `update-entity-schema`) run DataForge themselves. Do not add an external pre-flight for these tools.
 
 			       Layer 0 — Health preflight

--- a/clio/Command/McpServer/Tools/SkillManagementTool.cs
+++ b/clio/Command/McpServer/Tools/SkillManagementTool.cs
@@ -12,7 +12,7 @@ namespace Clio.Command.McpServer.Tools;
 [McpServerToolType]
 public sealed class InstallSkillsTool(InstallSkillsCommand command, ILogger logger)
 	: BaseTool<InstallSkillsOptions>(command, logger) {
-	internal const string ToolName = "install-adac";
+	internal const string ToolName = "install-toolkit";
 
 	/// <summary>
 	/// Installs the Creatio toolkit skill globally for detected coding agents.
@@ -36,7 +36,7 @@ public sealed class InstallSkillsTool(InstallSkillsCommand command, ILogger logg
 [McpServerToolType]
 public sealed class UpdateSkillTool(UpdateSkillCommand command, ILogger logger)
 	: BaseTool<UpdateSkillOptions>(command, logger) {
-	internal const string ToolName = "update-adac";
+	internal const string ToolName = "update-toolkit";
 
 	/// <summary>
 	/// Updates the Creatio toolkit skill for detected coding agents (Claude included).
@@ -60,7 +60,7 @@ public sealed class UpdateSkillTool(UpdateSkillCommand command, ILogger logger)
 [McpServerToolType]
 public sealed class DeleteSkillTool(DeleteSkillCommand command, ILogger logger)
 	: BaseTool<DeleteSkillOptions>(command, logger) {
-	internal const string ToolName = "delete-adac";
+	internal const string ToolName = "delete-toolkit";
 
 	/// <summary>
 	/// Uninstalls the Creatio toolkit skill from detected coding agents (idempotent).

--- a/clio/Command/SkillCommands.cs
+++ b/clio/Command/SkillCommands.cs
@@ -56,24 +56,24 @@ public abstract class SkillCommandOptions {
 /// <summary>
 /// Options for the <c>install-skills</c> command.
 /// </summary>
-[Verb("install-adac", Aliases = ["install-skills"],
-	HelpText = "Install the Creatio AI App Development Toolkit (ADAC) for all detected coding agents")]
+[Verb("install-toolkit", Aliases = ["install-skills"],
+	HelpText = "Install the Creatio AI App Development Toolkit for all detected coding agents")]
 public class InstallSkillsOptions : SkillCommandOptions {
 }
 
 /// <summary>
 /// Options for the <c>update-skill</c> command.
 /// </summary>
-[Verb("update-adac", Aliases = ["update-skill"],
-	HelpText = "Update the Creatio AI App Development Toolkit (ADAC) for all detected coding agents")]
+[Verb("update-toolkit", Aliases = ["update-skill"],
+	HelpText = "Update the Creatio AI App Development Toolkit for all detected coding agents")]
 public class UpdateSkillOptions : SkillCommandOptions {
 }
 
 /// <summary>
 /// Options for the <c>delete-skill</c> command.
 /// </summary>
-[Verb("delete-adac", Aliases = ["delete-skill"],
-	HelpText = "Uninstall the Creatio AI App Development Toolkit (ADAC) from coding agents")]
+[Verb("delete-toolkit", Aliases = ["delete-skill"],
+	HelpText = "Uninstall the Creatio AI App Development Toolkit from coding agents")]
 public class DeleteSkillOptions : SkillCommandOptions {
 }
 

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -555,8 +555,8 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 
 ## Integrations & Tools
 
-<a id="delete-adac"></a>
-- [`delete-adac`](docs/commands/delete-adac.md) - Uninstall the Creatio AI App Development Toolkit from coding agents (alias: delete-skill)
+<a id="delete-toolkit"></a>
+- [`delete-toolkit`](docs/commands/delete-toolkit.md) - Uninstall the Creatio AI App Development Toolkit from coding agents (alias: delete-skill)
 <a id="env-ui"></a>
 <a id="far"></a>
 <a id="gui"></a>
@@ -566,16 +566,16 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="installgate"></a>
 <a id="update-gate"></a>
 - [`install-gate`](docs/commands/install-gate.md) - Install or update cliogate in Creatio, `gate`, `installgate`, `update-gate`
-<a id="install-adac"></a>
-- [`install-adac`](docs/commands/install-adac.md) - Install the Creatio AI App Development Toolkit for all detected coding agents (alias: install-skills)
+<a id="install-toolkit"></a>
+- [`install-toolkit`](docs/commands/install-toolkit.md) - Install the Creatio AI App Development Toolkit for all detected coding agents (alias: install-skills)
 <a id="link-package-store"></a>
 <a id="lps"></a>
 - [`link-package-store`](docs/commands/link-package-store.md) - Link PackageStore packages into an environment, `lps`
 <a id="mcp-server"></a>
 <a id="mcp"></a>
 - [`mcp-server`](docs/commands/mcp-server.md) - Start the MCP server over stdio, `mcp`
-<a id="update-adac"></a>
-- [`update-adac`](docs/commands/update-adac.md) - Update the Creatio AI App Development Toolkit for all detected coding agents (alias: update-skill)
+<a id="update-toolkit"></a>
+- [`update-toolkit`](docs/commands/update-toolkit.md) - Update the Creatio AI App Development Toolkit for all detected coding agents (alias: update-skill)
 
 ## Identity & Authentication
 

--- a/clio/HelpSystem/CommandHelpCatalog.cs
+++ b/clio/HelpSystem/CommandHelpCatalog.cs
@@ -234,13 +234,13 @@ internal sealed class CommandHelpCatalog {
 
 	private static readonly HashSet<string> IntegrationCommands =
 		[
-			"delete-adac",
+			"delete-toolkit",
 			"env-ui",
 			"install-gate",
-			"install-adac",
+			"install-toolkit",
 			"link-package-store",
 			"mcp-server",
-			"update-adac"
+			"update-toolkit"
 		];
 
 	private static readonly HashSet<string> DevelopmentCommands =

--- a/clio/Wiki/WikiAnchors.txt
+++ b/clio/Wiki/WikiAnchors.txt
@@ -43,7 +43,7 @@ delete-infrastructure:delete-infrastructure,di-delete,remove-infrastructure
 delete-pkg-remote:delete-pkg-remote,delete
 delete-app-section:delete-app-section
 delete-schema:delete-schema
-delete-adac:delete-adac
+delete-toolkit:delete-toolkit
 deploy-application:deploy-application,deploy-app
 deploy-creatio:deploy-creatio,dc,ic,install-creatio
 deploy-identity:deploy-identity
@@ -96,7 +96,7 @@ info:info,get-version,i,ver
 install-application:install-application,install-app,push-app
 install-gate:install-gate,gate,installgate,update-gate
 install-nuget-pkg:install-nuget-pkg,installng
-install-adac:install-adac
+install-toolkit:install-toolkit
 install-sql-schema:install-sql-schema,sql-schema-install,execute-sql-schema
 last-compilation-log:last-compilation-log,lcl
 link-core-src:link-core-src,lcs
@@ -172,7 +172,7 @@ update-client-unit-schema:update-client-unit-schema,client-unit-schema-update
 update-cli:update-cli,update
 update-entity-schema:update-entity-schema
 update-schema:update-schema,schema-update
-update-adac:update-adac
+update-toolkit:update-toolkit
 update-sql-schema:update-sql-schema,sql-schema-update
 upload-license:upload-license,license,load-license,loadlicense
 upload-licenses:upload-licenses,lic

--- a/clio/docs/commands/delete-toolkit.md
+++ b/clio/docs/commands/delete-toolkit.md
@@ -1,4 +1,4 @@
-# delete-adac
+# delete-toolkit
 
 ## Command Type
 
@@ -6,11 +6,11 @@
 
 ## Name
 
-delete-adac - Uninstall the Creatio toolkit skill from coding agents
+delete-toolkit - Uninstall the Creatio toolkit skill from coding agents
 
 ## Description
 
-delete-adac removes the Creatio AI App Development Toolkit skill from every detected
+delete-toolkit removes the Creatio AI App Development Toolkit skill from every detected
 coding agent, performing the per-agent inverse of install: it uninstalls the plugin
 and removes the marketplace for the CLI agents (Claude/Codex/Copilot), and removes the
 local plugin directory and orchestrator rule for Cursor. Use `--target` to limit to one
@@ -20,13 +20,13 @@ The shared `clio` MCP server entry in Codex `config.toml` and Cursor `mcp.json` 
 intentionally **left in place** — it is shared infrastructure that may be used
 independently of this skill.
 
-delete-adac is idempotent: an already-clean agent is reported as success. A detected
+delete-toolkit is idempotent: an already-clean agent is reported as success. A detected
 agent whose CLI is not on PATH is skipped with a warning and does not fail the command.
 
 ## Synopsis
 
 ```bash
-clio delete-adac [options]
+clio delete-toolkit [options]
 ```
 
 ## Options
@@ -40,13 +40,13 @@ clio delete-adac [options]
 
 ```bash
 # Uninstall from all detected agents
-clio delete-adac
+clio delete-toolkit
 
 # Uninstall only from Codex
-clio delete-adac --target codex
+clio delete-toolkit --target codex
 ```
 
-> **Breaking change:** `--scope` and `--skill` have been removed. delete-adac no longer
+> **Breaking change:** `--scope` and `--skill` have been removed. delete-toolkit no longer
 > requires `--skill`; it operates on the whole toolkit bundle across agents (use `--target`).
 
-- [Clio Command Reference](../../Commands.md#delete-adac)
+- [Clio Command Reference](../../Commands.md#delete-toolkit)

--- a/clio/docs/commands/install-toolkit.md
+++ b/clio/docs/commands/install-toolkit.md
@@ -1,4 +1,4 @@
-# install-adac
+# install-toolkit
 
 ## Command Type
 
@@ -6,11 +6,11 @@
 
 ## Name
 
-install-adac - Install the Creatio toolkit skill for all detected coding agents
+install-toolkit - Install the Creatio toolkit skill for all detected coding agents
 
 ## Description
 
-install-adac installs the Creatio AI App Development Toolkit skill globally for
+install-toolkit installs the Creatio AI App Development Toolkit skill globally for
 every supported coding agent detected on the machine, using each agent's native
 plugin mechanism. No Python runtime is required.
 
@@ -23,20 +23,20 @@ An agent is "detected" when its home directory exists:
 | Cursor | `~/.cursor` | copies the plugin into `plugins/local`, merges `mcp.json`, writes the orchestrator rule |
 | GitHub Copilot CLI | `~/.copilot` | `copilot plugin marketplace add` + `plugin install` |
 
-By default install-adac processes all detected agents. Use `--target` to limit to one.
+By default install-toolkit processes all detected agents. Use `--target` to limit to one.
 
 The default source is the public toolkit marketplace
 (`https://github.com/Creatio-Platform/creatio-ai-app-development-toolkit.git`).
 Use `--repo` to override it: a marketplace git URL for claude/codex/copilot, or a
 local path/git URL for the Cursor file-copy.
 
-install-adac is idempotent. A detected agent whose CLI is not on PATH is skipped
+install-toolkit is idempotent. A detected agent whose CLI is not on PATH is skipped
 with a warning and does not fail the command.
 
 ## Synopsis
 
 ```bash
-clio install-adac [options]
+clio install-toolkit [options]
 ```
 
 ## Options
@@ -54,13 +54,13 @@ clio install-adac [options]
 
 ```bash
 # Install for all detected agents
-clio install-adac
+clio install-toolkit
 
 # Install only for Codex
-clio install-adac --target codex
+clio install-toolkit --target codex
 
 # Install for Cursor from a local toolkit checkout
-clio install-adac --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
+clio install-toolkit --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
 ```
 
 > **Breaking change:** `--scope` and `--skill` have been removed. Skills now install
@@ -68,4 +68,4 @@ clio install-adac --target cursor --repo C:\Repos\creatio-ai-app-development-too
 > gone because the whole toolkit bundle is installed per agent. The default `--repo`
 > changed from the internal bootstrap repository to the public toolkit marketplace.
 
-- [Clio Command Reference](../../Commands.md#install-adac)
+- [Clio Command Reference](../../Commands.md#install-toolkit)

--- a/clio/docs/commands/update-toolkit.md
+++ b/clio/docs/commands/update-toolkit.md
@@ -1,4 +1,4 @@
-# update-adac
+# update-toolkit
 
 ## Command Type
 
@@ -6,11 +6,11 @@
 
 ## Name
 
-update-adac - Update the Creatio toolkit skill for all detected coding agents
+update-toolkit - Update the Creatio toolkit skill for all detected coding agents
 
 ## Description
 
-update-adac refreshes the Creatio AI App Development Toolkit skill for every
+update-toolkit refreshes the Creatio AI App Development Toolkit skill for every
 detected coding agent, using each agent's native update mechanism. No Python
 runtime is required.
 
@@ -21,13 +21,13 @@ source. Use `--target` to limit to one agent.
 The default source is the public toolkit marketplace. Use `--repo` to override it
 (marketplace git URL for claude/codex/copilot; local path or git URL for cursor).
 
-update-adac is idempotent and reports a per-agent outcome. A detected agent whose
+update-toolkit is idempotent and reports a per-agent outcome. A detected agent whose
 CLI is not on PATH is skipped with a warning and does not fail the command.
 
 ## Synopsis
 
 ```bash
-clio update-adac [options]
+clio update-toolkit [options]
 ```
 
 ## Options
@@ -45,13 +45,13 @@ clio update-adac [options]
 
 ```bash
 # Update every detected agent
-clio update-adac
+clio update-toolkit
 
 # Update only Cursor from a local checkout
-clio update-adac --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
+clio update-toolkit --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
 ```
 
-> **Breaking change:** `--scope` and `--skill` have been removed. update-adac operates
+> **Breaking change:** `--scope` and `--skill` have been removed. update-toolkit operates
 > on the whole toolkit bundle across agents (use `--target` to narrow).
 
-- [Clio Command Reference](../../Commands.md#update-adac)
+- [Clio Command Reference](../../Commands.md#update-toolkit)

--- a/clio/help/en/delete-toolkit.txt
+++ b/clio/help/en/delete-toolkit.txt
@@ -2,10 +2,10 @@ COMMAND TYPE
     Skill management commands
 
 NAME
-    delete-adac - Uninstall the Creatio AI App Development Toolkit from coding agents (alias: delete-skill)
+    delete-toolkit - Uninstall the Creatio AI App Development Toolkit from coding agents (alias: delete-skill)
 
 DESCRIPTION
-    delete-adac removes the Creatio AI App Development Toolkit skill from every
+    delete-toolkit removes the Creatio AI App Development Toolkit skill from every
     detected coding agent, performing the per-agent inverse of install: it
     uninstalls the plugin and removes the marketplace for the CLI agents
     (Claude/Codex/Copilot) and removes the local plugin directory and orchestrator
@@ -15,12 +15,12 @@ DESCRIPTION
     is intentionally LEFT in place — it is shared infrastructure that may be used
     independently of this skill.
 
-    delete-adac is idempotent: an already-clean agent (nothing to remove) is
+    delete-toolkit is idempotent: an already-clean agent (nothing to remove) is
     reported as success. A detected agent whose CLI is not on PATH is skipped with
     a warning and does not fail the command.
 
 SYNOPSIS
-    clio delete-adac [options]
+    clio delete-toolkit [options]
 
 OPTIONS
     --target                            Optional agent to limit to:
@@ -29,11 +29,11 @@ OPTIONS
 
 EXAMPLES
     Uninstall from all detected agents:
-        clio delete-adac
+        clio delete-toolkit
 
     Uninstall only from Codex:
-        clio delete-adac --target codex
+        clio delete-toolkit --target codex
 
 NOTES
-    --scope and --skill have been removed. delete-adac no longer requires --skill;
+    --scope and --skill have been removed. delete-toolkit no longer requires --skill;
     it operates on the whole toolkit bundle across agents (use --target to narrow).

--- a/clio/help/en/help.txt
+++ b/clio/help/en/help.txt
@@ -37,7 +37,7 @@ Commands:
   delete-infrastructure                Delete Kubernetes infrastructure for Creatio (removes namespace and all resources), di-delete, remove-infrastructure
   delete-pkg-remote                    Delete a package from Creatio, delete
   delete-schema                        Delete a schema from a workspace package
-  delete-adac                          Uninstall the Creatio AI App Development Toolkit from coding agents
+  delete-toolkit                       Uninstall the Creatio AI App Development Toolkit from coding agents
   deploy-application                   Copy an application package between Creatio environments, deploy-app
   deploy-creatio                       Install Creatio from a distribution package, dc, ic, install-creatio
   deploy-infrastructure                Deploy Kubernetes infrastructure for Creatio (namespace, storage, redis, postgres, pgadmin), di
@@ -66,7 +66,7 @@ Commands:
   install-application                  Install an application package into Creatio, install-app, push-app
   install-gate                         Install or update cliogate in Creatio, gate, installgate, update-gate
   install-nuget-pkg                    Install NuGet package to a web application (website), installng
-  install-adac                         Install the Creatio AI App Development Toolkit for all detected coding agents
+  install-toolkit                      Install the Creatio AI App Development Toolkit for all detected coding agents
   last-compilation-log                 Get last compilation log, lcl
   link-core-src                        Link core source code to environment for development, lcs
   link-from-repository                 Link repository package(s) to environment, l4r, link4repo
@@ -134,7 +134,7 @@ Commands:
   unregister                           Remove clio shell integrations
   update-cli                           Update clio, update
   update-entity-schema                 Apply batch column operations to a remote Creatio entity schema
-  update-adac                          Update the Creatio AI App Development Toolkit for all detected coding agents
+  update-toolkit                       Update the Creatio AI App Development Toolkit for all detected coding agents
   upload-license                       Load license to selected environment, license, load-license, loadlicense
   upload-licenses                      Upload license files to Creatio, lic
   upsert-data-binding-row-db           Upsert a row in a DB-first package data binding

--- a/clio/help/en/install-toolkit.txt
+++ b/clio/help/en/install-toolkit.txt
@@ -2,10 +2,10 @@ COMMAND TYPE
     Skill management commands
 
 NAME
-    install-adac - Install the Creatio AI App Development Toolkit for all detected coding agents (alias: install-skills)
+    install-toolkit - Install the Creatio AI App Development Toolkit for all detected coding agents (alias: install-skills)
 
 DESCRIPTION
-    install-adac installs the Creatio AI App Development Toolkit skill globally
+    install-toolkit installs the Creatio AI App Development Toolkit skill globally
     for every supported coding agent detected on the machine, using each agent's
     native plugin mechanism. No Python runtime is required.
 
@@ -19,7 +19,7 @@ DESCRIPTION
                                           merges mcp.json, writes the orchestrator rule.
         GitHub Copilot CLI  ~/.copilot  - copilot plugin marketplace + plugin install.
 
-    By default install-adac processes all detected agents. Use --target to limit
+    By default install-toolkit processes all detected agents. Use --target to limit
     the operation to a single agent.
 
     The default source is the public toolkit marketplace:
@@ -27,12 +27,12 @@ DESCRIPTION
     Use --repo to override it (a marketplace git URL for claude/codex/copilot;
     a local path or git URL for the cursor file-copy).
 
-    install-adac is idempotent: re-running it refreshes/repairs the install.
+    install-toolkit is idempotent: re-running it refreshes/repairs the install.
     If a detected agent's CLI is not on PATH, that agent is skipped with a warning
     and does not fail the command.
 
 SYNOPSIS
-    clio install-adac [options]
+    clio install-toolkit [options]
 
 OPTIONS
     --target                            Optional agent to limit to:
@@ -45,13 +45,13 @@ OPTIONS
 
 EXAMPLES
     Install for all detected agents:
-        clio install-adac
+        clio install-toolkit
 
     Install only for Codex:
-        clio install-adac --target codex
+        clio install-toolkit --target codex
 
     Install from a local toolkit checkout (useful for Cursor iteration):
-        clio install-adac --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
+        clio install-toolkit --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
 
 NOTES
     --scope and --skill have been removed. Skills now install globally for all

--- a/clio/help/en/update-toolkit.txt
+++ b/clio/help/en/update-toolkit.txt
@@ -2,10 +2,10 @@ COMMAND TYPE
     Skill management commands
 
 NAME
-    update-adac - Update the Creatio AI App Development Toolkit for all detected coding agents (alias: update-skill)
+    update-toolkit - Update the Creatio AI App Development Toolkit for all detected coding agents (alias: update-skill)
 
 DESCRIPTION
-    update-adac refreshes the Creatio AI App Development Toolkit skill for every
+    update-toolkit refreshes the Creatio AI App Development Toolkit skill for every
     detected coding agent, using each agent's native update mechanism. No Python
     runtime is required.
 
@@ -17,11 +17,11 @@ DESCRIPTION
     (a marketplace git URL for claude/codex/copilot; a local path or git URL for the
     cursor file-copy).
 
-    update-adac is idempotent and reports a per-agent outcome. A detected agent
+    update-toolkit is idempotent and reports a per-agent outcome. A detected agent
     whose CLI is not on PATH is skipped with a warning and does not fail the command.
 
 SYNOPSIS
-    clio update-adac [options]
+    clio update-toolkit [options]
 
 OPTIONS
     --target                            Optional agent to limit to:
@@ -34,11 +34,11 @@ OPTIONS
 
 EXAMPLES
     Update every detected agent:
-        clio update-adac
+        clio update-toolkit
 
     Update only Cursor from a local checkout:
-        clio update-adac --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
+        clio update-toolkit --target cursor --repo C:\Repos\creatio-ai-app-development-toolkit
 
 NOTES
-    --scope and --skill have been removed. update-adac operates on the whole
+    --scope and --skill have been removed. update-toolkit operates on the whole
     toolkit bundle across agents (use --target to narrow).


### PR DESCRIPTION
@
## Summary

ADAC (the AI App Development Toolkit) was rebranded, so the `adac` token in the skill-management command names no longer fits. This renames `adac` → `toolkit` across the entire command surface. `adac` was only ever a command-name token, so this is a **pure rename with no behavior change**. The `install-skills` / `update-skill` / `delete-skill` aliases are kept; `adac` is dropped entirely (no backward-compat alias, per the decision to retire the brand).

## Changes

- **CLI verbs:** `install-adac` / `update-adac` / `delete-adac` → `install-toolkit` / `update-toolkit` / `delete-toolkit`
- **MCP tool names:** `install-toolkit` / `update-toolkit` / `delete-toolkit`
- **MCP prompt names:** `install-toolkit-guidance` / `update-toolkit-guidance` / `delete-toolkit-guidance`
- **Help catalog** classification updated to the new verbs
- **DataForge guidance:** the single retired-brand label "ADAC / AI consumer" → "Toolkit / AI consumer"
- **Docs/help** renamed via `git mv` (history preserved): `help/en/{install,update,delete}-toolkit.txt`, `docs/commands/{install,update,delete}-toolkit.md`; bodies + `Commands.md` + `help.txt` + `WikiAnchors.txt` updated
- **Tests:** `SkillManagementToolTests` assertions updated to the new tool names

C# class/identifier names were already `*Skills*`-based (e.g. `InstallSkillsCommand`, `InstallSkillsTool`), so no class renames were needed — only the user-facing `adac` strings.

## Not changed
- `.codex/workspace-diary.md` (append-only history) and `research/` inventory snapshots — historical `adac` references left as-is.

## Testing
- `dotnet test --filter "Category=Unit&(Module=Command|Module=McpServer|Module=Core)"` — 3552 passed (includes `HelpArtifactConsistencyTests`, which ties each verb to its docs/help/wiki artifacts).
- CLI smoke: `install-toolkit -H` renders; `install-adac` is now unrecognized.
- Pre-PR agentic review: complete and consistent, no missed `adac` references, aliases preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
@