### PR TITLE
ENG-92669: drop build comment so least-privilege token suffices

### DIFF
--- a/.github/workflows/teamcity-mcp-e2e.yml
+++ b/.github/workflows/teamcity-mcp-e2e.yml
@@ -95,8 +95,6 @@ jobs:
           BUILD_TYPE: Team_Atf_ClioMcpE2eTests
           # pull_request -> PR head branch; workflow_dispatch -> the chosen branch.
           HEAD_REF: ${{ github.event.pull_request.head.ref || inputs.branch }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number || '(manual)' }}
         run: |
           $ErrorActionPreference = 'Stop'
           if ([string]::IsNullOrWhiteSpace($env:TC_TOKEN)) {
@@ -108,7 +106,9 @@ jobs:
           # PR heads (they exist as refs/heads/<head.ref>); fork PRs are filtered
           # out by the job-level `if:` above, so BranchNameClio is always a branch
           # that exists in the main repo.
-          $shaSuffix = if ([string]::IsNullOrWhiteSpace($env:HEAD_SHA)) { '' } else { " @ $env:HEAD_SHA" }
+          # No `comment` field: adding a build comment needs the "Comment build"
+          # permission, which the least-privilege token intentionally lacks. The
+          # branch is already captured in the build number (%counter%_%BranchNameClio%).
           $body = @{
             buildType  = @{ id = $env:BUILD_TYPE }
             properties = @{ property = @(
@@ -117,7 +117,6 @@ jobs:
               @{ name = 'env.McpE2E__AllowDestructiveMcpTests';  value = 'true' }
               @{ name = 'ProductName';                           value = 'Studio' }
             ) }
-            comment    = @{ text = "clio PR #$env:PR_NUMBER ($env:HEAD_REF$shaSuffix) - MCP e2e via GitHub Actions" }
           } | ConvertTo-Json -Depth 6
 
           $resp = Invoke-RestMethod -Method Post -Uri "$env:TC_URL/app/rest/buildQueue" `


### PR DESCRIPTION
🔗 **Jira:** [ENG-92669](https://creatio.atlassian.net/browse/ENG-92669)

Second hotfix for the workflow from #831 (follows #832). Found while validating the live trigger via `workflow_dispatch`.

**Problem:** the trigger POST body included a `comment` field. Adding a build comment needs the TeamCity **"Comment build"** permission, which the least-privilege `TEAMCITY_TOKEN` (Run build + View project) intentionally lacks — so TeamCity returned **403** (`You do not have "Comment build" permission`) and the trigger job failed. (The earlier manual validation passed only because it used an admin token.)

**Fix:** remove the `comment` field (and the now-unused `HEAD_SHA` / `PR_NUMBER` inputs). The branch is already captured in the TeamCity build number (`%counter%_%BranchNameClio%`), so nothing is lost. The POST now needs only **Run build** — matching the token scope. Keeps the token least-privilege (no permission broadening).

After the ASCII fix (#832), the PowerShell parses and reaches TeamCity — this was the next (and expected-final) blocker in the live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-92669]: https://creatio.atlassian.net/browse/ENG-92669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ