### PR TITLE
docs: require draft-first pull request workflow

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5781,3 +5781,10 @@ Decision: Require an issue before each PR, classify it with an enabled issue typ
 Discovery: The organization enables `Task`, `Bug`, and `Feature` issue types; the repository has domain and change-kind labels available for filtering.
 Files: CONTRIBUTING.md
 Impact: Contributors now have a concise issue-to-PR workflow with clear ownership and searchable classification.
+
+## 2026-07-13 12:06 – Draft-first pull request workflow
+Context: Repository auto-merge can complete a ready pull request as soon as protection checks pass, while project review may happen outside GitHub.
+Decision: Require every pull request to start as a draft and prohibit enabling auto-merge until implementation, validation, documentation, and external review are complete and the pull request is marked ready.
+Discovery: Draft status provides an explicit author-controlled readiness boundary without adding a GitHub approval requirement or privileged pull-request automation.
+Files: CONTRIBUTING.md
+Impact: Human and agent contributions now have a clear handoff from work-in-progress to protected auto-merge eligibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,12 +212,23 @@ When creating the issue:
 
 When opening the pull request:
 
+- Open the pull request as a draft. Keep it in draft while implementation, validation,
+  documentation, or the project's external review process is still in progress.
 - Reference at least one issue in the pull request description. Prefer a closing keyword such as
   `Fixes #123` or `Closes #123` when the pull request fully resolves the issue.
 - Assign the pull request to yourself. If your GitHub permissions do not allow this, ask a
   maintainer to assign it to you before review.
 - Keep the pull request scope aligned with the referenced issue. Update the issue before expanding
   or materially changing that scope.
+
+When the work is complete:
+
+- Confirm the implementation, required tests, documentation, and external review are complete and
+  that no known blocking feedback remains.
+- Mark the pull request as ready for review.
+- After the pull request is ready, a contributor or agent with permission may enable auto-merge
+  when appropriate. Do not enable auto-merge while the pull request is a draft or before the work
+  is ready.
 
 ```bash
 # Check PR status and CI results


### PR DESCRIPTION
## Summary

- require every pull request to start as a draft
- keep the draft state while implementation, validation, documentation, or external review is in progress
- allow contributors or agents to enable auto-merge only after the completed work is marked ready

## Validation

- `git diff --check`
- Documentation-only change; automated tests were not run

## Review

- Comprehensive pre-PR review completed across quality/testing, security/workflow policy, and correctness/edge cases
- No actionable findings
- Command documentation and MCP review are not applicable because command behavior did not change

Fixes #858