### PR TITLE
Fix concurrent clio settings updates

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5767,3 +5767,10 @@ Decision: 0 Blocker/High regressions; all changes are behavior-preserving extrac
 Discovery: MeasureRestartAsync now reads the stopwatch after the post-restart verification call, inflating the restart metric vs older ipc-proof reports (advisory only).
 Files: clio/Command/RingCommand.cs, clio-ring/ClioRing.Ipc/IpcProofRunner.cs, clio-ring/ClioRing/SingleInstance.cs, clio-ring/ClioRing/App.axaml.cs
 Impact: PR #851 still clear of Blocker/High; review trail complete in room codex-e2e-test-debugging-clio-mcp-e2e.
+
+## 2026-07-13 10:40 – Concurrent settings mutation safety
+Context: Concurrent deploy-creatio commands, deploy/uninstall overlap, and manual edits could be lost when a long-running command saved its startup settings snapshot.
+Decision: Serialize settings mutations with a sibling cross-process lock, reload immediately before each mutation, and replace a securely prepared file only after exact-content validation under a deny-write handle.
+Discovery: SettingsRepository loaded settings in its constructor and every mutation recreated appsettings.json from that stale model; deploy registration and uninstall removal both reached this path.
+Files: clio/Environment/ConfigurationOptions.cs, clio/Environment/SettingsBootstrapService.cs, clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
+Impact: Cooperating clio processes no longer overwrite one another, completed manual edits are retained, malformed settings fail closed, and real multi-process coverage protects the behavior.

--- a/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
+++ b/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Clio.Tests.Infrastructure;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Command")]
+[NonParallelizable]
+public sealed class SettingsRepositoryConcurrencyTests {
+
+	private MockFileSystem _fileSystem;
+
+	[SetUp]
+	public void SetUp() {
+		_fileSystem = TestFileSystem.MockFileSystem();
+		_fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData(JsonConvert.SerializeObject(
+			new Settings {
+				ActiveEnvironmentKey = "existing",
+				Environments = new Dictionary<string, EnvironmentSettings> {
+					["existing"] = new() { Uri = "https://existing.example.com" }
+				}
+			})));
+	}
+
+	[Test]
+	[Description("Two repositories created from the same snapshot preserve both environment registrations.")]
+	public void ConfigureEnvironment_ShouldPreserveCompletedRegistration_WhenRepositorySnapshotIsStale() {
+		// Arrange
+		SettingsRepository firstDeployment = new(_fileSystem);
+		SettingsRepository laterDeployment = new(_fileSystem);
+
+		// Act
+		firstDeployment.ConfigureEnvironment("first", new EnvironmentSettings { Uri = "https://first.example.com" });
+		laterDeployment.ConfigureEnvironment("later", new EnvironmentSettings { Uri = "https://later.example.com" });
+		SettingsRepository persisted = new(_fileSystem);
+
+		// Assert
+		persisted.GetAllEnvironments().Should().ContainKey("existing",
+			because: "the environment that existed before either deployment must be preserved");
+		persisted.GetAllEnvironments().Should().ContainKey("first",
+			because: "the first completed deployment must not be erased by a later deployment");
+		persisted.GetAllEnvironments().Should().ContainKey("later",
+			because: "the later deployment must also register its environment");
+	}
+
+	[Test]
+	[Description("An uninstall using a stale repository snapshot preserves an environment registered by a completed deployment.")]
+	public void RemoveEnvironment_ShouldPreserveNewRegistration_WhenRepositorySnapshotIsStale() {
+		// Arrange
+		SettingsRepository deployment = new(_fileSystem);
+		SettingsRepository uninstall = new(_fileSystem);
+
+		// Act
+		deployment.ConfigureEnvironment("deployed", new EnvironmentSettings { Uri = "https://deployed.example.com" });
+		uninstall.RemoveEnvironment("existing");
+		SettingsRepository persisted = new(_fileSystem);
+
+		// Assert
+		persisted.GetAllEnvironments().Should().ContainKey("deployed",
+			because: "uninstall must remove from the latest settings without erasing a concurrently registered environment");
+		persisted.GetAllEnvironments().Should().NotContainKey("existing",
+			because: "the requested environment must still be unregistered");
+	}
+
+	[Test]
+	[Description("Registering an environment preserves unrelated settings changed after the repository was created.")]
+	public void ConfigureEnvironment_ShouldPreserveManualChanges_WhenRepositorySnapshotIsStale() {
+		// Arrange
+		SettingsRepository deployment = new(_fileSystem);
+		Settings manuallyEdited = JsonConvert.DeserializeObject<Settings>(
+			_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+		manuallyEdited.RemoteArtefactServerPath = "manual-edit";
+		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile,
+			JsonConvert.SerializeObject(manuallyEdited));
+
+		// Act
+		deployment.ConfigureEnvironment("deployed", new EnvironmentSettings { Uri = "https://deployed.example.com" });
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		persisted.RemoteArtefactServerPath.Should().Be("manual-edit",
+			because: "the settings file must be reloaded immediately before applying the deployment registration");
+		persisted.Environments.Should().ContainKey("deployed",
+			because: "the requested environment registration must still be persisted");
+	}
+
+	[TestCase("{ invalid json")]
+	[TestCase("null")]
+	[TestCase("   ")]
+	[Description("A settings mutation fails without replacing the file when the latest settings content is unreadable.")]
+	public void ConfigureEnvironment_ShouldPreserveFile_WhenLatestSettingsAreUnreadable(string unreadableSettings) {
+		// Arrange
+		SettingsRepository deployment = new(_fileSystem);
+		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, unreadableSettings);
+
+		// Act
+		Action act = () => deployment.ConfigureEnvironment("deployed",
+			new EnvironmentSettings { Uri = "https://deployed.example.com" });
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+			because: "a stale in-memory snapshot must not replace settings that can no longer be read safely");
+		_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile).Should().Be(unreadableSettings,
+			because: "the unreadable file must remain untouched for the user to repair or recover");
+	}
+
+	[Test]
+	[Description("A settings mutation waits while another writer holds the settings lock.")]
+	public void ConfigureEnvironment_ShouldWait_WhenAnotherWriterHoldsSettingsLock() {
+		// Arrange
+		SettingsRepository deployment = new(_fileSystem);
+		using ManualResetEventSlim lockAcquired = new(false);
+		using ManualResetEventSlim releaseLock = new(false);
+		using ManualResetEventSlim mutationStarted = new(false);
+		Task lockHolder = Task.Run(() => SettingsRepository.ExecuteWithSettingsLock(_fileSystem, () => {
+			lockAcquired.Set();
+			releaseLock.Wait();
+			return true;
+		}));
+		lockAcquired.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
+			because: "the test writer must hold the real settings lock before the competing mutation starts");
+
+		// Act
+		Task mutation = Task.Run(() => {
+			mutationStarted.Set();
+			deployment.ConfigureEnvironment("deployed", new EnvironmentSettings { Uri = "https://deployed.example.com" });
+		});
+		mutationStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
+			because: "the competing mutation must have started before its blocked state is asserted");
+		bool completedWhileLocked = mutation.Wait(TimeSpan.FromMilliseconds(500));
+		releaseLock.Set();
+		Task.WaitAll([lockHolder, mutation], TimeSpan.FromSeconds(5)).Should().BeTrue(
+			because: "both writers must complete after the lock holder releases the settings lock");
+
+		// Assert
+		completedWhileLocked.Should().BeFalse(
+			because: "a second writer must not enter the read-modify-write section while the lock is held");
+		new SettingsRepository(_fileSystem).GetAllEnvironments().Should().ContainKey("deployed",
+			because: "the blocked mutation must persist after acquiring the released lock");
+	}
+
+	[Test]
+	[Description("A repository keeps reading and writing through its own filesystem after another repository is constructed.")]
+	public void ConfigureEnvironment_ShouldUseInstanceFileSystem_WhenAnotherRepositoryChangesStaticDefault() {
+		// Arrange
+		SettingsRepository first = new(_fileSystem);
+		MockFileSystem otherFileSystem = TestFileSystem.MockFileSystem();
+		otherFileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData(JsonConvert.SerializeObject(
+			new Settings { Environments = new Dictionary<string, EnvironmentSettings>() })));
+		_ = new SettingsRepository(otherFileSystem);
+
+		// Act
+		first.ConfigureEnvironment("first", new EnvironmentSettings { Uri = "https://first.example.com" });
+		SettingsRepository persistedFirst = new(_fileSystem);
+		SettingsRepository persistedOther = new(otherFileSystem);
+
+		// Assert
+		persistedFirst.GetAllEnvironments().Should().ContainKey("first",
+			because: "the first repository must persist through the filesystem it was constructed with");
+		persistedOther.GetAllEnvironments().Should().NotContainKey("first",
+			because: "constructing another repository must not redirect the first repository's save into a different filesystem");
+	}
+
+}
+
+[TestFixture]
+[Category("Integration")]
+[Property("Module", "Command")]
+[NonParallelizable]
+public sealed class SettingsRepositoryProcessConcurrencyTests {
+
+	[Test]
+	[Description("Independent clio processes sharing CLIO_HOME preserve every concurrent environment registration.")]
+	public void RegWebApp_ShouldPreserveEveryEnvironment_WhenProcessesRunConcurrently() {
+		// Arrange
+		const int processCount = 8;
+		string clioHome = Path.Combine(Path.GetTempPath(), $"clio-settings-concurrency-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(clioHome);
+		string clioAssemblyPath = typeof(SettingsRepository).Assembly.Location;
+		List<Process> processes = [];
+
+		try {
+			// Act
+			for (int index = 1; index <= processCount; index++) {
+				ProcessStartInfo startInfo = new("dotnet") {
+					UseShellExecute = false,
+					CreateNoWindow = true,
+					RedirectStandardOutput = true,
+					RedirectStandardError = true
+				};
+				startInfo.Environment["CLIO_HOME"] = clioHome;
+				startInfo.ArgumentList.Add(clioAssemblyPath);
+				startInfo.ArgumentList.Add("reg-web-app");
+				startInfo.ArgumentList.Add($"env-{index}");
+				startInfo.ArgumentList.Add("--uri");
+				startInfo.ArgumentList.Add($"http://env-{index}");
+				startInfo.ArgumentList.Add("-i");
+				startInfo.ArgumentList.Add("true");
+				Process process = Process.Start(startInfo)
+					?? throw new InvalidOperationException("Failed to start the clio regression-test process.");
+				processes.Add(process);
+			}
+
+			foreach (Process process in processes) {
+				process.WaitForExit(30_000).Should().BeTrue(
+					because: "every concurrent registration process must finish without waiting indefinitely for the settings lock");
+				process.ExitCode.Should().Be(0,
+					because: $"each registration must succeed; stderr was: {process.StandardError.ReadToEnd()}");
+			}
+
+			Settings persisted = JsonConvert.DeserializeObject<Settings>(
+				File.ReadAllText(Path.Combine(clioHome, "appsettings.json")));
+			string[] environmentNames = persisted.Environments.Keys.OrderBy(name => name).ToArray();
+
+			// Assert
+			environmentNames.Should().HaveCount(processCount,
+				because: "the cross-process file lock must prevent any registration from overwriting another");
+			for (int index = 1; index <= processCount; index++) {
+				environmentNames.Should().Contain($"env-{index}",
+					because: "every process must append its environment to the latest persisted settings");
+			}
+			Directory.GetFiles(clioHome, "*.tmp").Should().BeEmpty(
+				because: "atomic settings replacement must clean up every temporary file");
+		}
+		finally {
+			foreach (Process process in processes) {
+				if (!process.HasExited) {
+					process.Kill(entireProcessTree: true);
+				}
+				process.Dispose();
+			}
+			Directory.Delete(clioHome, recursive: true);
+		}
+	}
+}

--- a/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
+++ b/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Tests.Infrastructure;
+using Clio.UserEnvironment;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -171,6 +172,48 @@ public sealed class SettingsRepositoryConcurrencyTests {
 			because: "the first repository must persist through the filesystem it was constructed with");
 		persistedOther.GetAllEnvironments().Should().NotContainKey("first",
 			because: "constructing another repository must not redirect the first repository's save into a different filesystem");
+	}
+
+	[Test]
+	[Description("A settings mutation retries when an editor leaves transient invalid JSON between validation and the exact read.")]
+	public void ConfigureEnvironment_ShouldRetry_WhenLatestSettingsAreTransientlyInvalid() {
+		// Arrange
+		string validSettings = _fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		SettingsBootstrapResult healthyResult = new SettingsBootstrapService(_fileSystem).GetResult();
+		TransientInvalidSettingsBootstrapService bootstrap = new(_fileSystem, healthyResult, validSettings);
+		SettingsRepository deployment = new(_fileSystem, bootstrap);
+
+		// Act
+		deployment.ConfigureEnvironment("deployed", new EnvironmentSettings { Uri = "https://deployed.example.com" });
+
+		// Assert
+		bootstrap.GetResultCallCount.Should().Be(3,
+			because: "the mutation must reload after the transient parse failure instead of failing immediately");
+		new SettingsRepository(_fileSystem).GetAllEnvironments().Should().ContainKey("deployed",
+			because: "the retried mutation must apply to the restored valid settings");
+	}
+
+	private sealed class TransientInvalidSettingsBootstrapService(
+		MockFileSystem fileSystem,
+		SettingsBootstrapResult healthyResult,
+		string validSettings) : ISettingsBootstrapService {
+
+		public int GetResultCallCount { get; private set; }
+
+		public SettingsBootstrapResult GetResult() {
+			GetResultCallCount++;
+			if (GetResultCallCount == 2) {
+				fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, "{ transient invalid json");
+			}
+			else if (GetResultCallCount == 3) {
+				fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, validSettings);
+			}
+			return healthyResult;
+		}
+
+		public SettingsBootstrapReport GetReport() {
+			return GetResult().Report;
+		}
 	}
 
 }

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -558,64 +558,15 @@ namespace Clio
 				fileSystem.Directory.CreateDirectory(AppSettingsFolderPath);
 			}
 			bool isRealFileSystem = fileSystem is FileSystem;
-			if (isRealFileSystem && System.IO.File.Exists(AppSettingsFile)
-				&& new FileInfo(AppSettingsFile).LinkTarget != null) {
-				throw new IOException(
-					$"Refusing to replace symbolic-link settings file '{AppSettingsFile}'.");
-			}
-			UnixFileMode? unixFileMode = null;
-			System.Security.AccessControl.FileSecurity windowsFileSecurity = null;
-			if (isRealFileSystem && System.IO.File.Exists(AppSettingsFile)) {
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-					windowsFileSecurity = new FileInfo(AppSettingsFile).GetAccessControl();
-				}
-				else {
-					unixFileMode = System.IO.File.GetUnixFileMode(AppSettingsFile);
-				}
-			}
+			(System.Security.AccessControl.FileSecurity windowsFileSecurity, UnixFileMode? unixFileMode) =
+				GetSettingsFileSecurity(isRealFileSystem);
 			string tempFilePath = Path.Combine(AppSettingsFolderPath,
 				$".{FileName}.{Guid.NewGuid():N}.tmp");
 			try {
 				WriteSettingsTempFile(fileSystem, tempFilePath, settings, isRealFileSystem,
 					windowsFileSecurity, unixFileMode);
-
-				if (!verifyExpectedContent) {
-					fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
-				}
-				else if (expectedContent == null) {
-					try {
-						fileSystem.File.Move(tempFilePath, AppSettingsFile);
-					}
-					catch (IOException) when (fileSystem.File.Exists(AppSettingsFile)) {
-						throw new SettingsFileChangedException();
-					}
-				}
-				else {
-					Stream currentSettingsStream;
-					try {
-						currentSettingsStream = fileSystem.File.Open(AppSettingsFile, FileMode.Open,
-							FileAccess.Read, FileShare.Read | FileShare.Delete);
-					}
-					catch (FileNotFoundException) {
-						throw new SettingsFileChangedException();
-					}
-					using (currentSettingsStream) {
-						using StreamReader reader = new(currentSettingsStream, Encoding.UTF8,
-							detectEncodingFromByteOrderMarks: true, leaveOpen: true);
-						string currentContent = reader.ReadToEnd();
-						if (!string.Equals(currentContent, expectedContent, StringComparison.Ordinal)) {
-							throw new SettingsFileChangedException();
-						}
-						if (isRealFileSystem) {
-							fileSystem.File.Replace(tempFilePath, AppSettingsFile, destinationBackupFileName: null,
-								ignoreMetadataErrors: true);
-						}
-						else {
-							currentSettingsStream.Dispose();
-							fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
-						}
-					}
-				}
+				CommitSettingsFile(fileSystem, tempFilePath, expectedContent, verifyExpectedContent,
+					isRealFileSystem);
 			}
 			finally {
 				if (fileSystem.File.Exists(tempFilePath)) {
@@ -623,6 +574,67 @@ namespace Clio
 				}
 			}
 			SaveSchema(fileSystem);
+		}
+
+		private static (System.Security.AccessControl.FileSecurity WindowsFileSecurity, UnixFileMode? UnixFileMode)
+			GetSettingsFileSecurity(bool isRealFileSystem) {
+			if (!isRealFileSystem || !System.IO.File.Exists(AppSettingsFile)) {
+				return (null, null);
+			}
+			FileInfo settingsFile = new(AppSettingsFile);
+			if (settingsFile.LinkTarget != null) {
+				throw new IOException(
+					$"Refusing to replace symbolic-link settings file '{AppSettingsFile}'.");
+			}
+			return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+				? (settingsFile.GetAccessControl(), null)
+				: (null, System.IO.File.GetUnixFileMode(AppSettingsFile));
+		}
+
+		private static void CommitSettingsFile(IFileSystem fileSystem, string tempFilePath, string expectedContent,
+			bool verifyExpectedContent, bool isRealFileSystem) {
+			if (!verifyExpectedContent) {
+				fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
+				return;
+			}
+			if (expectedContent == null) {
+				MoveNewSettingsFile(fileSystem, tempFilePath);
+				return;
+			}
+
+			using Stream currentSettingsStream = OpenCurrentSettings(fileSystem);
+			using StreamReader reader = new(currentSettingsStream, Encoding.UTF8,
+				detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+			string currentContent = reader.ReadToEnd();
+			if (!string.Equals(currentContent, expectedContent, StringComparison.Ordinal)) {
+				throw new SettingsFileChangedException();
+			}
+			if (isRealFileSystem) {
+				fileSystem.File.Replace(tempFilePath, AppSettingsFile, destinationBackupFileName: null,
+					ignoreMetadataErrors: true);
+				return;
+			}
+			currentSettingsStream.Dispose();
+			fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
+		}
+
+		private static void MoveNewSettingsFile(IFileSystem fileSystem, string tempFilePath) {
+			try {
+				fileSystem.File.Move(tempFilePath, AppSettingsFile);
+			}
+			catch (IOException) when (fileSystem.File.Exists(AppSettingsFile)) {
+				throw new SettingsFileChangedException();
+			}
+		}
+
+		private static Stream OpenCurrentSettings(IFileSystem fileSystem) {
+			try {
+				return fileSystem.File.Open(AppSettingsFile, FileMode.Open,
+					FileAccess.Read, FileShare.Read | FileShare.Delete);
+			}
+			catch (FileNotFoundException) {
+				throw new SettingsFileChangedException();
+			}
 		}
 
 		private static void WriteSettingsTempFile(IFileSystem fileSystem, string tempFilePath, Settings settings,
@@ -707,21 +719,9 @@ namespace Clio
 		private void UpdateSettings(Action<Settings> mutation) {
 			ExecuteWithSettingsLock(_fileSystem, () => {
 				for (int attempt = 0; attempt < 3; attempt++) {
-					SettingsBootstrapResult latest = _settingsBootstrapService.GetResult();
-					if (string.Equals(latest.Report.Status, "broken", StringComparison.OrdinalIgnoreCase)) {
-						string issue = latest.Report.Issues.FirstOrDefault()?.Message
-							?? "appsettings.json is unreadable.";
-						throw new InvalidOperationException(
-							$"Cannot update settings because {issue}");
-					}
-
-					string expectedContent = _fileSystem.File.ReadAllText(AppSettingsFile);
+					string expectedContent;
 					try {
-						_settings = JsonConvert.DeserializeObject<Settings>(expectedContent);
-						if (_settings == null) {
-							throw new Newtonsoft.Json.JsonSerializationException(
-								"appsettings.json did not contain a settings object.");
-						}
+						_settings = LoadLatestSettings(out expectedContent);
 					}
 					catch (Newtonsoft.Json.JsonException) when (attempt < 2) {
 						Thread.Sleep(10);
@@ -749,6 +749,21 @@ namespace Clio
 				}
 				throw new InvalidOperationException("Settings update retry loop ended unexpectedly.");
 			});
+		}
+
+		private Settings LoadLatestSettings(out string expectedContent) {
+			SettingsBootstrapResult latest = _settingsBootstrapService.GetResult();
+			if (string.Equals(latest.Report.Status, "broken", StringComparison.OrdinalIgnoreCase)) {
+				string issue = latest.Report.Issues.FirstOrDefault()?.Message
+					?? "appsettings.json is unreadable.";
+				throw new InvalidOperationException(
+					$"Cannot update settings because {issue}");
+			}
+
+			expectedContent = _fileSystem.File.ReadAllText(AppSettingsFile);
+			return JsonConvert.DeserializeObject<Settings>(expectedContent)
+				?? throw new Newtonsoft.Json.JsonSerializationException(
+					"appsettings.json did not contain a settings object.");
 		}
 
 		internal static T ExecuteWithSettingsLock<T>(IFileSystem fileSystem, Func<T> action) {

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -2,12 +2,16 @@ using Clio.UserEnvironment;
 using Clio.Utilities;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json.Serialization;
+using System.Threading;
 using Clio.Common;
 using Clio.Common.db;
 using ConsoleTables;
@@ -454,9 +458,15 @@ namespace Clio
 	{
 		private const string FileName = "appsettings.json";
 		private const string SchemaFileName = "schema.json";
+		private const int SettingsLockTimeoutSeconds = 30;
 		private static readonly object SchemaFileLock = new ();
+		private static readonly ConcurrentDictionary<string, object> ProcessSettingsLocks = new();
+		[ThreadStatic]
+		private static HashSet<string> _heldSettingsLocks;
 
 		private Settings _settings = new ();
+		private readonly IFileSystem _fileSystem;
+		private readonly ISettingsBootstrapService _settingsBootstrapService;
 		// Used by GetEnvironment to confirm Safe-environment operations without deadlocking a
 		// non-interactive host. Null only for the internal/direct (non-DI) construction sites that
 		// never call GetEnvironment; those fall back to RealInteractiveConsole.Shared.
@@ -494,14 +504,16 @@ namespace Clio
 
 		public SettingsRepository(IFileSystem fileSystem = null, ISettingsBootstrapService settingsBootstrapService = null, IInteractiveConsole interactiveConsole = null) {
 	_interactiveConsole = interactiveConsole;
+	_fileSystem = fileSystem ?? FileSystem;
 	if (fileSystem != null) {
 		FileSystem = fileSystem;
 	}
 	ISettingsBootstrapService bootstrapService = settingsBootstrapService;
 	if (bootstrapService == null) {
-		bootstrapService = new SettingsBootstrapService(FileSystem);
+		bootstrapService = new SettingsBootstrapService(_fileSystem);
 	}
-	SettingsBootstrapResult bootstrapResult = bootstrapService.GetResult();
+	_settingsBootstrapService = bootstrapService;
+	SettingsBootstrapResult bootstrapResult = ExecuteWithSettingsLock(_fileSystem, bootstrapService.GetResult);
 	_settings = bootstrapResult.Settings ?? new Settings();
 	EnsureSettingsCollections();
 	AttachDbServers(_settings);
@@ -532,18 +544,118 @@ namespace Clio
 			}
 		}
 
-		internal static void SaveSettings(IFileSystem fileSystem, Settings settings) {
+		internal static void SaveSettings(IFileSystem fileSystem, Settings settings, string expectedContent = null,
+			bool verifyExpectedContent = false) {
+			ExecuteWithSettingsLock(fileSystem, () => {
+				SaveSettingsUnlocked(fileSystem, settings, expectedContent, verifyExpectedContent);
+				return true;
+			});
+		}
+
+		private static void SaveSettingsUnlocked(IFileSystem fileSystem, Settings settings, string expectedContent,
+			bool verifyExpectedContent) {
 			if (!fileSystem.Directory.Exists(AppSettingsFolderPath)) {
 				fileSystem.Directory.CreateDirectory(AppSettingsFolderPath);
 			}
-			using (StreamWriter fileWriter = fileSystem.File.CreateText(AppSettingsFile)) {
-				JsonSerializer serializer = new() {
-					Formatting = Formatting.Indented,
-					NullValueHandling = NullValueHandling.Ignore
-				};
-				serializer.Serialize(fileWriter, settings);
+			bool isRealFileSystem = fileSystem is FileSystem;
+			if (isRealFileSystem && System.IO.File.Exists(AppSettingsFile)
+				&& new FileInfo(AppSettingsFile).LinkTarget != null) {
+				throw new IOException(
+					$"Refusing to replace symbolic-link settings file '{AppSettingsFile}'.");
+			}
+			UnixFileMode? unixFileMode = null;
+			System.Security.AccessControl.FileSecurity windowsFileSecurity = null;
+			if (isRealFileSystem && System.IO.File.Exists(AppSettingsFile)) {
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+					windowsFileSecurity = new FileInfo(AppSettingsFile).GetAccessControl();
+				}
+				else {
+					unixFileMode = System.IO.File.GetUnixFileMode(AppSettingsFile);
+				}
+			}
+			string tempFilePath = Path.Combine(AppSettingsFolderPath,
+				$".{FileName}.{Guid.NewGuid():N}.tmp");
+			try {
+				WriteSettingsTempFile(fileSystem, tempFilePath, settings, isRealFileSystem,
+					windowsFileSecurity, unixFileMode);
+
+				if (!verifyExpectedContent) {
+					fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
+				}
+				else if (expectedContent == null) {
+					try {
+						fileSystem.File.Move(tempFilePath, AppSettingsFile);
+					}
+					catch (IOException) when (fileSystem.File.Exists(AppSettingsFile)) {
+						throw new SettingsFileChangedException();
+					}
+				}
+				else {
+					Stream currentSettingsStream;
+					try {
+						currentSettingsStream = fileSystem.File.Open(AppSettingsFile, FileMode.Open,
+							FileAccess.Read, FileShare.Read | FileShare.Delete);
+					}
+					catch (FileNotFoundException) {
+						throw new SettingsFileChangedException();
+					}
+					using (currentSettingsStream) {
+						using StreamReader reader = new(currentSettingsStream, Encoding.UTF8,
+							detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+						string currentContent = reader.ReadToEnd();
+						if (!string.Equals(currentContent, expectedContent, StringComparison.Ordinal)) {
+							throw new SettingsFileChangedException();
+						}
+						if (isRealFileSystem) {
+							fileSystem.File.Replace(tempFilePath, AppSettingsFile, destinationBackupFileName: null,
+								ignoreMetadataErrors: true);
+						}
+						else {
+							currentSettingsStream.Dispose();
+							fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
+						}
+					}
+				}
+			}
+			finally {
+				if (fileSystem.File.Exists(tempFilePath)) {
+					fileSystem.File.Delete(tempFilePath);
+				}
 			}
 			SaveSchema(fileSystem);
+		}
+
+		private static void WriteSettingsTempFile(IFileSystem fileSystem, string tempFilePath, Settings settings,
+			bool isRealFileSystem, System.Security.AccessControl.FileSecurity windowsFileSecurity,
+			UnixFileMode? unixFileMode) {
+			JsonSerializer serializer = new() {
+				Formatting = Formatting.Indented,
+				NullValueHandling = NullValueHandling.Ignore
+			};
+			if (!isRealFileSystem) {
+				using StreamWriter mockWriter = fileSystem.File.CreateText(tempFilePath);
+				serializer.Serialize(mockWriter, settings);
+				mockWriter.Flush();
+				return;
+			}
+
+			FileStreamOptions options = new() {
+				Mode = FileMode.CreateNew,
+				Access = FileAccess.Write,
+				Share = FileShare.None
+			};
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+				options.UnixCreateMode = unixFileMode ?? (UnixFileMode.UserRead | UnixFileMode.UserWrite);
+			}
+			using FileStream stream = new(tempFilePath, options);
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && windowsFileSecurity != null) {
+				new FileInfo(tempFilePath).SetAccessControl(windowsFileSecurity);
+			}
+			using (StreamWriter fileWriter = new(stream, new UTF8Encoding(false), leaveOpen: true)) {
+				serializer.Serialize(fileWriter, settings);
+				fileWriter.Flush();
+			}
+			stream.Flush(flushToDisk: true);
 		}
 
 		private static void SaveSchema(IFileSystem fileSystem) {
@@ -592,10 +704,102 @@ namespace Clio
 			_settings.Features = rebuilt;
 		}
 
-		private void Save() {
-			EnsureSettingsCollections();
-			SaveSettings(FileSystem, _settings);
+		private void UpdateSettings(Action<Settings> mutation) {
+			ExecuteWithSettingsLock(_fileSystem, () => {
+				for (int attempt = 0; attempt < 3; attempt++) {
+					SettingsBootstrapResult latest = _settingsBootstrapService.GetResult();
+					if (string.Equals(latest.Report.Status, "broken", StringComparison.OrdinalIgnoreCase)) {
+						string issue = latest.Report.Issues.FirstOrDefault()?.Message
+							?? "appsettings.json is unreadable.";
+						throw new InvalidOperationException(
+							$"Cannot update settings because {issue}");
+					}
+
+					string expectedContent = _fileSystem.File.ReadAllText(AppSettingsFile);
+					try {
+						_settings = JsonConvert.DeserializeObject<Settings>(expectedContent);
+						if (_settings == null) {
+							throw new Newtonsoft.Json.JsonSerializationException(
+								"appsettings.json did not contain a settings object.");
+						}
+					}
+					catch (Newtonsoft.Json.JsonException) when (attempt < 2) {
+						Thread.Sleep(10);
+						continue;
+					}
+					catch (Newtonsoft.Json.JsonException exception) {
+						throw new InvalidOperationException(
+							"Cannot update settings because appsettings.json changed to unreadable content.", exception);
+					}
+					AttachDbServers(_settings);
+					EnsureSettingsCollections();
+					mutation(_settings);
+					EnsureSettingsCollections();
+					try {
+						SaveSettings(_fileSystem, _settings, expectedContent, verifyExpectedContent: true);
+						return true;
+					}
+					catch (SettingsFileChangedException) {
+						if (attempt == 2) {
+							throw new IOException(
+								"appsettings.json kept changing while clio was updating it. Try the command again.");
+						}
+						// An editor changed the file after it was reloaded. Retry the mutation against that version.
+					}
+				}
+				throw new InvalidOperationException("Settings update retry loop ended unexpectedly.");
+			});
 		}
+
+		internal static T ExecuteWithSettingsLock<T>(IFileSystem fileSystem, Func<T> action) {
+			string lockFilePath = $"{AppSettingsFile}.lock";
+			object processLock = ProcessSettingsLocks.GetOrAdd(lockFilePath, _ => new object());
+			Stopwatch stopwatch = Stopwatch.StartNew();
+			if (!Monitor.TryEnter(processLock, TimeSpan.FromSeconds(SettingsLockTimeoutSeconds))) {
+				throw new TimeoutException(
+					$"Timed out waiting to update {AppSettingsFile}. Another clio operation may still be using settings.");
+			}
+			try {
+				_heldSettingsLocks ??= [];
+				if (_heldSettingsLocks.Contains(lockFilePath)) {
+					return action();
+				}
+
+				if (!fileSystem.Directory.Exists(AppSettingsFolderPath)) {
+					fileSystem.Directory.CreateDirectory(AppSettingsFolderPath);
+				}
+				Stream lockStream = null;
+				while (lockStream == null) {
+					try {
+						lockStream = fileSystem.File.Open(lockFilePath, FileMode.OpenOrCreate,
+							FileAccess.ReadWrite, FileShare.None);
+					}
+					catch (IOException) when (stopwatch.Elapsed < TimeSpan.FromSeconds(SettingsLockTimeoutSeconds)) {
+						Thread.Sleep(50);
+					}
+					catch (IOException exception) {
+						throw new TimeoutException(
+							$"Timed out waiting to update {AppSettingsFile}. Another clio process may still be updating settings.",
+							exception);
+					}
+				}
+
+				using (lockStream) {
+					_heldSettingsLocks.Add(lockFilePath);
+					try {
+						return action();
+					}
+					finally {
+						_heldSettingsLocks.Remove(lockFilePath);
+					}
+				}
+			}
+			finally {
+				Monitor.Exit(processLock);
+			}
+		}
+
+		internal sealed class SettingsFileChangedException : IOException { }
 
 		public void ShowSettingsTo(TextWriter streamWriter, string environment = null, bool showShort = false) {
 			EnsureSettingsCollections();
@@ -747,8 +951,7 @@ namespace Clio
 		}
 
 		public void SetAutoupdate(bool value) {
-			_settings.Autoupdate = value;
-			Save();
+			UpdateSettings(settings => settings.Autoupdate = value);
 		}
 
 		public bool IsFeatureEnabled(string featureName) {
@@ -763,9 +966,7 @@ namespace Clio
 			if (string.IsNullOrWhiteSpace(featureName)) {
 				throw new ArgumentException("Feature name must be a non-empty value.", nameof(featureName));
 			}
-			EnsureSettingsCollections();
-			_settings.Features[featureName] = enabled;
-			Save();
+			UpdateSettings(settings => settings.Features[featureName] = enabled);
 		}
 
 		public IReadOnlyDictionary<string, bool> GetFeatures() {
@@ -774,38 +975,36 @@ namespace Clio
 		}
 
 		public void ConfigureEnvironment(string name, EnvironmentSettings environment) {
-			EnsureSettingsCollections();
-			if (string.IsNullOrEmpty(name)) {
-				if (_settings.Environments.Count == 0) {
-					_settings = CreateDefaultSettings(_settings);
+			UpdateSettings(settings => {
+				if (string.IsNullOrEmpty(name)) {
+					if (settings.Environments.Count == 0) {
+						_settings = settings = CreateDefaultSettings(settings);
+					}
+					settings.GetActiveEnvironment().Merge(environment);
+				} else if (!settings.Environments.TryAdd(name, environment)) {
+					settings.Environments[name].Merge(environment);
+				} else if (string.IsNullOrWhiteSpace(settings.ActiveEnvironmentKey)) {
+					settings.ActiveEnvironmentKey = name;
 				}
-				_settings.GetActiveEnvironment().Merge(environment);
-			} else if (!_settings.Environments.TryAdd(name, environment)) {
-				_settings.Environments[name].Merge(environment);
-			} else if (string.IsNullOrWhiteSpace(_settings.ActiveEnvironmentKey)) {
-				_settings.ActiveEnvironmentKey = name;
-			}
-			Save();
+			});
 		}
 
 		public void SetActiveEnvironment(string activeEnvironment) {
-			EnsureSettingsCollections();
-			_settings.ActiveEnvironmentKey = activeEnvironment;
-			Save();
+			UpdateSettings(settings => settings.ActiveEnvironmentKey = activeEnvironment);
 		}
 
 		public void RemoveEnvironment(string environment) {
-			EnsureSettingsCollections();
-			string actualKey = FindEnvironmentKey(environment);
-			if (actualKey == null) {
-				throw new KeyNotFoundException($"Application \"{environment}\" not found");
-			}
-			if (_settings.Environments.Remove(actualKey)) {
-				if (string.Equals(_settings.ActiveEnvironmentKey, actualKey, StringComparison.OrdinalIgnoreCase)) {
-					_settings.ActiveEnvironmentKey = _settings.Environments.Keys.FirstOrDefault();
+			UpdateSettings(settings => {
+				string actualKey = settings.Environments.Keys.FirstOrDefault(key =>
+					string.Equals(key, environment, StringComparison.OrdinalIgnoreCase));
+				if (actualKey == null) {
+					throw new KeyNotFoundException($"Application \"{environment}\" not found");
 				}
-				Save();
-			}
+				if (settings.Environments.Remove(actualKey)
+					&& string.Equals(settings.ActiveEnvironmentKey, actualKey, StringComparison.OrdinalIgnoreCase)) {
+					settings.ActiveEnvironmentKey = settings.Environments.Keys.FirstOrDefault();
+				}
+			});
 		}
 
 		public static void OpenSettingsFile() {
@@ -824,10 +1023,10 @@ namespace Clio
 		}
 
 		void ISettingsRepository.RemoveAllEnvironment() {
-			EnsureSettingsCollections();
-			_settings.Environments.Clear();
-			_settings.ActiveEnvironmentKey = null;
-			Save();
+			UpdateSettings(settings => {
+				settings.Environments.Clear();
+				settings.ActiveEnvironmentKey = null;
+			});
 		}
 
 		public string GetIISClioRootPath() {
@@ -907,8 +1106,8 @@ namespace Clio
 		}
 
 		public void SetDeployCreatioDefaults(DeployCreatioDefaults defaults) {
-			_settings.DeployCreatioDefaults = defaults is null || defaults.IsEmpty ? null : defaults;
-			Save();
+			UpdateSettings(settings =>
+				settings.DeployCreatioDefaults = defaults is null || defaults.IsEmpty ? null : defaults);
 		}
 
 	}

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -602,19 +602,19 @@ namespace Clio
 				return;
 			}
 
-			using Stream currentSettingsStream = OpenCurrentSettings(fileSystem);
-			using StreamReader reader = new(currentSettingsStream, Encoding.UTF8,
-				detectEncodingFromByteOrderMarks: true, leaveOpen: true);
-			string currentContent = reader.ReadToEnd();
-			if (!string.Equals(currentContent, expectedContent, StringComparison.Ordinal)) {
-				throw new SettingsFileChangedException();
+			using (Stream currentSettingsStream = OpenCurrentSettings(fileSystem)) {
+				using StreamReader reader = new(currentSettingsStream, Encoding.UTF8,
+					detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+				string currentContent = reader.ReadToEnd();
+				if (!string.Equals(currentContent, expectedContent, StringComparison.Ordinal)) {
+					throw new SettingsFileChangedException();
+				}
+				if (isRealFileSystem) {
+					fileSystem.File.Replace(tempFilePath, AppSettingsFile, destinationBackupFileName: null,
+						ignoreMetadataErrors: true);
+					return;
+				}
 			}
-			if (isRealFileSystem) {
-				fileSystem.File.Replace(tempFilePath, AppSettingsFile, destinationBackupFileName: null,
-					ignoreMetadataErrors: true);
-				return;
-			}
-			currentSettingsStream.Dispose();
 			fileSystem.File.Move(tempFilePath, AppSettingsFile, overwrite: true);
 		}
 

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -60,11 +60,30 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	}
 
 	private SettingsBootstrapResult Load() {
+		return SettingsRepository.ExecuteWithSettingsLock(_fileSystem, () => {
+			for (int attempt = 0; attempt < 3; attempt++) {
+				try {
+					return LoadUnlocked();
+				}
+				catch (SettingsRepository.SettingsFileChangedException) {
+					if (attempt == 2) {
+						throw new IOException(
+							"appsettings.json kept changing while clio was loading it. Try the command again.");
+					}
+					// Reload and reapply migrations if another writer won the atomic settings replacement.
+				}
+			}
+			throw new InvalidOperationException("The settings load retry loop completed unexpectedly.");
+		});
+	}
+
+	private SettingsBootstrapResult LoadUnlocked() {
 		string settingsFilePath = SettingsRepository.AppSettingsFile;
 		if (!_fileSystem.File.Exists(settingsFilePath)) {
 			Settings emptySettings = new() { Environments = [], SettingsVersion = CurrentSettingsVersion };
 			if (_applyRepairs) {
-				SettingsRepository.SaveSettings(_fileSystem, emptySettings);
+				SettingsRepository.SaveSettings(_fileSystem, emptySettings, expectedContent: null,
+					verifyExpectedContent: true);
 			}
 			return BuildResult("healthy", settingsFilePath, null, emptySettings, [], []);
 		}
@@ -107,7 +126,7 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 		}
 		SettingsRepository.AttachDbServers(settingsModel);
 		if (_applyRepairs && ApplyMigrations(settingsModel, repairs)) {
-			SettingsRepository.SaveSettings(_fileSystem, settingsModel);
+			SettingsRepository.SaveSettings(_fileSystem, settingsModel, fileContent, verifyExpectedContent: true);
 		}
 		return BuildResult(
 			issues.Count > 0 ? "issues-detected" : "healthy",


### PR DESCRIPTION
## Summary
- serialize appsettings mutations across clio processes with a bounded sibling-file lock
- reload the latest settings immediately before append/remove/update operations
- validate the exact source content and atomically replace a securely prepared file while preserving existing permissions
- fail closed on malformed settings and cover stale deploy/deploy, deploy/uninstall, manual edits, lock waiting, and real multi-process registration

Fixes #853

## Validation
- `dotnet build clio.tests/clio.tests.csproj --no-restore --verbosity quiet`
- `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~Clio.Tests.Command.SettingsRepositoryConcurrencyTests" --no-build --no-restore` (9/9 on net8.0 and net10.0)
- `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~Clio.Tests.Command.SettingsRepositoryProcessConcurrencyTests" --no-build --no-restore` (1/1 on net8.0 and net10.0)
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Command" --no-build --no-restore` (net8.0: 2167 passed, 15 skipped; net10.0: 2167 passed, 15 skipped)
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` (95/95)
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true`

## Reviews
- Comprehensive 3-lens agentic review completed (quality, correctness/performance, security); Blocker/High gate clear.
- Residual Medium advisory: a non-cooperating editor can still atomically replace the pathname in the narrow final compare/replace window; edits completed before final mutation are preserved.
- docs reviewed, no update required
- MCP reviewed, no update required
- ClioRing compatibility reviewed; deploy/uninstall are consumed through `clio-run`, and the exact Ring test/AOT commands above passed.