### PR TITLE
#ENG-92791 The title should be set for the replacement schema in case of updating dashboard

### DIFF
--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -3237,6 +3237,77 @@ public class PageToolsTests
 	}
 
 	[Test]
+	[Description("TryUpdatePage materializes the parent schema caption onto a newly created replacing schema so its runtime title is not lost")]
+	public void TryUpdatePage_WhenCreatingReplacing_PreservesParentCaption() {
+		// Arrange
+		var applicationClient = Substitute.For<IApplicationClient>();
+		var serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		var logger = Substitute.For<ILogger>();
+		var hierarchyClient = Substitute.For<IPageDesignerHierarchyClient>();
+		const string originalUId = "f537fd79-9bdc-43ea-a9ce-b068c29d0b22";
+		const string originalPackageUId = "2ecba2bd-b810-47a5-a1b1-08c888529d6c";
+		const string virtualDesignPackageUId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+		serviceUrlBuilder.Build(Arg.Any<string>()).Returns(ci => "http://test" + ci.ArgAt<string>(0));
+		hierarchyClient.GetDesignPackageUId(originalUId).Returns(virtualDesignPackageUId);
+		hierarchyClient.GetParentSchemas(originalUId, virtualDesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			new() { UId = originalUId, Name = "Accounts_ListPage", PackageUId = originalPackageUId, PackageName = "CrtCustomer360App" }
+		});
+		string validBody = "define(\"Accounts_ListPage\", /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, function/**SCHEMA_ARGS*/()/**SCHEMA_ARGS*/ { return { viewConfigDiff: /**SCHEMA_VIEW_CONFIG_DIFF*/[]/**SCHEMA_VIEW_CONFIG_DIFF*/, viewModelConfigDiff: /**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/[]/**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/, modelConfigDiff: /**SCHEMA_MODEL_CONFIG_DIFF*/[]/**SCHEMA_MODEL_CONFIG_DIFF*/, handlers: /**SCHEMA_HANDLERS*/[]/**SCHEMA_HANDLERS*/, converters: /**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/, validators: /**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/ }; });";
+		var parentCaption = new JArray {
+			new JObject { ["cultureName"] = "en-US", ["value"] = "Accounts list" },
+			new JObject { ["cultureName"] = "uk-UA", ["value"] = "Список контрагентів" }
+		};
+		var metadataResponse = new JObject {
+			["success"] = true,
+			["rows"] = new JArray { new JObject { ["UId"] = originalUId } }
+		};
+		var getSchemaResponse = new JObject {
+			["success"] = true,
+			["schema"] = new JObject {
+				["uId"] = originalUId,
+				["name"] = "Accounts_ListPage",
+				["schemaType"] = 9,
+				["schemaVersion"] = 1,
+				["body"] = "original body",
+				["caption"] = parentCaption.DeepClone(),
+				["localizableStrings"] = new JArray(),
+				["package"] = new JObject { ["uId"] = originalPackageUId, ["name"] = "CrtCustomer360App" },
+				["parent"] = new JObject { ["uId"] = "b7b898d0-8c77-4953-c097-23fa6800da02", ["name"] = "ListPageV3Template" },
+				["isReadOnly"] = true,
+				["optionalProperties"] = new JArray()
+			}
+		};
+		var saveResponse = new JObject { ["success"] = true };
+		var noRowsResponse = new JObject { ["success"] = true, ["rows"] = new JArray() };
+		string lastSavePayload = null;
+		int callIndex = 0;
+		applicationClient.ExecutePostRequest(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(ci => {
+				callIndex++;
+				if (callIndex == 1) return metadataResponse.ToString();
+				if (callIndex == 2) return noRowsResponse.ToString();
+				if (callIndex == 3) return getSchemaResponse.ToString();
+				if (callIndex == 4) { lastSavePayload = ci.ArgAt<string>(1); return saveResponse.ToString(); }
+				return new JObject { ["success"] = true }.ToString();
+			});
+
+		// Act
+		var command = new PageUpdateCommand(applicationClient, serviceUrlBuilder, logger, Substitute.For<IPageBaselineGuard>(), hierarchyClient);
+		bool ok = command.TryUpdatePage(new PageUpdateOptions { SchemaName = "Accounts_ListPage", Body = validBody, DryRun = false }, out PageUpdateResponse response);
+
+		// Assert
+		ok.Should().BeTrue(because: "the create-replacing save should succeed; error: " + response.Error);
+		var savedDto = JObject.Parse(lastSavePayload);
+		savedDto["extendParent"].Value<bool>().Should().BeTrue(
+			because: "a create-replacing DTO must extend its parent");
+		savedDto["caption"].Should().NotBeNull(
+			because: "the replacing schema must carry a caption so its runtime title (e.g. a dashboard tab) is not lost");
+		JToken.DeepEquals(savedDto["caption"], parentCaption).Should().BeTrue(
+			because: "the parent schema caption must be materialized verbatim onto the replacing schema, mirroring the platform designer and CreateDesignSchema");
+	}
+
+	[Test]
 	[Description("TryUpdatePage without hierarchy client falls back to legacy direct-update flow (backward compatibility)")]
 	public void TryUpdatePage_WhenHierarchyClientOmitted_FallsBackToLegacyFlow() {
 		var applicationClient = Substitute.For<IApplicationClient>();

--- a/clio/Command/PageUpdateOptions.cs
+++ b/clio/Command/PageUpdateOptions.cs
@@ -570,7 +570,6 @@ namespace Clio.Command {
 			dto["name"] = originalName;
 			dto["isReadOnly"] = false;
 			dto["extendParent"] = true;
-			dto["caption"] = template["caption"]?.DeepClone();
 			dto[LocalizableStringsKey] = template[LocalizableStringsKey]?.DeepClone() ?? new JArray();
 			dto["package"] = new JObject {
 				["uId"] = context.DesignPackageUId,

--- a/clio/Command/PageUpdateOptions.cs
+++ b/clio/Command/PageUpdateOptions.cs
@@ -570,7 +570,7 @@ namespace Clio.Command {
 			dto["name"] = originalName;
 			dto["isReadOnly"] = false;
 			dto["extendParent"] = true;
-			dto["caption"] = null;
+			dto["caption"] = template["caption"]?.DeepClone();
 			dto[LocalizableStringsKey] = template[LocalizableStringsKey]?.DeepClone() ?? new JArray();
 			dto["package"] = new JObject {
 				["uId"] = context.DesignPackageUId,


### PR DESCRIPTION
## Summary

`update-page` (and its MCP tool) lost the page **title** whenever it had to create a *replacing* schema — i.e. when editing a page whose original schema lives in a locked application package, so the edit is written to a new replacing schema in the design package.

For a **dashboard** this is user-visible: the section's dashboard selector renders the raw schema code (e.g. `Page_ItRequestAnalyticsDashboard`) instead of the dashboard title (e.g. *"IT Request analytics dashboard"*).

## Root cause

When no replacing schema exists yet, `BuildNewReplacingSchemaDto` built the new schema DTO and explicitly set `dto["caption"] = null`, on the assumption that a replacing schema (`extendParent = true`) inherits its caption from the parent.

That assumption does not hold at runtime. Creatio resolves a schema's title from its **own** record only — `SchemaManager.CreateSelectInitializeCaption` joins `SysSchemaLcz.RecordId = SysSchema.Id` with **no** parent fallback. So a replacing schema with an empty caption has no title, and the Freedom UI dashboard selector falls back to the schema code (`Name || Code` in `dashboards.component.ts`).

The platform's own designer does the opposite: `SchemaManager.CreateDesignSchema` copies `parentSchema.Caption` onto the replacing schema at creation, and `create-page` (`ClientUnitSchemaCreate`) likewise persists the caption. clio's `update-page` was the only path that nulled it.

(Non-dashboard pages — Home/Form/List — also received an empty caption but are unaffected, because their visible title is not sourced from the schema caption.)

## Fix

Materialize the parent caption onto the new replacing schema, matching `CreateDesignSchema` / `create-page`:

```diff
- dto["caption"] = null;
+ dto["caption"] = template["caption"]?.DeepClone();
```

`template` is the parent/root schema loaded via `GetSchema`, so its `caption` is the localized caption array; it is round-tripped verbatim back to `SaveSchema`.

## Tests

- New unit test `PageToolsTests.TryUpdatePage_WhenCreatingReplacing_PreservesParentCaption` — asserts the create-replacing `SaveSchema` DTO carries the parent caption verbatim (`JToken.DeepEquals`) and `extendParent = true`.
- Validated: `dotnet test -f net8.0 --filter "Category=Unit&(Module=Command|Module=McpServer)"` → **3435 passed, 0 failed**.

## Notes

- **MCP reviewed, no update required** — the `update-page` tool contract/arguments are unchanged; only the persisted schema DTO differs.
- **Docs reviewed, no update required** — internal save behavior; no command options changed.
- Replacing schemas that were **already** saved with an empty caption need a one-time re-save (open in the designer and Apply, or re-run `update-page` with this build) — the code fix does not retroactively repair existing schemas.

Fixes ENG-92791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
