### PR TITLE
docs: require issue-first pull request workflow

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5774,3 +5774,10 @@ Decision: Serialize settings mutations with a sibling cross-process lock, reload
 Discovery: SettingsRepository loaded settings in its constructor and every mutation recreated appsettings.json from that stale model; deploy registration and uninstall removal both reached this path.
 Files: clio/Environment/ConfigurationOptions.cs, clio/Environment/SettingsBootstrapService.cs, clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
 Impact: Cooperating clio processes no longer overwrite one another, completed manual edits are retained, malformed settings fail closed, and real multi-process coverage protects the behavior.
+
+## 2026-07-13 11:42 – Contributor issue-first PR policy
+Context: Contributor guidance needed a mandatory, searchable GitHub issue trail for every pull request.
+Decision: Require an issue before each PR, classify it with an enabled issue type and relevant labels, link it with a closing keyword when appropriate, and self-assign the PR; contributors without metadata permissions must request maintainer help before review.
+Discovery: The organization enables `Task`, `Bug`, and `Feature` issue types; the repository has domain and change-kind labels available for filtering.
+Files: CONTRIBUTING.md
+Impact: Contributors now have a concise issue-to-PR workflow with clear ownership and searchable classification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,25 @@ See [Test targets](#test-targets) above and [AGENTS.md](AGENTS.md#smart-regressi
 
 ## PR workflow
 
+Every pull request must have a GitHub issue filed before the pull request is opened.
+
+When creating the issue:
+
+- Keep the title and description accurate and concise. Update them if the scope changes.
+- Select exactly one GitHub issue type: `Task`, `Bug`, or `Feature`.
+- Add at least one relevant repository label so the issue can be found and filtered easily.
+- If your GitHub permissions do not allow you to set the issue type or labels, state the requested
+  type and labels in the issue and ask a maintainer to apply them before review.
+
+When opening the pull request:
+
+- Reference at least one issue in the pull request description. Prefer a closing keyword such as
+  `Fixes #123` or `Closes #123` when the pull request fully resolves the issue.
+- Assign the pull request to yourself. If your GitHub permissions do not allow this, ask a
+  maintainer to assign it to you before review.
+- Keep the pull request scope aligned with the referenced issue. Update the issue before expanding
+  or materially changing that scope.
+
 ```bash
 # Check PR status and CI results
 make check-pr


### PR DESCRIPTION
## Summary

- require a GitHub issue before every pull request
- require one issue type and at least one searchable label
- require issue references, PR self-assignment, and scope alignment
- provide a maintainer-assisted fallback for contributors without metadata permissions

## Validation

- `git diff --check`
- Documentation-only change; automated tests were not run

## Review

- Comprehensive pre-PR review: code quality/testing, security/best practices, and performance/correctness
- One external-contributor permissions finding was fixed and re-reviewed
- No remaining Blocker/High findings
- Command documentation and MCP review are not applicable because command behavior did not change

Fixes #856