### PR TITLE
fix(ci): make release smoke-test compatible with packageSourceMapping

### DIFF
--- a/.github/workflows/reliase-to-nuget.yml
+++ b/.github/workflows/reliase-to-nuget.yml
@@ -117,7 +117,40 @@ jobs:
             Remove-Item $toolPath -Recurse -Force
           }
 
-          dotnet tool install clio --tool-path $toolPath --version $version --add-source (Join-Path $PWD "output")
+          # The repo nuget.config enables <packageSourceMapping>, and newer NuGet SDKs hard-reject
+          # `--add-source` when source mapping is active ("The --add-source option cannot be combined
+          # with package source mapping"). Instead of --add-source, write a dedicated smoke config that
+          # maps the freshly packed `clio` to the local ./output source and routes everything else the
+          # same way the repo config does, then install with --configfile. This keeps the smoke test
+          # working regardless of the runner's NuGet source-mapping enforcement.
+          $outputSource = Join-Path $PWD "output"
+          $smokeConfig = Join-Path $PWD "tool-smoke-nuget.config"
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local-output" value="$outputSource" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="Terrasoft" value="https://ts1-infr-nexus.bpmonline.com/repository/nuget-v3/index.json" />
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local-output">
+                <package pattern="clio" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+                <package pattern="creatio.client" />
+              </packageSource>
+              <packageSource key="Terrasoft">
+                <package pattern="Terrasoft.*" />
+                <package pattern="Creatio.*" />
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>
+          "@ | Set-Content -Path $smokeConfig -Encoding UTF8
+
+          dotnet tool install clio --tool-path $toolPath --version $version --configfile $smokeConfig
           if ($LASTEXITCODE -ne 0) {
             throw "dotnet tool install failed with exit code $LASTEXITCODE"
           }


### PR DESCRIPTION
## Problem

The `release-to-nuget` workflow's **Verify packaged tool version** smoke step installs the freshly packed `clio` with:

```
dotnet tool install clio --tool-path ... --version ... --add-source ./output
```

Newer NuGet SDKs on the self-hosted runner now **hard-reject** `--add-source` when the repo `nuget.config` has `<packageSourceMapping>` active:

```
The --add-source option cannot be combined with package source mapping.
```

This broke the **8.1.0.71** release publish (the step failed → `Publish to NuGet` was skipped → package never reached NuGet). The identical step passed on 8.1.0.70 (02.07) under the older SDK — neither the step nor `nuget.config` changed since; only the runner's SDK did.

## Fix

Replace `--add-source` with a dedicated smoke `nuget.config` written at step time and passed via `--configfile`:

- `clio` → local `./output` source
- `*` (+ `creatio.client`) → nuget.org
- `Terrasoft.*` / `Creatio.*` → Terrasoft mirror

This mirrors the repo config and works regardless of the runner's source-mapping enforcement.

## Verification

- YAML validated; after YAML de-indentation both here-string delimiters (`@"` / `"@`) land at column 0 as PowerShell 5.1 requires.
- Workflow-only change; no product code touched. **MCP reviewed, no update required. Docs reviewed, no update required** (CI-internal change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)