### PR TITLE
fix(tests): serialize Program.IsDebugMode fixtures to stop a parallel race

### DIFF
--- a/clio.tests/Command/DownloadConfigurationCommandTests.cs
+++ b/clio.tests/Command/DownloadConfigurationCommandTests.cs
@@ -19,6 +19,7 @@ using SysIoAbstractions = System.IO.Abstractions;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Description("Tests for DownloadConfigurationCommand and DownloadConfigurationCommandOptionsValidator")]
 [Property("Module", "Command")]
 public class DownloadConfigurationCommandTests : BaseCommandTests<DownloadConfigurationCommandOptions>{

--- a/clio.tests/Command/GetPkgListCommandTests.cs
+++ b/clio.tests/Command/GetPkgListCommandTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Property("Module", "Command")]
 public class GetPkgListCommandTests {

--- a/clio.tests/Command/LoadPackagesToDbCommandTests.cs
+++ b/clio.tests/Command/LoadPackagesToDbCommandTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Property("Module", "Command")]
 public class LoadPackagesToDbCommandTests {

--- a/clio.tests/Command/LoadPackagesToFileSystemCommandTests.cs
+++ b/clio.tests/Command/LoadPackagesToFileSystemCommandTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Property("Module", "Command")]
 public class LoadPackagesToFileSystemCommandTests {

--- a/clio.tests/Command/NewPkgCommand.Tests.cs
+++ b/clio.tests/Command/NewPkgCommand.Tests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Property("Module", "Command")]
 public class NewPkgCommandTestCase

--- a/clio.tests/Command/OpenAppCommandTests.cs
+++ b/clio.tests/Command/OpenAppCommandTests.cs
@@ -15,6 +15,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Author("GitHub Copilot", "copilot@github.com")]
 [Description("Tests for OpenAppCommand - verifies opening web applications in browsers across different platforms")]

--- a/clio.tests/Command/RestartCommand.Tests.cs
+++ b/clio.tests/Command/RestartCommand.Tests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Property("Module", "Command")]
 public class RestartCommandTestCase : BaseCommandTests<RestartOptions> {
 

--- a/clio.tests/Command/RestoreDb.LogArtifact.Tests.cs
+++ b/clio.tests/Command/RestoreDb.LogArtifact.Tests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Category("Unit")]
 [Property("Module", "Command")]
 public sealed class RestoreDbLogArtifactTests {

--- a/clio.tests/Command/UnregisterCommand.Tests.cs
+++ b/clio.tests/Command/UnregisterCommand.Tests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command;
 
 [TestFixture]
+[NonParallelizable]
 [Property("Module", "Command")]
 internal class UnregisterCommandTests : BaseCommandTests<UnregisterOptions>{
 	#region Fields: Private


### PR DESCRIPTION
## Problem

`Execute_ShouldLogMessageOnly_WhenExceptionOccurs_InNormalMode` (and its siblings) fail **intermittently** in CI, e.g. [run on PR #807](https://github.com/Advance-Technologies-Foundation/clio/actions):

```
Expected to receive exactly 1 call matching: WriteError("fs failed")
Actually received no matching calls.
Received 1 non-matching call: WriteError("System.Exception: fs failed  at ...")
```

## Root cause — a data race on a process-wide static

- `clio.tests` runs fixtures in parallel: `[assembly: Parallelizable(ParallelScope.Fixtures)]` + `LevelOfParallelism(3)` (`TestAssemblySetup.cs`).
- `Program.IsDebugMode` is a **process-wide `static`**. The command logs `e.GetReadableMessageException(Program.IsDebugMode)` → `e.Message` in normal mode, full `e.ToString()` in debug mode. The command is **correct**.
- **Nine** command fixtures mutate `Program.IsDebugMode` to test both branches. Under parallel fixtures they race: while fixture A sets it `false` and asserts the message-only output, fixture B (on another worker) sets it `true`, so A's command reads `true` and logs the full stack trace → assertion fails. The per-test `try/finally` save/restore guards ordering, not concurrent readers.

This is a **pre-existing latent flake** (introduced when these parallel-unsafe tests were added to the already-parallel assembly), unrelated to any single PR — it fails whichever run loses the scheduling race.

## Fix

Mark all nine `Program.IsDebugMode`-mutating fixtures `[NonParallelizable]`, so they never run concurrently with any other test. This matches the repo's existing convention — `Program.Tests.cs` is already `[NonParallelizable]` for the same reason (the process-wide `Program.IsMcpServerMode` static).

Fixtures updated:
`DownloadConfigurationCommandTests`, `GetPkgListCommandTests`, `LoadPackagesToDbCommandTests`, `LoadPackagesToFileSystemCommandTests`, `NewPkgCommandTestCase`, `OpenAppCommandTests`, `RestartCommandTestCase`, `RestoreDbLogArtifactTests`, `UnregisterCommandTests`.

## Validation

`dotnet test --filter "Category=Unit&Module=Command"` → **1903 passed, 0 failed** (11 skipped).

One-line change per file (attribute only); no test logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
