### PR TITLE
Preserve password-change state for Ring and Explorer deployments

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5802,3 +5802,24 @@ Decision: Removed ZIP-filename site-name inference, retained explicit and config
 Discovery: The existing Explorer registry verb and interactive installer prompt already provide the desired flow; only the defaults resolver prevented the prompt. The MCP tool and ClioRing always provide a site name, so their contracts remain unchanged.
 Files: clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs, clio/Command/CreatioInstallCommand/InstallerCommand.cs, clio.tests/Command/DeployCreatioDefaultsResolverTests.cs, clio.tests/Command/InstallerCommandSilentSiteNameTests.cs, clio/docs/commands/deploy-creatio.md, clio/help/en/deploy-creatio.txt
 Impact: Explorer deployments now request a safe explicit site name, while automation receives a clear configuration error and existing explicit/configured precedence remains compatible.
+
+## 2026-07-13 12:56 – Ring build discovery empty-state diagnosis
+Context: Ring deploy UI connected successfully but showed no Creatio builds.
+Decision: Traced the UI empty state through `list-creatio-builds` to the shared clio settings rather than the Ring installation directory.
+Discovery: `%LOCALAPPDATA%\Creatio\clio\appsettings.json` configured `F:\CreatioProductBuild`, which does not exist; the live repository is `F:\CreatioBuilds` and contains 42 recursively discoverable ZIP files.
+Files: clio-ring/ClioRing/ViewModels/InstallFormViewModel.cs, clio/Command/McpServer/Tools/ListCreatioBuildsTool.cs, clio/Environment/ConfigurationOptions.cs
+Impact: Future Ring empty build-list reports should first validate the shared `creatio-products` path and distinguish missing-folder discovery from UI binding failures.
+
+## 2026-07-13 13:14 – Ring deploy password-reset warning hidden inside restore stage
+Context: A Ring deployment completed successfully but Creatio still required the Supervisor password change.
+Decision: Traced the deployed run receipt to its per-operation database log and compared the Ring/MCP plan with the installer helper.
+Discovery: Ring has no password-reset input or stage; MCP hard-codes `DisableResetPassword = true`, and the helper runs inside `restore-db`. Run `10ab095c-431c-41b4-add1-82c3b93a0c0f` failed to update `SysAdminUnit` with PostgreSQL error 42501 (permission denied), but the helper intentionally logged a warning and continued, so restore and the overall deployment were reported successful.
+Files: clio/Command/McpServer/Tools/InstallerCommandTool.cs, clio/Command/CreatioInstallCommand/CreatioInstallerService.cs, C:/Tools/clio-ring/Logs/deploy-10ab095c-431c-41b4-add1-82c3b93a0c0f.ndjson
+Impact: Password-reset-disable failures need explicit Ring visibility and ownership/permission remediation; current pipeline success does not prove the forced-change flag was cleared.
+
+## 2026-07-13 13:52 – Preserve password-change state for Ring and Explorer deploys
+Context: Issue #861 requested `DisableResetPassword = false` for ClioRing and Windows Explorer ZIP deployments after a Ring run silently failed to clear `SysAdminUnit.ForceChangePassword`.
+Decision: Made false the deploy-creatio CLI default and the explicit MCP/Ring adapter value; Explorer's existing `--ZipFile` command inherits the CLI default. Updated MCP tool, prompt, lazy contract, deploy guidance, CLI help, and detailed docs to state that clio preserves the restored database value rather than promising to enable it.
+Discovery: `DisableResetPassword = false` skips the SQL that writes false; it does not write true. The pre-PR quality/security/correctness review caught this distinction and also found the legacy compatibility fixture's `UnitTests` category excluded it from the mandatory `Category=Unit` gate, so the fixture now uses `Unit`.
+Files: clio/Command/CreatioInstallCommand/InstallerCommand.cs, clio/Command/McpServer/Tools/InstallerCommandTool.cs, clio/Command/McpServer/Tools/ToolContractGetTool.cs, clio/Command/McpServer/Prompts/DeployCreatioPrompt.cs, clio/Command/McpServer/Resources/DeployLifecycleGuidanceResource.cs, clio.tests/Command/CliOptionNamingBackwardCompatibilityTests.cs, clio.tests/Command/McpServer/InstallerCommandToolTests.cs, clio.mcp.e2e/DeployCreatioToolE2ETests.cs, clio/docs/commands/deploy-creatio.md, clio/help/en/deploy-creatio.txt
+Impact: Ring and Explorer no longer clear the restored build's password-change state by default; Command/MCP suites pass 4196/4211 with 15 skips on net8 and net10, MCP E2E passes 2/2 per framework, Ring passes 95/95, and Windows x64 NativeAOT publish succeeds.

--- a/clio.mcp.e2e/DeployCreatioToolE2ETests.cs
+++ b/clio.mcp.e2e/DeployCreatioToolE2ETests.cs
@@ -56,6 +56,8 @@ public sealed class DeployCreatioToolE2ETests : McpContractFixtureBase
 			because: "the deploy-creatio contract description should tell the agent to review full infrastructure first");
 		contract.Description.Should().Contain("show-passing-infrastructure",
 			because: "the deploy-creatio contract description should tell the agent to fetch deployable recommendations second");
+		contract.Description.Should().Contain("existing forced-password-change state",
+			because: "the real MCP contract should disclose the preserved database behavior used by Ring");
 		contract.InputSchema.Properties.Select(property => property.Name).Should().BeEquivalentTo(
 			["siteName", "zipFile", "sitePort", "dbServerName", "redisServerName"],
 			because: "the full deploy-creatio contract should only expose the five approved arguments");

--- a/clio.tests/Command/CliOptionNamingBackwardCompatibilityTests.cs
+++ b/clio.tests/Command/CliOptionNamingBackwardCompatibilityTests.cs
@@ -14,7 +14,7 @@ namespace Clio.Tests.Command;
 /// TDD workflow: new-form tests fail first (RED), fix adds kebab alias, both pass (GREEN).
 /// </summary>
 [TestFixture]
-[Category("UnitTests")]
+[Category("Unit")]
 [Property("Module", "Command")]
 internal sealed class CliOptionNamingBackwardCompatibilityTests {
 
@@ -1254,6 +1254,24 @@ internal sealed class CliOptionNamingBackwardCompatibilityTests {
 		PfInstallerOptions? opts = null;
 		result.WithParsed(o => opts = o);
 		opts!.ZipFile.Should().Be("/pkg.zip", because: "new --zip-file must map to the ZipFile property");
+	}
+
+	[Test]
+	[Description("Explorer ZIP deployment preserves the database's forced-password-change state when disable-reset-password is omitted")]
+	public void PfInstallerOptions_ShouldDefaultDisableResetPasswordToFalse_WhenExplorerContextArgumentsOmitIt() {
+		// Arrange
+		string[] arguments = ["--ZipFile", "/pkg.zip"];
+
+		// Act
+		ParserResult<PfInstallerOptions> result = Parser.Default.ParseArguments<PfInstallerOptions>(arguments);
+		PfInstallerOptions? options = null;
+		result.WithParsed(parsed => options = parsed);
+
+		// Assert
+		result.Tag.Should().Be(ParserResultType.Parsed,
+			because: "the Windows Explorer registry command should parse when the hidden password-reset option is omitted");
+		options!.DisableResetPassword.Should().BeFalse(
+			because: "CLI and Explorer deployments should not clear the database's existing forced-password-change state by default");
 	}
 
 	// ─── ExecuteSqlScriptOptions ───────────────────────────────────────────────

--- a/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
+++ b/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
@@ -61,6 +61,8 @@ public sealed class InstallerCommandToolTests
 			because: "the tool description should direct agents to run passing-infrastructure discovery before deployment");
 		text.Should().Contain("find-empty-iis-port",
 			because: "the tool description should tell agents how to choose a safe local IIS sitePort");
+		text.Should().Contain("existing forced-password-change state",
+			because: "the tool description should disclose that deployment preserves the database's existing state");
 	}
 
 	[Test]
@@ -105,8 +107,8 @@ public sealed class InstallerCommandToolTests
 			because: "local Redis server selection should be forwarded when provided");
 		command.ReceivedOptions.RedisDb.Should().Be(-1,
 			because: "the reduced MCP contract should keep automatic Redis DB detection");
-		command.ReceivedOptions.DisableResetPassword.Should().BeTrue(
-			because: "the MCP wrapper should preserve the CLI default and disable forced password reset unless explicitly changed in code");
+		command.ReceivedOptions.DisableResetPassword.Should().BeFalse(
+			because: "Ring deployments should not clear the database's existing forced-password-change state");
 		command.ReceivedOptions.DB.Should().BeNull(
 			because: "the reduced MCP contract should let the installer detect the database type from the build");
 		command.ReceivedOptions.DropIfExists.Should().BeTrue(
@@ -180,6 +182,8 @@ public sealed class InstallerCommandToolTests
 			because: "the prompt should direct the agent to discover a safe local IIS port when sitePort selection matters");
 		prompt.Should().Contain("deploy-creatio",
 			because: "the prompt should conclude with the actual deployment call");
+		prompt.Should().Contain("existing forced-password-change state",
+			because: "the prompt should disclose that deployment preserves the database's existing state");
 	}
 
 	private static McpServerToolAttribute GetDeployCreatioAttribute()

--- a/clio.tests/Command/RestoreDb.LocalServer.Tests.cs
+++ b/clio.tests/Command/RestoreDb.LocalServer.Tests.cs
@@ -412,7 +412,7 @@ public class RestoreDbLocalServerTests : BaseCommandTests<RestoreDbCommandOption
 		capturedInstallerOptions.Should().NotBeNull(
 			because: "successful restore-db execution should reuse the shared password-reset helper");
 		capturedInstallerOptions!.DisableResetPassword.Should().BeTrue(
-			because: "restore-db should keep the same default disable-reset-password behavior as deploy-creatio");
+			because: "restore-db should retain its intentional legacy disable-reset-password default");
 		capturedDbType.Should().Be(InstallerHelper.DatabaseType.MsSql,
 			because: "the shared helper should receive the resolved MSSQL database type");
 	}

--- a/clio/Command/CreatioInstallCommand/InstallerCommand.cs
+++ b/clio/Command/CreatioInstallCommand/InstallerCommand.cs
@@ -85,7 +85,8 @@ public class PfInstallerOptions : EnvironmentNameOptions{
 	/// <summary>
 	/// Gets or sets a value indicating whether force-password-reset disabling script may be executed.
 	/// </summary>
-	[Option("disable-reset-password", Required = false, Hidden = true, Default = true, HelpText = "Disables reset password after installation")]
+	[Option("disable-reset-password", Required = false, Hidden = true, Default = false,
+		HelpText = "When true, disables the forced password change after installation")]
 	public bool DisableResetPassword { get; set; }
 	
 	/// <summary>

--- a/clio/Command/McpServer/Prompts/DeployCreatioPrompt.cs
+++ b/clio/Command/McpServer/Prompts/DeployCreatioPrompt.cs
@@ -32,6 +32,8 @@ public static class DeployCreatioPrompt
 		 deployable choices and the recommended `dbServerName` and `redisServerName` values.
 		 If you are deploying locally to IIS, run `{FindEmptyIisPortTool.FindEmptyIisPortToolName}` to pick
 		 a safe `sitePort` between {FindEmptyIisPortTool.RangeStart} and {FindEmptyIisPortTool.RangeEnd}.
+		 The deployment preserves the build database's existing forced-password-change state and does not
+		 clear it automatically.
 		 After that preflight, call `{InstallerCommandTool.DeployCreatioToolName}` with site name `{siteName}`,
 		 zip file `{zipFile}`, site port `{sitePort}`, and the selected or recommended server-name arguments.
 		 """;

--- a/clio/Command/McpServer/Resources/DeployLifecycleGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DeployLifecycleGuidanceResource.cs
@@ -52,6 +52,8 @@ public sealed class DeployLifecycleGuidanceResource {
 		         `dbServerName`, `redisServerName` (omit to keep the default Kubernetes deployment path).
 		       - Prefer the recommended bundle from `show-passing-infrastructure` and the port from `find-empty-iis-port`.
 		       - Do not proceed if assert-infrastructure left the targeted database/Redis sections failing.
+		       - Deployments preserve the build database's existing forced-password-change state by default and do
+		         not clear it automatically. deploy-creatio does not assign a new Supervisor password.
 
 		       IdentityService
 		       - `deploy-identity` deploys IdentityService to IIS for an already registered local Creatio environment,

--- a/clio/Command/McpServer/Tools/InstallerCommandTool.cs
+++ b/clio/Command/McpServer/Tools/InstallerCommandTool.cs
@@ -46,6 +46,8 @@ public class InstallerCommandTool(
 				 If you are deploying locally to IIS, also run `find-empty-iis-port` to choose a safe `sitePort`.
 				 Review the failing areas from `assert-infrastructure`, prefer the recommended bundle from
 				 `show-passing-infrastructure`, and then call `deploy-creatio` with the selected arguments.
+				 Deployment preserves the build database's existing forced-password-change state and does not
+				 clear it automatically.
 				 """)]
 	public CommandExecutionResult DeployCreatio(
 		RequestContext<CallToolRequestParams> requestContext,
@@ -64,7 +66,7 @@ public class InstallerCommandTool(
 			DbServerName = args.DbServerName,
 			RedisServerName = args.RedisServerName,
 			RedisDb = -1,
-			DisableResetPassword = true,
+			DisableResetPassword = false,
 			AutoRun = true,
 			IsSilent = true,
 			DropIfExists = true

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -4571,7 +4571,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildDeployCreatio() {
 		return new ToolContractDefinition(
 			InstallerCommandTool.DeployCreatioToolName,
-			"Deploys Creatio from a zip archive using the real deploy-creatio command path. This is the most consequential, hardest-to-reverse lifecycle tool: it drops and recreates the target site. Run the deploy preflight first (assert-infrastructure -> show-passing-infrastructure -> find-empty-iis-port) and prefer the recommended bundle from show-passing-infrastructure.",
+			"Deploys Creatio from a zip archive using the real deploy-creatio command path. This is the most consequential, hardest-to-reverse lifecycle tool: it drops and recreates the target site. Run the deploy preflight first (assert-infrastructure -> show-passing-infrastructure -> find-empty-iis-port) and prefer the recommended bundle from show-passing-infrastructure. Deployment preserves the build database's existing forced-password-change state and does not clear it automatically.",
 			new ToolInputSchemaContract(
 				[SiteNameFieldName, ZipFileFieldName, SitePortFieldName],
 				[

--- a/clio/docs/commands/deploy-creatio.md
+++ b/clio/docs/commands/deploy-creatio.md
@@ -167,8 +167,8 @@ Only applicable when using --db-server-name for local database restore
 Default: false (will prompt user)
 
 --disable-reset-password
-Disable automatic password-reset script after installation
-Hidden option, Default: true
+When true, disable Creatio's forced password change after installation
+Hidden option, Default: false (preserves the build database's existing ForceChangePassword value)
 
 Corporate-gated behavior (script executes only when ALL conditions are met):
 - Option value is true
@@ -278,7 +278,10 @@ operation log artifact
 
 Password Reset Script (Creatio >= 8.3.3):
 - Applies SQL script that sets Supervisor ForceChangePassword to false
-- Runs only when --disable-reset-password is true (default)
+- Runs only when --disable-reset-password is explicitly set to true
+- By default, the script is skipped and the build database's existing ForceChangePassword value is preserved
+- Creatio asks the user to choose a new password only when that preserved value is true
+- This option does not assign a new Supervisor password
 - Runs only for corporate-eligible machines:
 - tscrm domain member (Windows)
 - OR tscrm.com reachable via ping

--- a/clio/help/en/deploy-creatio.txt
+++ b/clio/help/en/deploy-creatio.txt
@@ -156,8 +156,8 @@ OPTIONS
         Default: false (will prompt user)
 
     --disable-reset-password
-        Disable automatic password-reset script after installation
-        Hidden option, Default: true
+        When true, disable Creatio's forced password change after installation
+        Hidden option, Default: false (preserves the build database's existing ForceChangePassword value)
 
         Corporate-gated behavior (script executes only when ALL conditions are met):
         - Option value is true
@@ -264,7 +264,10 @@ BEHAVIOR
 
     Password Reset Script (Creatio >= 8.3.3):
     - Applies SQL script that sets Supervisor ForceChangePassword to false
-    - Runs only when --disable-reset-password is true (default)
+    - Runs only when --disable-reset-password is explicitly set to true
+    - By default, the script is skipped and the build database's existing ForceChangePassword value is preserved
+    - Creatio asks the user to choose a new password only when that preserved value is true
+    - This option does not assign a new Supervisor password
     - Runs only for corporate-eligible machines:
       - tscrm domain member (Windows)
       - OR tscrm.com reachable via ping


### PR DESCRIPTION
Closes #861

## What changed

- Change the `deploy-creatio` default to `DisableResetPassword = false`.
- Make the Ring MCP adapter explicitly use the same value.
- Cover the Windows Explorer ZIP context-menu argument shape, which inherits the CLI default.
- Keep MCP tool descriptions, the lazy contract, prompt, deploy guidance, CLI help, and detailed command documentation aligned.
- Clarify that `false` preserves the restored database's existing `ForceChangePassword` value; it does not assign a password or force the value to `true`.

## Why

Ring and Explorer deployments previously cleared `Supervisor.ForceChangePassword` by default. Preserving the restored database state avoids automatically disabling Creatio's password-change behavior.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Debug --framework net10.0 --filter "Category=Unit&(Module=Command|Module=McpServer)"` - 4196 passed, 15 skipped, 0 failed.
- `dotnet test clio.tests/clio.tests.csproj -c Debug --framework net8.0 --filter "Category=Unit&(Module=Command|Module=McpServer)"` - 4196 passed, 15 skipped, 0 failed.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --filter "FullyQualifiedName~DeployCreatioToolE2ETests"` - 2/2 passed on net8.0 and 2/2 passed on net10.0, zero skips.
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` - 95/95 passed.
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` - succeeded without trim/AOT warnings.

## Reviews

- Comprehensive pre-PR three-lens agentic review: code quality/testing, correctness/performance, and security/best practices.
- No Blocker/High findings.
- Review wording and test-category findings were addressed before commit.
- Docs reviewed and updated; `Commands.md` and `WikiAnchors.txt` required no changes.
- MCP tool, prompt, guidance, unit coverage, and external-process E2E coverage updated.
- ClioRing compatibility reviewed; no Ring-consumed wire argument changed, and Ring tests plus Windows x64 NativeAOT publish passed.
