### PR TITLE
ENG-92669: fix PowerShell 5.1 parse error in teamcity-mcp-e2e workflow

### DIFF
--- a/.github/workflows/teamcity-mcp-e2e.yml
+++ b/.github/workflows/teamcity-mcp-e2e.yml
@@ -1,28 +1,28 @@
 ---
-# ENG-92669 — surface the TeamCity MCP e2e result on clio PRs.
+# ENG-92669 - surface the TeamCity MCP e2e result on clio PRs.
 #
 # TeamCity is internal (teamcity-rnd.bpmonline.com) and clio lives on public
 # github.com, so we cannot rely on TeamCity's native "Pull Requests" auto-
 # discovery: the Team_Atf_ClioMcpE2eTests config checks out its branch from the
 # `BranchNameClio` parameter (root branch = refs/heads/%BranchNameClio%), not via
-# TeamCity branch-tracking. Instead, this workflow — running on the self-hosted
-# runner that already lives inside the corporate network — triggers the TeamCity
+# TeamCity branch-tracking. Instead, this workflow - running on the self-hosted
+# runner that already lives inside the corporate network - triggers the TeamCity
 # build for the PR head branch. TeamCity's Commit Status Publisher (GitHub App
 # "TeamCity ATF") then posts pending/success/failure back onto the PR head SHA as
 # a commit status, so the result shows in the PR checks list.
 #
-# Phase 1 is advisory (non-blocking) — the status is informational and is NOT a
+# Phase 1 is advisory (non-blocking) - the status is informational and is NOT a
 # required check. The unit-tests config (Team_Atf_ClioUnitTests) uses a different
 # branch model and is handled as a fast-follow, not here.
 #
-# Prerequisites (one-time, outside this repo) — all in place at merge time:
+# Prerequisites (one-time, outside this repo) - all in place at merge time:
 #   1. TeamCity: Commit Status Publisher on Team_Atf_ClioMcpE2eTests (GitHub App
-#      connection "TeamCity ATF") — DONE; validated against PR #651.
-#   2. GitHub repo secret TEAMCITY_TOKEN — a *least-privilege* TeamCity token that
+#      connection "TeamCity ATF") - DONE; validated against PR #651.
+#   2. GitHub repo secret TEAMCITY_TOKEN - a *least-privilege* TeamCity token that
 #      can only trigger (Run build) these ATF builds. A same-repo PR can edit this
 #      workflow, so the token must not grant more than queueing builds; it
 #      deliberately cannot cancel/stop builds.
-#   3. Repo setting Actions → "Require approval for all external contributors"
+#   3. Repo setting Actions -> "Require approval for all external contributors"
 #      (authoritative fork control; the in-file `if:` guard below is only
 #      defense-in-depth). To be confirmed by a repo admin.
 #
@@ -40,7 +40,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [master]
-    # Trigger on clio source changes, but NOT docs-only PRs — command docs live
+    # Trigger on clio source changes, but NOT docs-only PRs - command docs live
     # under clio/ (clio/docs, clio/help, clio/Commands.md) and would otherwise
     # queue the ~45-min full-Creatio build for nothing.
     paths:
@@ -53,7 +53,7 @@ on:
       - 'Directory.Packages.props'
   # Manual retrigger for a specific clio branch (e.g. re-run e2e after a flaky
   # failure, or validate the trigger). Only usable once the workflow is on the
-  # default branch — a GitHub constraint.
+  # default branch - a GitHub constraint.
   workflow_dispatch:
     inputs:
       branch:
@@ -63,7 +63,7 @@ on:
 
 # De-dupes rapid GitHub trigger runs per PR (the sub-second POST job only).
 # NOTE: this does NOT stop the ~45-min TeamCity build a prior run already queued
-# — the least-privilege token cannot cancel builds. Concurrent full-Creatio
+# - the least-privilege token cannot cancel builds. Concurrent full-Creatio
 # deploys are bounded on the TeamCity side (build config: max simultaneous
 # builds), which is where superseded/parallel runs are actually serialized.
 # Manual runs key off run_id so they don't cancel each other.
@@ -79,9 +79,9 @@ jobs:
     timeout-minutes: 10
     # SECURITY: this job runs on an in-network self-hosted runner. On a public
     # repo, a fork PR still fires `pull_request` and would run the fork-controlled
-    # workflow body on that runner (a network-pivot surface) — so restrict to
+    # workflow body on that runner (a network-pivot surface) - so restrict to
     # same-repo PRs and manual dispatch. This in-file guard is defense-in-depth;
-    # the authoritative control is the repo setting Actions → "Require approval
+    # the authoritative control is the repo setting Actions -> "Require approval
     # for all external contributors" (must be enabled).
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -93,14 +93,14 @@ jobs:
           TC_URL: https://teamcity-rnd.bpmonline.com
           TC_TOKEN: ${{ secrets.TEAMCITY_TOKEN }}
           BUILD_TYPE: Team_Atf_ClioMcpE2eTests
-          # pull_request → PR head branch; workflow_dispatch → the chosen branch.
+          # pull_request -> PR head branch; workflow_dispatch -> the chosen branch.
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.branch }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number || '(manual)' }}
         run: |
           $ErrorActionPreference = 'Stop'
           if ([string]::IsNullOrWhiteSpace($env:TC_TOKEN)) {
-            throw 'TEAMCITY_TOKEN secret is not set — cannot trigger TeamCity.'
+            throw 'TEAMCITY_TOKEN secret is not set - cannot trigger TeamCity.'
           }
 
           # The e2e config resolves its checkout from BranchNameClio
@@ -117,16 +117,16 @@ jobs:
               @{ name = 'env.McpE2E__AllowDestructiveMcpTests';  value = 'true' }
               @{ name = 'ProductName';                           value = 'Studio' }
             ) }
-            comment    = @{ text = "clio PR #$env:PR_NUMBER ($env:HEAD_REF$shaSuffix) — MCP e2e via GitHub Actions" }
+            comment    = @{ text = "clio PR #$env:PR_NUMBER ($env:HEAD_REF$shaSuffix) - MCP e2e via GitHub Actions" }
           } | ConvertTo-Json -Depth 6
 
           $resp = Invoke-RestMethod -Method Post -Uri "$env:TC_URL/app/rest/buildQueue" `
             -Headers @{ Authorization = "Bearer $env:TC_TOKEN"; Accept = 'application/json' } `
             -ContentType 'application/json' -Body $body -TimeoutSec 60
 
-          # A 2xx with an unexpected body must not read as success — require a build id.
+          # A 2xx with an unexpected body must not read as success - require a build id.
           if (-not $resp.id) {
-            throw "TeamCity accepted the request but returned no build id — the trigger likely failed."
+            throw "TeamCity accepted the request but returned no build id - the trigger likely failed."
           }
 
           Write-Host "Queued TeamCity build #$($resp.id) on BranchNameClio=$env:HEAD_REF"


### PR DESCRIPTION
🔗 **Jira:** [ENG-92669](https://creatio.atlassian.net/browse/ENG-92669)

Hotfix for the workflow added in #831.

**Problem:** the `teamcity-mcp-e2e.yml` PowerShell `run:` block contained em-dashes / arrows (`—`, `→`). Windows PowerShell 5.1 mis-decodes the UTF-8 (no-BOM) script file, and the em-dash broke parsing — `Unexpected token 'MCP'`, `The hash literal was incomplete` — so the **Trigger TeamCity MCP e2e** job failed at ~6s on every clio PR touching the gated paths (observed on #651).

**Fix:** replace all non-ASCII characters with ASCII equivalents (`—` → `-`, `→` → `->`). No behavior change; the workflow logic is untouched.

Validated: YAML parses; file is ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-92669]: https://creatio.atlassian.net/browse/ENG-92669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ