### PR TITLE
Add IIS environment import to ClioRing

### DIFF
--- a/clio-ring/ClioRing.Desktop/actions.json
+++ b/clio-ring/ClioRing.Desktop/actions.json
@@ -119,6 +119,22 @@
       "Risk": "None"
     },
     {
+      "Id": "clio-import-iis-environments",
+      "Title": "Import IIS Environments",
+      "ShortTitle": "Import IIS",
+      "Icon": "globe",
+      "Kind": "ClioCommand",
+      "ClioCommand": {
+        "Verb": "reg",
+        "Args": ["--add-from-iis"]
+      },
+      "Parameters": [],
+      "Risk": "Confirm",
+      "ConfirmText": "Scan local IIS and update the local clio environment catalog?",
+      "ConsequenceText": "Existing registrations with matching IIS site names will be replaced with detected local settings, including credentials and safety flags.",
+      "RefreshEnvironmentsOnSuccess": true
+    },
+    {
       "Id": "clio-manage-envs",
       "Title": "Manage Environments",
       "ShortTitle": "Manage Envs",

--- a/clio-ring/ClioRing.Desktop/actions.schema.json
+++ b/clio-ring/ClioRing.Desktop/actions.schema.json
@@ -175,6 +175,11 @@
           "type": "string",
           "title": "Consequence line",
           "description": "Optional explicit consequence line shown prominently in the confirm dialog (distinct from ConfirmText), spelling out the concrete irreversible effect."
+        },
+        "RefreshEnvironmentsOnSuccess": {
+          "type": "boolean",
+          "title": "Refresh environments on success",
+          "description": "When true, reloads clio's registered-environment catalog after the command exits successfully."
         }
       },
       "allOf": [

--- a/clio-ring/ClioRing.Tests/ActionCatalogUninstallCreatioTests.cs
+++ b/clio-ring/ClioRing.Tests/ActionCatalogUninstallCreatioTests.cs
@@ -105,4 +105,42 @@ public sealed class ActionCatalogUninstallCreatioTests {
 		manageEnvironments.ClioCommand.Args.Should().Equal(["--json"],
 			because: "JSON output uses clio's masked projection and must not expose stored credentials");
 	}
+
+	[Test]
+	[Description("The shipped catalog exposes a confirmed Import IIS action that runs clio reg --add-from-iis and refreshes environments.")]
+	public void Load_ShouldContainImportIisAction_WhenShippedActionsJsonIsUsed() {
+		// Arrange
+		var loader = new ActionCatalogLoader();
+
+		// Act
+		ActionCatalog catalog = loader.Load(ShippedCatalogPath);
+		RingAction importIis = catalog.Actions.First(a =>
+			string.Equals(a.Id, "clio-import-iis-environments", StringComparison.OrdinalIgnoreCase));
+
+		// Assert
+		importIis.Title.Should().Be("Import IIS Environments",
+			because: "the ring should clearly describe what will be imported");
+		importIis.Kind.Should().Be(ActionKind.ClioCommand,
+			because: "the existing clio command owns IIS discovery and environment registration");
+		importIis.ClioCommand.Should().NotBeNull(
+			because: "a ClioCommand action requires a typed command payload");
+		importIis.ClioCommand!.Verb.Should().Be("reg",
+			because: "the requested Ring action must execute the existing clio reg alias");
+		importIis.ClioCommand.Args.Should().Equal(["--add-from-iis"],
+			because: "the action must activate IIS environment discovery");
+		importIis.Parameters.Should().BeEmpty(
+			because: "local IIS discovery does not require a selected registered environment");
+		importIis.Risk.Should().Be(Risk.Confirm,
+			because: "matching registrations can be overwritten and the user must explicitly approve that catalog change");
+		importIis.ConfirmText.Should().Contain("local clio environment catalog",
+			because: "the confirmation must identify the actual target rather than the currently selected environment");
+		importIis.ConsequenceText.Should().Contain("matching IIS site names",
+			because: "the confirmation must disclose that same-name registrations can be replaced");
+		importIis.ConsequenceText.Should().Contain("credentials",
+			because: "the confirmation must disclose that stored credentials can be replaced");
+		importIis.ConsequenceText.Should().Contain("safety flags",
+			because: "the confirmation must disclose that stored safety settings can be replaced");
+		importIis.RefreshEnvironmentsOnSuccess.Should().BeTrue(
+			because: "newly imported registrations must appear without relying solely on the file watcher");
+	}
 }

--- a/clio-ring/ClioRing.Tests/RingViewModelConfirmTests.cs
+++ b/clio-ring/ClioRing.Tests/RingViewModelConfirmTests.cs
@@ -157,4 +157,140 @@ public sealed class RingViewModelConfirmTests {
 		_sut.PendingConfirmItem.Should().BeNull(because: "no confirm is pending when the listed-env guard trips");
 		_sut.FocusCaption.Should().Be("Select an environment first.", because: "the guard tells the user why nothing happened");
 	}
+
+	[Test]
+	[Description("A confirmed action with a fixed environment displays that immutable target rather than the current selection.")]
+	public async Task SelectCommand_ShouldDisplayFixedEnvironment_WhenActionHasExplicitTarget() {
+		// Arrange — the selected environment differs from the action's fixed target.
+		_sut.SetEnvironments(new[] { LocalEnv("selected"), LocalEnv("fixed") });
+		var action = new RingAction {
+			Id = "fixed-target",
+			Title = "Fixed target action",
+			Kind = ActionKind.ClioCommand,
+			ClioCommand = new ClioCommandSpec { Verb = "get-info", EnvName = "fixed" },
+			Risk = Risk.Confirm,
+			ConfirmText = "Run against '{env}'?"
+		};
+
+		// Act
+		await OpenConfirmForAsync(action);
+
+		// Assert
+		_sut.ConfirmMessage.Should().Contain("fixed",
+			because: "the confirmation must display the immutable environment carried by the action");
+		_sut.ConfirmMessage.Should().NotContain("selected",
+			because: "the current selection is unrelated when the action declares a fixed environment");
+		_sut.ConfirmExpected.Should().Be("fixed",
+			because: "typed confirmation, when enabled, must use the immutable fixed target");
+	}
+
+	[Test]
+	[Description("Confirmation is cancelled when the displayed environment disappears before execution.")]
+	public async Task ConfirmCommand_ShouldCancel_WhenConfirmedEnvironmentDisappears() {
+		// Arrange — open confirmation for the original selected environment, then replace the catalog selection.
+		_sut.SetEnvironments(new[] { LocalEnv("original") });
+		_clio.ListEnvironmentsAsync(Arg.Any<CancellationToken>()).Returns(System.Array.Empty<ClioEnvironment>());
+		await OpenConfirmForAsync(TypedConfirmUninstall());
+		_sut.SetEnvironments(new[] { LocalEnv("replacement") });
+		_sut.ConfirmArmed = true;
+		_sut.ConfirmInput = "original";
+
+		// Act
+		await _sut.ConfirmCommand.ExecuteAsync(null);
+
+		// Assert
+		_sut.FocusCaption.Should().Be("Environment changed. Review and confirm again.",
+			because: "a removed confirmed target requires a fresh selection and confirmation");
+		await _clio.DidNotReceive().RunAsync(
+			Arg.Any<ClioInvocation>(),
+			Arg.Any<System.Action<ClioOutputLine>>(),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	[Description("Confirmation executes the captured environment when clio's authoritative target signature is unchanged.")]
+	public async Task ConfirmCommand_ShouldExecuteCapturedEnvironment_WhenAuthoritativeTargetIsUnchanged() {
+		// Arrange
+		ClioEnvironment original = LocalEnv("original");
+		_sut.SetEnvironments(new[] { original });
+		_clio.ListEnvironmentsAsync(Arg.Any<CancellationToken>()).Returns(new[] { original });
+		_clio.RunAsync(Arg.Any<ClioInvocation>(), Arg.Any<System.Action<ClioOutputLine>>(), Arg.Any<CancellationToken>())
+			.Returns(new ClioRunResult(0, string.Empty, string.Empty, Cancelled: false));
+		await OpenConfirmForAsync(TypedConfirmUninstall());
+		_sut.ConfirmArmed = true;
+		_sut.ConfirmInput = "original";
+
+		// Act
+		await _sut.ConfirmCommand.ExecuteAsync(null);
+
+		// Assert
+		await _clio.Received(1).RunAsync(
+			Arg.Is<ClioInvocation>(invocation => invocation != null && invocation.EnvName == "original"),
+			Arg.Any<System.Action<ClioOutputLine>>(),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	[Description("Confirmation is cancelled when the displayed environment name is retargeted to a different endpoint before execution.")]
+	public async Task ConfirmCommand_ShouldCancel_WhenConfirmedEnvironmentEndpointChanges() {
+		// Arrange — keep the UI cache unchanged while clio's authoritative catalog retargets the same name.
+		_sut.SetEnvironments(new[] { new ClioEnvironment("original", "http://localhost:5000", IsNetCore: true) });
+		_clio.ListEnvironmentsAsync(Arg.Any<CancellationToken>())
+			.Returns(new[] { new ClioEnvironment("original", "http://localhost:5001", IsNetCore: true) });
+		await OpenConfirmForAsync(TypedConfirmUninstall());
+		_sut.ConfirmArmed = true;
+		_sut.ConfirmInput = "original";
+
+		// Act
+		await _sut.ConfirmCommand.ExecuteAsync(null);
+
+		// Assert
+		_sut.HasPendingConfirm.Should().BeFalse(
+			because: "a stale confirmation must close instead of remaining executable");
+		_sut.FocusCaption.Should().Be("Environment changed. Review and confirm again.",
+			because: "the user must be told to review the new endpoint before retrying");
+		await _clio.DidNotReceive().RunAsync(
+			Arg.Any<ClioInvocation>(),
+			Arg.Any<System.Action<ClioOutputLine>>(),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	[Description("A confirmed environment-catalog action omits the selected environment target and refreshes environments after success.")]
+	public async Task ConfirmCommand_ShouldRefreshEnvironmentsWithoutSelectedTarget_WhenCatalogActionSucceeds() {
+		// Arrange — no selected environment; the command updates the catalog itself and then discovers its result.
+		var action = new RingAction {
+			Id = "clio-import-iis-environments",
+			Title = "Import IIS Environments",
+			Kind = ActionKind.ClioCommand,
+			ClioCommand = new ClioCommandSpec { Verb = "reg", Args = new[] { "--add-from-iis" } },
+			Risk = Risk.Confirm,
+			ConfirmText = "Scan local IIS and update the local clio environment catalog?",
+			RefreshEnvironmentsOnSuccess = true
+		};
+		_clio.RunAsync(Arg.Any<ClioInvocation>(), Arg.Any<System.Action<ClioOutputLine>>(), Arg.Any<CancellationToken>())
+			.Returns(new ClioRunResult(0, string.Empty, string.Empty, Cancelled: false));
+		_clio.ListEnvironmentsAsync(Arg.Any<CancellationToken>()).Returns(new[] { LocalEnv("imported") });
+		await OpenConfirmForAsync(action);
+		_sut.ConfirmMessage.Should().Be("Scan local IIS and update the local clio environment catalog?",
+			because: "a catalog-wide action must not present the unrelated selected-environment target");
+
+		// Act — approve the catalog-level confirmation.
+		_sut.ConfirmArmed = true;
+		await _sut.ConfirmCommand.ExecuteAsync(null);
+
+		// Assert — no unrelated selected target is shown and the successful command refreshes the picker.
+		_sut.ConfirmMessage.Should().BeEmpty(because: "the approved confirmation closes before execution");
+		_sut.FilteredEnvironments.Should().Contain(environment => environment.Name == "imported",
+			because: "successful catalog mutation must refresh environments even without a filesystem watcher");
+		await _clio.Received(1).RunAsync(
+			Arg.Is<ClioInvocation>(invocation => invocation != null
+				&& invocation.Verb == "reg"
+				&& invocation.Args.Count == 1
+				&& invocation.Args[0] == "--add-from-iis"
+				&& invocation.EnvName == null),
+			Arg.Any<System.Action<ClioOutputLine>>(),
+			Arg.Any<CancellationToken>());
+		await _clio.Received(1).ListEnvironmentsAsync(Arg.Any<CancellationToken>());
+	}
 }

--- a/clio-ring/ClioRing/Models/ActionCatalog.cs
+++ b/clio-ring/ClioRing/Models/ActionCatalog.cs
@@ -148,6 +148,12 @@ public sealed record RingAction {
 	/// e.g. "the database will be dropped and application files removed, with no undo". Null = none.
 	/// </summary>
 	public string? ConsequenceText { get; init; }
+
+	/// <summary>
+	/// When true, refreshes the clio-owned environment catalog after this action completes successfully.
+	/// Use for commands that add, update, or remove registered environments.
+	/// </summary>
+	public bool RefreshEnvironmentsOnSuccess { get; init; }
 }
 
 /// <summary>Root document of <c>actions.json</c>: the full declarative action graph.</summary>

--- a/clio-ring/ClioRing/ViewModels/RingViewModel.cs
+++ b/clio-ring/ClioRing/ViewModels/RingViewModel.cs
@@ -80,6 +80,8 @@ public partial class RingViewModel : ViewModelBase {
 	private CancellationTokenSource? _cts;
 	private bool _environmentLoadInProgress;
 	private bool _environmentReloadPending;
+	private string? _pendingConfirmEnvironment;
+	private ClioEnvironment? _pendingConfirmEnvironmentSnapshot;
 
 	/// <summary>All ring nodes (outer actions + up to 6 inner env quick-chips).</summary>
 	public ObservableCollection<RingItemViewModel> Items { get; } = new();
@@ -245,13 +247,15 @@ public partial class RingViewModel : ViewModelBase {
 	public bool HasSelectedEnvironment => _allEnvironments.Any(e => e.Name == SelectedEnvironmentName);
 
 	/// <summary>Compact hint for the selected env (host · Local/Cloud · flavour).</summary>
-	public string SelectedEnvironmentHint {
-		get {
-			ClioEnvironment? env = _allEnvironments.FirstOrDefault(e => e.Name == SelectedEnvironmentName);
-			return env is null
-				? "no environment selected"
-				: $"{(env.Host.Length > 0 ? env.Host : "?")} · {env.LocationLabel} · {env.FrameworkLabel}";
-		}
+	public string SelectedEnvironmentHint => HasSelectedEnvironment
+		? EnvironmentHint(SelectedEnvironmentName)
+		: "no environment selected";
+
+	private string EnvironmentHint(string environmentName) {
+		ClioEnvironment? env = _allEnvironments.FirstOrDefault(e => e.Name == environmentName);
+		return env is null
+			? "environment details unavailable"
+			: $"{(env.Host.Length > 0 ? env.Host : "?")} · {env.LocationLabel} · {env.FrameworkLabel}";
 	}
 
 	/// <summary>Whether the All location filter is active.</summary>
@@ -815,15 +819,27 @@ public partial class RingViewModel : ViewModelBase {
 		action.Parameters.Any(p => p.ParameterType == ParameterType.Env);
 
 	private void OpenConfirm(RingItemViewModel item, RingAction action) {
-		string env = SelectedEnvironmentName;
-		string lead = string.IsNullOrWhiteSpace(action.ConfirmText)
+		string? fixedEnvironment = string.IsNullOrWhiteSpace(action.ClioCommand?.EnvName)
+			? null
+			: action.ClioCommand!.EnvName;
+		string? env = fixedEnvironment ?? (ActionTargetsEnvParameter(action) ? SelectedEnvironmentName : null);
+		bool targetsEnvironment = env is not null;
+		string defaultLead = targetsEnvironment
 			? $"Run '{action.Title}' against '{env}'?"
-			: action.ConfirmText!.Replace("{env}", env);
+			: $"Run '{action.Title}'?";
+		string lead = string.IsNullOrWhiteSpace(action.ConfirmText)
+			? defaultLead
+			: action.ConfirmText!.Replace("{env}", env ?? string.Empty);
 
-		// Append the RESOLVED target so the user sees exactly which endpoint is affected.
-		ConfirmMessage = $"{lead}\n\nTarget: {env} · {SelectedEnvironmentHint}";
+		// Append the resolved endpoint only when this action targets a selected or fixed environment.
+		ConfirmMessage = targetsEnvironment ? $"{lead}\n\nTarget: {env} · {EnvironmentHint(env!)}" : lead;
 		RequiresTypedConfirm = action.RequireTypedConfirm;
-		ConfirmExpected = env;
+		ConfirmExpected = env ?? string.Empty;
+		_pendingConfirmEnvironment = env;
+		_pendingConfirmEnvironmentSnapshot = env is null
+			? null
+			: _allEnvironments.FirstOrDefault(environment =>
+				string.Equals(environment.Name, env, StringComparison.OrdinalIgnoreCase));
 		ConfirmConsequence = action.ConsequenceText ?? string.Empty;
 		ConfirmInput = string.Empty;
 		PendingConfirmItem = item;
@@ -842,16 +858,38 @@ public partial class RingViewModel : ViewModelBase {
 	[RelayCommand(CanExecute = nameof(CanConfirm))]
 	private async Task ConfirmAsync() {
 		RingItemViewModel? item = PendingConfirmItem;
-		PendingConfirmItem = null;
-		ConfirmMessage = string.Empty;
-		ConfirmArmed = false;
-		RequiresTypedConfirm = false;
-		ConfirmExpected = string.Empty;
-		ConfirmConsequence = string.Empty;
-		ConfirmInput = string.Empty;
-		if (item is not null) {
-			await ExecuteItemAsync(item).ConfigureAwait(true);
+		string? confirmedEnvironment = _pendingConfirmEnvironment;
+		if (await EnvironmentTargetChangedAsync(_pendingConfirmEnvironmentSnapshot).ConfigureAwait(true)) {
+			ClearPendingConfirm();
+			FocusCaption = "Environment changed. Review and confirm again.";
+			return;
 		}
+		ClearPendingConfirm();
+		if (item is not null) {
+			await ExecuteItemAsync(item, confirmedEnvironment).ConfigureAwait(true);
+		}
+	}
+
+	private async Task<bool> EnvironmentTargetChangedAsync(ClioEnvironment? snapshot) {
+		if (snapshot is null) {
+			return false;
+		}
+
+		IReadOnlyList<ClioEnvironment> environments = await _clio.ListEnvironmentsAsync().ConfigureAwait(true);
+		ClioEnvironment? current = environments.FirstOrDefault(environment =>
+			string.Equals(environment.Name, snapshot.Name, StringComparison.OrdinalIgnoreCase));
+		return current is null
+			|| current.IsNetCore != snapshot.IsNetCore
+			|| !EnvironmentUrisEqual(current.Uri, snapshot.Uri);
+	}
+
+	private static bool EnvironmentUrisEqual(string? left, string? right) {
+		if (Uri.TryCreate(left, UriKind.Absolute, out Uri? leftUri)
+			&& Uri.TryCreate(right, UriKind.Absolute, out Uri? rightUri)) {
+			return leftUri.Equals(rightUri);
+		}
+
+		return string.Equals(left?.TrimEnd('/'), right?.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
 	}
 
 	private bool CanConfirm() =>
@@ -860,8 +898,12 @@ public partial class RingViewModel : ViewModelBase {
 
 	/// <summary>Dismisses a pending confirmation without running.</summary>
 	[RelayCommand]
-	private void DismissConfirm() {
+	private void DismissConfirm() => ClearPendingConfirm();
+
+	private void ClearPendingConfirm() {
 		PendingConfirmItem = null;
+		_pendingConfirmEnvironment = null;
+		_pendingConfirmEnvironmentSnapshot = null;
 		ConfirmMessage = string.Empty;
 		ConfirmArmed = false;
 		RequiresTypedConfirm = false;
@@ -917,7 +959,7 @@ public partial class RingViewModel : ViewModelBase {
 		HotkeyNotice = message;
 	}
 
-	private async Task ExecuteItemAsync(RingItemViewModel item) {
+	private async Task ExecuteItemAsync(RingItemViewModel item, string? confirmedEnvironment = null) {
 		RingAction action = item.Action!;
 		switch (action.Kind) {
 			case ActionKind.ClioCommand:
@@ -925,8 +967,11 @@ public partial class RingViewModel : ViewModelBase {
 				await RunClioAsync(new ClioInvocation {
 					Verb = spec.Verb,
 					Args = spec.Args,
-					EnvName = spec.EnvName ?? ResolveEnvParameter(action)
+					EnvName = spec.EnvName ?? confirmedEnvironment ?? ResolveEnvParameter(action)
 				}, item).ConfigureAwait(true);
+				if (action.RefreshEnvironmentsOnSuccess && Outcome == RunOutcome.Success) {
+					await LoadEnvironmentsAsync().ConfigureAwait(true);
+				}
 				break;
 			case ActionKind.OpenUrl:
 				OpenShell(action.OpenUrl!.Url);


### PR DESCRIPTION
## What changed

- add an **Import IIS** Ring action that runs `clio reg --add-from-iis`
- require explicit confirmation because matching registrations can be overwritten
- warn that credentials and safety flags may be replaced
- refresh Ring's environment catalog after a successful import
- harden confirmed environment-targeted actions by capturing the displayed target and revalidating name, URI, and runtime against clio's authoritative catalog immediately before dispatch
- fail closed and require fresh confirmation if the target changes or disappears

## User impact

Windows users can import local IIS Creatio environments directly from ClioRing. Newly imported registrations appear immediately. Existing same-name registrations are never overwritten without a clear confirmation.

## Validation

- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 95 passed
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` — passed
- offscreen UI harness — 19 states rendered; Import IIS node visually verified at the default 500x502 layout
- local AOT installation at `C:\Tools\clio-ring` updated and SHA-256 verified: `E13CB3C9ADD03EA4D976AEFB62A1EFA826B705C93D4C5D52D0ADCE37DE051898`

## Review

Comprehensive pre-PR review tier: full three-lens fan-out because confirmation and command-target safety were affected.

- code quality and testing: no findings
- security and best practices: no findings
- correctness, performance, and edge cases: no findings

Docs reviewed, no update required. MCP reviewed, no update required. ClioRing compatibility reviewed; no provider MCP/CLI contract changed.