### PR TITLE
ENG-90883 e2e: gate process-designer MCP tests on the process-designer feature

### DIFF
--- a/clio.mcp.e2e/CreateBusinessProcessToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateBusinessProcessToolE2ETests.cs
@@ -122,6 +122,7 @@ public sealed class CreateBusinessProcessToolE2ETests {
 	private static async Task<ArrangeContext> ArrangeAsync(bool requireReachableEnvironment) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
 		string environmentName = settings.Sandbox.EnvironmentName;
 		if (requireReachableEnvironment) {
 			if (string.IsNullOrWhiteSpace(environmentName)) {

--- a/clio.mcp.e2e/DescribeProcessToolE2ETests.cs
+++ b/clio.mcp.e2e/DescribeProcessToolE2ETests.cs
@@ -83,6 +83,7 @@ public sealed class DescribeProcessToolE2ETests {
 	private static async Task<ArrangeContext> ArrangeAsync(bool requireReachableEnvironment) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
 		string environmentName = settings.Sandbox.EnvironmentName;
 		string processCode = settings.Sandbox.ProcessCode;
 		if (requireReachableEnvironment) {

--- a/clio.mcp.e2e/ListUserTasksToolE2ETests.cs
+++ b/clio.mcp.e2e/ListUserTasksToolE2ETests.cs
@@ -75,6 +75,7 @@ public sealed class ListUserTasksToolE2ETests {
 	private static async Task<ArrangeContext> ArrangeAsync(bool requireReachableEnvironment) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
 		string environmentName = settings.Sandbox.EnvironmentName;
 		if (requireReachableEnvironment) {
 			if (string.IsNullOrWhiteSpace(environmentName)) {

--- a/clio.mcp.e2e/ModifyBusinessProcessToolE2ETests.cs
+++ b/clio.mcp.e2e/ModifyBusinessProcessToolE2ETests.cs
@@ -160,6 +160,7 @@ public sealed class ModifyBusinessProcessToolE2ETests {
 	private static async Task<ArrangeContext> ArrangeAsync(bool requireReachableEnvironment) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
 		string environmentName = settings.Sandbox.EnvironmentName;
 		if (requireReachableEnvironment) {
 			if (string.IsNullOrWhiteSpace(environmentName)) {

--- a/clio.mcp.e2e/Support/Configuration/ProcessDesignerE2EGate.cs
+++ b/clio.mcp.e2e/Support/Configuration/ProcessDesignerE2EGate.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Clio.Mcp.E2E.Support.Configuration;
+
+/// <summary>
+/// Skip-gate for the process-designer MCP E2E fixtures. The process-designer tools
+/// (<c>create</c>/<c>modify</c>/<c>describe-business-process</c>, <c>list-user-tasks</c>,
+/// <c>validate-process-graph</c>) are <c>[FeatureToggle("process-designer")]</c>-gated, so the clio MCP
+/// server does NOT advertise them while the feature is off — which is the default until the
+/// clioprocessbuilder package ships. These fixtures therefore <see cref="Assert.Ignore(string)"/> (skip)
+/// rather than fail when the feature is disabled, exactly like the reachable-environment gate. Enable the
+/// feature (<c>clio experimental --name process-designer --enable</c>) on the stand's clio settings to run them.
+/// </summary>
+internal static class ProcessDesignerE2EGate {
+	private const string FeatureKey = "process-designer";
+
+	/// <summary>
+	/// Skips the calling test when <c>process-designer</c> is disabled in the appsettings the configured
+	/// clio MCP server process loads. Call FIRST in a fixture's arrange (after <c>ClioProcessPath</c> is set).
+	/// </summary>
+	public static void SkipIfFeatureDisabled(McpE2ESettings settings) {
+		if (!IsFeatureEnabled(settings)) {
+			Assert.Ignore(
+				$"The '{FeatureKey}' feature is disabled, so its MCP tools are not advertised. Enable it "
+				+ $"(clio experimental --name {FeatureKey} --enable) to run the process-designer MCP E2E tests.");
+		}
+	}
+
+	// Reads the `features` map from the clio appsettings the MCP server process will load (the same file
+	// McpFeatureToggleFilter reads to decide which tools to register) and reports whether the feature is on.
+	private static bool IsFeatureEnabled(McpE2ESettings settings) {
+		try {
+			string appSettingsPath = TemporaryClioSettingsOverride.GetClioAppSettingsPath(
+				settings.ClioProcessPath, settings.ProcessEnvironmentVariables);
+			if (!File.Exists(appSettingsPath)) {
+				return false;
+			}
+			if (JObject.Parse(File.ReadAllText(appSettingsPath))["features"] is not JObject features) {
+				return false;
+			}
+			// Feature keys compare case-insensitively (the IFeatureToggleService contract).
+			JProperty? flag = features.Properties()
+				.FirstOrDefault(property => string.Equals(property.Name, FeatureKey, StringComparison.OrdinalIgnoreCase));
+			return flag is not null && flag.Value.Type == JTokenType.Boolean && flag.Value.Value<bool>();
+		}
+		catch (Exception exception) when (
+			exception is InvalidOperationException or IOException or Newtonsoft.Json.JsonException) {
+			// If the feature state cannot be resolved (settings path/read/parse failure), treat it as
+			// disabled and skip — the gate must never itself fail the test.
+			return false;
+		}
+	}
+}

--- a/clio.mcp.e2e/Support/Configuration/TemporaryClioSettingsOverride.cs
+++ b/clio.mcp.e2e/Support/Configuration/TemporaryClioSettingsOverride.cs
@@ -62,7 +62,7 @@ internal sealed class TemporaryClioSettingsOverride : IDisposable {
 			processEnvironmentVariables);
 	}
 
-	private static string GetClioAppSettingsPath(
+	internal static string GetClioAppSettingsPath(
 		string? clioProcessPath = null,
 		IReadOnlyDictionary<string, string?>? processEnvironmentVariables = null) {
 		if (!string.IsNullOrWhiteSpace(clioProcessPath)) {

--- a/clio.mcp.e2e/ValidateProcessGraphToolE2ETests.cs
+++ b/clio.mcp.e2e/ValidateProcessGraphToolE2ETests.cs
@@ -164,6 +164,7 @@ public sealed class ValidateProcessGraphToolE2ETests {
 	private static async Task<ArrangeContext> ArrangeAsync() {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
 		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		return new ArrangeContext(session, cancellationTokenSource);


### PR DESCRIPTION
## Problem

The `CLIO MCP e2e tests` job on `trunk` fails the 9 process-designer e2e tests (the `*_Should_Be_Advertised_By_Mcp_Server` cases first). The `create`/`modify`/`describe-business-process`, `list-user-tasks` and `validate-process-graph` MCP tools are `[FeatureToggle("process-designer")]`-gated, so the clio MCP server does **not** advertise them while the feature is off — which is the default on trunk (the `clioprocessbuilder` package isn't GA yet). The fixtures asserted the tools *are* advertised, so they **failed** instead of skipping.

## Fix

Gate the process-designer e2e fixtures on the feature, the same way the suite already skips on an unreachable environment:

- New `Support/Configuration/ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings)` reads `features.process-designer` from the appsettings the MCP server process loads (the same file `McpFeatureToggleFilter` reads to decide which tools to register) and `Assert.Ignore`s when it's off. Any settings-path/parse failure is treated as "disabled" (skip), so the gate never itself fails a test.
- Called first in each of the 5 process-designer fixtures' arrange (after `ClioProcessPath` is set).
- `TemporaryClioSettingsOverride.GetClioAppSettingsPath` exposed `private` → `internal` for reuse.

## Result

- Feature **off** (trunk default) → the 9 process-designer e2e tests **skip** (`Assert.Ignore`) instead of failing.
- Feature **on** (`clio experimental --name process-designer --enable`) → they **run** (advertised + functional).

Does **not** modify `clio/appsettings.json` — the feature stays off on trunk by design; enabling it for a real run is a per-stand/local toggle.

Build: `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
