### PR TITLE
fix(mcp): declare clio-run args as type=object (ENG-92653)

### DIFF
--- a/clio.mcp.e2e/ClioRunToolE2ETests.cs
+++ b/clio.mcp.e2e/ClioRunToolE2ETests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Mcp;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>
+/// End-to-end tests for the clio-run generic executor over the real MCP server (ENG-92653).
+/// These exercise the wire path the unit tests deliberately bypass: with args declared as
+/// <c>Dictionary&lt;string, JsonElement&gt;?</c> the SDK now binds a JSON object, so the args
+/// payload must survive real by-name binding + re-serialization and reach the dispatched target
+/// tool. Both the flat call shape <c>{"command":"X","args":{...}}</c> and the wrapped shape
+/// <c>{"args":{"command":"X","args":{...}}}</c> are covered.
+/// A read-only, environment-free target (<c>get-guidance</c>) is used so the assertion proves the
+/// args reached the target without needing a live Creatio environment.
+/// </summary>
+[TestFixture]
+[Category("McpE2E.NoEnvironment")]
+[AllureNUnit]
+[AllureFeature(ClioRunTool.ToolName)]
+[NonParallelizable]
+public sealed class ClioRunToolE2ETests : McpContractFixtureBase {
+
+	// A stable, always-registered guidance name + a marker unique to its article body. If the args
+	// object failed to reach get-guidance, the target would report a missing-name failure instead.
+	private const string GuidanceName = "page-schema-handlers";
+	private const string GuidanceMarker = "clio MCP page-schema handlers guide";
+
+	[Test]
+	[Category("E2E")]
+	[Description("clio-run dispatches the flat call shape {command, args} through the real MCP server and the args object reaches the target tool (ENG-92653).")]
+	[AllureTag(ClioRunTool.ToolName)]
+	[AllureName("clio-run forwards flat-shape args to the target tool over the wire")]
+	public async Task ClioRun_ShouldForwardArgsToTarget_WhenCalledWithFlatShape() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act — flat shape: top-level command + args, args being the object get-guidance expects.
+		CallToolResult callResult = await context.Session.CallToolAsync(
+			ClioRunTool.ToolName,
+			new Dictionary<string, object?> {
+				["command"] = "get-guidance",
+				["args"] = new Dictionary<string, object?> {
+					["name"] = GuidanceName
+				}
+			},
+			context.CancellationTokenSource.Token);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "a well-formed flat clio-run call must dispatch to get-guidance and succeed");
+		SerializeResult(callResult).Should().Contain(GuidanceMarker,
+			because: "the args object must reach get-guidance so it resolves the requested guidance article (ENG-92653)");
+	}
+
+	[Test]
+	[Category("E2E")]
+	[Description("clio-run dispatches the wrapped call shape {args:{command, args}} through the real MCP server and the args object reaches the target tool (ENG-92653).")]
+	[AllureTag(ClioRunTool.ToolName)]
+	[AllureName("clio-run forwards wrapped-shape args to the target tool over the wire")]
+	public async Task ClioRun_ShouldForwardArgsToTarget_WhenCalledWithWrappedShape() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act — wrapped shape: everything nested under args, top-level command omitted. With the new
+		// Dictionary binding the SDK binds this whole object under args; the executor must recover the
+		// real command/args from it (the exact path most affected by the JsonElement?→Dictionary change).
+		CallToolResult callResult = await context.Session.CallToolAsync(
+			ClioRunTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["command"] = "get-guidance",
+					["args"] = new Dictionary<string, object?> {
+						["name"] = GuidanceName
+					}
+				}
+			},
+			context.CancellationTokenSource.Token);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "the wrapped clio-run shape must be recovered and dispatched to get-guidance over the wire");
+		SerializeResult(callResult).Should().Contain(GuidanceMarker,
+			because: "the wrapped args object must survive binding + recovery and reach get-guidance (ENG-92653)");
+	}
+
+	// Serializes the tool result (structured content preferred, content blocks as fallback) to a JSON
+	// string so the assertion can look for the guidance marker without coupling to the response DTO shape.
+	private static string SerializeResult(CallToolResult callResult) =>
+		JsonSerializer.Serialize(callResult.StructuredContent) + JsonSerializer.Serialize(callResult.Content);
+}

--- a/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
+++ b/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
@@ -935,4 +935,105 @@ public sealed class ClioRunDispatchTests {
 		result.Should().BeSameAs(expected,
 			because: "null Dictionary must convert to null JsonElement for the executor");
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("ClioRunTool preserves the wrapped call shape when the Dictionary carries an inner command/args, so the executor's RecoverWrappedCall still sees the original object (ENG-92653).")]
+	public async Task ClioRunTool_ShouldPreserveWrappedShape_WhenDictionaryContainsCommandAndArgs() {
+		// Arrange — the SDK binds the wrapped shape {"args":{"command":"X","args":{...}}} entirely under
+		// the `args` Dictionary with `command` left null. The Dictionary→JsonElement conversion must keep
+		// that object intact so ClioRunExecutor.RecoverWrappedCall can extract the real command/args.
+		IClioRunExecutor executor = Substitute.For<IClioRunExecutor>();
+		CallToolResult expected = new() { Content = [] };
+		JsonElement? capturedArgs = null;
+		executor.RunAsync(
+			null,
+			Arg.Any<JsonElement?>(),
+			false,
+			Arg.Any<RequestContext<CallToolRequestParams>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(call => {
+				capturedArgs = call.ArgAt<JsonElement?>(1);
+				return new ValueTask<CallToolResult>(expected);
+			});
+		ClioRunTool tool = new(executor);
+
+		// Act — command is null (wrapped shape); the real command lives inside the args Dictionary.
+		Dictionary<string, JsonElement> wrapped = new() {
+			["command"] = JsonDocument.Parse("\"echo-tool\"").RootElement,
+			["args"] = JsonDocument.Parse("{\"value\":\"hello\"}").RootElement
+		};
+		CallToolResult result = await tool.Run(CallContext(), null, wrapped);
+
+		// Assert
+		result.Should().BeSameAs(expected,
+			because: "the tool must forward the converted wrapped args to the executor and return its result");
+		capturedArgs.Should().NotBeNull(because: "a non-null wrapped Dictionary must convert to a non-null JsonElement");
+		capturedArgs!.Value.ValueKind.Should().Be(JsonValueKind.Object,
+			because: "the converted wrapped payload must remain a JSON object for RecoverWrappedCall to parse");
+		capturedArgs.Value.GetProperty("command").GetString().Should().Be("echo-tool",
+			because: "the inner command must survive the conversion so the executor can recover the real target tool");
+		capturedArgs.Value.GetProperty("args").GetProperty("value").GetString().Should().Be("hello",
+			because: "the inner target args must survive the conversion intact");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("ClioRunDestructiveTool converts a non-null Dictionary args to a JsonElement object and passes it through to the executor on the destructive surface (ENG-92653).")]
+	public async Task ClioRunDestructiveTool_ShouldConvertDictionaryArgs_WhenArgsAreProvided() {
+		// Arrange — the destructive alias runs the same DictionaryToElement conversion; cover its flat path.
+		IClioRunExecutor executor = Substitute.For<IClioRunExecutor>();
+		CallToolResult expected = new() { Content = [] };
+		JsonElement? capturedArgs = null;
+		executor.RunAsync(
+			"sync-schemas",
+			Arg.Any<JsonElement?>(),
+			true,
+			Arg.Any<RequestContext<CallToolRequestParams>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(call => {
+				capturedArgs = call.ArgAt<JsonElement?>(1);
+				return new ValueTask<CallToolResult>(expected);
+			});
+		ClioRunDestructiveTool tool = new(executor);
+
+		// Act
+		Dictionary<string, JsonElement> args = new() {
+			["value"] = JsonDocument.Parse("\"hello\"").RootElement
+		};
+		CallToolResult result = await tool.Run(CallContext(), "sync-schemas", args);
+
+		// Assert
+		result.Should().BeSameAs(expected,
+			because: "the destructive tool must forward the converted args to the executor and return its result");
+		capturedArgs.Should().NotBeNull(because: "a non-null Dictionary must convert to a non-null JsonElement");
+		capturedArgs!.Value.ValueKind.Should().Be(JsonValueKind.Object,
+			because: "the converted JsonElement must be a JSON object");
+		capturedArgs.Value.GetProperty("value").GetString().Should().Be("hello",
+			because: "the Dictionary entries must survive the conversion intact on the destructive surface");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("ClioRunDestructiveTool passes null to the executor when the Dictionary args is null (ENG-92653).")]
+	public async Task ClioRunDestructiveTool_ShouldPassNullArgs_WhenDictionaryIsNull() {
+		// Arrange
+		IClioRunExecutor executor = Substitute.For<IClioRunExecutor>();
+		CallToolResult expected = new() { Content = [] };
+		executor.RunAsync(
+			"sync-schemas",
+			Arg.Is<JsonElement?>(el => !el.HasValue),
+			true,
+			Arg.Any<RequestContext<CallToolRequestParams>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(new ValueTask<CallToolResult>(expected));
+		ClioRunDestructiveTool tool = new(executor);
+
+		// Act
+		CallToolResult result = await tool.Run(CallContext(), "sync-schemas", null);
+
+		// Assert
+		result.Should().BeSameAs(expected,
+			because: "null Dictionary must convert to null JsonElement for the executor on the destructive surface");
+	}
 }

--- a/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
+++ b/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Clio.Command.McpServer;
 using Clio.Command.McpServer.Tools;
 using FluentAssertions;
 using ModelContextProtocol.Protocol;
@@ -804,5 +806,133 @@ public sealed class ClioRunDispatchTests {
 		// Assert
 		attribute.Name.Should().Be(ClioRunDestructiveTool.ToolName, because: "the tool uses its stable name constant");
 		attribute.Destructive.Should().BeTrue(because: "the destructive surface must flag Destructive=true");
+	}
+
+	// --- Schema guard: the emitted input schema must declare args as "type":"object" -------------------
+	// ENG-92653: without "type":"object" Claude Code (and other clients that rely on the schema for
+	// serialization decisions) drops or stringifies the args payload, making the entire hidden-tool
+	// surface unreachable. This test builds the tool through the SDK (the same path BindingsModule uses)
+	// and inspects the actual emitted schema — a regression guard against future type-widening.
+
+	[Test]
+	[Category("Unit")]
+	[Description("clio-run input schema declares args as type=object so MCP clients serialize the payload correctly (ENG-92653 regression guard).")]
+	public void ClioRunTool_ShouldDeclareArgsAsObjectType_InEmittedInputSchema() {
+		// Arrange — instance method requires a target; pass a stub executor since the schema is derived
+		// from the method signature, not from the runtime instance state.
+		McpServerTool tool = McpServerTool.Create(
+			typeof(ClioRunTool).GetMethod(nameof(ClioRunTool.Run))!,
+			target: new ClioRunTool(Substitute.For<IClioRunExecutor>()),
+			new McpServerToolCreateOptions { SerializerOptions = BindingsModule.CreateMcpSerializerOptions() });
+
+		// Act
+		JsonElement schema = tool.ProtocolTool.InputSchema;
+		JsonElement argsProperty = schema.GetProperty("properties").GetProperty("args");
+
+		// Assert — nullable Dictionary<string, JsonElement>? emits type as ["object","null"] (an array)
+		// or "object" (a string) depending on the SDK version; either shape includes "object".
+		argsProperty.TryGetProperty("type", out JsonElement typeElement).Should().BeTrue(
+			because: "the args property must have an explicit type declaration so MCP clients know to serialize it as a JSON object (ENG-92653)");
+		AssertTypeIncludesObject(typeElement);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("clio-run-destructive input schema declares args as type=object (same fix as clio-run, ENG-92653 regression guard).")]
+	public void ClioRunDestructiveTool_ShouldDeclareArgsAsObjectType_InEmittedInputSchema() {
+		// Arrange
+		McpServerTool tool = McpServerTool.Create(
+			typeof(ClioRunDestructiveTool).GetMethod(nameof(ClioRunDestructiveTool.Run))!,
+			target: new ClioRunDestructiveTool(Substitute.For<IClioRunExecutor>()),
+			new McpServerToolCreateOptions { SerializerOptions = BindingsModule.CreateMcpSerializerOptions() });
+
+		// Act
+		JsonElement schema = tool.ProtocolTool.InputSchema;
+		JsonElement argsProperty = schema.GetProperty("properties").GetProperty("args");
+
+		// Assert
+		argsProperty.TryGetProperty("type", out JsonElement typeElement).Should().BeTrue(
+			because: "the args property must have an explicit type declaration (ENG-92653)");
+		AssertTypeIncludesObject(typeElement);
+	}
+
+	private static void AssertTypeIncludesObject(JsonElement typeElement) {
+		if (typeElement.ValueKind == JsonValueKind.String) {
+			typeElement.GetString().Should().Be("object",
+				because: "args must be declared as type=object for MCP client serialization compatibility");
+		} else if (typeElement.ValueKind == JsonValueKind.Array) {
+			typeElement.EnumerateArray()
+				.Select(item => item.GetString())
+				.Should().Contain("object",
+					because: "args type array must include 'object' so MCP clients serialize the payload correctly (ENG-92653)");
+		} else {
+			typeElement.ValueKind.Should().BeOneOf([JsonValueKind.String, JsonValueKind.Array],
+				because: "JSON Schema type must be a string or an array of strings");
+		}
+	}
+
+	// --- Dictionary→JsonElement conversion at the tool method level ------------------------------------
+	// The tool methods accept Dictionary<string, JsonElement>? (to emit the correct schema) and convert to
+	// JsonElement? before passing to the executor. These tests verify the conversion, covering the path the
+	// delegation tests (null args) do not reach.
+
+	[Test]
+	[Category("Unit")]
+	[Description("ClioRunTool converts a non-null Dictionary args to a JsonElement object and passes it through to the executor.")]
+	public async Task ClioRunTool_ShouldConvertDictionaryArgs_WhenArgsAreProvided() {
+		// Arrange
+		IClioRunExecutor executor = Substitute.For<IClioRunExecutor>();
+		CallToolResult expected = new() { Content = [] };
+		JsonElement? capturedArgs = null;
+		executor.RunAsync(
+			"echo-tool",
+			Arg.Any<JsonElement?>(),
+			false,
+			Arg.Any<RequestContext<CallToolRequestParams>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(call => {
+				capturedArgs = call.ArgAt<JsonElement?>(1);
+				return new ValueTask<CallToolResult>(expected);
+			});
+		ClioRunTool tool = new(executor);
+
+		// Act
+		Dictionary<string, JsonElement> args = new() {
+			["value"] = JsonDocument.Parse("\"hello\"").RootElement
+		};
+		CallToolResult result = await tool.Run(CallContext(), "echo-tool", args);
+
+		// Assert
+		result.Should().BeSameAs(expected,
+			because: "the tool must forward the converted args to the executor and return its result");
+		capturedArgs.Should().NotBeNull(because: "a non-null Dictionary must convert to a non-null JsonElement");
+		capturedArgs!.Value.ValueKind.Should().Be(JsonValueKind.Object,
+			because: "the converted JsonElement must be a JSON object");
+		capturedArgs.Value.GetProperty("value").GetString().Should().Be("hello",
+			because: "the Dictionary entries must survive the conversion intact");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("ClioRunTool passes null to executor when Dictionary args is null.")]
+	public async Task ClioRunTool_ShouldPassNullArgs_WhenDictionaryIsNull() {
+		// Arrange
+		IClioRunExecutor executor = Substitute.For<IClioRunExecutor>();
+		CallToolResult expected = new() { Content = [] };
+		executor.RunAsync(
+			"echo-tool",
+			Arg.Is<JsonElement?>(el => !el.HasValue),
+			false,
+			Arg.Any<RequestContext<CallToolRequestParams>>(),
+			Arg.Any<CancellationToken>())
+			.Returns(new ValueTask<CallToolResult>(expected));
+		ClioRunTool tool = new(executor);
+
+		// Act
+		CallToolResult result = await tool.Run(CallContext(), "echo-tool", null);
+
+		// Assert
+		result.Should().BeSameAs(expected,
+			because: "null Dictionary must convert to null JsonElement for the executor");
 	}
 }

--- a/clio/Command/McpServer/Tools/ClioRunTool.cs
+++ b/clio/Command/McpServer/Tools/ClioRunTool.cs
@@ -468,9 +468,12 @@ public sealed class ClioRunTool(IClioRunExecutor executor) {
 	public ValueTask<CallToolResult> Run(
 		RequestContext<CallToolRequestParams> context,
 		[Description("clio MCP tool name (kebab-case), e.g. \"execute-esq\"")] string? command = null,
-		[Description("JSON arguments object the target tool expects")] JsonElement? args = null,
+		[Description("JSON arguments object the target tool expects")] Dictionary<string, JsonElement>? args = null,
 		CancellationToken cancellationToken = default)
-		=> executor.RunAsync(command, args, destructiveSurface: false, context, cancellationToken);
+		=> executor.RunAsync(command, DictionaryToElement(args), destructiveSurface: false, context, cancellationToken);
+
+	internal static JsonElement? DictionaryToElement(Dictionary<string, JsonElement>? dict)
+		=> dict is not null ? JsonSerializer.SerializeToElement(dict) : null;
 }
 
 /// <summary>
@@ -492,7 +495,7 @@ public sealed class ClioRunDestructiveTool(IClioRunExecutor executor) {
 	public ValueTask<CallToolResult> Run(
 		RequestContext<CallToolRequestParams> context,
 		[Description("clio MCP tool name (kebab-case), e.g. \"sync-schemas\"")] string? command = null,
-		[Description("JSON arguments object the target tool expects")] JsonElement? args = null,
+		[Description("JSON arguments object the target tool expects")] Dictionary<string, JsonElement>? args = null,
 		CancellationToken cancellationToken = default)
-		=> executor.RunAsync(command, args, destructiveSurface: true, context, cancellationToken);
+		=> executor.RunAsync(command, ClioRunTool.DictionaryToElement(args), destructiveSurface: true, context, cancellationToken);
 }


### PR DESCRIPTION
🔗 **Jira:** [ENG-92653](https://creatio.atlassian.net/browse/ENG-92653)

## Summary
- `clio-run` / `clio-run-destructive` `args` parameter was `JsonElement?`, which generates no `"type"` in the JSON Schema
- Claude Code (and other schema-driven MCP clients) require `"type": "object"` to serialize a parameter as a JSON object — without it the args payload is dropped/stringified
- This made the entire hidden-tool surface (~102 tools) unreachable from Claude Code
- Changed parameter type to `Dictionary<string, JsonElement>?` → SDK emits `type: ["object", "null"]`
- Added `DictionaryToElement()` helper to convert before forwarding to executor (executor interface unchanged)

## Schema before/after

**Before:** `"args": { "description": "..." }` — no type declaration

**After:**
```json
"args": {
  "description": "JSON arguments object the target tool expects",
  "type": ["object", "null"],
  "default": null
}
```

## Tests added (4)
- `ClioRunTool_ShouldDeclareArgsAsObjectType_InEmittedInputSchema` — schema regression guard (builds tool via SDK, asserts emitted schema)
- `ClioRunDestructiveTool_ShouldDeclareArgsAsObjectType_InEmittedInputSchema` — same for destructive alias
- `ClioRunTool_ShouldConvertDictionaryArgs_WhenArgsAreProvided` — verifies Dictionary→JsonElement conversion
- `ClioRunTool_ShouldPassNullArgs_WhenDictionaryIsNull` — null path

## Test plan
- [x] `dotnet test --filter "Category=Unit & Module=McpServer"` — 1692 passed
- [x] `dotnet test --filter "Category=Unit & Module=Command"` — 1837 passed
- [ ] Live Claude Code test: repeat ticket repro steps (flat form, wrapped form, control) against fresh build

## Why this was missed in PR #743
Unit tests called `RunAsync(...)` directly with pre-constructed `JsonElement` objects, bypassing the SDK parameter binding and emitted schema entirely. The new schema guard tests build the tool through the SDK and assert the real emitted schema — a type regression will now fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-92653]: https://creatio.atlassian.net/browse/ENG-92653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ