### PR TITLE
Support Creatio virtual entity schemas

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5830,3 +5830,10 @@ Decision: Hid the inherited maintainer property only in `CallServiceCommandOptio
 Discovery: A delegating `new` property keeps the parsed maintainer value on the `RemoteCommandOptions` base contract, so downstream environment handling remains unchanged while other remote commands retain their existing `-m/--maintainer` alias.
 Files: clio/Query/DataServiceQuery.cs, clio.tests/Query/CallServiceCommandTests.cs, clio/docs/commands/call-service.md, clio/docs/commands/dataservice.md
 Impact: `call-service -m POST --maintainer Customer` and the inherited `dataservice` option contract parse on net8.0 and net10.0, generated help exposes unique short names, and neither the MCP surface nor a ClioRing-consumed contract changes.
+
+## 2026-07-13 19:56 – Virtual entity schema creation and readback
+Context: GitHub issue #864 required atomic virtual entity creation through standalone and batched MCP paths without creating a physical table.
+Decision: Added positive-only `is-virtual` mapping before the first schema save, preserved inherited virtual state for replacements, rejected virtual seed rows before mutation, and exposed virtual state through schema and application readback.
+Discovery: Creatio's normal DB-structure lifecycle excludes virtual schemas itself; live Creatio 10.0.0.802 PostgreSQL validation confirmed the schema is runtime-readable while no table is created.
+Files: clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs, clio/Command/McpServer/Tools/EntitySchemaTool.cs, clio/Command/McpServer/Tools/SchemaSyncTool.cs, clio/Command/ApplicationInfoService.cs, clio.mcp.e2e/EntitySchemaToolE2ETests.cs, clio.mcp.e2e/ApplicationToolE2ETests.cs
+Impact: CLI and MCP callers can create and verify virtual entities safely, with persistent creation remaining the default and PostgreSQL catalog behavior covered explicitly.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5837,3 +5837,10 @@ Decision: Added positive-only `is-virtual` mapping before the first schema save,
 Discovery: Creatio's normal DB-structure lifecycle excludes virtual schemas itself; live Creatio 10.0.0.802 PostgreSQL validation confirmed the schema is runtime-readable while no table is created.
 Files: clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs, clio/Command/McpServer/Tools/EntitySchemaTool.cs, clio/Command/McpServer/Tools/SchemaSyncTool.cs, clio/Command/ApplicationInfoService.cs, clio.mcp.e2e/EntitySchemaToolE2ETests.cs, clio.mcp.e2e/ApplicationToolE2ETests.cs
 Impact: CLI and MCP callers can create and verify virtual entities safely, with persistent creation remaining the default and PostgreSQL catalog behavior covered explicitly.
+
+## 2026-07-13 20:36 – Align related-page add-on E2E with lazy MCP discovery
+Context: PR #869's TeamCity MCP E2E build failed because create-related-page-addon was expected in the resident tools/list surface.
+Decision: Replaced the stale runtime-schema assertion with discovery through the established lazy-surface union, while retaining the fixture's existing nested pages payload-binding coverage.
+Discovery: Long-tail tools are intentionally absent from tools/list and remain discoverable through the get-tool-contract compact index.
+Files: clio.mcp.e2e/CreateRelatedPageAddonToolE2ETests.cs
+Impact: The full related-page add-on fixture passes all six scenarios on both net8.0 and net10.0 and now tests the supported MCP discovery contract.

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -116,6 +116,10 @@ public sealed class ApplicationToolE2ETests {
 			because: "get-app-info should include page summaries in the structured metadata envelope even when the list is empty");
 		infoResult.Result.Entities.Should().NotBeNull(
 			because: "get-app-info should include entity summaries in the structured metadata envelope even when the list is empty");
+		infoResult.Result.Entities.Should().NotBeEmpty(
+			because: "the seeded application must expose at least one entity before its virtual flags can be verified end to end");
+		infoResult.Result.Entities.Should().OnlyContain(entity => entity.Virtual.HasValue,
+			because: "get-app-info must serialize an explicit virtual flag for every returned entity, including persistent schemas");
 		infoResult.Result.Error.Should().BeNullOrWhiteSpace(
 			because: "successful get-app-info calls should not include an error payload");
 		infoResult.Result.SchemaNamePrefix.Should().NotBeNull(
@@ -405,16 +409,16 @@ public sealed class ApplicationToolE2ETests {
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
-	[Description("Creates an application, mutates the canonical main entity through sync-schemas, and verifies get-app-info still returns the application display name instead of Base object.")]
+	[Description("Creates an application, mutates its schemas through sync-schemas, and verifies canonical caption plus virtual-entity readback through get-app-info.")]
 	[AllureFeature(CreateToolName)]
 	[AllureFeature(SchemaSyncToolName)]
 	[AllureFeature(InfoToolName)]
 	[AllureTag(CreateToolName)]
 	[AllureTag(SchemaSyncToolName)]
 	[AllureTag(InfoToolName)]
-	[AllureName("Application get info keeps canonical main entity caption after sync-schemas")]
-	[AllureDescription("Uses the real clio MCP server to create an application, applies a minimal sync-schemas update-entity mutation to the canonical main entity, then verifies get-app-info still returns the installed application display name instead of the generic Base object fallback.")]
-	public async Task ApplicationGetInfo_Should_Keep_Canonical_Main_Entity_Caption_After_SchemaSync() {
+	[AllureName("Application get info keeps canonical caption and exposes virtual entities after sync-schemas")]
+	[AllureDescription("Uses the real clio MCP server to create an application, updates its canonical entity, creates a virtual entity, and verifies both through get-app-info.")]
+	public async Task ApplicationGetInfo_Should_Read_Virtual_Entity_After_SchemaSync() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
 		if (!settings.AllowDestructiveMcpTests) {
@@ -427,6 +431,7 @@ public sealed class ApplicationToolE2ETests {
 		string createdApplicationCode = $"UsrCodex{suffix}";
 		string applicationName = $"Codex E2E {suffix}";
 		string addedColumnName = $"UsrStatus{suffix[..4]}";
+		string virtualSchemaName = $"UsrVirtual{suffix}";
 
 		ApplicationInfoActResult createResult = await ActCreateAsync(
 			arrangeContext.Session,
@@ -447,7 +452,8 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.EnvironmentName,
 			createResult.Result.PackageName!,
 			createdApplicationCode,
-			addedColumnName);
+			addedColumnName,
+			virtualSchemaName);
 		JsonElement schemaSyncResponse = ExtractSchemaSyncResponse(schemaSyncCallResult);
 		// sync-schemas triggers an asynchronous server-side schema recompile; the canonical main
 		// entity can be momentarily absent from get-app-info until that settles. Poll the readback so
@@ -457,9 +463,12 @@ public sealed class ApplicationToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token,
 			arrangeContext.EnvironmentName,
 			createdApplicationCode,
-			applicationName);
+			applicationName,
+			virtualSchemaName);
 		ApplicationEntityEnvelope? canonicalMainEntity = infoResult.Result.Entities?
 			.FirstOrDefault(entity => string.Equals(entity.Name, createdApplicationCode, StringComparison.OrdinalIgnoreCase));
+		ApplicationEntityEnvelope? virtualEntity = infoResult.Result.Entities?
+			.FirstOrDefault(entity => string.Equals(entity.Name, virtualSchemaName, StringComparison.OrdinalIgnoreCase));
 
 		// Assert
 		createResult.Result.Success.Should().BeTrue(
@@ -472,6 +481,10 @@ public sealed class ApplicationToolE2ETests {
 			because: "get-app-info should continue to return the canonical main entity after sync-schemas mutations");
 		canonicalMainEntity!.Caption.Should().Be(applicationName,
 			because: "the canonical main entity should keep the installed application display name instead of degrading to Base object after sync-schemas");
+		virtualEntity.Should().NotBeNull(
+			because: "get-app-info must include the virtual schema created in the application's primary package");
+		virtualEntity!.Virtual.Should().BeTrue(
+			because: "get-app-info must preserve the runtime virtual state for a real schema created through sync-schemas");
 	}
 
 	[Category("McpE2E.Sandbox")]
@@ -753,7 +766,8 @@ public sealed class ApplicationToolE2ETests {
 		CancellationToken cancellationToken,
 		string environmentName,
 		string applicationCode,
-		string expectedCaption) {
+		string expectedCaption,
+		string expectedVirtualEntityName) {
 		// The canonical main entity schema name equals the installed application code, so the same
 		// value is both the get-app-info lookup code and the expected entity name in the readback.
 		// Gate the poll on the fully-settled state the downstream assertions check: the entity must be
@@ -765,7 +779,8 @@ public sealed class ApplicationToolE2ETests {
 			try {
 				ApplicationInfoActResult candidate = await ActInfoAsync(
 					session, cancellationToken, environmentName, id: null, code: applicationCode);
-				if (ContainsCanonicalMainEntity(candidate, applicationCode, expectedCaption)) {
+				if (ContainsExpectedEntities(
+					candidate, applicationCode, expectedCaption, expectedVirtualEntityName)) {
 					return candidate;
 				}
 			}
@@ -782,11 +797,16 @@ public sealed class ApplicationToolE2ETests {
 		return await ActInfoAsync(session, cancellationToken, environmentName, id: null, code: applicationCode);
 	}
 
-	private static bool ContainsCanonicalMainEntity(
-		ApplicationInfoActResult infoResult, string expectedEntityName, string expectedCaption) {
-		return infoResult.Result.Entities?
-			.Any(entity => string.Equals(entity.Name, expectedEntityName, StringComparison.OrdinalIgnoreCase)
-				&& string.Equals(entity.Caption, expectedCaption, StringComparison.Ordinal)) == true;
+	private static bool ContainsExpectedEntities(
+		ApplicationInfoActResult infoResult,
+		string expectedEntityName,
+		string expectedCaption,
+		string expectedVirtualEntityName) {
+		IReadOnlyList<ApplicationEntityEnvelope>? entities = infoResult.Result.Entities;
+		return entities?.Any(entity => string.Equals(entity.Name, expectedEntityName, StringComparison.OrdinalIgnoreCase)
+				&& string.Equals(entity.Caption, expectedCaption, StringComparison.Ordinal)) == true
+			&& entities.Any(entity => string.Equals(entity.Name, expectedVirtualEntityName, StringComparison.OrdinalIgnoreCase)
+				&& entity.Virtual == true);
 	}
 
 	[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters",
@@ -944,7 +964,8 @@ public sealed class ApplicationToolE2ETests {
 		string environmentName,
 		string packageName,
 		string schemaName,
-		string addedColumnName) {
+		string addedColumnName,
+		string virtualSchemaName) {
 		IReadOnlyCollection<string> reachableToolNames = await session.ListReachableToolNamesAsync(cancellationToken);
 		reachableToolNames.Should().Contain(SchemaSyncToolName,
 			because: "the sync-schemas MCP tool must be discoverable via the get-tool-contract compact index before the canonical-main-entity regression scenario can be executed");
@@ -967,6 +988,12 @@ public sealed class ApplicationToolE2ETests {
 									["title-localizations"] = BuildLocalizations("Status")
 								}
 							}
+						},
+						new Dictionary<string, object?> {
+							["type"] = "create-entity",
+							["schema-name"] = virtualSchemaName,
+							["title-localizations"] = BuildLocalizations("Virtual item"),
+							["is-virtual"] = true
 						}
 					}
 				}

--- a/clio.mcp.e2e/CreateRelatedPageAddonToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateRelatedPageAddonToolE2ETests.cs
@@ -7,9 +7,7 @@ using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
-using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
-using System.Text.Json;
 
 namespace Clio.Mcp.E2E;
 
@@ -25,29 +23,21 @@ public sealed class CreateRelatedPageAddonToolE2ETests {
 	private const string ToolName = CreateRelatedPageAddonTool.ToolName;
 
 	[Test]
-	[Description("Advertises the pages-array runtime schema for create-related-page-addon through the real MCP server.")]
+	[Description("Exposes create-related-page-addon through the get-tool-contract compact index on the lazy MCP surface.")]
 	[AllureTag(ToolName)]
-	[AllureName("create-related-page-addon MCP tool advertises the pages-array schema")]
-	[AllureDescription("Starts the real clio MCP server, lists tools, and verifies create-related-page-addon exposes a pages array whose items carry page-schema-name, is-default and is-add.")]
-	public async Task CreateRelatedPageAddon_Should_Advertise_Pages_Array_Runtime_Schema() {
+	[AllureName("create-related-page-addon MCP tool is discoverable on the lazy surface")]
+	[AllureDescription("Starts the real clio MCP server and verifies create-related-page-addon is discoverable via the get-tool-contract compact index even though long-tail tools are not resident in tools/list.")]
+	public async Task CreateRelatedPageAddon_Should_Be_Discoverable_On_Lazy_Surface() {
 		// Arrange
 		await using ArrangeContext arrangeContext = await ArrangeAsync(TimeSpan.FromMinutes(3));
 
 		// Act
-		IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(
+		IReadOnlyCollection<string> toolNames = await arrangeContext.Session.ListReachableToolNamesAsync(
 			arrangeContext.CancellationTokenSource.Token);
 
 		// Assert
-		McpClientTool tool = tools.Single(candidate => candidate.Name == ToolName);
-		JsonElement inputSchema = JsonSerializer.SerializeToElement(tool.ProtocolTool.InputSchema);
-		JsonElement argsSchema = inputSchema.GetProperty("properties").GetProperty("args").GetProperty("properties");
-		argsSchema.EnumerateObject().Select(property => property.Name).Should().Contain(
-			["entity-schema-name", "package-name", "pages"],
-			because: "the tool should advertise the object, package and pages inputs");
-		JsonElement pageItemSchema = argsSchema.GetProperty("pages").GetProperty("items").GetProperty("properties");
-		pageItemSchema.EnumerateObject().Select(property => property.Name).Should().Contain(
-			["page-schema-name", "is-default", "is-add"],
-			because: "each related-page entry should advertise the page name and the default/add flags");
+		toolNames.Should().Contain(ToolName,
+			because: "create-related-page-addon must be discoverable through get-tool-contract even though it is not resident in tools/list");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -123,6 +123,43 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
+	[Description("Creates a virtual entity schema and verifies both structured readback and absence of a PostgreSQL table through the real MCP server.")]
+	[AllureTag(CreateToolName)]
+	[AllureTag(ReadSchemaToolName)]
+	[AllureName("Virtual entity schema is saved without a physical table")]
+	[AllureDescription("Creates a virtual entity through create-entity-schema, reads the virtual flag through get-entity-schema-properties, and queries the disposable sandbox PostgreSQL catalog to prove no physical table was created.")]
+	public async Task CreateEntitySchema_Should_Create_Virtual_Schema_Without_Physical_Table() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		TestConfiguration.RequirePostgreSqlSandbox(settings);
+		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSandboxPackageAsync();
+		SandboxEnvironmentContext sandbox = SandboxEnvironmentResolver.Resolve(settings);
+
+		// Act
+		CallToolResult callResult = await CallCreateEntitySchemaAsync(
+			arrangeContext.Session,
+			arrangeContext.EnvironmentName,
+			arrangeContext.PackageName,
+			arrangeContext.SchemaName,
+			arrangeContext.CancellationTokenSource.Token,
+			isVirtual: true);
+		CommandExecutionEnvelope createResult = McpCommandExecutionParser.Extract(callResult);
+		EntitySchemaPropertiesInfo schemaProperties = await ActGetSchemaPropertiesAsync(arrangeContext);
+		bool physicalTableExists = PostgresTableProbe.Exists(
+			sandbox.DatabaseConnectionString,
+			arrangeContext.SchemaName);
+
+		// Assert
+		AssertCommandSucceeded(createResult,
+			"create-entity-schema should accept an explicit virtual entity request on the disposable sandbox");
+		schemaProperties.Virtual.Should().BeTrue(
+			because: "get-entity-schema-properties must read back the saved virtual-schema flag");
+		physicalTableExists.Should().BeFalse(
+			because: "Creatio must not materialize a PostgreSQL table for a virtual entity schema");
+	}
+
+	[Category("McpE2E.Sandbox")]
+	[Test]
 	[Description("Creates a remote lookup schema through MCP and verifies the resulting schema inherits from BaseLookup.")]
 	[AllureTag(CreateLookupToolName)]
 	[AllureTag(ReadSchemaToolName)]
@@ -1218,7 +1255,8 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		string packageName,
 		string schemaName,
 		CancellationToken cancellationToken,
-		IReadOnlyList<Dictionary<string, object?>>? columns = null) {
+		IReadOnlyList<Dictionary<string, object?>>? columns = null,
+		bool isVirtual = false) {
 		IReadOnlyCollection<string> reachableToolNames = await session.ListReachableToolNamesAsync(cancellationToken);
 		reachableToolNames.Should().Contain(CreateToolName,
 			because: "the create-entity-schema MCP tool must be discoverable via the get-tool-contract compact index before the end-to-end call can be executed");
@@ -1231,7 +1269,8 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 					["package-name"] = packageName,
 					["schema-name"] = schemaName,
 					["title-localizations"] = BuildLocalizations("Vehicle"),
-					["columns"] = columns
+					["columns"] = columns,
+					["is-virtual"] = isVirtual
 				}
 			},
 			cancellationToken);

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -226,6 +226,104 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 	}
 
 	[Test]
+	[Description("Creates a virtual entity through sync-schemas and verifies readback plus absence of a PostgreSQL table.")]
+	[AllureTag(ToolName)]
+	[AllureTag(ReadSchemaToolName)]
+	[AllureName("sync-schemas creates a virtual entity without a physical table")]
+	[AllureDescription("Runs a real sync-schemas create-entity operation with is-virtual=true, verifies the schema readback, and checks the disposable PostgreSQL catalog for table absence.")]
+	public async Task SchemaSync_CreateEntity_Should_Create_Virtual_Schema_Without_Physical_Table() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		TestConfiguration.RequirePostgreSqlSandbox(settings);
+		await using ArrangeContext context = await ArrangeAsync(requireEnvironment: true);
+		SandboxEnvironmentContext sandbox = SandboxEnvironmentResolver.Resolve(settings);
+
+		// Act
+		CallToolResult callResult = await context.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = context.EnvironmentName,
+					["package-name"] = context.PackageName,
+					["operations"] = new object?[] {
+						new Dictionary<string, object?> {
+							["type"] = "create-entity",
+							["schema-name"] = context.EntitySchemaName,
+							["title-localizations"] = BuildLocalizations("Virtual schema sync entity"),
+							["is-virtual"] = true
+						}
+					}
+				}
+			},
+			context.CancellationTokenSource.Token);
+		JsonElement response = ExtractSchemaSyncResponse(callResult);
+		EntitySchemaPropertiesInfo schemaProperties = await GetSchemaPropertiesAsync(
+			context.Session,
+			context.EnvironmentName!,
+			context.PackageName!,
+			context.EntitySchemaName!,
+			context.CancellationTokenSource.Token);
+		bool physicalTableExists = PostgresTableProbe.Exists(
+			sandbox.DatabaseConnectionString,
+			context.EntitySchemaName!);
+
+		// Assert
+		response.GetProperty("success").GetBoolean().Should().BeTrue(
+			because: $"sync-schemas should create the virtual schema successfully. Payload: {FormatPayload(response)}");
+		schemaProperties.Virtual.Should().BeTrue(
+			because: "get-entity-schema-properties must read back the virtual flag created through sync-schemas");
+		physicalTableExists.Should().BeFalse(
+			because: "sync-schemas must not cause Creatio to materialize a PostgreSQL table for a virtual entity");
+	}
+
+	[Test]
+	[Description("Rejects seed rows for virtual entity creation before environment resolution.")]
+	[AllureTag(ToolName)]
+	[AllureName("sync-schemas rejects seed rows for virtual entities before mutation")]
+	[AllureDescription("Starts the real MCP server without a reachable environment and verifies that is-virtual plus seed-rows returns a structured validation failure before any schema is created.")]
+	public async Task SchemaSyncTool_Should_Reject_SeedRows_For_Virtual_Entity_Before_Environment_Resolution() {
+		// Arrange
+		await using ArrangeContext context = await ArrangeAsync(requireEnvironment: false);
+		string invalidEnvironmentName = $"missing-sync-schemas-env-{Guid.NewGuid():N}";
+
+		// Act
+		CallToolResult callResult = await context.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = invalidEnvironmentName,
+					["package-name"] = "UsrPkg",
+					["operations"] = new object?[] {
+						new Dictionary<string, object?> {
+							["type"] = "create-entity",
+							["schema-name"] = "UsrVirtualItem",
+							["title-localizations"] = BuildLocalizations("Virtual item"),
+							["is-virtual"] = true,
+							["seed-rows"] = new object?[] {
+								new Dictionary<string, object?> {
+									["values"] = new Dictionary<string, object?> { ["Name"] = "Unavailable" }
+								}
+							}
+						}
+					}
+				}
+			},
+			context.CancellationTokenSource.Token);
+		JsonElement response = ExtractSchemaSyncResponse(callResult);
+		JsonElement result = response.GetProperty("results").EnumerateArray().Single();
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "invalid field combinations should use the normal structured MCP result envelope");
+		response.GetProperty("success").GetBoolean().Should().BeFalse(
+			because: "virtual entities cannot accept table-backed seed data");
+		result.GetProperty("error").GetString().Should().Contain("cannot include seed-rows",
+			because: "the caller must receive actionable guidance before any remote mutation");
+		result.GetProperty("error").GetString().Should().NotContain(invalidEnvironmentName,
+			because: "local validation must happen before environment resolution");
+	}
+
+	[Test]
 	[Description("Rejects inherited BaseLookup columns in create-lookup operations before environment resolution.")]
 	[AllureTag(ToolName)]
 	[AllureName("sync-schemas rejects inherited BaseLookup columns before environment resolution")]

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -476,7 +476,7 @@ internal static class ClioCliCommandRunner {
 		await probe.WaitUntilServingAsync(probeUrl, cancellationToken);
 	}
 
-	private static bool TryReadSuccessFlag(string output, out bool success) {
+	internal static bool TryReadSuccessFlag(string output, out bool success) {
 		success = false;
 		if (string.IsNullOrWhiteSpace(output)) {
 			return false;
@@ -484,7 +484,8 @@ internal static class ClioCliCommandRunner {
 
 		try {
 			using JsonDocument document = JsonDocument.Parse(output);
-			if (!document.RootElement.TryGetProperty("success", out JsonElement successElement) ||
+			if ((!document.RootElement.TryGetProperty("success", out JsonElement successElement) &&
+				 !document.RootElement.TryGetProperty("ok", out successElement)) ||
 				(successElement.ValueKind != JsonValueKind.True && successElement.ValueKind != JsonValueKind.False)) {
 				return false;
 			}

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunnerEnvelopeTests.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunnerEnvelopeTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E.Support.Configuration;
+
+[TestFixture]
+[Category("McpE2E.NoEnvironment")]
+public sealed class ClioCliCommandRunnerEnvelopeTests {
+	[TestCase("{\"success\":true}")]
+	[TestCase("{\"schemaVersion\":\"1.0\",\"ok\":true,\"data\":[]}")]
+	[Description("Recognizes both legacy success and canonical ok flags in structured CLI envelopes.")]
+	public void TryReadSuccessFlag_Should_Accept_Supported_Envelope_Fields(string json) {
+		// Arrange
+
+		// Act
+		bool parsed = ClioCliCommandRunner.TryReadSuccessFlag(json, out bool success);
+
+		// Assert
+		parsed.Should().BeTrue(
+			because: "the E2E readiness harness must understand both supported CLI envelope generations");
+		success.Should().BeTrue(
+			because: "the supplied structured envelope reports a successful command");
+	}
+}

--- a/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
+++ b/clio.mcp.e2e/Support/Configuration/McpE2ESettings.cs
@@ -45,6 +45,12 @@ internal sealed class SandboxSettings {
 	/// </summary>
 	public string? EnvironmentPath { get; set; }
 
+	/// <summary>
+	/// Database provider used by provider-specific sandbox assertions. Set to <c>postgresql</c>
+	/// through <c>McpE2E__Sandbox__DatabaseProvider</c> to enable PostgreSQL catalog checks.
+	/// </summary>
+	public string? DatabaseProvider { get; set; }
+
 	public string? ProcessCode { get; set; }
 
 	public string? ApplicationPackagePath { get; set; }

--- a/clio.mcp.e2e/Support/Configuration/TestConfiguration.cs
+++ b/clio.mcp.e2e/Support/Configuration/TestConfiguration.cs
@@ -36,6 +36,14 @@ internal static class TestConfiguration {
 			because: "seeded Redis keys must use a predictable prefix for cleanup and diagnostics");
 	}
 
+	public static void RequirePostgreSqlSandbox(McpE2ESettings settings) {
+		if (!string.Equals(settings.Sandbox.DatabaseProvider, "postgresql", StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(settings.Sandbox.DatabaseProvider, "postgres", StringComparison.OrdinalIgnoreCase)) {
+			Assert.Ignore(
+				"Set McpE2E__Sandbox__DatabaseProvider=postgresql to run PostgreSQL physical-table assertions.");
+		}
+	}
+
 	public static string ResolveFreshClioProcessPath() {
 		string? runtimeRepositoryRoot = ResolveRepositoryRootFromTestOutput();
 		if (!string.IsNullOrWhiteSpace(runtimeRepositoryRoot)) {

--- a/clio.mcp.e2e/Support/Creatio/PostgresTableProbe.cs
+++ b/clio.mcp.e2e/Support/Creatio/PostgresTableProbe.cs
@@ -1,0 +1,23 @@
+using Npgsql;
+
+namespace Clio.Mcp.E2E.Support.Creatio;
+
+internal static class PostgresTableProbe {
+	internal static bool Exists(string connectionString, string tableName) {
+		using NpgsqlConnection connection = new(connectionString);
+		connection.Open();
+		using NpgsqlCommand command = connection.CreateCommand();
+		command.CommandText = """
+			select exists (
+				select 1
+				from pg_catalog.pg_class relation
+				join pg_catalog.pg_namespace namespace on namespace.oid = relation.relnamespace
+				where relation.relname = @tableName
+					and relation.relkind in ('r', 'p')
+					and namespace.nspname not in ('pg_catalog', 'information_schema')
+			)
+			""";
+		command.Parameters.AddWithValue("tableName", tableName);
+		return (bool)command.ExecuteScalar()!;
+	}
+}

--- a/clio.mcp.e2e/Support/Results/ApplicationEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/ApplicationEnvelope.cs
@@ -88,7 +88,8 @@ internal sealed record ApplicationEntityEnvelope(
 	[property: JsonPropertyName("u-id")] string UId,
 	[property: JsonPropertyName("name")] string Name,
 	[property: JsonPropertyName("caption")] string Caption,
-	[property: JsonPropertyName("columns")] IReadOnlyList<ApplicationColumnEnvelope> Columns);
+	[property: JsonPropertyName("columns")] IReadOnlyList<ApplicationColumnEnvelope> Columns,
+	[property: JsonPropertyName("virtual")] bool? Virtual);
 
 internal sealed record ApplicationColumnEnvelope(
 	[property: JsonPropertyName("name")] string Name,

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -17,6 +17,52 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 	[Test]
+	[Description("Returns the virtual entity create defaults and readback fields for both standalone and batched schema tools.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract advertises virtual entity schema support")]
+	public async Task ToolContractGet_Should_Advertise_Virtual_Entity_Contracts() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["tool-names"] = new[] {
+					CreateEntitySchemaTool.CreateEntitySchemaToolName,
+					SchemaSyncTool.ToolName,
+					GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName,
+					ApplicationGetInfoTool.ApplicationGetInfoToolName
+				}
+			});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "the MCP server should return all virtual entity related contracts in one request");
+		response.Tools.Should().NotBeNull(
+			because: "a successful contract lookup must include the requested tool definitions");
+		IReadOnlyList<ToolContractDefinition> contracts = response.Tools!;
+		ToolContractDefinition createContract = contracts.Single(tool =>
+			tool.Name == CreateEntitySchemaTool.CreateEntitySchemaToolName);
+		createContract.InputSchema.Properties.Should().Contain(field => field.Name == "is-virtual",
+			because: "the standalone creation contract must expose the virtual-schema argument");
+		createContract.Defaults.Should().Contain(value => value.Name == "is-virtual" && value.Value == "false",
+			because: "standalone entity creation must document persistent schemas as the default");
+		ToolContractDefinition syncContract = contracts.Single(tool => tool.Name == SchemaSyncTool.ToolName);
+		syncContract.Defaults.Should().Contain(value =>
+				value.Name == "operations[*].is-virtual" && value.Value == "false",
+			because: "batched create-entity operations must advertise the same persistent default");
+		contracts.Single(tool => tool.Name == GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName)
+			.OutputContract.Fields.Should().Contain(field => field.Name == "virtual",
+				because: "schema properties must advertise virtual status for readback verification");
+		contracts.Single(tool => tool.Name == ApplicationGetInfoTool.ApplicationGetInfoToolName)
+			.OutputContract.Fields.Should().Contain(field =>
+				field.Name == "entities" && field.Description.Contains("`virtual`", StringComparison.Ordinal),
+				because: "application context must document the virtual flag on each entity");
+	}
+
+	[Test]
 	[AllureTag(ToolContractGetTool.ToolName)]
 	[AllureName("get-tool-contract tool is advertised by the MCP server")]
 	public async Task ToolContractGet_Should_Be_Listed_By_Mcp_Server() {

--- a/clio.mcp.e2e/appsettings.example.json
+++ b/clio.mcp.e2e/appsettings.example.json
@@ -7,6 +7,8 @@
       "_EnvironmentUrl_comment": "When set, the harness re-registers the sandbox env at this URL via reg-web-app before tests. In CI set via McpE2E__Sandbox__EnvironmentUrl=%DeployedUrl%.",
       "EnvironmentUrl": "",
       "EnvironmentPath": "",
+      "_DatabaseProvider_comment": "Set to postgresql to enable PostgreSQL catalog assertions (McpE2E__Sandbox__DatabaseProvider=postgresql in CI).",
+      "DatabaseProvider": "",
       "ProcessCode": "sandbox-process-code",
       "ApplicationPackagePath": "C:\\Packages\\application-package.gz",
       "SeedKeyPrefix": "clio-mcp-e2e"

--- a/clio.mcp.e2e/clio.mcp.e2e.csproj
+++ b/clio.mcp.e2e/clio.mcp.e2e.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
 		<PackageReference Include="NRedisStack" />
+		<PackageReference Include="Npgsql" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit.Analyzers" />
 		<PackageReference Include="NUnit3TestAdapter" />

--- a/clio.tests/Command/ApplicationInfoServiceTests.cs
+++ b/clio.tests/Command/ApplicationInfoServiceTests.cs
@@ -62,6 +62,10 @@ public sealed class ApplicationInfoServiceTests {
 			because: "application entities should be sorted by caption");
 		result.Entities[0].Columns.Should().ContainSingle(
 			because: "inherited runtime columns should be excluded from the final payload");
+		result.Entities[0].IsVirtual.Should().BeTrue(
+			because: "application readback should preserve the runtime virtual-schema flag");
+		result.Entities[1].IsVirtual.Should().BeFalse(
+			because: "schemas without an explicit runtime virtual flag should remain persistent");
 		result.Entities[0].Columns[0].DataValueType.Should().Be("Text",
 			because: "runtime schema data-value types should be mapped to readable names");
 		result.Entities[1].Columns[0].DefaultValueSource.Should().Be("Const",
@@ -396,7 +400,7 @@ public sealed class ApplicationInfoServiceTests {
 		_applicationClient.ExecutePostRequest(
 				Arg.Is<string>(url => url.EndsWith("RuntimeEntitySchemaRequest", StringComparison.Ordinal)),
 				Arg.Is<string>(body => body.Contains("\"uId\":\"entity-a\"", StringComparison.Ordinal)))
-			.Returns("""{"success":true,"schema":{"uId":"entity-a","name":"UsrAlpha","caption":{"en-US":"Alpha caption"},"columns":{"Items":{"visible":{"name":"Name","caption":{"en-US":"Name"},"dataValueType":1,"isInherited":false},"inherited":{"name":"CreatedOn","caption":{"en-US":"Created On"},"dataValueType":7,"isInherited":true}}}}}""");
+			.Returns("""{"success":true,"schema":{"uId":"entity-a","name":"UsrAlpha","caption":{"en-US":"Alpha caption"},"isVirtual":true,"columns":{"Items":{"visible":{"name":"Name","caption":{"en-US":"Name"},"dataValueType":1,"isInherited":false},"inherited":{"name":"CreatedOn","caption":{"en-US":"Created On"},"dataValueType":7,"isInherited":true}}}}}""");
 		_applicationClient.ExecutePostRequest(
 				Arg.Is<string>(url => url.EndsWith("RuntimeEntitySchemaRequest", StringComparison.Ordinal)),
 				Arg.Is<string>(body => body.Contains("\"uId\":\"entity-b\"", StringComparison.Ordinal)))

--- a/clio.tests/Command/CreateEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/CreateEntitySchemaCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Clio.Command;
 using Clio.Command.EntitySchemaDesigner;
 using Clio.Common;
@@ -89,5 +90,32 @@ internal class CreateEntitySchemaCommandTests : BaseCommandTests<CreateEntitySch
 			because: "a successful parse should produce create-entity-schema options");
 		parsedOptions!.Columns.Should().BeEquivalentTo([jsonColumn],
 			because: "semicolons inside a JSON title or default value are part of the payload, not column separators");
+	}
+
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Parses the optional --is-virtual flag and defaults it to false for persistent entity schemas.")]
+	public void Parse_Should_Map_IsVirtual_Option(bool expected) {
+		// Arrange
+		List<string> arguments = [
+			"--package", "UsrPkg",
+			"--name", "UsrVehicle",
+			"--title", "Vehicle"
+		];
+		if (expected) {
+			arguments.Add("--is-virtual");
+		}
+		CreateEntitySchemaOptions? parsedOptions = null;
+
+		// Act
+		ParserResult<CreateEntitySchemaOptions> parseResult = Parser.Default
+			.ParseArguments<CreateEntitySchemaOptions>(arguments)
+			.WithParsed(result => parsedOptions = result);
+
+		// Assert
+		parseResult.Tag.Should().Be(ParserResultType.Parsed,
+			because: "the optional virtual-schema flag should be accepted by the command parser");
+		parsedOptions!.IsVirtual.Should().Be(expected,
+			because: "the command must distinguish persistent schemas from explicitly virtual schemas");
 	}
 }

--- a/clio.tests/Command/McpServer/ApplicationToolTests.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTests.cs
@@ -260,7 +260,8 @@ public sealed class ApplicationToolTests {
 								"Const",
 								"Default",
 								Required: true)
-						])
+						],
+						IsVirtual: true)
 				],
 				[
 					new PageListItem {
@@ -305,6 +306,8 @@ public sealed class ApplicationToolTests {
 			because: "the MCP tool should preserve the installed application version");
 		result.Entities.Should().ContainSingle(
 			because: "the MCP tool should surface the entity metadata returned by the backend service");
+		result.Entities![0].Virtual.Should().BeTrue(
+			because: "get-app-info should expose the runtime virtual-schema flag");
 		result.Entities![0].Columns[0].DataValueType.Should().Be("Text",
 			because: "the Clio response should preserve application column types");
 		result.Entities![0].Columns[0].Type.Should().Be("Text",
@@ -952,7 +955,8 @@ public sealed class ApplicationToolTests {
 							DataValueType: "Text",
 							ReferenceSchema: "Contact",
 							Required: true)
-					])
+					],
+					Virtual: true)
 			],
 			Pages: [
 				new PageListItem {
@@ -1001,6 +1005,8 @@ public sealed class ApplicationToolTests {
 			because: "application page payloads should use schema-name instead of name");
 		json.Should().Contain("\"u-id\":\"entity-uid\"",
 			because: "entity payloads should keep Clio kebab-case payload fields");
+		json.Should().Contain("\"virtual\":true",
+			because: "entity payloads should expose the virtual-schema readback flag");
 		json.Should().Contain("\"data-value-type\":\"Text\"",
 			because: "column payloads should keep the legacy data-value-type field for backward compatibility");
 		json.Should().Contain("\"reference-schema\":\"Contact\"",

--- a/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateEntitySchemaToolTests.cs
@@ -58,7 +58,7 @@ public class CreateEntitySchemaToolTests {
 			new List<CreateEntitySchemaColumnArgs> {
 				new("Name", "Text", Localizations("Vehicle name")),
 				new("Owner", "Lookup", Localizations("Owner"), "Contact")
-			}));
+			}) { IsVirtual = true });
 
 		// Assert
 		result.ExitCode.Should().Be(0, "because the tool should forward a valid create entity schema request");
@@ -67,6 +67,7 @@ public class CreateEntitySchemaToolTests {
 			&& options.SchemaName == "UsrVehicle"
 			&& options.Title == "Vehicle"
 			&& options.ParentSchemaName == "BaseEntity"
+			&& options.IsVirtual
 			&& options.Environment == "docker_fix2"));
 		defaultCommand.CapturedOptions.Should().BeNull(
 			"because the environment-aware tool should use the resolved command");

--- a/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
@@ -91,6 +91,8 @@ public sealed class SchemaSyncToolTests {
 			because: "create-lookup must always inherit from BaseLookup");
 		fakeCreateCommand.CapturedOptions.Environment.Should().Be("dev",
 			because: "the environment should be forwarded from the batch args");
+		fakeCreateCommand.CapturedOptions.IsVirtual.Should().BeFalse(
+			because: "lookup schemas remain persistent even if the virtual property is absent");
 		registrationService.Received(1).EnsureLookupRegistration("UsrPkg", "UsrTodoStatus", "Todo Status");
 	}
 
@@ -147,7 +149,7 @@ public sealed class SchemaSyncToolTests {
 		SchemaSyncArgs args = new(
 			"dev", "UsrPkg",
 			[new SchemaSyncOperation("create-entity", "UsrTodoList",
-				TitleLocalizations: Localizations("Todo List"), ParentSchemaName: "BaseEntity")]);
+				TitleLocalizations: Localizations("Todo List"), ParentSchemaName: "BaseEntity") { IsVirtual = true }]);
 
 		// Act
 		SchemaSyncResponse response = await tool.SchemaSync(args);
@@ -157,6 +159,8 @@ public sealed class SchemaSyncToolTests {
 			because: "a create-entity with exit code 0 should succeed");
 		fakeCreateCommand.CapturedOptions!.ParentSchemaName.Should().Be("BaseEntity",
 			because: "create-entity should use the specified parent schema");
+		fakeCreateCommand.CapturedOptions.IsVirtual.Should().BeTrue(
+			because: "create-entity should preserve the explicit virtual-schema request");
 	}
 
 	[Test]
@@ -669,6 +673,42 @@ public sealed class SchemaSyncToolTests {
 			because: "the caller must be told that each seed row requires a values wrapper");
 		fakeCreateCommand.CapturedOptions.Should().BeNull(
 			because: "sync-schemas should not attempt create-lookup after local seed-row validation fails");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects seed rows for virtual entity creation before executing any remote command.")]
+	public async Task SchemaSync_VirtualEntityWithSeedRows_Should_Fail_Before_Command_Resolution() {
+		// Arrange
+		var fakeCreateCommand = new FakeCreateEntitySchemaCommand();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreateEntitySchemaCommand>(Arg.Any<CreateEntitySchemaOptions>())
+			.Returns(fakeCreateCommand);
+		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance);
+		SchemaSyncArgs args = new(
+			"missing-env", "UsrPkg",
+			[
+				new SchemaSyncOperation("create-entity", "UsrVirtualItem",
+					TitleLocalizations: Localizations("Virtual item"),
+					SeedRows: [new SchemaSyncSeedRow(new Dictionary<string, System.Text.Json.JsonElement> {
+						["Name"] = ToJsonElement("Unavailable")
+					})]) {
+					IsVirtual = true
+				}
+			]);
+
+		// Act
+		SchemaSyncResponse response = await tool.SchemaSync(args);
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "a virtual entity has no physical table that seed rows could populate");
+		response.Results.Should().ContainSingle(
+			because: "the invalid combined operation must stop before mutating the target environment");
+		response.Results[0].Error.Should().Contain("cannot include seed-rows",
+			because: "the caller needs an actionable explanation of the incompatible fields");
+		fakeCreateCommand.CapturedOptions.Should().BeNull(
+			because: "validation must reject the request before resolving or executing the create command");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -1186,6 +1186,28 @@ public sealed class ToolContractGetToolTests {
 					GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName
 				}),
 			because: "update-entity-schema should advertise the canonical inspect-mutate-verify flow");
+		ToolContractDefinition createEntityContract = result.Tools.Single(contract =>
+			contract.Name == CreateEntitySchemaTool.CreateEntitySchemaToolName);
+		createEntityContract.InputSchema.Properties.Should().Contain(field =>
+				field.Name == "is-virtual" && field.Type == "boolean",
+			because: "the standalone create contract must advertise virtual entity creation");
+		createEntityContract.Defaults.Should().Contain(defaultValue =>
+				defaultValue.Name == "is-virtual" && defaultValue.Value == "false",
+			because: "persistent entity creation must remain the documented default");
+		ToolContractDefinition syncContract = result.Tools.Single(contract =>
+			contract.Name == SchemaSyncTool.ToolName);
+		syncContract.Defaults.Should().Contain(defaultValue =>
+				defaultValue.Name == "operations[*].is-virtual" && defaultValue.Value == "false",
+			because: "batched create-entity operations must document the same persistent default");
+		syncContract.InputSchema.Validators.Should().Contain(validator =>
+				validator.Name == "sync-schemas-virtual-entity-seed-rows"
+				&& validator.Code == "invalid-workflow-shape",
+			because: "the contract must reject seed rows before creating a virtual schema that has no table");
+		ToolContractDefinition propertiesContract = result.Tools.Single(contract =>
+			contract.Name == GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName);
+		propertiesContract.OutputContract.Fields.Should().Contain(field =>
+				field.Name == "virtual" && field.Type == "boolean",
+			because: "schema readback must advertise the virtual flag for verification");
 	}
 
 	[Test]
@@ -1380,6 +1402,9 @@ public sealed class ToolContractGetToolTests {
 			because: "the contract should advertise the installed application version");
 		contract.OutputContract.Fields.Should().Contain(field => field.Name == "schema-name-prefix",
 			because: "the contract should advertise the active SchemaNamePrefix so agents know the correct prefix for subsequent schema names");
+		contract.OutputContract.Fields.Should().Contain(field =>
+				field.Name == "entities" && field.Description.Contains("`virtual`", StringComparison.Ordinal),
+			because: "get-app-info should document virtual status within each entity result");
 	}
 
 	[Test]

--- a/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaCreatorTests.cs
@@ -53,9 +53,10 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 		containerBuilder.AddTransient(_ => _sysSettingsManager);
 	}
 
-	[Test]
-	[Description("Creates a root entity schema, auto-adds the prefixed primary column from SchemaNamePrefix when needed, and persists the requested text column metadata.")]
-	public void Create_CreatesSchemaWithoutParent_AndShapesSavePayload()
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Creates persistent and virtual root entity schemas, auto-adds the primary column, and persists the requested virtual flag in the save payload.")]
+	public void Create_CreatesSchemaWithoutParent_AndShapesSavePayload(bool isVirtual)
 	{
 		string saveBody = null;
 		bool saveDbStructureCalled = false;
@@ -86,6 +87,7 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			Package = "UsrPkg",
 			SchemaName = "UsrVehicle",
 			Title = "Vehicle",
+			IsVirtual = isVirtual,
 			Columns = ["Name:Text:Vehicle name"]
 		});
 
@@ -113,6 +115,8 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 		var json = JObject.Parse(saveBody);
 		json["name"]!.Value<string>().Should().Be("UsrVehicle");
 		json["caption"]![0]!["value"]!.Value<string>().Should().Be("Vehicle");
+		json["isVirtual"]!.Value<bool>().Should().Be(isVirtual,
+			because: "the schema designer DTO must distinguish persistent and virtual entities before SaveSchema");
 		Guid.Parse(json["package"]!["uId"]!.Value<string>()!).Should().Be(_packageUId);
 		json["primaryColumn"]!["name"]!.Value<string>().Should().Be("UsrId",
 			because: "the generated primary GUID column should use the configured SchemaNamePrefix");
@@ -260,12 +264,13 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 	}
 
 	[Test]
-	[Description("Creates an entity schema with an assigned parent schema before saving the final designer payload.")]
-	public void Create_CreatesSchemaWithParent_AndCallsAssignParentSchema()
+	[Description("Preserves virtual state inherited by a replacement schema when the caller omits the virtual option.")]
+	public void Create_ReplacementOfVirtualParent_PreservesInheritedVirtualState()
 	{
+		string saveBody = null;
 		bool saveDbStructureCalled = false;
 		bool runtimeVerifyCalled = false;
-		SetupApplicationClient((url, _) => {
+		SetupApplicationClient((url, body) => {
 			if (url.Contains("CreateNewSchema", StringComparison.Ordinal)) {
 				return "{\"success\":true,\"schema\":{\"uId\":\"22222222-2222-2222-2222-222222222222\",\"package\":{\"uId\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"UsrPkg\"},\"columns\":[],\"inheritedColumns\":[],\"indexes\":[]}}";
 			}
@@ -276,9 +281,10 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 				return "{\"success\":true,\"items\":[{\"uId\":\"33333333-3333-3333-3333-333333333333\",\"name\":\"Account\",\"caption\":\"Account\"}]}";
 			}
 			if (url.Contains("AssignParentSchema", StringComparison.Ordinal)) {
-				return "{\"success\":true,\"schema\":{\"uId\":\"22222222-2222-2222-2222-222222222222\",\"package\":{\"uId\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"UsrPkg\"},\"parentSchema\":{\"uId\":\"33333333-3333-3333-3333-333333333333\",\"name\":\"Account\"},\"columns\":[],\"inheritedColumns\":[],\"indexes\":[]}}";
+				return "{\"success\":true,\"schema\":{\"uId\":\"22222222-2222-2222-2222-222222222222\",\"package\":{\"uId\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"UsrPkg\"},\"parentSchema\":{\"uId\":\"33333333-3333-3333-3333-333333333333\",\"name\":\"Account\"},\"isVirtual\":true,\"columns\":[],\"inheritedColumns\":[],\"indexes\":[]}}";
 			}
 			if (url.Contains("SaveSchema", StringComparison.Ordinal)) {
+				saveBody = body;
 				return "{\"success\":true,\"schemaUid\":\"22222222-2222-2222-2222-222222222222\"}";
 			}
 			if (url.Contains("SchemaDesignerRequest", StringComparison.Ordinal)) {
@@ -296,7 +302,8 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			Package = "UsrPkg",
 			SchemaName = "UsrAccount",
 			Title = "Account",
-			ParentSchemaName = "Account"
+			ParentSchemaName = "Account",
+			ExtendParent = true
 		});
 
 		_applicationClient.Received().ExecutePostRequest(
@@ -311,8 +318,12 @@ internal class RemoteEntitySchemaCreatorTests : BaseClioModuleTests
 			Arg.Any<int>(),
 			Arg.Any<int>(),
 			Arg.Any<int>());
-		saveDbStructureCalled.Should().BeTrue();
-		runtimeVerifyCalled.Should().BeTrue();
+		JObject.Parse(saveBody)["isVirtual"]!.Value<bool>().Should().BeTrue(
+			because: "an omitted positive-only option must not erase virtual state inherited by a replacement schema");
+		saveDbStructureCalled.Should().BeTrue(
+			because: "the normal designer actualization lifecycle remains required for virtual replacement schemas");
+		runtimeVerifyCalled.Should().BeTrue(
+			because: "the replacement schema must still be verified through the runtime readback path");
 	}
 
 	[Test]

--- a/clio/Command/ApplicationInfoService.cs
+++ b/clio/Command/ApplicationInfoService.cs
@@ -313,7 +313,8 @@ public sealed class ApplicationInfoService(
 				canonicalMainEntityCaptionFallback,
 				entityRow.Caption,
 				entityName),
-			columns);
+			columns,
+			response.Schema.IsVirtual);
 	}
 
 	private static ApplicationColumnInfoResult MapColumn(RuntimeSchemaColumnDto column, DesignSchemaColumnDto? designColumn)
@@ -787,6 +788,9 @@ public sealed class ApplicationInfoService(
 		[JsonPropertyName("caption")]
 		public Dictionary<string, string>? Caption { get; set; }
 
+		[JsonPropertyName("isVirtual")]
+		public bool IsVirtual { get; set; }
+
 		[JsonPropertyName("columns")]
 		public RuntimeSchemaColumnsDto? Columns { get; set; }
 	}
@@ -898,11 +902,13 @@ public sealed record ApplicationInfoResult(
 /// <param name="Name">Entity schema name.</param>
 /// <param name="Caption">Entity caption.</param>
 /// <param name="Columns">Non-inherited runtime columns.</param>
+/// <param name="IsVirtual">Whether the entity schema is virtual and has no physical database table.</param>
 public sealed record ApplicationEntityInfoResult(
 	string UId,
 	string Name,
 	string Caption,
-	IReadOnlyList<ApplicationColumnInfoResult> Columns);
+	IReadOnlyList<ApplicationColumnInfoResult> Columns,
+	bool IsVirtual = false);
 
 /// <summary>
 /// Structured column information returned as part of application info results.

--- a/clio/Command/CreateEntitySchemaCommand.cs
+++ b/clio/Command/CreateEntitySchemaCommand.cs
@@ -32,6 +32,13 @@ public class CreateEntitySchemaOptions : RemoteCommandOptions
 	[Option("extend-parent", Required = false, Default = false, HelpText = "Create replacement schema")]
 	public bool ExtendParent { get; set; }
 
+	/// <summary>
+	/// Gets or sets whether the created entity schema is virtual and therefore has no physical database table.
+	/// </summary>
+	[Option("is-virtual", Required = false, Default = false,
+		HelpText = "Create a virtual entity schema without a physical database table")]
+	public bool IsVirtual { get; set; }
+
 	[Option("column", Required = false, HelpText = "Column spec <name>:<type>[:<title>[:<refSchema>]] or JSON with name/type/title/reference-schema-name/required/default-value-source/default-value. Repeat the option for multiple columns.")]
 	public IEnumerable<string> Columns { get; set; }
 

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaCreator.cs
@@ -135,6 +135,9 @@ internal sealed class RemoteEntitySchemaCreator : IRemoteEntitySchemaCreator{
 		schema.Columns ??= [];
 		schema.Indexes ??= [];
 		schema.InheritedColumns ??= [];
+		if (options.IsVirtual) {
+			schema.IsVirtual = true;
+		}
 		NormalizeAdministrationMetadata(schema);
 
 		Dictionary<string, ManagerItemDto> referenceSchemas = parsedColumns.Any(c => c.IsLookup)

--- a/clio/Command/McpServer/Prompts/EntitySchemaPrompt.cs
+++ b/clio/Command/McpServer/Prompts/EntitySchemaPrompt.cs
@@ -41,6 +41,7 @@ public static class EntitySchemaPrompt {
 		 Set `parent-schema-name` only when inheritance or replacement behavior was explicitly requested.
 		 Set `extend-parent` to `true` only when the request is specifically for a replacement schema, and only
 		 together with `parent-schema-name`.
+		 Set `is-virtual` to `true` only when the entity must not have a physical database table; it defaults to `false`.
 		 Include `columns` only when the request explicitly describes initial fields. `title-localizations` is
 		 OPTIONAL for a column add; when omitted, `en-US` is auto-derived from a scalar title/caption or the
 		 column name. Provide `title-localizations` for a proper caption; the `en-US` value must be English.
@@ -175,7 +176,7 @@ public static class EntitySchemaPrompt {
 		$"""
 		 Use clio mcp server `{GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName}` to read structured
 		 properties for entity schema `{schemaName}` from environment `{environmentName}`. The result is a schema
-		 summary object with a nested `columns` list for machine-readable column inspection.
+		 summary object with a `virtual` flag and a nested `columns` list for machine-readable column inspection.
 		 Pass `schema-name` and `environment-name` exactly as provided. Leave `package-name` empty to get the
 		 MERGED/EFFECTIVE schema with columns from ALL packages (this is what you want for column discovery,
 		 because custom columns are frequently added in a package other than the one that defines the schema).

--- a/clio/Command/McpServer/Resources/AppModelingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/AppModelingGuidanceResource.cs
@@ -65,6 +65,7 @@ public sealed class AppModelingGuidanceResource {
 			       - `create-app` already performs internal Data Forge enrichment and returns optional `dataforge` diagnostics. Do not require a separate external Data Forge preflight for the standard create flow.
 			       - If Data Forge is unavailable or partially degraded, `create-app` still creates the app shell and reports degraded enrichment through warnings and coverage flags instead of failing the whole create path.
 			       - `sync-schemas` requests use `operations[*].type`. Responses also identify each result by `type`; do not invent or send `operations[*].operation`.
+			       - For a virtual entity with no physical database table, set `is-virtual: true` on a `sync-schemas` `create-entity` operation or on `create-entity-schema`. It defaults to false. Verify the saved flag through `get-app-info` or `get-entity-schema-properties`.
 			       - Canonical page flow after planning a page change: `list-pages` -> `get-page` -> `get-component-info` when needed -> `sync-pages` or `update-page` -> `get-page` when explicit read-back verification is required.
 			       - Entity-schema mutations are DB-first. After a successful schema tool call, treat the schema as immediately usable without a compile step.
 			       - Treat single-tool entity or page mutations as compatibility fallbacks. Keep the preferred workflow in the current MCP contract unless the task is truly limited to one column, one lookup, or one page save.

--- a/clio/Command/McpServer/Tools/ApplicationTool.cs
+++ b/clio/Command/McpServer/Tools/ApplicationTool.cs
@@ -61,7 +61,7 @@ public sealed class ApplicationGetInfoTool(IApplicationInfoService applicationIn
 	/// </summary>
 	[McpServerTool(Name = ApplicationGetInfoToolName, ReadOnly = true, Destructive = false, Idempotent = true,
 		OpenWorld = false)]
-	[Description("Gets application information from Creatio through backend MCP. Returns installed application identity plus package and entity context. "
+	[Description("Gets installed app identity, package, and entities from Creatio; each entity includes virtual. "
 		+ "Each entity column round-trips into sync-schemas update-entity as-is — send the same column object back and add an 'action' verb (modify/remove); "
 		+ "no field renaming needed, and no separate get-tool-contract call is required to learn the write shape. "
 		+ "Long-running: streams notifications/progress while working — await completion and do not retry on a perceived timeout.")]

--- a/clio/Command/McpServer/Tools/ApplicationToolResponses.cs
+++ b/clio/Command/McpServer/Tools/ApplicationToolResponses.cs
@@ -132,7 +132,8 @@ public sealed record ApplicationEntityResult(
 	[property: JsonPropertyName("u-id")] string UId,
 	[property: JsonPropertyName("name")] string Name,
 	[property: JsonPropertyName("caption")] string Caption,
-	[property: JsonPropertyName("columns")] IReadOnlyList<ApplicationColumnResult> Columns);
+	[property: JsonPropertyName("columns")] IReadOnlyList<ApplicationColumnResult> Columns,
+	[property: JsonPropertyName("virtual")] bool Virtual = false);
 
 /// <summary>
 /// Structured application column item returned by the application MCP tool family.

--- a/clio/Command/McpServer/Tools/ApplicationToolSupport.cs
+++ b/clio/Command/McpServer/Tools/ApplicationToolSupport.cs
@@ -33,7 +33,8 @@ internal static class ApplicationToolResultMapper {
 							column.DataValueType,
 							column.ReferenceSchema,
 							column.Required))
-						.ToList()))
+						.ToList(),
+					entity.IsVirtual))
 				.ToList(),
 			result.Pages?
 				.Select(page => new PageListItem {
@@ -79,7 +80,8 @@ internal static class ApplicationToolResultMapper {
 							column.DataValueType,
 							column.ReferenceSchema,
 							column.Required))
-						.ToList()),
+						.ToList(),
+					result.Entity.IsVirtual),
 			result.Pages
 				.Select(page => new PageListItem {
 					SchemaName = page.SchemaName,

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -34,6 +34,7 @@ public sealed class CreateEntitySchemaTool(
 
 				 Use this when the schema should be created directly on the target environment instead of generating
 				 local source files. The package must already exist on the target environment.
+				 Set `is-virtual` to true only when the schema must not have a physical database table; it defaults to false.
 
 				 The tool applies the DB structure and publishes the schema automatically, so the new entity is
 				 immediately usable as a Lookup reference in sys-settings and lookup pickers — no compile needed.
@@ -52,7 +53,8 @@ public sealed class CreateEntitySchemaTool(
 				BuildCandidateTerms(args.SchemaName, args.TitleLocalizations))
 			: null;
 		try {
-			CreateEntitySchemaOptions options = CreateOptions(args, args.ParentSchemaName, args.ExtendParent);
+			CreateEntitySchemaOptions options = CreateOptions(
+				args, args.ParentSchemaName, args.ExtendParent, args.IsVirtual);
 			CommandExecutionResult result = InternalExecute<CreateEntitySchemaCommand>(options);
 			return result with { DataForge = dataForge };
 		} catch (Exception exception) {
@@ -74,7 +76,8 @@ public sealed class CreateEntitySchemaTool(
 	internal static CreateEntitySchemaOptions CreateOptions(
 		EntitySchemaCreateArgsBase args,
 		string? parentSchemaName,
-		bool extendParent) {
+		bool extendParent,
+		bool isVirtual = false) {
 		string context = $"Schema '{args.SchemaName}'";
 		IReadOnlyDictionary<string, string> titleLocalizations = EntitySchemaLocalizationContract.RequireTitleLocalizations(
 			args.TitleLocalizations,
@@ -93,6 +96,7 @@ public sealed class CreateEntitySchemaTool(
 			TitleLocalizations = titleNormalization.Localizations ?? titleLocalizations,
 			ParentSchemaName = (!extendParent && string.IsNullOrWhiteSpace(parentSchemaName)) ? "BaseEntity" : parentSchemaName,
 			ExtendParent = extendParent,
+			IsVirtual = isVirtual,
 			Columns = SerializeColumns(args.Columns, context),
 			Environment = args.EnvironmentName,
 			CaptionCulture = args.CaptionCulture
@@ -376,7 +380,8 @@ public sealed class GetEntitySchemaPropertiesTool(
 		+ "Omit package-name for the MERGED/EFFECTIVE view (columns from all packages) — use this for column discovery; "
 		+ "an empty column list from a single-package read does NOT prove a column is absent. "
 		+ "Supply package-name to inspect one package layer and to read schema-level fields that the merged view returns as null "
-		+ "(parent-schema-name, indexes-count, ssp-available, use-record-deactivation, use-deny-record-rights, use-live-editing).")]
+		+ "(parent-schema-name, indexes-count, ssp-available, use-record-deactivation, use-deny-record-rights, use-live-editing). "
+		+ "The result always includes virtual so callers can verify whether the schema has a physical database table.")]
 	public EntitySchemaPropertiesInfo GetEntitySchemaProperties(
 		[Description("environment-name, schema-name (required); package-name (optional — omit for the merged all-packages view)")] [Required] GetEntitySchemaPropertiesArgs args) {
 		GetEntitySchemaPropertiesOptions options = new() {
@@ -608,7 +613,14 @@ public sealed record CreateEntitySchemaArgs(
 	bool ExtendParent = false,
 
 	IEnumerable<CreateEntitySchemaColumnArgs>? Columns = null
-) : EntitySchemaCreateArgsBase(PackageName, SchemaName, TitleLocalizations, EnvironmentName, Columns);
+) : EntitySchemaCreateArgsBase(PackageName, SchemaName, TitleLocalizations, EnvironmentName, Columns) {
+	/// <summary>
+	/// Gets whether the entity schema is virtual and must not have a physical database table.
+	/// </summary>
+	[property: JsonPropertyName("is-virtual")]
+	[property: Description("Create a virtual entity schema without a physical database table. Defaults to false.")]
+	public bool IsVirtual { get; init; }
+}
 
 /// <summary>
 /// Arguments for the <c>create-lookup</c> MCP tool.

--- a/clio/Command/McpServer/Tools/SchemaSyncTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaSyncTool.cs
@@ -36,6 +36,7 @@ public sealed class SchemaSyncTool(
 		Idempotent = false, OpenWorld = false)]
 	[Description("Executes a batch of schema operations in a single call: " +
 		"create lookups, create entities, seed data, update entities. " +
+		"For create-entity, set is-virtual to true only when the schema must not have a physical database table; it defaults to false. " +
 		"Reduces MCP round-trips and lock overhead compared to individual tool calls. " +
 		"Stops on first failure because subsequent operations may depend on earlier ones. " +
 		"For update-entity, column field names match the get-app-info read shape (read-shape aliases " +
@@ -160,6 +161,15 @@ public sealed class SchemaSyncTool(
 		if (op.SeedRows?.Any() != true) {
 			return false;
 		}
+		if (string.Equals(op.Type, CreateEntityOperationName, StringComparison.Ordinal) && op.IsVirtual) {
+			validationFailure = new SchemaSyncOperationResult {
+				Type = CreateEntityOperationName,
+				SchemaName = op.SchemaName,
+				Success = false,
+				Error = $"sync-schemas operations[{operationIndex}] is invalid: virtual create-entity operations cannot include seed-rows because virtual entities have no physical database table."
+			};
+			return true;
+		}
 
 		if (op.SeedRows.Any(row => row is null || row.Values is null)) {
 			validationFailure = new SchemaSyncOperationResult {
@@ -191,7 +201,9 @@ public sealed class SchemaSyncTool(
 					args.PackageName, op.SchemaName,
 					new Dictionary<string, string>(titleLocalizations, StringComparer.OrdinalIgnoreCase), args.EnvironmentName,
 					op.Columns),
-				parentSchemaName, extendParent);
+				parentSchemaName, extendParent,
+				isVirtual: string.Equals(operationName, CreateEntityOperationName, StringComparison.Ordinal)
+					&& op.IsVirtual);
 			CreateEntitySchemaCommand command = commandResolver.Resolve<CreateEntitySchemaCommand>(options);
 			int exitCode = command.Execute(options);
 			if (exitCode == 0 && string.Equals(operationName, CreateLookupOperationName, StringComparison.Ordinal)) {
@@ -495,6 +507,13 @@ public sealed record SchemaSyncOperation(
 	[property: Description("Rows to seed after creating the schema. Each object must have a 'values' key.")]
 	IEnumerable<SchemaSyncSeedRow>? SeedRows = null
 ) {
+	/// <summary>
+	/// Gets whether a <c>create-entity</c> operation creates a virtual schema without a physical database table.
+	/// </summary>
+	[property: JsonPropertyName("is-virtual")]
+	[property: Description("For create-entity only: create a virtual schema without a physical database table. Defaults to false. Virtual entities cannot include seed-rows.")]
+	public bool IsVirtual { get; init; }
+
 	[property: JsonPropertyName("title")]
 	[property: Description("Legacy scalar title. Not accepted by MCP. Use title-localizations instead.")]
 	public string? LegacyTitle { get; init; }

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -461,6 +461,7 @@ internal static class ToolContractCatalog {
 	private const string InstalledApplicationIdentifierDescription = "Installed application identifier.";
 	private const string InstalledApplicationVersionDescription = "Installed application version.";
 	private const string InvalidWorkflowShapeCode = "invalid-workflow-shape";
+	private const string IsVirtualFieldName = "is-virtual";
 	private const string MissingRequiredParameterCode = "missing-required-parameter";
 	private const string PackageUIdFieldName = "package-u-id";
 	private const string PackageNameDescription = "Target package name.";
@@ -1228,7 +1229,7 @@ internal static class ToolContractCatalog {
 				Field(ApplicationNameFieldName, StringType, InstalledApplicationDisplayNameDescription),
 				Field(ApplicationCodeFieldName, StringType, InstalledApplicationCodeDescription),
 				Field(ApplicationVersionFieldName, StringType, InstalledApplicationVersionDescription),
-				Field("entities", ArrayType, "Application entities. Each entity `columns` item carries a vocabulary unified with the sync-schemas write surfaces so it round-trips without translation: `name`, `caption`, canonical `type` (with `data-value-type` kept as a legacy alias), canonical `reference-schema-name` (with `reference-schema` kept as a legacy alias), and `required`. Send a column back to sync-schemas update-entity by adding the `action` verb."),
+				Field("entities", ArrayType, "Application entities. Each entity includes `virtual`, and each entity `columns` item carries a vocabulary unified with the sync-schemas write surfaces so it round-trips without translation: `name`, `caption`, canonical `type` (with `data-value-type` kept as a legacy alias), canonical `reference-schema-name` (with `reference-schema` kept as a legacy alias), and `required`. Send a column back to sync-schemas update-entity by adding the `action` verb."),
 				Field(PagesFieldName, ArrayType, "Primary-package Freedom UI pages using list-pages item shape (`schema-name`, `uId`, `packageName`, `parentSchemaName`)."),
 				Field("schema-name-prefix", StringType, "Active SchemaNamePrefix resolved from the environment. Use as the prefix for all subsequent custom schema codes (lookups, columns, supporting entities). Empty string means no prefix is configured."),
 				Field("dataforge", ObjectType, "Optional Data Forge enrichment diagnostics including health/status/coverage, warnings, and a compact context-summary."),
@@ -2076,7 +2077,7 @@ internal static class ToolContractCatalog {
 				Field(ApplicationNameFieldName, StringType, InstalledApplicationDisplayNameDescription),
 				Field(ApplicationCodeFieldName, StringType, InstalledApplicationCodeDescription),
 				Field(ApplicationVersionFieldName, StringType, InstalledApplicationVersionDescription),
-				Field("entities", ArrayType, "Application entities. Each entity `columns` item carries a vocabulary unified with the sync-schemas write surfaces so it round-trips without translation: `name`, `caption`, canonical `type` (with `data-value-type` kept as a legacy alias), canonical `reference-schema-name` (with `reference-schema` kept as a legacy alias), and `required`. Send a column back to sync-schemas update-entity by adding the `action` verb."),
+				Field("entities", ArrayType, "Application entities. Each entity includes `virtual`, and each entity `columns` item carries a vocabulary unified with the sync-schemas write surfaces so it round-trips without translation: `name`, `caption`, canonical `type` (with `data-value-type` kept as a legacy alias), canonical `reference-schema-name` (with `reference-schema` kept as a legacy alias), and `required`. Send a column back to sync-schemas update-entity by adding the `action` verb."),
 				Field(PagesFieldName, ArrayType, "Primary-package Freedom UI pages using list-pages item shape (`schema-name`, `uId`, `packageName`, `parentSchemaName`)."),
 				Field("schema-name-prefix", StringType, "Active SchemaNamePrefix system setting for the environment. Use as the prefix for all subsequent custom schema codes. Empty string means no prefix is configured."),
 				Field(ErrorFieldName, StringType, FailureMessageDescription)
@@ -2903,12 +2904,17 @@ internal static class ToolContractCatalog {
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName, PackageNameFieldName, OperationsFieldName],
 				EnvironmentPackageFields(
-					Field(OperationsFieldName, ArrayType, "Ordered schema operations. For update-entity, supply `update-operations` (add/modify/remove) or a `columns` add-batch. Column fields are unified with get-app-info: `column-name` (alias `name`), `type` (alias `data-value-type`), `reference-schema-name` (alias `reference-schema`), `required` (alias `is-required`) — so a column read from get-app-info can be sent back by adding the `action` verb. For an add, `title-localizations` is OPTIONAL: when omitted, `en-US` is auto-derived from a scalar `title`/`caption` or the column name (the `en-US` value must be English when supplied).")),
+					Field(OperationsFieldName, ArrayType, "Ordered schema operations. For create-entity, set `is-virtual` to true to create a virtual schema without a physical table; it defaults to false and cannot be combined with `seed-rows`. For update-entity, supply `update-operations` (add/modify/remove) or a `columns` add-batch. Column fields are unified with get-app-info: `column-name` (alias `name`), `type` (alias `data-value-type`), `reference-schema-name` (alias `reference-schema`), `required` (alias `is-required`) — so a column read from get-app-info can be sent back by adding the `action` verb. For an add, `title-localizations` is OPTIONAL: when omitted, `en-US` is auto-derived from a scalar `title`/`caption` or the column name (the `en-US` value must be English when supplied).")),
 				Validators: [
 					new ToolContractValidator(
 						"sync-schemas-operations-localizations",
 						InvalidLocalizationMapCode,
-						Field: OperationsFieldName)
+						Field: OperationsFieldName),
+					new ToolContractValidator(
+						"sync-schemas-virtual-entity-seed-rows",
+						InvalidWorkflowShapeCode,
+						Fields: [$"{OperationsFieldName}[*].{IsVirtualFieldName}", $"{OperationsFieldName}[*].seed-rows"],
+						Context: "A create-entity operation cannot combine is-virtual=true with seed-rows because a virtual entity has no physical table.")
 				]),
 			EnvelopeOutput(
 				SuccessFieldName,
@@ -2920,7 +2926,9 @@ internal static class ToolContractCatalog {
 			),
 			CommonErrorContract,
 			EnvironmentPackageAliases(),
-			[],
+			[
+				Default($"{OperationsFieldName}[*].{IsVirtualFieldName}", "false", "Create-entity operations create persistent schemas unless explicitly marked virtual.")
+			],
 			[
 				Example("Create a lookup and extend the main entity", new Dictionary<string, object?> {
 					[EnvironmentNameFieldName] = ExampleEnvironmentName,
@@ -3231,7 +3239,8 @@ internal static class ToolContractCatalog {
 					Field(TitleLocalizationsFieldName, ObjectType, "Localization map that must include en-US."),
 					Field("columns", ArrayType, "Optional initial columns."),
 					Field(ParentSchemaNameFieldName, StringType, "Optional parent schema name."),
-					Field("extend-parent", BooleanType, "Optional replacement-schema flag.")),
+					Field("extend-parent", BooleanType, "Optional replacement-schema flag."),
+					Field(IsVirtualFieldName, BooleanType, "Creates a virtual entity schema without a physical database table when true.")),
 				Validators: [
 					RequiredLocalizationMapValidator(TitleLocalizationsFieldName)
 				]),
@@ -3242,7 +3251,9 @@ internal static class ToolContractCatalog {
 				Alias(ParameterScope, "extend-parent", "extendParent", RejectedStatus, "Use 'extend-parent' instead of 'extendParent'."),
 				TitleParameterAlias(),
 				CaptionParameterAlias()),
-			[],
+			[
+				Default(IsVirtualFieldName, "false", "Entity schemas are persistent unless explicitly marked virtual.")
+			],
 			[
 				Example("Create an additional business entity", new Dictionary<string, object?> {
 					[EnvironmentNameFieldName] = ExampleEnvironmentName,
@@ -3567,6 +3578,7 @@ internal static class ToolContractCatalog {
 			StructuredResultOutput(
 				Field("name", StringType, "Schema name."),
 				Field("title", StringType, "Schema title."),
+				Field("virtual", BooleanType, "Whether the entity schema is virtual and has no physical database table."),
 				Field(ColumnsFieldName, ArrayType, "Column metadata.")),
 			CommonErrorContract,
 			EnvironmentPackageSchemaAliases(),

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -23,7 +23,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="create-app"></a>
 - [`create-app`](docs/commands/create-app.md) - Create a new application in Creatio
 <a id="get-app-info"></a>
-- [`get-app-info`](docs/commands/get-app-info.md) - Get information about an installed Creatio application
+- [`get-app-info`](docs/commands/get-app-info.md) - Get information about an installed Creatio application, including each entity's virtual flag
 <a id="list-apps"></a>
 <a id="get-app-list"></a>
 <a id="app-list"></a>
@@ -328,7 +328,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="client-unit-schema-create"></a>
 - [`create-client-unit-schema`](docs/commands/create-client-unit-schema.md) - Create a new JavaScript (ClientUnit) schema on a remote Creatio environment, `client-unit-schema-create`
 <a id="create-entity-schema"></a>
-- [`create-entity-schema`](docs/commands/create-entity-schema.md) - Create an entity schema in a remote Creatio package
+- [`create-entity-schema`](docs/commands/create-entity-schema.md) - Create a persistent or virtual entity schema in a remote Creatio package
 <a id="create-lookup"></a>
 - [`create-lookup`](docs/commands/create-lookup.md) - Create a lookup entity schema in a remote Creatio package
 <a id="create-schema"></a>

--- a/clio/docs/commands/create-entity-schema.md
+++ b/clio/docs/commands/create-entity-schema.md
@@ -17,6 +17,9 @@ The command saves the schema, applies the DB structure, and publishes the
 configuration, so the new schema is immediately visible to lookup pickers and
 sys-setting reference schema lists. No separate compile is required.
 
+Set `--is-virtual` when the schema must not have a physical database table.
+The option defaults to `false`, so existing calls continue to create persistent entities.
+
 Publishing also requests an OData entities rebuild, so the schema becomes
 reachable over OData (`/0/odata/<Entity>`) without a manual full compile. That
 rebuild runs in the background — OData access appears within a few minutes, not
@@ -27,6 +30,9 @@ wait and retry rather than running a full compile.
 
 ```bash
 clio create-entity-schema -e dev
+
+# Create a virtual entity without a physical database table
+clio create-entity-schema -e dev --package Custom --name UsrExternalVehicle --title "External vehicle" --is-virtual
 ```
 
 ## Options
@@ -42,6 +48,8 @@ Schema title. Required.
 Parent schema name
 --extend-parent
 Create replacement schema
+--is-virtual
+Create a virtual entity schema without a physical database table. Default: false.
 --column <VALUE>
 Column spec <name>:<type>[:<title>[:<refSchema>]] or JSON with
 name/type/title/reference-schema-name/required/default-value-source/default-value/default-value-config.
@@ -119,6 +127,7 @@ cliogate must be installed on the target Creatio environment.
 ## Notes
 
 - `default-value-config` is recommended for non-constant sources.
+- `--is-virtual` is independent of inheritance and replacement behavior; use it only for entities whose data comes from a custom provider rather than a Creatio table.
 - For `default-value-config.source = SystemValue`, `value-source` can be Guid, alias, or caption; clio persists canonical Guid.
 - For `default-value-config.source = Settings`, `value-source` can be code, name, or id; clio persists canonical setting code.
 - **Caption language validation.** Every `title-localizations` / `description-localizations` value must be written in the language of its culture key. The mandatory `en-US` value must be English; a value written in a script that does not match a Latin-script culture key (for example Cyrillic text under `en-US`) is rejected with an actionable error. Put localized text under its own culture key (e.g. `uk-UA`). This guarantees generated captions match the connected user's profile language.

--- a/clio/docs/commands/get-app-info.md
+++ b/clio/docs/commands/get-app-info.md
@@ -46,6 +46,9 @@ The command prints:
 
 With --json the full JSON response is printed.
 
+Each CLI JSON entity includes `IsVirtual`; the MCP result exposes the same value as `virtual`.
+A `true` value means the schema has no physical database table.
+
 ### Column fields (round-trip with `sync-schemas`)
 
 Each entity column in the JSON response carries a vocabulary unified with the `sync-schemas`

--- a/clio/docs/commands/get-entity-schema-properties.md
+++ b/clio/docs/commands/get-entity-schema-properties.md
@@ -36,6 +36,7 @@ There are two modes, selected by the presence of `--package`:
   SSP availability, and the other schema flags).
 
 This is the canonical verification path after create-entity-schema.
+Structured output includes `virtual`, which is `true` when the schema has no physical database table.
 
 ## Options
 

--- a/clio/docs/commands/sync-schemas.md
+++ b/clio/docs/commands/sync-schemas.md
@@ -53,8 +53,11 @@ Creates an entity schema with an optional parent.
 | `title-localizations` | Yes | Schema title localizations. Must include `en-US` |
 | `parent-schema-name` | No | Parent schema name |
 | `extend-parent` | No | Create a replacement schema (default: false) |
+| `is-virtual` | No | Create a virtual entity schema without a physical database table (default: false) |
 | `columns` | No | Initial columns |
 | `seed-rows` | No | Rows to insert after creation |
+
+Use `is-virtual: true` only when the entity is backed by a custom data provider rather than a Creatio database table. A virtual `create-entity` operation cannot include `seed-rows` because there is no table to populate. Verify the result through `get-entity-schema-properties` or the entity list returned by `get-app-info`.
 
 #### `update-entity`
 

--- a/clio/help/en/create-entity-schema.txt
+++ b/clio/help/en/create-entity-schema.txt
@@ -19,6 +19,8 @@ DESCRIPTION
     Publishing also requests an OData entities rebuild, so the schema becomes
     reachable over OData (/0/odata/<Entity>) without a manual full compile;
     that rebuild runs in the background and appears within a few minutes.
+    Use --is-virtual when the schema must not have a physical database table.
+    The option defaults to false.
 
     Current clio entity-schema commands are part of the canonical clio MCP
     contract. Keep using create-entity-schema / modify-entity-schema-column
@@ -46,6 +48,8 @@ OPTIONS
     --title                Entity schema title/caption
     --parent               Parent schema name
     --extend-parent        Create a replacement schema. Requires --parent
+    --is-virtual           Create a virtual entity schema without a physical
+                           database table. Default: false
     --column               Column definition in format
                            <name>:<type>[:<title>[:<refSchema>]]
                            or JSON with name/type/title or caption/
@@ -89,10 +93,14 @@ EXAMPLES
     # Create a replacement schema
     clio create-entity-schema -e dev --package Custom --name UsrAccount --title "Account" --parent Account --extend-parent
 
+    # Create a virtual entity without a physical database table
+    clio create-entity-schema -e dev --package Custom --name UsrExternalVehicle --title "External vehicle" --is-virtual
+
 NOTES
     - The command works against a remote Creatio environment only
     - Package resolution requires cliogate to be installed on the target environment
     - If no Guid column is supplied for a root schema, Id:Guid is added automatically
+    - --is-virtual is independent of parent and replacement-schema settings
     - If no display column is set, the first text-like column is used as primary display column
     - Prefer default-value-config for Settings, SystemValue, or Sequence; keep
       default-value-source/default-value as shorthand only for Const and None

--- a/clio/help/en/get-app-info.txt
+++ b/clio/help/en/get-app-info.txt
@@ -15,6 +15,9 @@ DESCRIPTION
     By default the command prints a readable summary. Use --json to output
     the raw JSON response instead.
 
+    In CLI JSON output, every entity includes IsVirtual. The MCP result exposes
+    the same value as virtual. A true value means the schema has no physical table.
+
 SYNOPSIS
     clio get-app-info [options]
 

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -1054,3 +1054,17 @@ stories:
     adr: spec/clio-ring-companion-integration/adr/adr-clio-ring-companion-integration.md
     depends_on: []
     blocks: []
+
+  - id: story-virtual-entity-schema-1
+    title: "Create and read Creatio virtual entity schemas through MCP"
+    feature: "virtual-entity-schema"
+    repo: "clio"
+    size: M
+    status: review
+    issue: 864
+    file: spec/virtual-entity-schema/virtual-entity-schema-story.md
+    prd: spec/virtual-entity-schema/virtual-entity-schema-spec.md
+    adr: spec/virtual-entity-schema/virtual-entity-schema-plan.md
+    test_plan: spec/virtual-entity-schema/virtual-entity-schema-qa.md
+    depends_on: []
+    blocks: []

--- a/spec/virtual-entity-schema/virtual-entity-schema-plan.md
+++ b/spec/virtual-entity-schema/virtual-entity-schema-plan.md
@@ -1,0 +1,39 @@
+# Virtual entity schema — PLAN (ADR)
+
+> GitHub: [#864](https://github.com/Advance-Technologies-Foundation/clio/issues/864)
+
+## Decision
+
+Carry `IsVirtual` on `CreateEntitySchemaOptions`, map `is-virtual` from both MCP creation surfaces,
+and assign the value to `EntityDesignSchemaDto.IsVirtual` inside `ApplySchemaMetadata` before
+`SaveSchema`.
+
+Keep `SaveSchemaDbStructure` in the existing lifecycle. Creatio's
+`DbStructureInstaller.CanInstallEntitySchemaDbStructure` and DB meta-script logic explicitly
+exclude `EntitySchema.IsVirtual`, so sending the saved virtual schema through the ordinary pipeline
+preserves runtime activation while preventing a physical table. A sandbox E2E test will verify the
+database outcome directly.
+
+## Contract shape
+
+- CLI: `create-entity-schema --is-virtual`, optional Boolean, default `false`.
+- MCP `create-entity-schema`: top-level `is-virtual`, optional Boolean, default `false`.
+- MCP `sync-schemas`: `operations[*].is-virtual`, meaningful only for `create-entity`, default
+  `false`.
+- `get-entity-schema-properties`: existing `virtual` output becomes part of its curated contract.
+- `get-app-info`: each `entities[]` item gains required Boolean `virtual`.
+
+## Compatibility
+
+The change is additive. Existing callers omit the field and retain normal entities. The application
+read model gains a non-null Boolean, which is backward compatible for tolerant JSON consumers.
+Search of `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and
+`clio-ring/ClioRing.Desktop/actions.json` must confirm whether Ring consumes these surfaces.
+
+## Rejected alternatives
+
+- Create normally and update later: rejected because physical synchronization may already occur.
+- Skip `SaveSchemaDbStructure` for virtual schemas: rejected because the platform already owns the
+  exclusion rule and the ordinary lifecycle performs other required actualization work.
+- Put `is-virtual` on the shared lookup/entity argument base: rejected because `create-lookup`
+  should not advertise unsupported virtual lookup creation.

--- a/spec/virtual-entity-schema/virtual-entity-schema-qa.md
+++ b/spec/virtual-entity-schema/virtual-entity-schema-qa.md
@@ -1,0 +1,40 @@
+# Virtual entity schema — QA plan
+
+## Command and designer unit tests
+
+| ID | Case | Expected |
+|---|---|---|
+| TC-U-1 | Parse `create-entity-schema` without `--is-virtual` | `IsVirtual == false` |
+| TC-U-2 | Parse `--is-virtual` | `IsVirtual == true` |
+| TC-U-3 | Create a normal entity | first saved DTO has `IsVirtual == false` |
+| TC-U-4 | Create a virtual entity | first saved DTO has `IsVirtual == true` before DB-structure actualization |
+
+## MCP unit and contract tests
+
+| ID | Case | Expected |
+|---|---|---|
+| TC-U-5 | `create-entity-schema` omits/adds `is-virtual` | options map false/true |
+| TC-U-6 | `sync-schemas` create-entity omits/adds `is-virtual` | options map false/true |
+| TC-U-7 | curated contracts for both write tools | Boolean field documented, default false |
+| TC-U-8 | get-entity-schema-properties contract | output documents `virtual` |
+| TC-U-9 | get-app-info mapping and contract | each entity returns/documents `virtual` |
+
+## MCP sandbox E2E
+
+| ID | Case | Expected |
+|---|---|---|
+| TC-E-1 | Discover both write contracts | `is-virtual` is present with false default |
+| TC-E-2 | Create a virtual entity via `sync-schemas` | success and read-back `virtual == true` |
+| TC-E-3 | Inspect PostgreSQL metadata after creation | no physical table exists for the schema |
+| TC-E-4 | Read owning application | matching entity has `virtual == true` |
+
+The E2E scenario is destructive, requires the dedicated sandbox opt-in, uses a schema name derived
+from the sandbox prefix, and cleans up its application/package artifacts through the existing test
+harness.
+
+## Regression commands
+
+```powershell
+dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=McpServer)" --no-build
+dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj --filter "FullyQualifiedName~VirtualEntity" --no-build
+```

--- a/spec/virtual-entity-schema/virtual-entity-schema-spec.md
+++ b/spec/virtual-entity-schema/virtual-entity-schema-spec.md
@@ -1,0 +1,39 @@
+# Virtual entity schema — SPEC
+
+> GitHub: [#864](https://github.com/Advance-Technologies-Foundation/clio/issues/864)
+
+## Problem
+
+Clio's entity creation pipeline always saves a normal persisted entity because neither
+`create-entity-schema` nor the canonical `sync-schemas` `create-entity` operation accepts the
+Creatio entity designer's `isVirtual` flag. Creating a normal entity first is unsafe because the
+database structure can be synchronized before the schema is changed.
+
+## Requirements
+
+- R1. Add canonical Boolean `is-virtual` input to the standalone CLI/MCP entity creation path and
+  to `sync-schemas` `create-entity`; default it to `false`.
+- R2. Set `EntityDesignSchemaDto.IsVirtual` before the first schema save.
+- R3. Preserve the existing save, DB-structure, publish, OData rebuild, and runtime verification
+  sequence. Creatio's DB structure installer must receive the virtual schema and exclude it from
+  physical-table synchronization.
+- R4. Expose virtual state as `virtual` in `get-entity-schema-properties` and every entity returned
+  by `get-app-info`.
+- R5. Document the input and output fields in CLI help/docs and curated `get-tool-contract` output.
+- R6. Cover default-false and explicit-true mapping at command, MCP adapter, sync, read-back, and
+  real sandbox levels.
+
+## Acceptance criteria
+
+- AC1. Omitting `is-virtual` produces the current normal entity behavior.
+- AC2. `is-virtual: true` reaches the first `SaveSchema` request as `isVirtual: true`.
+- AC3. A real virtual entity is readable with `virtual: true` and has no PostgreSQL table.
+- AC4. Both creation contracts advertise `is-virtual` with default `false`.
+- AC5. `get-entity-schema-properties` and `get-app-info` advertise and return virtual state.
+- AC6. Required Command/MCP unit tests and MCP sandbox E2E tests pass.
+
+## Out of scope
+
+- Generating or registering an `IEntityQueryExecutor` implementation.
+- Making lookup schemas virtual.
+- Converting an existing persisted entity into a virtual entity.

--- a/spec/virtual-entity-schema/virtual-entity-schema-story.md
+++ b/spec/virtual-entity-schema/virtual-entity-schema-story.md
@@ -1,0 +1,17 @@
+# Virtual entity schema — STORY
+
+Status: review
+
+As an MCP client, I want to create a Creatio virtual entity atomically so that its data is supplied
+by an `IEntityQueryExecutor` without ever creating a physical database table.
+
+## Definition of done
+
+- [x] Standalone and batched creation accept `is-virtual` with default `false`.
+- [x] The flag is present on the designer DTO before schema save.
+- [x] Read-back exposes virtual state through both requested surfaces.
+- [x] Curated tool contracts, command help, detailed docs, and command index are aligned.
+- [x] Command, MCP unit, MCP E2E, and real database side-effect coverage pass.
+- [x] ClioRing consumer compatibility is reviewed.
+- [x] Comprehensive agentic review has no unresolved Blocker/High findings.
+- [x] Draft PR references and closes GitHub issue #864.


### PR DESCRIPTION
Closes #864

## Summary

- add `--is-virtual` to standalone entity creation and `is-virtual` to both MCP creation paths
- set virtual state before the first designer save while preserving inherited virtual state for replacement schemas
- expose `virtual` through `get-entity-schema-properties` and `get-app-info`
- reject virtual `create-entity` operations with `seed-rows` before any remote mutation
- align curated MCP contracts, prompts, guidance, CLI help, detailed command docs, and BMAD artifacts

## Validation

- `dotnet test clio.tests/clio.tests.csproj --no-build --filter "Category=Unit&(Module=Command|Module=McpServer)"` — passed on net8.0 and net10.0: 4,322 passed, 15 skipped per framework
- focused environment-free MCP contract, validation, and envelope E2E tests — passed on net8.0 and net10.0: 4 passed per framework
- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj --no-restore` — succeeded on net8.0 and net10.0
- live disposable Creatio 10.0.0.802 Studio .NET 8 / PostgreSQL validation:
  - standalone and `sync-schemas` virtual creation succeeded
  - schema readback returned `virtual: true`
  - PostgreSQL catalog contained the persistent control table and no virtual entity table
  - `get-app-info` returned the virtual entity with `virtual: true`
  - the disposable IIS site/app pool, registered environment, files, port, and database were removed and verified absent

## Review and compatibility

- comprehensive three-lens pre-PR review completed; all findings resolved; no remaining Blocker, High, or Medium findings
- docs reviewed and updated
- MCP tools, prompts, guidance, unit tests, and E2E coverage updated
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`