### PR TITLE
Fix Explorer deploy site-name prompt

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5788,3 +5788,17 @@ Decision: Require every pull request to start as a draft and prohibit enabling a
 Discovery: Draft status provides an explicit author-controlled readiness boundary without adding a GitHub approval requirement or privileged pull-request automation.
 Files: CONTRIBUTING.md
 Impact: Human and agent contributions now have a clear handoff from work-in-progress to protected auto-merge eligibility.
+
+## 2026-07-13 11:26 – Explorer deploy site-name inference regression traced
+Context: Right-clicking a Creatio ZIP in Windows Explorer derives the deployment site name from the archive, producing oversized or incompatible database and IIS identifiers for long build filenames.
+Decision: Proposed removing only the unconditional ZIP-name derivation from DeployCreatioDefaultsResolver; preserve explicit --site-name and configured deploy-site-name precedence, then let the existing interactive installer prompt when neither is present.
+Discovery: PR #845 introduced DeriveSiteNameFromZipWhenUnset after the Explorer registry verb had already passed only --zip-file; this fills SiteName before CreatioInstallerService can execute its existing prompt.
+Files: clio/reg/clio_context_menu_win.reg, clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs, clio/Command/CreatioInstallCommand/CreatioInstallerService.cs, clio.tests/Command/DeployCreatioDefaultsResolverTests.cs, clio/docs/commands/config.md, clio/help/en/config.txt
+Impact: The future fix can restore per-deployment site-name entry for Explorer without changing the registry command or MCP wire contract.
+
+## 2026-07-13 12:06 – Explorer deploy prompts for site name
+Context: GitHub issue #855 requested an explicit site-name prompt when deploying a ZIP from the Windows Explorer context menu.
+Decision: Removed ZIP-filename site-name inference, retained explicit and configured defaults, and made silent deployments without a site name fail fast instead of waiting for input.
+Discovery: The existing Explorer registry verb and interactive installer prompt already provide the desired flow; only the defaults resolver prevented the prompt. The MCP tool and ClioRing always provide a site name, so their contracts remain unchanged.
+Files: clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs, clio/Command/CreatioInstallCommand/InstallerCommand.cs, clio.tests/Command/DeployCreatioDefaultsResolverTests.cs, clio.tests/Command/InstallerCommandSilentSiteNameTests.cs, clio/docs/commands/deploy-creatio.md, clio/help/en/deploy-creatio.txt
+Impact: Explorer deployments now request a safe explicit site name, while automation receives a clear configuration error and existing explicit/configured precedence remains compatible.

--- a/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
+++ b/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
@@ -1,32 +1,40 @@
-using System.IO.Abstractions.TestingHelpers;
 using Clio;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
-using Clio.Tests.Infrastructure;
 using Clio.UserEnvironment;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
 
 [TestFixture]
-[Category("Unit")]
 [Property("Module", "Command")]
-public sealed class DeployCreatioDefaultsResolverTests {
+public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 
 	private ISettingsRepository _settingsRepository;
-	private MockFileSystem _fileSystem;
 	private ILogger _logger;
 	private DeployCreatioDefaultsResolver _sut;
 
-	[SetUp]
-	public void SetUp() {
+	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
+		base.AdditionalRegistrations(containerBuilder);
 		_settingsRepository = Substitute.For<ISettingsRepository>();
-		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults());
-		_fileSystem = TestFileSystem.MockFileSystem();
 		_logger = Substitute.For<ILogger>();
-		_sut = new DeployCreatioDefaultsResolver(_settingsRepository, _fileSystem, _logger);
+		containerBuilder.AddSingleton(_settingsRepository);
+		containerBuilder.AddSingleton(_logger);
+	}
+
+	public override void Setup() {
+		base.Setup();
+		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults());
+		_sut = (DeployCreatioDefaultsResolver)Container.GetRequiredService<IDeployCreatioDefaultsResolver>();
+	}
+
+	public override void TearDown() {
+		_settingsRepository.ClearReceivedCalls();
+		_logger.ClearReceivedCalls();
+		base.TearDown();
 	}
 
 	[Test]
@@ -110,22 +118,24 @@ public sealed class DeployCreatioDefaultsResolverTests {
 	}
 
 	[Test]
-	[Description("Derives the site name from the zip file name when no site name is configured or supplied.")]
-	public void ApplyDefaults_ShouldDeriveSiteNameFromZip_WhenSiteNameUnsetAndNoDefault() {
+	[Description("Leaves the site name unset when only a zip file is supplied so interactive deployment can prompt for it.")]
+	public void ApplyDefaults_ShouldLeaveSiteNameUnset_WhenZipProvidedAndNoDefault() {
 		// Arrange
-		PfInstallerOptions options = new() { ZipFile = @"F:\CreatioBuilds\lcap_local.zip" };
+		PfInstallerOptions options = new() {
+			ZipFile = @"F:\CreatioBuilds\10.0.0.777_BankSales_MarketingNet8_PostgreSQL_ENU.zip"
+		};
 
 		// Act
 		_sut.ApplyDefaults(options);
 
 		// Assert
-		options.SiteName.Should().Be("lcap_local",
-			because: "with no configured or supplied site name, the name is derived from the zip file name");
+		options.SiteName.Should().BeNullOrEmpty(
+			because: "the installer must prompt instead of turning a long archive name into database and IIS identifiers");
 	}
 
 	[Test]
-	[Description("Prefers the configured default site name over the name derived from the zip file.")]
-	public void ApplyDefaults_ShouldPreferConfiguredSiteName_OverDerivedFromZip() {
+	[Description("Uses the configured default site name when no site name is supplied on the command line.")]
+	public void ApplyDefaults_ShouldUseConfiguredSiteName_WhenSiteNameUnset() {
 		// Arrange
 		_settingsRepository.GetDeployCreatioDefaults()
 			.Returns(new DeployCreatioDefaults { SiteName = "lcap-local" });
@@ -136,37 +146,23 @@ public sealed class DeployCreatioDefaultsResolverTests {
 
 		// Assert
 		options.SiteName.Should().Be("lcap-local",
-			because: "a configured default site name takes precedence over deriving one from the zip file");
+			because: "a configured default site name should continue to avoid the interactive prompt");
 	}
 
 	[Test]
-	[Description("Sanitizes separators when deriving a site name so the result is usable as a database name.")]
-	public void ApplyDefaults_ShouldSanitizeDerivedSiteName_WhenZipNameHasSeparators() {
+	[Description("Keeps an explicitly supplied site name instead of replacing it with the configured default.")]
+	public void ApplyDefaults_ShouldKeepExplicitSiteName_WhenDefaultConfigured() {
 		// Arrange
-		PfInstallerOptions options = new() {
-			ZipFile = @"F:\CreatioBuilds\10.0.0.777_BankSales_MarketingNet8_PostgreSQL_ENU.zip"
-		};
+		_settingsRepository.GetDeployCreatioDefaults()
+			.Returns(new DeployCreatioDefaults { SiteName = "configured-site" });
+		PfInstallerOptions options = new() { SiteName = "explicit-site" };
 
 		// Act
 		_sut.ApplyDefaults(options);
 
 		// Assert
-		options.SiteName.Should().Be("_10_0_0_777_BankSales_MarketingNet8_PostgreSQL_ENU",
-			because: "dots and other separators fold to single underscores and a leading digit is prefixed so the derived name is a valid unquoted database identifier");
-	}
-
-	[Test]
-	[Description("Folds non-ASCII characters when deriving a site name so the result is a valid ASCII identifier.")]
-	public void ApplyDefaults_ShouldFoldNonAsciiCharacters_WhenDerivingSiteName() {
-		// Arrange
-		PfInstallerOptions options = new() { ZipFile = @"F:\CreatioBuilds\Проект_local.zip" };
-
-		// Act
-		_sut.ApplyDefaults(options);
-
-		// Assert
-		options.SiteName.Should().Be("local",
-			because: "non-ASCII characters are folded so the derived name is a valid ASCII database/site identifier");
+		options.SiteName.Should().Be("explicit-site",
+			because: "command-line options must continue to take precedence over configured defaults");
 	}
 
 	[Test]
@@ -180,6 +176,6 @@ public sealed class DeployCreatioDefaultsResolverTests {
 
 		// Assert
 		options.DbServerName.Should().BeNullOrEmpty(because: "no default was configured to apply");
-		options.SiteName.Should().BeNullOrEmpty(because: "there is no zip file to derive a site name from");
+		options.SiteName.Should().BeNullOrEmpty(because: "no site name was supplied or configured");
 	}
 }

--- a/clio.tests/Command/InstallerCommand.LogArtifact.Tests.cs
+++ b/clio.tests/Command/InstallerCommand.LogArtifact.Tests.cs
@@ -32,7 +32,8 @@ public sealed class InstallerCommandLogArtifactTests {
 		// Act
 		int result = sut.Execute(new PfInstallerOptions {
 			IsSilent = true,
-			DbServerName = "local-pg"
+			DbServerName = "local-pg",
+			SiteName = "test-site"
 		});
 
 		// Assert

--- a/clio.tests/Command/InstallerCommand.cs
+++ b/clio.tests/Command/InstallerCommand.cs
@@ -28,17 +28,25 @@ internal class InstallerCommandTests : BaseCommandTests<PfInstallerOptions>
 		base.Setup();
 	}
 
+	public override void TearDown() {
+		_testKubernetesMock.ClearReceivedCalls();
+		_creatioInstallerServiceMock.ClearReceivedCalls();
+		base.TearDown();
+	}
+
 	[OneTimeTearDown]
 	public void OneTimeTearDown() {
 		_testKubernetesMock?.Dispose();
 	}
 
-	[Test(Description = "Should return without waiting for user input")]
+	[Test]
+	[Description("Should return without waiting for user input")]
 	public void Execute_ReturnsWithoutWaitingForInput_WhenSilent(){
 		//Arrange
 		var command = Container.GetRequiredService<InstallerCommand>();
 		PfInstallerOptions options = new () {
-			IsSilent = true
+			IsSilent = true,
+			SiteName = "test-site"
 		};
 		_creatioInstallerServiceMock.Execute(Arg.Any<PfInstallerOptions>())
 			.Returns(0);
@@ -47,7 +55,7 @@ internal class InstallerCommandTests : BaseCommandTests<PfInstallerOptions>
 		var actual = command.Execute(options);
 		
 		//Assert
-		actual.Should().Be(0);
+		actual.Should().Be(0, "because silent deployment should complete without waiting for console input");
 	}
 	
 	[Test(Description = "Execute completes on Enter when not silent")]
@@ -70,12 +78,14 @@ internal class InstallerCommandTests : BaseCommandTests<PfInstallerOptions>
 		
 	}
 	
-	[Test(Description = "Should return 0 when OK")]
+	[Test]
+	[Description("Should return 0 when OK")]
 	public void Execute_DoesNotOpenBrowser_WhenSilent(){
 		//Arrange
 		var command = Container.GetRequiredService<InstallerCommand>();
 		PfInstallerOptions options = new PfInstallerOptions() {
-			IsSilent = true
+			IsSilent = true,
+			SiteName = "test-site"
 		};
 		_creatioInstallerServiceMock.Execute(Arg.Any<PfInstallerOptions>())
 			.Returns(0);
@@ -87,8 +97,10 @@ internal class InstallerCommandTests : BaseCommandTests<PfInstallerOptions>
 		var actual = command.Execute(options);
 		
 		//Assert
-		actual.Should().Be(0);
-		_creatioInstallerServiceMock.Received(0).StartWebBrowser(options);
+		actual.Should().Be(0, "because a successful silent deployment returns the installer exit code");
+		_creatioInstallerServiceMock.ReceivedCalls().Should().NotContain(
+			call => call.GetMethodInfo().Name == nameof(ICreatioInstallerService.StartWebBrowser),
+			"because silent deployment must not open a browser");
 	}
 	
 	[Ignore( "StartWebBrowser is now called from the CreatioInstallerService directly" )]

--- a/clio.tests/Command/InstallerCommandSilentSiteNameTests.cs
+++ b/clio.tests/Command/InstallerCommandSilentSiteNameTests.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using Clio.Command.CreatioInstallCommand;
+using Clio.Common;
+using FluentAssertions;
+using k8s;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+[TestFixture]
+[Property("Module", "Command")]
+internal sealed class InstallerCommandSilentSiteNameTests : BaseCommandTests<PfInstallerOptions> {
+	private readonly ICreatioInstallerService _creatioInstallerService = Substitute.For<ICreatioInstallerService>();
+	private readonly IDeployCreatioDefaultsResolver _defaultsResolver =
+		Substitute.For<IDeployCreatioDefaultsResolver>();
+	private readonly IKubernetes _kubernetes = Substitute.For<IKubernetes>();
+	private readonly ILogger _logger = Substitute.For<ILogger>();
+
+	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
+		base.AdditionalRegistrations(containerBuilder);
+		containerBuilder.AddSingleton(_creatioInstallerService);
+		containerBuilder.AddSingleton<IDbOperationLogSessionFactory>(_ => NullDbOperationLogSessionFactory.Instance);
+		containerBuilder.AddSingleton(_defaultsResolver);
+		containerBuilder.AddSingleton(_kubernetes);
+		containerBuilder.AddSingleton(_logger);
+	}
+
+	public override void TearDown() {
+		_creatioInstallerService.ClearReceivedCalls();
+		_defaultsResolver.ClearReceivedCalls();
+		_kubernetes.ClearReceivedCalls();
+		_logger.ClearReceivedCalls();
+		base.TearDown();
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown() {
+		_kubernetes.Dispose();
+	}
+
+	[Test]
+	[Description("Silent deployment without an explicit or configured site name fails instead of waiting for console input.")]
+	public void Execute_ShouldFailWithoutRunningInstaller_WhenSilentSiteNameIsMissing() {
+		// Arrange
+		InstallerCommand command = Container.GetRequiredService<InstallerCommand>();
+		PfInstallerOptions options = new() {
+			DbServerName = "local-postgres",
+			IsSilent = true,
+			ZipFile = @"C:\CreatioBuilds\creatio.zip"
+		};
+
+		// Act
+		int result = command.Execute(options);
+
+		// Assert
+		result.Should().Be(1,
+			because: "silent deployment cannot ask a user to provide the missing site name");
+		_creatioInstallerService.ReceivedCalls().Should().BeEmpty(
+			because: "validation must fail before the installer reaches its interactive site-name prompt");
+		string[] errors = _logger.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(ILogger.WriteError))
+			.Select(call => call.GetArguments().Single()?.ToString())
+			.Where(message => message is not null)
+			.Cast<string>()
+			.ToArray();
+		errors.Should().Contain(
+			"Site name is required for silent deployment. Specify --site-name or configure deploy-site-name.",
+			because: "the error should explain how an unattended caller can provide the required site name");
+	}
+}

--- a/clio/Command/ConfigCommand.cs
+++ b/clio/Command/ConfigCommand.cs
@@ -33,10 +33,10 @@ public class ConfigOptions {
 
 	/// <summary>
 	/// Gets or sets the default site name applied when <c>deploy-creatio</c> is run without <c>--site-name</c>.
-	/// When left unset the site name is derived from the deployed zip file name.
+	/// When left unset, interactive deployment prompts for the site name.
 	/// </summary>
 	[Option("deploy-site-name", Required = false,
-		HelpText = "Default site name for deploy-creatio. When unset, the site name is derived from the zip file name.")]
+		HelpText = "Default site name for deploy-creatio. When unset, interactive deployment prompts for the site name.")]
 	public string DeploySiteName { get; set; }
 
 	/// <summary>

--- a/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
+++ b/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Linq;
-using System.Text;
 using Clio.Common;
 using Clio.UserEnvironment;
-using IFileSystem = System.IO.Abstractions.IFileSystem;
 
 namespace Clio.Command.CreatioInstallCommand;
 
@@ -13,8 +10,8 @@ namespace Clio.Command.CreatioInstallCommand;
 /// </summary>
 public interface IDeployCreatioDefaultsResolver {
 	/// <summary>
-	/// Fills unspecified deployment options from the saved defaults and, when no site name is available,
-	/// derives one from the deployed zip file name. Options supplied on the command line are never overwritten.
+	/// Fills unspecified deployment options from the saved defaults. Options supplied on the command line are
+	/// never overwritten, and an unset site name remains empty so interactive deployment can prompt for it.
 	/// </summary>
 	/// <param name="options">The deployment options to complete in place.</param>
 	void ApplyDefaults(PfInstallerOptions options);
@@ -27,7 +24,6 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 	#region Fields: Private
 
 	private readonly ISettingsRepository _settingsRepository;
-	private readonly IFileSystem _fileSystem;
 	private readonly ILogger _logger;
 
 	#endregion
@@ -38,11 +34,9 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 	/// Initializes a new instance of the <see cref="DeployCreatioDefaultsResolver"/> class.
 	/// </summary>
 	/// <param name="settingsRepository">Repository that supplies the persisted deploy-creatio defaults.</param>
-	/// <param name="fileSystem">Filesystem abstraction used to derive a site name from the zip file path.</param>
 	/// <param name="logger">Logger used to report which defaults were applied.</param>
-	public DeployCreatioDefaultsResolver(ISettingsRepository settingsRepository, IFileSystem fileSystem, ILogger logger) {
+	public DeployCreatioDefaultsResolver(ISettingsRepository settingsRepository, ILogger logger) {
 		_settingsRepository = settingsRepository;
-		_fileSystem = fileSystem;
 		_logger = logger;
 	}
 
@@ -58,7 +52,6 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 
 		DeployCreatioDefaults defaults = _settingsRepository.GetDeployCreatioDefaults();
 		ApplyConfiguredDefaults(options, defaults);
-		DeriveSiteNameFromZipWhenUnset(options);
 	}
 
 	#endregion
@@ -98,55 +91,9 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 		}
 	}
 
-	private void DeriveSiteNameFromZipWhenUnset(PfInstallerOptions options) {
-		if (!string.IsNullOrWhiteSpace(options.SiteName) || string.IsNullOrWhiteSpace(options.ZipFile)) {
-			return;
-		}
-
-		string derived = SanitizeSiteName(_fileSystem.Path.GetFileNameWithoutExtension(options.ZipFile));
-		if (string.IsNullOrWhiteSpace(derived)) {
-			return;
-		}
-
-		options.SiteName = derived;
-		_logger.WriteInfo($"[Site Name] derived from zip file: {derived}");
-	}
-
 	private static bool IsDeploymentMethodUnset(string deploymentMethod) =>
 		string.IsNullOrWhiteSpace(deploymentMethod)
 		|| string.Equals(deploymentMethod, PfInstallerOptions.AutoDeploymentMethod, StringComparison.OrdinalIgnoreCase);
-
-	// Produces a site name that is also valid as an unquoted database/catalog name and IIS site name:
-	// keep ASCII letters, digits and underscores; fold every other character (dots, spaces, hyphens,
-	// non-ASCII) to a single underscore. A leading digit is prefixed with an underscore because unquoted
-	// database identifiers cannot start with a digit (Creatio build zips typically begin with a version).
-	private static string SanitizeSiteName(string rawName) {
-		if (string.IsNullOrWhiteSpace(rawName)) {
-			return string.Empty;
-		}
-
-		StringBuilder builder = new(rawName.Length);
-		bool lastWasSeparator = false;
-		foreach (char symbol in rawName) {
-			if (IsAllowedSiteNameChar(symbol)) {
-				builder.Append(symbol);
-				lastWasSeparator = false;
-			}
-			else if (!lastWasSeparator && builder.Length > 0) {
-				builder.Append('_');
-				lastWasSeparator = true;
-			}
-		}
-
-		string sanitized = builder.ToString().Trim('_');
-		if (sanitized.Length > 0 && char.IsDigit(sanitized[0])) {
-			sanitized = "_" + sanitized;
-		}
-		return sanitized;
-	}
-
-	private static bool IsAllowedSiteNameChar(char symbol) =>
-		symbol is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '_';
 
 	#endregion
 }

--- a/clio/Command/CreatioInstallCommand/InstallerCommand.cs
+++ b/clio/Command/CreatioInstallCommand/InstallerCommand.cs
@@ -234,6 +234,13 @@ public class PfInstallerOptions : EnvironmentNameOptions{
 /// Executes Creatio deployment using validated command options.
 /// </summary>
 public class InstallerCommand : Command<PfInstallerOptions>, IStageEventSource{
+	#region Constants: Private
+
+	private const string MissingSilentSiteNameError =
+		"Site name is required for silent deployment. Specify --site-name or configure deploy-site-name.";
+
+	#endregion
+
 	#region Fields: Private
 
 	private readonly ICreatioInstallerService _creatioInstallerService;
@@ -309,6 +316,10 @@ public class InstallerCommand : Command<PfInstallerOptions>, IStageEventSource{
 			// Kubernetes-vs-local branch below, so a configured default db-server-name routes the plain
 			// Explorer context-menu deploy (which passes only --zip-file) to the local database.
 			_deployCreatioDefaultsResolver.ApplyDefaults(options);
+			if (options.IsSilent && string.IsNullOrWhiteSpace(options.SiteName)) {
+				_logger.WriteError(MissingSilentSiteNameError);
+				return 1;
+			}
 
 			if (_kubernetes is FakeKubernetes && string.IsNullOrEmpty(options.DbServerName)) {
 				_logger.WriteError(

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -281,8 +281,8 @@ namespace Clio
 		public string RedisServerName { get; set; }
 
 		/// <summary>
-		/// Gets or sets the default site name used when <c>--site-name</c> is omitted. When left empty the
-		/// site name is derived from the deployed zip file name.
+		/// Gets or sets the default site name used when <c>--site-name</c> is omitted. When left empty,
+		/// interactive deployment prompts for the site name.
 		/// </summary>
 		[JsonProperty("site-name")]
 		public string SiteName { get; set; }

--- a/clio/docs/commands/config.md
+++ b/clio/docs/commands/config.md
@@ -31,7 +31,8 @@ back to a Kubernetes cluster.
 
 Options passed on the `deploy-creatio` command line always take precedence over
 these defaults. When no default site name is configured and none is passed on
-the command line, the site name is derived from the deployed zip file name.
+the command line, interactive deployment asks the user to enter a site name.
+This includes the Windows Explorer right-click action.
 
 ## Options
 
@@ -42,8 +43,8 @@ the command line, the site name is derived from the deployed zip file name.
 --deploy-redis-server-name <name>  Default local Redis server name for deploy-creatio.
                                    Must be a key in the 'redis' block of appsettings.json.
 
---deploy-site-name <name>          Default site name for deploy-creatio. When unset, the
-                                   site name is derived from the deployed zip file name.
+--deploy-site-name <name>          Default site name for deploy-creatio. When unset,
+                                   interactive deployment prompts for the site name.
 
 --deploy-site-port <port>          Default site port for deploy-creatio.
 
@@ -73,7 +74,8 @@ clio config --reset
 
 After configuring the defaults above, the "clio: deploy Creatio" Windows
 Explorer right-click action deploys to the local database and Redis without any
-further arguments.
+further arguments. If `--deploy-site-name` is not configured, the CLI asks for
+the site name before deployment proceeds.
 
 ## Behavior
 

--- a/clio/docs/commands/deploy-creatio.md
+++ b/clio/docs/commands/deploy-creatio.md
@@ -18,6 +18,11 @@ Deploys Creatio application from a zip file. On Windows, deploys to Internet Inf
 Services (IIS) by default. On macOS and Linux, uses dotnet runtime. Supports cross-platform
 deployment with optional HTTPS configuration and automatic service management.
 
+When `--site-name` and the configured `deploy-site-name` default are both
+omitted, interactive deployment prompts for the site name. The Windows Explorer
+"clio: deploy Creatio" action uses this prompt instead of deriving a name from
+the selected ZIP archive.
+
 Every deploy-creatio run creates a temp database-operation log file for the
 database restore portion of deployment. The final CLI output includes the
 absolute path in a "Database operation log:" line. For MCP tool execution,
@@ -63,14 +68,17 @@ Default: NET8 (if available)
 --product PRODUCT_NAME
 Product to deploy (optional)
 
---SiteName SITE_NAME
-Website/application name in IIS (Windows) or service name (macOS/Linux)
+--site-name SITE_NAME
+Website/application name in IIS (Windows) or service name (macOS/Linux).
+When omitted and no configured default exists, interactive deployment prompts
+for this value. Silent deployment fails with a clear error instead of waiting
+for console input.
 
---SitePort PORT
+--site-port PORT
 HTTP port number for the application
 Default: 80 (HTTP), 443 (HTTPS)
 
---ZipFile FILE_PATH
+--zip-file FILE_PATH
 Required. Path to Creatio zip file or directory
 - If zip file: Will be automatically extracted
 - If directory: Used directly as already-extracted Creatio application
@@ -185,77 +193,77 @@ Default: false
 
 ```bash
 1. Basic deployment with default settings (PostgreSQL, port 40001, auto-run):
-clio deploy-creatio -e "Default" --ZipFile "C:\creatio-app.zip" --SitePort 40001 --silent
+clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --site-port 40001 --silent
 
 2. Deploy with MS SQL and custom port:
-clio deploy-creatio -e "Production" --db mssql --SitePort 8080 \\
---ZipFile "/path/to/creatio-app.zip"
+clio deploy-creatio -e "Production" --db mssql --site-port 8080 \\
+--zip-file "/path/to/creatio-app.zip"
 
 3. Deploy with .NET Framework (Windows):
 clio deploy-creatio -e "LegacyApp" --platform netframework \\
---ZipFile "C:\creatio-framework.zip"
+--zip-file "C:\creatio-framework.zip"
 
 4. Deploy with HTTPS on Windows using dotnet (no IIS):
 clio deploy-creatio -e "SecureApp" --no-iis --use-https \\
---cert-path "C:\certs\app.pem" --ZipFile "C:\creatio-app.zip"
+--cert-path "C:\certs\app.pem" --zip-file "C:\creatio-app.zip"
 
 5. Deploy to custom path on macOS:
 clio deploy-creatio -e "CreatioApp" --app-path "/var/creatio" \\
---ZipFile "/Users/downloads/creatio-app.zip"
+--zip-file "/Users/downloads/creatio-app.zip"
 
 6. Deploy on Linux with systemd service management:
 clio deploy-creatio -e "LinuxApp" --deployment dotnet \\
---app-path "/opt/creatio-prod" --ZipFile "/home/admin/creatio-app.zip"
+--app-path "/opt/creatio-prod" --zip-file "/home/admin/creatio-app.zip"
 
 7. Deploy without auto-launching browser:
 clio deploy-creatio -e "BackgroundApp" --auto-run false \\
---ZipFile "C:\creatio-app.zip"
+--zip-file "C:\creatio-app.zip"
 
 8. Silent deployment with all parameters:
 clio deploy-creatio -e "AutoDeploy" --db pg --platform net6 \\
---SiteName "AutoCreatio" --SitePort 8443 --use-https \\
---cert-path "/certs/server.pem" --ZipFile "/app/creatio.zip" --silent
+--site-name "AutoCreatio" --site-port 8443 --use-https \\
+--cert-path "/certs/server.pem" --zip-file "/app/creatio.zip" --silent
 
 9. Deploy with specific Redis database (when auto-detection fails):
-clio deploy-creatio -e "RedisApp" --ZipFile "C:\creatio-app.zip" --redis-db 5
+clio deploy-creatio -e "RedisApp" --zip-file "C:\creatio-app.zip" --redis-db 5
 
 10. Deploy in production with manual Redis DB to avoid conflicts:
-clio deploy-creatio -e "Production" --db mssql --SitePort 8080 \\
---redis-db 3 --ZipFile "/path/to/creatio-app.zip"
+clio deploy-creatio -e "Production" --db mssql --site-port 8080 \\
+--redis-db 3 --zip-file "/path/to/creatio-app.zip"
 
 11. Deploy to local database server (automatic database restore):
 # Configure database server in appsettings.json first (see DATABASE RESTORATION)
 # Single command deploys everything: extract -> restore DB -> deploy app -> configure
-clio deploy-creatio -e "LocalDev" --db mssql --SitePort 40001 \\
+clio deploy-creatio -e "LocalDev" --db mssql --site-port 40001 \\
 --db-server-name my-local-mssql \\
---ZipFile "C:\Creatio\8.3.3.1343_Studio_MSSQL_ENU.zip"
+--zip-file "C:\Creatio\8.3.3.1343_Studio_MSSQL_ENU.zip"
 
 12. Deploy PostgreSQL to local server with automatic DB drop:
-clio deploy-creatio -e "QA" --db pg --SitePort 8080 \\
+clio deploy-creatio -e "QA" --db pg --site-port 8080 \\
 --db-server-name my-local-postgres --drop-if-exists \\
---ZipFile "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
+--zip-file "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
 
 13. Deploy PostgreSQL running in Docker via published host port:
-clio deploy-creatio -e "DockerDev" --db pg --SitePort 8080 \\
+clio deploy-creatio -e "DockerDev" --db pg --site-port 8080 \\
 --db-server-name docker-postgres --drop-if-exists \\
---ZipFile "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
+--zip-file "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
 
 14. Silent deployment to local database without browser launch:
-clio deploy-creatio -e "AutoDeploy" --db mssql --SitePort 8443 \\
+clio deploy-creatio --site-name "AutoDeploy" --db mssql --site-port 8443 \\
 --db-server-name my-local-mssql --drop-if-exists \\
 --auto-run=false --silent \\
---ZipFile "C:\Creatio\app.zip"
+--zip-file "C:\Creatio\app.zip"
 
 15. Deploy PostgreSQL with long filename (template reuse):
 # First deployment: Creates template from backup (slower)
-clio deploy-creatio -e "Dev" --db pg --SitePort 8080 \\
+clio deploy-creatio -e "Dev" --db pg --site-port 8080 \\
 --db-server-name my-local-postgres \\
---ZipFile "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
+--zip-file "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
 
 # Subsequent deployments: Reuses template (faster)
-clio deploy-creatio -e "Dev2" --db pg --SitePort 8081 \\
+clio deploy-creatio -e "Dev2" --db pg --site-port 8081 \\
 --db-server-name my-local-postgres \\
---ZipFile "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
+--zip-file "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
 ```
 
 ## Behavior
@@ -411,8 +419,8 @@ Linux:
     WORKFLOW:
     1. Configure database server in appsettings.json (if using local database)
     2. Run deploy-creatio with --db-server-name to automatically restore and deploy:
-       clio deploy-creatio -e "LocalDev" --db mssql --SitePort 40001 \\
-           --db-server-name my-local-mssql --ZipFile "C:\Creatio\app.zip"
+       clio deploy-creatio -e "LocalDev" --db mssql --site-port 40001 \\
+           --db-server-name my-local-mssql --zip-file "C:\Creatio\app.zip"
     3. The command will:
        a. Extract the zip file
        b. Automatically restore database from db/*.bak or db/*.backup to local server

--- a/clio/help/en/config.txt
+++ b/clio/help/en/config.txt
@@ -24,7 +24,9 @@ DESCRIPTION
     local database and Redis instead of falling back to a Kubernetes cluster.
 
     Options passed on the deploy-creatio command line always take precedence
-    over these defaults.
+    over these defaults. When no default site name is configured, interactive
+    deployment asks the user to enter one. This includes the Windows Explorer
+    right-click action.
 
 OPTIONS
     --deploy-db-server-name <name>     Default local database server name for
@@ -36,8 +38,8 @@ OPTIONS
                                        'redis' block of appsettings.json.
 
     --deploy-site-name <name>          Default site name for deploy-creatio.
-                                       When unset, the site name is derived from
-                                       the deployed zip file name.
+                                       When unset, interactive deployment
+                                       prompts for the site name.
 
     --deploy-site-port <port>          Default site port for deploy-creatio.
 
@@ -62,6 +64,9 @@ EXAMPLES
 
     # Clear all deploy-creatio defaults
     config --reset
+
+    If deploy-site-name is not configured, the Windows Explorer right-click
+    action asks for the site name before deployment proceeds.
 
 BEHAVIOR
     - With no arguments (or with --show), prints the appsettings.json path and a

--- a/clio/help/en/deploy-creatio.txt
+++ b/clio/help/en/deploy-creatio.txt
@@ -13,6 +13,11 @@ DESCRIPTION
     Services (IIS) by default. On macOS and Linux, uses dotnet runtime. Supports cross-platform
     deployment with optional HTTPS configuration and automatic service management.
 
+    When --site-name and the configured deploy-site-name default are both
+    omitted, interactive deployment prompts for the site name. The Windows
+    Explorer "clio: deploy Creatio" action uses this prompt instead of deriving
+    a name from the selected ZIP archive.
+
     Every deploy-creatio run creates a temp database-operation log file for the
     database restore portion of deployment. The final CLI output includes the
     absolute path in a "Database operation log:" line. For MCP tool execution,
@@ -52,14 +57,17 @@ OPTIONS
     --product PRODUCT_NAME
         Product to deploy (optional)
 
-    --SiteName SITE_NAME
-        Website/application name in IIS (Windows) or service name (macOS/Linux)
+    --site-name SITE_NAME
+        Website/application name in IIS (Windows) or service name (macOS/Linux).
+        When omitted and no configured default exists, interactive deployment
+        prompts for this value. Silent deployment fails with a clear error
+        instead of waiting for console input.
 
-    --SitePort PORT
+    --site-port PORT
         HTTP port number for the application
         Default: 80 (HTTP), 443 (HTTPS)
 
-    --ZipFile FILE_PATH
+    --zip-file FILE_PATH
         Required. Path to Creatio zip file or directory
         - If zip file: Will be automatically extracted
         - If directory: Used directly as already-extracted Creatio application
@@ -172,77 +180,77 @@ OPTIONS
 EXAMPLES
 
     1. Basic deployment with default settings (PostgreSQL, port 40001, auto-run):
-       clio deploy-creatio -e "Default" --ZipFile "C:\creatio-app.zip" --SitePort 40001 --silent
+       clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --site-port 40001 --silent
 
     2. Deploy with MS SQL and custom port:
-       clio deploy-creatio -e "Production" --db mssql --SitePort 8080 \\
-           --ZipFile "/path/to/creatio-app.zip"
+       clio deploy-creatio -e "Production" --db mssql --site-port 8080 \\
+           --zip-file "/path/to/creatio-app.zip"
 
     3. Deploy with .NET Framework (Windows):
        clio deploy-creatio -e "LegacyApp" --platform netframework \\
-           --ZipFile "C:\creatio-framework.zip"
+           --zip-file "C:\creatio-framework.zip"
 
     4. Deploy with HTTPS on Windows using dotnet (no IIS):
        clio deploy-creatio -e "SecureApp" --no-iis --use-https \\
-           --cert-path "C:\certs\app.pem" --ZipFile "C:\creatio-app.zip"
+           --cert-path "C:\certs\app.pem" --zip-file "C:\creatio-app.zip"
 
     5. Deploy to custom path on macOS:
        clio deploy-creatio -e "CreatioApp" --app-path "/var/creatio" \\
-           --ZipFile "/Users/downloads/creatio-app.zip"
+           --zip-file "/Users/downloads/creatio-app.zip"
 
     6. Deploy on Linux with systemd service management:
        clio deploy-creatio -e "LinuxApp" --deployment dotnet \\
-           --app-path "/opt/creatio-prod" --ZipFile "/home/admin/creatio-app.zip"
+           --app-path "/opt/creatio-prod" --zip-file "/home/admin/creatio-app.zip"
 
     7. Deploy without auto-launching browser:
        clio deploy-creatio -e "BackgroundApp" --auto-run false \\
-           --ZipFile "C:\creatio-app.zip"
+           --zip-file "C:\creatio-app.zip"
 
     8. Silent deployment with all parameters:
        clio deploy-creatio -e "AutoDeploy" --db pg --platform net6 \\
-           --SiteName "AutoCreatio" --SitePort 8443 --use-https \\
-           --cert-path "/certs/server.pem" --ZipFile "/app/creatio.zip" --silent
+           --site-name "AutoCreatio" --site-port 8443 --use-https \\
+           --cert-path "/certs/server.pem" --zip-file "/app/creatio.zip" --silent
 
     9. Deploy with specific Redis database (when auto-detection fails):
-       clio deploy-creatio -e "RedisApp" --ZipFile "C:\creatio-app.zip" --redis-db 5
+       clio deploy-creatio -e "RedisApp" --zip-file "C:\creatio-app.zip" --redis-db 5
 
     10. Deploy in production with manual Redis DB to avoid conflicts:
-        clio deploy-creatio -e "Production" --db mssql --SitePort 8080 \\
-            --redis-db 3 --ZipFile "/path/to/creatio-app.zip"
+        clio deploy-creatio -e "Production" --db mssql --site-port 8080 \\
+            --redis-db 3 --zip-file "/path/to/creatio-app.zip"
 
     11. Deploy to local database server (automatic database restore):
         # Configure database server in appsettings.json first (see DATABASE RESTORATION)
         # Single command deploys everything: extract -> restore DB -> deploy app -> configure
-        clio deploy-creatio -e "LocalDev" --db mssql --SitePort 40001 \\
+        clio deploy-creatio -e "LocalDev" --db mssql --site-port 40001 \\
             --db-server-name my-local-mssql \\
-            --ZipFile "C:\Creatio\8.3.3.1343_Studio_MSSQL_ENU.zip"
+            --zip-file "C:\Creatio\8.3.3.1343_Studio_MSSQL_ENU.zip"
 
     12. Deploy PostgreSQL to local server with automatic DB drop:
-        clio deploy-creatio -e "QA" --db pg --SitePort 8080 \\
+        clio deploy-creatio -e "QA" --db pg --site-port 8080 \\
             --db-server-name my-local-postgres --drop-if-exists \\
-            --ZipFile "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
+            --zip-file "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
 
     13. Deploy PostgreSQL running in Docker via published host port:
-        clio deploy-creatio -e "DockerDev" --db pg --SitePort 8080 \\
+        clio deploy-creatio -e "DockerDev" --db pg --site-port 8080 \\
             --db-server-name docker-postgres --drop-if-exists \\
-            --ZipFile "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
+            --zip-file "C:\Creatio\8.3.3.1343_Studio_PG_ENU.zip"
 
     14. Silent deployment to local database without browser launch:
-        clio deploy-creatio -e "AutoDeploy" --db mssql --SitePort 8443 \\
+        clio deploy-creatio --site-name "AutoDeploy" --db mssql --site-port 8443 \\
             --db-server-name my-local-mssql --drop-if-exists \\
             --auto-run=false --silent \\
-            --ZipFile "C:\Creatio\app.zip"
+            --zip-file "C:\Creatio\app.zip"
 
     15. Deploy PostgreSQL with long filename (template reuse):
         # First deployment: Creates template from backup (slower)
-        clio deploy-creatio -e "Dev" --db pg --SitePort 8080 \\
+        clio deploy-creatio -e "Dev" --db pg --site-port 8080 \\
             --db-server-name my-local-postgres \\
-            --ZipFile "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
+            --zip-file "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
 
         # Subsequent deployments: Reuses template (faster)
-        clio deploy-creatio -e "Dev2" --db pg --SitePort 8081 \\
+        clio deploy-creatio -e "Dev2" --db pg --site-port 8081 \\
             --db-server-name my-local-postgres \\
-            --ZipFile "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
+            --zip-file "C:\Creatio\8.3.3.5678_Studio_Enterprise_Marketing_PostgreSQL_ENU.zip"
 
 BEHAVIOR
 
@@ -395,8 +403,8 @@ DATABASE RESTORATION
     WORKFLOW:
     1. Configure database server in appsettings.json (if using local database)
     2. Run deploy-creatio with --db-server-name to automatically restore and deploy:
-       clio deploy-creatio -e "LocalDev" --db mssql --SitePort 40001 \\
-           --db-server-name my-local-mssql --ZipFile "C:\Creatio\app.zip"
+       clio deploy-creatio -e "LocalDev" --db mssql --site-port 40001 \\
+           --db-server-name my-local-mssql --zip-file "C:\Creatio\app.zip"
     3. The command will:
        a. Extract the zip file
        b. Automatically restore database from db/*.bak or db/*.backup to local server


### PR DESCRIPTION
## Summary

- stop deriving `SiteName` from the selected ZIP filename
- preserve explicit `--site-name` and configured `deploy-site-name` precedence
- let interactive Explorer deployments use the existing site-name prompt
- fail fast with actionable guidance when silent deployment has no site name
- update command help and documentation

Fixes #855

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release -f net10.0 --filter "Category=Unit&(Module=Command|Module=CreatioInstallCommand)" --no-build` — 2174 passed, 15 skipped
- `dotnet test clio.tests/clio.tests.csproj -c Release -f net8.0 --filter "Category=Unit&(Module=Command|Module=CreatioInstallCommand)" --no-build` — 2174 passed, 15 skipped
- `dotnet test clio.tests/clio.tests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~HelpArtifactConsistencyTests" --no-build` — 4 passed
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 95 passed
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` — succeeded

## Reviews

- Comprehensive pre-PR three-lens agentic review completed against `origin/master`
- Code quality/maintainability: no findings
- Performance/correctness: no findings
- Security/testing: no findings
- Docs reviewed and updated
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed
  - inspected `clio/Command/McpServer/Tools/InstallerCommandTool.cs`
  - inspected `clio-ring/ClioRing.Ipc/DeployPlan.cs`
  - inspected `clio-ring/ClioRing/ViewModels/InstallFormViewModel.cs`