### PR TITLE
Fix flaky MCP progress completion waits

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5938,3 +5938,10 @@ Decision: Replace polling with notification-driven wakeups, recheck one final sn
 Discovery: The old cancellation path broke out of its delay without refreshing the queue, so a boundary-arriving terminal event could be present while the caller still received the previous stage-only snapshot.
 Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, clio.mcp.e2e/AGENTS.md, spec/mcp-progress-wait-timeout/
 Impact: Shared MCP E2E runs no longer convert a timeout race into misleading event-order failures, while genuine missing terminal events fail explicitly with safe diagnostics.
+
+## 2026-07-14 15:02 – Isolate and order MCP progress assertions
+Context: The first comprehensive review of issue #876 found that the fixture-wide capture queue could leak terminal events across invocations, accumulate wakeups, and format an unbounded diagnostic history; repeated validation then reproduced concurrent callback ordering as a separate flake.
+Decision: Scope every wait to an explicit progress token, coalesce notification wakeups, cap diagnostics to the latest 20 matching notifications, and replay typed events by their protocol sequence before asserting order.
+Discovery: MCP notification handlers can complete out of arrival order even within one request, so queue insertion order is not the protocol order; the versioned sequence field is authoritative and matches ClioRing's ordered-buffering contract.
+Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, clio.mcp.e2e/AGENTS.md, spec/mcp-progress-wait-timeout/
+Impact: Ten fresh-process fixture runs passed on each of net8.0 and net10.0 without installing or uninstalling Creatio, while unrelated streams can no longer satisfy a wait.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5931,3 +5931,10 @@ Decision: Track Explorer success across the whole command, render operation-log 
 Discovery: Failure visibility must span defaults resolution, infrastructure validation, installer return codes, and thrown exceptions; handling only the installer result is incomplete.
 Files: clio/Command/CreatioInstallCommand/InstallerCommand.cs, clio.tests/Command/InstallerCommandSilentSiteNameTests.cs
 Impact: Explorer success closes immediately, while all tested failure paths display the diagnostic and log location before waiting for Enter.
+
+## 2026-07-14 14:08 – Make MCP progress waits timeout-safe
+Context: TeamCity build 15725495 failed unrelated PR #866 because the corrupt-archive deploy progress test received a stale partial snapshot after its terminal-event wait timed out.
+Decision: Replace polling with notification-driven wakeups, recheck one final snapshot at the timeout boundary, and throw a secret-safe diagnostic timeout rather than returning unsatisfied data.
+Discovery: The old cancellation path broke out of its delay without refreshing the queue, so a boundary-arriving terminal event could be present while the caller still received the previous stage-only snapshot.
+Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, clio.mcp.e2e/AGENTS.md, spec/mcp-progress-wait-timeout/
+Impact: Shared MCP E2E runs no longer convert a timeout race into misleading event-order failures, while genuine missing terminal events fail explicitly with safe diagnostics.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -5945,3 +5945,17 @@ Decision: Scope every wait to an explicit progress token, coalesce notification 
 Discovery: MCP notification handlers can complete out of arrival order even within one request, so queue insertion order is not the protocol order; the versioned sequence field is authoritative and matches ClioRing's ordered-buffering contract.
 Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, clio.mcp.e2e/AGENTS.md, spec/mcp-progress-wait-timeout/
 Impact: Ten fresh-process fixture runs passed on each of net8.0 and net10.0 without installing or uninstalling Creatio, while unrelated streams can no longer satisfy a wait.
+
+## 2026-07-14 15:18 – Keep opaque progress tokens out of diagnostics
+Context: Final security review found that timeout text echoed the caller-supplied progress token even though opaque correlation values may contain sensitive identifiers and failures are written to CI logs.
+Decision: Use the token only for in-memory stream filtering, omit it from exception text, and cover the rule with a secret-shaped unrelated token.
+Discovery: Secret-safe typed-event summaries do not require exposing the correlation key used to select the stream.
+Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
+Impact: Timeout diagnostics retain event, sequence, stage, status, and outcome evidence without leaking opaque caller input.
+
+## 2026-07-14 15:36 – Require complete progress streams and broadcast wakeups
+Context: Final quality and testing reviews found that a terminal callback could arrive before lower sequences and that one shared consuming semaphore could wake the wrong token waiter.
+Decision: Broadcast each notification through a versioned task-completion signal, compare typed progress-token values, and require a distinct contiguous sequence from zero through terminal before completing a wait.
+Discovery: Sorting a partial snapshot cannot recover callbacks that have not arrived; terminal presence proves completeness only when every preceding sequence is already captured. This supersedes the earlier coalescing-semaphore decision.
+Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, spec/mcp-progress-wait-timeout/
+Impact: Deterministic terminal-first and typed-token regressions pass, and the five-test fixture passed ten fresh-process runs on each of net8.0 and net10.0 without real Creatio lifecycle operations.

--- a/clio.mcp.e2e/AGENTS.md
+++ b/clio.mcp.e2e/AGENTS.md
@@ -75,6 +75,8 @@ Environment variables should use the standard double-underscore form, for exampl
 - Keep tests safe by generating unique resource names per run to avoid collisions across repeated executions.
 - Raw progress waits must be notification-driven and throw an explicit, secret-safe diagnostic timeout when
   their condition remains unsatisfied. Never return a partial progress snapshot as though it met the condition.
+- Scope raw progress waits to the request's explicit progress token, and assert typed event order by the
+  protocol sequence rather than concurrent notification-callback completion order.
 
 ## Manual execution
 

--- a/clio.mcp.e2e/AGENTS.md
+++ b/clio.mcp.e2e/AGENTS.md
@@ -73,6 +73,8 @@ Environment variables should use the standard double-underscore form, for exampl
 - Prefer one feature-focused fixture per MCP tool or workflow.
 - Shared process startup, configuration loading, Redis helpers, and MCP client helpers should live in support folders.
 - Keep tests safe by generating unique resource names per run to avoid collisions across repeated executions.
+- Raw progress waits must be notification-driven and throw an explicit, secret-safe diagnostic timeout when
+  their condition remains unsatisfied. Never return a partial progress snapshot as though it met the condition.
 
 ## Manual execution
 

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -202,6 +202,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 	[Description("Requires a contiguous sequence-zero-through-terminal typed event stream before a progress wait can complete.")]
 	[AllureTag(ToolName)]
 	[AllureName("Progress completion rejects an out-of-order partial typed stream")]
+	[AllureDescription("Feeds terminal-first partial and complete typed streams to the completion predicate and proves it waits for every distinct protocol sequence from zero through terminal.")]
 	public void CompleteTerminalStream_Should_Require_Every_Sequence_Through_Terminal() {
 		// Arrange
 		Guid runId = Guid.NewGuid();
@@ -230,6 +231,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 	[Description("Keeps numeric and string MCP progress tokens distinct while selecting captured notifications.")]
 	[AllureTag(ToolName)]
 	[AllureName("Progress capture preserves the MCP token value type")]
+	[AllureDescription("Serializes a numeric MCP progress token and verifies typed matching accepts numeric 1 while rejecting the distinct string token value 1.")]
 	public void ProgressTokenMatching_Should_Not_Conflate_Numeric_And_String_Values() {
 		// Arrange
 		ProgressToken numericToken = new(1L);

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -72,8 +72,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		// Assert
 		IReadOnlyList<JsonNode> rawParams = await arrangeContext.Session.WaitForCapturedProgressAsync(
 			progressToken,
-			nodes => ExtractStageEvents(nodes).LastOrDefault()?.EventType
-				== ClioStageEventContract.EventTypes.RunCompleted,
+			HasCompleteTerminalStream,
 			TimeSpan.FromSeconds(30),
 			arrangeContext.CancellationTokenSource.Token);
 		IReadOnlyList<ClioStageEvent> events = ExtractStageEvents(rawParams);
@@ -118,8 +117,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		ProgressToken progressToken = await InvokeCorruptArchiveDeployAsync(arrangeContext);
 		await arrangeContext.Session.WaitForCapturedProgressAsync(
 			progressToken,
-			nodes => ExtractStageEvents(nodes).Any(stageEvent =>
-				stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted),
+			HasCompleteTerminalStream,
 			TimeSpan.FromSeconds(30),
 			arrangeContext.CancellationTokenSource.Token);
 
@@ -139,17 +137,19 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 			because: "timeout diagnostics should identify the captured terminal event");
 		assertion.Which.Message.Should().NotContain("fixture-password",
 			because: "progress timeout diagnostics must not expose configured credentials");
-		ProgressToken unrelatedToken = new($"clio-mcp-e2e-unrelated-{Guid.NewGuid():N}");
+		const string secretShapedToken = "Bearer fixture-progress-secret";
+		ProgressToken unrelatedToken = new(secretShapedToken);
 		Func<Task> unrelatedAct = async () => await arrangeContext.Session.WaitForCapturedProgressAsync(
 			unrelatedToken,
-			nodes => ExtractStageEvents(nodes).Any(stageEvent =>
-				stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted),
+			HasCompleteTerminalStream,
 			TimeSpan.FromMilliseconds(10),
 			arrangeContext.CancellationTokenSource.Token);
 		var unrelatedAssertion = await unrelatedAct.Should().ThrowAsync<TimeoutException>(
 			because: "a terminal event captured for another progress token must not satisfy this invocation");
 		unrelatedAssertion.Which.Message.Should().Contain("Captured 0 notification(s)",
 			because: "timeout diagnostics and conditions must be scoped to the requested progress token");
+		unrelatedAssertion.Which.Message.Should().NotContain(secretShapedToken,
+			because: "opaque caller-supplied progress tokens can contain sensitive identifiers and must not reach CI logs");
 	}
 
 	[Test]
@@ -186,8 +186,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 
 		IReadOnlyList<JsonNode> rawParams = await arrangeContext.Session.WaitForCapturedProgressAsync(
 			progressToken,
-			nodes => ExtractStageEvents(nodes).LastOrDefault()?.EventType
-				== ClioStageEventContract.EventTypes.RunCompleted,
+			HasCompleteTerminalStream,
 			TimeSpan.FromSeconds(30),
 			arrangeContext.CancellationTokenSource.Token);
 		IReadOnlyList<ClioStageEvent> events = ExtractStageEvents(rawParams);
@@ -197,6 +196,57 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 			because: "the unresolved target must terminate the typed progress stream as a failure");
 		events[^1].RunCompleted!.ErrorCode.Should().Be("uninstall-target-not-found",
 			because: "Ring and other MCP consumers need a stable machine-readable failure classification");
+	}
+
+	[Test]
+	[Description("Requires a contiguous sequence-zero-through-terminal typed event stream before a progress wait can complete.")]
+	[AllureTag(ToolName)]
+	[AllureName("Progress completion rejects an out-of-order partial typed stream")]
+	public void CompleteTerminalStream_Should_Require_Every_Sequence_Through_Terminal() {
+		// Arrange
+		Guid runId = Guid.NewGuid();
+		JsonNode manifest = CreateCapturedStageEventParams(CreateStageEvent(runId, 0,
+			ClioStageEventContract.EventTypes.Manifest));
+		JsonNode stage = CreateCapturedStageEventParams(CreateStageEvent(runId, 1,
+			ClioStageEventContract.EventTypes.Stage));
+		JsonNode terminal = CreateCapturedStageEventParams(CreateStageEvent(runId, 2,
+			ClioStageEventContract.EventTypes.RunCompleted));
+
+		// Act
+		bool terminalOnly = HasCompleteTerminalStream([terminal]);
+		bool missingIntermediate = HasCompleteTerminalStream([terminal, manifest]);
+		bool completeOutOfOrder = HasCompleteTerminalStream([terminal, manifest, stage]);
+
+		// Assert
+		terminalOnly.Should().BeFalse(
+			because: "a terminal callback can arrive before every lower-sequence callback has been captured");
+		missingIntermediate.Should().BeFalse(
+			because: "manifest and terminal events do not prove that the intermediate sequence was captured");
+		completeOutOfOrder.Should().BeTrue(
+			because: "callback order is irrelevant once every protocol sequence from zero through terminal is present");
+	}
+
+	[Test]
+	[Description("Keeps numeric and string MCP progress tokens distinct while selecting captured notifications.")]
+	[AllureTag(ToolName)]
+	[AllureName("Progress capture preserves the MCP token value type")]
+	public void ProgressTokenMatching_Should_Not_Conflate_Numeric_And_String_Values() {
+		// Arrange
+		ProgressToken numericToken = new(1L);
+		ProgressToken stringToken = new("1");
+		JsonNode capturedParams = new JsonObject {
+			["progressToken"] = JsonSerializer.SerializeToNode(numericToken)
+		};
+
+		// Act
+		bool matchesNumericToken = McpServerSession.HasProgressToken(capturedParams, numericToken);
+		bool matchesStringToken = McpServerSession.HasProgressToken(capturedParams, stringToken);
+
+		// Assert
+		matchesNumericToken.Should().BeTrue(
+			because: "a captured notification must match the same typed MCP progress token");
+		matchesStringToken.Should().BeFalse(
+			because: "numeric 1 and string 1 are distinct MCP progress-token values");
 	}
 
 	// Reads the typed ClioStageEvent out of each captured progress params node, skipping any
@@ -217,6 +267,47 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 
 		return [.. events.OrderBy(stageEvent => stageEvent.Sequence)];
 	}
+
+	private static bool HasCompleteTerminalStream(IReadOnlyList<JsonNode> rawParams) {
+		IReadOnlyList<ClioStageEvent> events = ExtractStageEvents(rawParams);
+		foreach (ClioStageEvent terminal in events.Where(stageEvent =>
+			stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted)) {
+			int[] sequences = [.. events
+				.Where(stageEvent => stageEvent.RunId == terminal.RunId && stageEvent.Sequence <= terminal.Sequence)
+				.Select(stageEvent => stageEvent.Sequence)
+				.Distinct()
+				.Order()];
+			if (terminal.Sequence >= 0
+				&& terminal.Sequence < int.MaxValue
+				&& sequences.Length == terminal.Sequence + 1
+				&& sequences[0] == 0
+				&& sequences[^1] == terminal.Sequence) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static JsonNode CreateCapturedStageEventParams(ClioStageEvent stageEvent) => new JsonObject {
+		["_meta"] = new JsonObject {
+			["clioStageEvent"] = JsonSerializer.SerializeToNode(stageEvent, ClioStageEventContract.SerializerOptions)
+		}
+	};
+
+	private static ClioStageEvent CreateStageEvent(Guid runId, int sequence, string eventType) => new(
+		ClioStageEventContract.SchemaVersion,
+		eventType,
+		runId,
+		sequence,
+		ClioStageEventContract.Operations.Deploy,
+		Stages: eventType == ClioStageEventContract.EventTypes.Manifest ? [] : null,
+		Stage: eventType == ClioStageEventContract.EventTypes.Stage
+			? new ClioStageDetail("unzip", "Unzip", 0, 1, ClioStageEventContract.StageStatuses.Running)
+			: null,
+		RunCompleted: eventType == ClioStageEventContract.EventTypes.RunCompleted
+			? new ClioRunCompleted(ClioStageEventContract.RunOutcomes.Failure, "Fixture failure")
+			: null);
 
 	private static async Task<ProgressToken> InvokeCorruptArchiveDeployAsync(ArrangeContext arrangeContext) {
 		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -67,10 +67,11 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 
 		// Act — use the same explicit-token + raw-handler path as ClioRing. The SDK's typed progress
 		// overload installs a competing handler and drops _meta during deserialization.
-		await InvokeCorruptArchiveDeployAsync(arrangeContext);
+		ProgressToken progressToken = await InvokeCorruptArchiveDeployAsync(arrangeContext);
 
 		// Assert
 		IReadOnlyList<JsonNode> rawParams = await arrangeContext.Session.WaitForCapturedProgressAsync(
+			progressToken,
 			nodes => ExtractStageEvents(nodes).LastOrDefault()?.EventType
 				== ClioStageEventContract.EventTypes.RunCompleted,
 			TimeSpan.FromSeconds(30),
@@ -114,8 +115,9 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		// Arrange
 		await using ArrangeContext arrangeContext = Arrange();
 		arrangeContext.Session.StartCapturingProgressNotifications();
-		await InvokeCorruptArchiveDeployAsync(arrangeContext);
+		ProgressToken progressToken = await InvokeCorruptArchiveDeployAsync(arrangeContext);
 		await arrangeContext.Session.WaitForCapturedProgressAsync(
+			progressToken,
 			nodes => ExtractStageEvents(nodes).Any(stageEvent =>
 				stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted),
 			TimeSpan.FromSeconds(30),
@@ -123,6 +125,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 
 		// Act
 		Func<Task> act = async () => await arrangeContext.Session.WaitForCapturedProgressAsync(
+			progressToken,
 			_ => false,
 			TimeSpan.FromMilliseconds(10),
 			arrangeContext.CancellationTokenSource.Token);
@@ -136,6 +139,17 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 			because: "timeout diagnostics should identify the captured terminal event");
 		assertion.Which.Message.Should().NotContain("fixture-password",
 			because: "progress timeout diagnostics must not expose configured credentials");
+		ProgressToken unrelatedToken = new($"clio-mcp-e2e-unrelated-{Guid.NewGuid():N}");
+		Func<Task> unrelatedAct = async () => await arrangeContext.Session.WaitForCapturedProgressAsync(
+			unrelatedToken,
+			nodes => ExtractStageEvents(nodes).Any(stageEvent =>
+				stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted),
+			TimeSpan.FromMilliseconds(10),
+			arrangeContext.CancellationTokenSource.Token);
+		var unrelatedAssertion = await unrelatedAct.Should().ThrowAsync<TimeoutException>(
+			because: "a terminal event captured for another progress token must not satisfy this invocation");
+		unrelatedAssertion.Which.Message.Should().Contain("Captured 0 notification(s)",
+			because: "timeout diagnostics and conditions must be scoped to the requested progress token");
 	}
 
 	[Test]
@@ -147,6 +161,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		// Arrange
 		await using ArrangeContext arrangeContext = Arrange();
 		arrangeContext.Session.StartCapturingProgressNotifications();
+		ProgressToken progressToken = new($"clio-mcp-e2e-{Guid.NewGuid():N}");
 
 		// Act
 		CallToolResult callResult = await arrangeContext.Session.CallToolWithRawProgressAsync(
@@ -156,6 +171,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 					["environment-name"] = MissingEnvironmentName
 				}
 			},
+			progressToken,
 			arrangeContext.CancellationTokenSource.Token);
 
 		// Assert
@@ -169,6 +185,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 			because: "the caller must receive an actionable target-resolution error");
 
 		IReadOnlyList<JsonNode> rawParams = await arrangeContext.Session.WaitForCapturedProgressAsync(
+			progressToken,
 			nodes => ExtractStageEvents(nodes).LastOrDefault()?.EventType
 				== ClioStageEventContract.EventTypes.RunCompleted,
 			TimeSpan.FromSeconds(30),
@@ -198,11 +215,12 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 			}
 		}
 
-		return events;
+		return [.. events.OrderBy(stageEvent => stageEvent.Sequence)];
 	}
 
-	private static async Task InvokeCorruptArchiveDeployAsync(ArrangeContext arrangeContext) {
+	private static async Task<ProgressToken> InvokeCorruptArchiveDeployAsync(ArrangeContext arrangeContext) {
 		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
+		ProgressToken progressToken = new($"clio-mcp-e2e-{Guid.NewGuid():N}");
 		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive",
 			arrangeContext.CancellationTokenSource.Token);
 		try {
@@ -218,11 +236,13 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 						["dbServerName"] = "e2e-unused-before-unzip"
 					}
 				},
+				progressToken,
 				arrangeContext.CancellationTokenSource.Token);
 		}
 		finally {
 			File.Delete(corruptZipFile);
 		}
+		return progressToken;
 	}
 
 }

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -64,29 +64,10 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		// Arrange
 		await using ArrangeContext arrangeContext = Arrange();
 		arrangeContext.Session.StartCapturingProgressNotifications();
-		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
-		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive", arrangeContext.CancellationTokenSource.Token);
 
 		// Act — use the same explicit-token + raw-handler path as ClioRing. The SDK's typed progress
 		// overload installs a competing handler and drops _meta during deserialization.
-		try {
-			await arrangeContext.Session.CallToolWithRawProgressAsync(
-				ToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["siteName"] = $"e2e-{Guid.NewGuid():N}",
-						["zipFile"] = corruptZipFile,
-						["sitePort"] = 5011,
-						// Cross the FakeKubernetes/no-defaults preflight on clean CI agents. The corrupt
-						// archive fails at unzip before this deliberately nonexistent server is resolved.
-						["dbServerName"] = "e2e-unused-before-unzip"
-					}
-				},
-				arrangeContext.CancellationTokenSource.Token);
-		}
-		finally {
-			File.Delete(corruptZipFile);
-		}
+		await InvokeCorruptArchiveDeployAsync(arrangeContext);
 
 		// Assert
 		IReadOnlyList<JsonNode> rawParams = await arrangeContext.Session.WaitForCapturedProgressAsync(
@@ -122,6 +103,39 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		string wire = string.Join('\n', rawParams.Select(node => node.ToJsonString())).ToLowerInvariant();
 		wire.Should().NotContainAny(["password=", "pwd=", "user id=", "bearer "],
 			because: "no connection string, credential, or token may cross the wire (AC-ERR; redaction is at source)");
+	}
+
+	[Test]
+	[Description("Reports safe typed-event diagnostics when a captured MCP progress condition times out.")]
+	[AllureTag(ToolName)]
+	[AllureName("Progress capture timeout reports the observed typed event sequence")]
+	[AllureDescription("Runs the non-destructive corrupt-archive deploy path, confirms its terminal event was captured, then verifies an intentionally impossible wait fails explicitly with safe typed-event diagnostics instead of returning a partial snapshot.")]
+	public async Task ProgressCaptureWait_Should_Report_Typed_Event_Diagnostics_When_Condition_Times_Out() {
+		// Arrange
+		await using ArrangeContext arrangeContext = Arrange();
+		arrangeContext.Session.StartCapturingProgressNotifications();
+		await InvokeCorruptArchiveDeployAsync(arrangeContext);
+		await arrangeContext.Session.WaitForCapturedProgressAsync(
+			nodes => ExtractStageEvents(nodes).Any(stageEvent =>
+				stageEvent.EventType == ClioStageEventContract.EventTypes.RunCompleted),
+			TimeSpan.FromSeconds(30),
+			arrangeContext.CancellationTokenSource.Token);
+
+		// Act
+		Func<Task> act = async () => await arrangeContext.Session.WaitForCapturedProgressAsync(
+			_ => false,
+			TimeSpan.FromMilliseconds(10),
+			arrangeContext.CancellationTokenSource.Token);
+
+		// Assert
+		var assertion = await act.Should().ThrowAsync<TimeoutException>(
+			because: "an unsatisfied progress condition must fail explicitly instead of returning a partial snapshot");
+		assertion.Which.Message.Should().Contain("manifest(",
+			because: "timeout diagnostics should identify the captured typed manifest without dumping raw payloads");
+		assertion.Which.Message.Should().Contain("run-completed(",
+			because: "timeout diagnostics should identify the captured terminal event");
+		assertion.Which.Message.Should().NotContain("fixture-password",
+			because: "progress timeout diagnostics must not expose configured credentials");
 	}
 
 	[Test]
@@ -185,6 +199,30 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		}
 
 		return events;
+	}
+
+	private static async Task InvokeCorruptArchiveDeployAsync(ArrangeContext arrangeContext) {
+		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
+		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive",
+			arrangeContext.CancellationTokenSource.Token);
+		try {
+			await arrangeContext.Session.CallToolWithRawProgressAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["siteName"] = $"e2e-{Guid.NewGuid():N}",
+						["zipFile"] = corruptZipFile,
+						["sitePort"] = 5011,
+						// Cross the FakeKubernetes/no-defaults preflight on clean CI agents. The corrupt
+						// archive fails at unzip before this deliberately nonexistent server is resolved.
+						["dbServerName"] = "e2e-unused-before-unzip"
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+		}
+		finally {
+			File.Delete(corruptZipFile);
+		}
 	}
 
 }

--- a/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Configuration;
@@ -15,7 +16,8 @@ internal sealed class McpServerSession : IAsyncDisposable {
 	private const int MaxDiagnosticNotifications = 20;
 	private readonly StdioClientTransport _transport;
 	private readonly ConcurrentQueue<JsonNode> _capturedProgressParams = new();
-	private readonly SemaphoreSlim _progressCapturedSignal = new(0, 1);
+	private readonly object _progressCapturedSignalLock = new();
+	private TaskCompletionSource<bool> _progressCapturedSignal = CreateProgressCapturedSignal();
 	private IAsyncDisposable? _progressCaptureRegistration;
 	private bool _progressCaptureRegistered;
 	private HashSet<string>? _advertisedToolNames;
@@ -125,45 +127,58 @@ internal sealed class McpServerSession : IAsyncDisposable {
 		Stopwatch stopwatch = Stopwatch.StartNew();
 		while (true) {
 			cancellationToken.ThrowIfCancellationRequested();
+			Task progressCaptured = GetProgressCapturedSignalTask();
 			IReadOnlyList<JsonNode> snapshot = GetCapturedProgressParams(progressToken);
 			if (condition(snapshot)) {
 				return snapshot;
 			}
 
 			TimeSpan remaining = timeout - stopwatch.Elapsed;
-			if (remaining <= TimeSpan.Zero
-				|| !await _progressCapturedSignal.WaitAsync(remaining, cancellationToken)) {
+			try {
+				if (remaining <= TimeSpan.Zero) {
+					throw new TimeoutException();
+				}
+				await progressCaptured.WaitAsync(remaining, cancellationToken);
+			}
+			catch (TimeoutException) {
 				IReadOnlyList<JsonNode> finalSnapshot = GetCapturedProgressParams(progressToken);
 				if (condition(finalSnapshot)) {
 					return finalSnapshot;
 				}
 
-				throw new TimeoutException(BuildProgressTimeoutMessage(progressToken, timeout, finalSnapshot));
+				throw new TimeoutException(BuildProgressTimeoutMessage(timeout, finalSnapshot));
 			}
 		}
 	}
 
 	private IReadOnlyList<JsonNode> GetCapturedProgressParams(ProgressToken progressToken) {
-		string expectedToken = progressToken.Token?.ToString() ?? string.Empty;
-		return [.. _capturedProgressParams.Where(node =>
-			string.Equals(node["progressToken"]?.ToString(), expectedToken, StringComparison.Ordinal))];
+		return [.. _capturedProgressParams.Where(node => HasProgressToken(node, progressToken))];
+	}
+
+	internal static bool HasProgressToken(JsonNode node, ProgressToken expectedToken) {
+		ProgressToken? capturedToken = node["progressToken"]?.Deserialize<ProgressToken>();
+		return capturedToken.HasValue && capturedToken.Value.Equals(expectedToken);
 	}
 
 	private void SignalProgressCaptured() {
-		if (_progressCapturedSignal.CurrentCount != 0) {
-			return;
+		TaskCompletionSource<bool> signal;
+		lock (_progressCapturedSignalLock) {
+			signal = _progressCapturedSignal;
+			_progressCapturedSignal = CreateProgressCapturedSignal();
 		}
+		signal.TrySetResult(true);
+	}
 
-		try {
-			_progressCapturedSignal.Release();
-		}
-		catch (SemaphoreFullException) {
-			// Concurrent notifications coalesce into the existing wakeup.
+	private Task GetProgressCapturedSignalTask() {
+		lock (_progressCapturedSignalLock) {
+			return _progressCapturedSignal.Task;
 		}
 	}
 
-	private static string BuildProgressTimeoutMessage(ProgressToken progressToken, TimeSpan timeout,
-		IReadOnlyList<JsonNode> snapshot) {
+	private static TaskCompletionSource<bool> CreateProgressCapturedSignal() =>
+		new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+	private static string BuildProgressTimeoutMessage(TimeSpan timeout, IReadOnlyList<JsonNode> snapshot) {
 		int omittedCount = Math.Max(0, snapshot.Count - MaxDiagnosticNotifications);
 		IEnumerable<JsonNode> diagnosticTail = snapshot.Skip(omittedCount);
 		string events = snapshot.Count == 0
@@ -171,7 +186,7 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			: string.Join(", ", diagnosticTail.Select(DescribeProgressNotification));
 		string omitted = omittedCount == 0 ? string.Empty : $" {omittedCount} earlier notification(s) omitted.";
 		return $"Timed out after {timeout.TotalSeconds:0.###} seconds waiting for MCP progress condition. "
-			+ $"Progress token: {progressToken}. Captured {snapshot.Count} notification(s): {events}.{omitted}";
+			+ $"Captured {snapshot.Count} notification(s): {events}.{omitted}";
 	}
 
 	private static string DescribeProgressNotification(JsonNode node) {
@@ -362,6 +377,5 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			await _progressCaptureRegistration.DisposeAsync();
 		}
 		await Client.DisposeAsync();
-		_progressCapturedSignal.Dispose();
 	}
 }

--- a/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
@@ -12,9 +12,10 @@ using ModelContextProtocol.Protocol;
 namespace Clio.Mcp.E2E.Support.Mcp;
 
 internal sealed class McpServerSession : IAsyncDisposable {
+	private const int MaxDiagnosticNotifications = 20;
 	private readonly StdioClientTransport _transport;
 	private readonly ConcurrentQueue<JsonNode> _capturedProgressParams = new();
-	private readonly SemaphoreSlim _progressCapturedSignal = new(0, int.MaxValue);
+	private readonly SemaphoreSlim _progressCapturedSignal = new(0, 1);
 	private IAsyncDisposable? _progressCaptureRegistration;
 	private bool _progressCaptureRegistered;
 	private HashSet<string>? _advertisedToolNames;
@@ -91,7 +92,7 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			JsonNode? paramsNode = notification.Params?.DeepClone();
 			if (paramsNode is not null) {
 				_capturedProgressParams.Enqueue(paramsNode);
-				_progressCapturedSignal.Release();
+				SignalProgressCaptured();
 			}
 
 			return default;
@@ -112,6 +113,7 @@ internal sealed class McpServerSession : IAsyncDisposable {
 	/// unsatisfied after one final snapshot at the timeout boundary.
 	/// </summary>
 	public async Task<IReadOnlyList<JsonNode>> WaitForCapturedProgressAsync(
+		ProgressToken progressToken,
 		Func<IReadOnlyList<JsonNode>, bool> condition,
 		TimeSpan timeout,
 		CancellationToken cancellationToken) {
@@ -123,7 +125,7 @@ internal sealed class McpServerSession : IAsyncDisposable {
 		Stopwatch stopwatch = Stopwatch.StartNew();
 		while (true) {
 			cancellationToken.ThrowIfCancellationRequested();
-			IReadOnlyList<JsonNode> snapshot = CapturedProgressParams;
+			IReadOnlyList<JsonNode> snapshot = GetCapturedProgressParams(progressToken);
 			if (condition(snapshot)) {
 				return snapshot;
 			}
@@ -131,22 +133,45 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			TimeSpan remaining = timeout - stopwatch.Elapsed;
 			if (remaining <= TimeSpan.Zero
 				|| !await _progressCapturedSignal.WaitAsync(remaining, cancellationToken)) {
-				IReadOnlyList<JsonNode> finalSnapshot = CapturedProgressParams;
+				IReadOnlyList<JsonNode> finalSnapshot = GetCapturedProgressParams(progressToken);
 				if (condition(finalSnapshot)) {
 					return finalSnapshot;
 				}
 
-				throw new TimeoutException(BuildProgressTimeoutMessage(timeout, finalSnapshot));
+				throw new TimeoutException(BuildProgressTimeoutMessage(progressToken, timeout, finalSnapshot));
 			}
 		}
 	}
 
-	private static string BuildProgressTimeoutMessage(TimeSpan timeout, IReadOnlyList<JsonNode> snapshot) {
+	private IReadOnlyList<JsonNode> GetCapturedProgressParams(ProgressToken progressToken) {
+		string expectedToken = progressToken.Token?.ToString() ?? string.Empty;
+		return [.. _capturedProgressParams.Where(node =>
+			string.Equals(node["progressToken"]?.ToString(), expectedToken, StringComparison.Ordinal))];
+	}
+
+	private void SignalProgressCaptured() {
+		if (_progressCapturedSignal.CurrentCount != 0) {
+			return;
+		}
+
+		try {
+			_progressCapturedSignal.Release();
+		}
+		catch (SemaphoreFullException) {
+			// Concurrent notifications coalesce into the existing wakeup.
+		}
+	}
+
+	private static string BuildProgressTimeoutMessage(ProgressToken progressToken, TimeSpan timeout,
+		IReadOnlyList<JsonNode> snapshot) {
+		int omittedCount = Math.Max(0, snapshot.Count - MaxDiagnosticNotifications);
+		IEnumerable<JsonNode> diagnosticTail = snapshot.Skip(omittedCount);
 		string events = snapshot.Count == 0
 			? "none"
-			: string.Join(", ", snapshot.Select(DescribeProgressNotification));
+			: string.Join(", ", diagnosticTail.Select(DescribeProgressNotification));
+		string omitted = omittedCount == 0 ? string.Empty : $" {omittedCount} earlier notification(s) omitted.";
 		return $"Timed out after {timeout.TotalSeconds:0.###} seconds waiting for MCP progress condition. "
-			+ $"Captured {snapshot.Count} notification(s): {events}.";
+			+ $"Progress token: {progressToken}. Captured {snapshot.Count} notification(s): {events}.{omitted}";
 	}
 
 	private static string DescribeProgressNotification(JsonNode node) {
@@ -239,9 +264,10 @@ internal sealed class McpServerSession : IAsyncDisposable {
 	public async Task<CallToolResult> CallToolWithRawProgressAsync(
 		string toolName,
 		IReadOnlyDictionary<string, object?> arguments,
+		ProgressToken progressToken,
 		CancellationToken cancellationToken) {
 		RequestOptions options = new() {
-			ProgressToken = new ProgressToken($"clio-mcp-e2e-{Guid.NewGuid():N}")
+			ProgressToken = progressToken
 		};
 		if (await IsToolAdvertisedAsync(toolName, cancellationToken)) {
 			return await Client.CallToolAsync(

--- a/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text.Json.Nodes;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Configuration;
@@ -13,6 +14,7 @@ namespace Clio.Mcp.E2E.Support.Mcp;
 internal sealed class McpServerSession : IAsyncDisposable {
 	private readonly StdioClientTransport _transport;
 	private readonly ConcurrentQueue<JsonNode> _capturedProgressParams = new();
+	private readonly SemaphoreSlim _progressCapturedSignal = new(0, int.MaxValue);
 	private IAsyncDisposable? _progressCaptureRegistration;
 	private bool _progressCaptureRegistered;
 	private HashSet<string>? _advertisedToolNames;
@@ -89,6 +91,7 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			JsonNode? paramsNode = notification.Params?.DeepClone();
 			if (paramsNode is not null) {
 				_capturedProgressParams.Enqueue(paramsNode);
+				_progressCapturedSignal.Release();
 			}
 
 			return default;
@@ -103,29 +106,62 @@ internal sealed class McpServerSession : IAsyncDisposable {
 
 	/// <summary>
 	/// Waits for asynchronously dispatched progress notifications to satisfy <paramref name="condition"/>,
-	/// returning the latest snapshot when the condition is met or the timeout expires. Tool completion and
-	/// notification dispatch use independent SDK continuations, so a completed call does not guarantee that
-	/// the raw notification handler has drained its queue yet.
+	/// returning the snapshot that satisfied the condition. Tool completion and notification dispatch use
+	/// independent SDK continuations, so a completed call does not guarantee that the raw notification handler
+	/// has drained its queue yet. Throws a diagnostic <see cref="TimeoutException"/> when the condition remains
+	/// unsatisfied after one final snapshot at the timeout boundary.
 	/// </summary>
 	public async Task<IReadOnlyList<JsonNode>> WaitForCapturedProgressAsync(
 		Func<IReadOnlyList<JsonNode>, bool> condition,
 		TimeSpan timeout,
 		CancellationToken cancellationToken) {
 		ArgumentNullException.ThrowIfNull(condition);
-		using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-		timeoutSource.CancelAfter(timeout);
-		IReadOnlyList<JsonNode> snapshot = CapturedProgressParams;
-		while (!condition(snapshot) && !timeoutSource.IsCancellationRequested) {
-			try {
-				await Task.Delay(TimeSpan.FromMilliseconds(20), timeoutSource.Token);
-			}
-			catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
-				break;
-			}
-			snapshot = CapturedProgressParams;
+		if (timeout <= TimeSpan.Zero) {
+			throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Progress wait timeout must be positive.");
 		}
-		cancellationToken.ThrowIfCancellationRequested();
-		return snapshot;
+
+		Stopwatch stopwatch = Stopwatch.StartNew();
+		while (true) {
+			cancellationToken.ThrowIfCancellationRequested();
+			IReadOnlyList<JsonNode> snapshot = CapturedProgressParams;
+			if (condition(snapshot)) {
+				return snapshot;
+			}
+
+			TimeSpan remaining = timeout - stopwatch.Elapsed;
+			if (remaining <= TimeSpan.Zero
+				|| !await _progressCapturedSignal.WaitAsync(remaining, cancellationToken)) {
+				IReadOnlyList<JsonNode> finalSnapshot = CapturedProgressParams;
+				if (condition(finalSnapshot)) {
+					return finalSnapshot;
+				}
+
+				throw new TimeoutException(BuildProgressTimeoutMessage(timeout, finalSnapshot));
+			}
+		}
+	}
+
+	private static string BuildProgressTimeoutMessage(TimeSpan timeout, IReadOnlyList<JsonNode> snapshot) {
+		string events = snapshot.Count == 0
+			? "none"
+			: string.Join(", ", snapshot.Select(DescribeProgressNotification));
+		return $"Timed out after {timeout.TotalSeconds:0.###} seconds waiting for MCP progress condition. "
+			+ $"Captured {snapshot.Count} notification(s): {events}.";
+	}
+
+	private static string DescribeProgressNotification(JsonNode node) {
+		JsonNode? stageEvent = node["_meta"]?["clioStageEvent"];
+		if (stageEvent is null) {
+			return "untyped";
+		}
+
+		string eventType = stageEvent["eventType"]?.ToString() ?? "missing-event-type";
+		string runId = stageEvent["runId"]?.ToString() ?? "missing-run-id";
+		string sequence = stageEvent["sequence"]?.ToString() ?? "missing-sequence";
+		string stageId = stageEvent["stage"]?["stageId"]?.ToString() ?? "none";
+		string status = stageEvent["stage"]?["status"]?.ToString() ?? "none";
+		string outcome = stageEvent["runCompleted"]?["outcome"]?.ToString() ?? "none";
+		return $"{eventType}(runId={runId}, sequence={sequence}, stage={stageId}, status={status}, outcome={outcome})";
 	}
 
 	public async Task<IList<McpClientTool>> ListToolsAsync(CancellationToken cancellationToken) =>
@@ -300,5 +336,6 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			await _progressCaptureRegistration.DisposeAsync();
 		}
 		await Client.DisposeAsync();
+		_progressCapturedSignal.Dispose();
 	}
 }

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Replace timer polling in `McpServerSession` with a `SemaphoreSlim` released by the raw notification handler. Each wake takes a fresh immutable queue snapshot. If the deadline is reached, take one final snapshot, return it only when the condition is satisfied, and otherwise throw `TimeoutException` with typed-event metadata only.
+Replace timer polling in `McpServerSession` with a coalescing `SemaphoreSlim` released by the raw notification handler. Each wake takes a fresh immutable queue snapshot scoped to the request's progress token. If the deadline is reached, take one final snapshot, return it only when the condition is satisfied, and otherwise throw `TimeoutException` with a bounded typed-event summary. Replay typed events by their protocol sequence before asserting order because MCP notification callbacks may complete concurrently.
 
 ## Compatibility
 

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
@@ -1,0 +1,13 @@
+# MCP progress wait timeout plan
+
+## Decision
+
+Replace timer polling in `McpServerSession` with a `SemaphoreSlim` released by the raw notification handler. Each wake takes a fresh immutable queue snapshot. If the deadline is reached, take one final snapshot, return it only when the condition is satisfied, and otherwise throw `TimeoutException` with typed-event metadata only.
+
+## Compatibility
+
+The change is confined to `clio.mcp.e2e`. Production MCP notifications and the ClioRing contract are unchanged.
+
+## Safety
+
+Timeout diagnostics include event type, run identifier, sequence, stage status, and terminal outcome. They do not serialize raw notification payloads or configuration values.

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Replace timer polling in `McpServerSession` with a coalescing `SemaphoreSlim` released by the raw notification handler. Each wake takes a fresh immutable queue snapshot scoped to the request's progress token. If the deadline is reached, take one final snapshot, return it only when the condition is satisfied, and otherwise throw `TimeoutException` with a bounded typed-event summary. Replay typed events by their protocol sequence before asserting order because MCP notification callbacks may complete concurrently.
+Replace timer polling in `McpServerSession` with a versioned task-completion signal broadcast by the raw notification handler. Each wake takes a fresh immutable queue snapshot scoped to the request's typed progress token. If the deadline is reached, take one final snapshot, return it only when the condition is satisfied, and otherwise throw `TimeoutException` with a bounded typed-event summary. Do not complete a terminal wait until every distinct protocol sequence from zero through terminal is present because MCP notification callbacks may complete concurrently.
 
 ## Compatibility
 

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
@@ -4,8 +4,10 @@
 
 - Run the real MCP server with the corrupt-archive deploy scenario and require the terminal failure event.
 - After a completed typed-event stream, request an impossible condition and assert an explicit timeout.
-- Request the terminal condition with an unrelated progress token and assert it times out with zero captured notifications.
+- Request the terminal condition with a secret-shaped unrelated progress token and assert it times out with zero captured notifications without echoing the token.
 - Replay typed events by protocol sequence before asserting manifest-to-terminal order.
+- Feed the completion predicate a terminal-first partial stream and require every distinct sequence from zero through terminal before it succeeds.
+- Verify numeric and string progress tokens with the same text remain distinct.
 - Assert timeout diagnostics identify manifest and terminal events without including fixture credentials.
 - Repeat the focused fixture on .NET 8 and .NET 10 to exercise process startup, stdio notification dispatch, and teardown.
 

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
@@ -4,6 +4,8 @@
 
 - Run the real MCP server with the corrupt-archive deploy scenario and require the terminal failure event.
 - After a completed typed-event stream, request an impossible condition and assert an explicit timeout.
+- Request the terminal condition with an unrelated progress token and assert it times out with zero captured notifications.
+- Replay typed events by protocol sequence before asserting manifest-to-terminal order.
 - Assert timeout diagnostics identify manifest and terminal events without including fixture credentials.
 - Repeat the focused fixture on .NET 8 and .NET 10 to exercise process startup, stdio notification dispatch, and teardown.
 

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
@@ -1,0 +1,12 @@
+# MCP progress wait timeout QA plan
+
+## Automated coverage
+
+- Run the real MCP server with the corrupt-archive deploy scenario and require the terminal failure event.
+- After a completed typed-event stream, request an impossible condition and assert an explicit timeout.
+- Assert timeout diagnostics identify manifest and terminal events without including fixture credentials.
+- Repeat the focused fixture on .NET 8 and .NET 10 to exercise process startup, stdio notification dispatch, and teardown.
+
+## Environment impact
+
+The corrupt archive fails during unzip before database, IIS, Redis, or filesystem deployment stages. No Creatio installation or uninstallation is performed.

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
@@ -10,6 +10,9 @@ The MCP E2E progress-capture helper returned its latest snapshot when a timeout 
 - Re-read the queue once at the timeout boundary before deciding that the condition failed.
 - Return only a snapshot that satisfies the caller's condition.
 - Throw an explicit timeout containing secret-safe typed-event summaries when the condition remains false.
+- Isolate captured notification streams by the request's explicit progress token.
+- Replay typed events by protocol sequence because MCP callback scheduling can be concurrent and out of order.
+- Coalesce notification wakeups and bound timeout diagnostics to the latest 20 notifications.
 - Keep the corrupt-archive validation non-destructive; no Creatio instance may be installed or uninstalled.
 
 ## Exclusions

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
@@ -1,0 +1,18 @@
+# MCP progress wait timeout specification
+
+## Problem
+
+The MCP E2E progress-capture helper returned its latest snapshot when a timeout expired, even when the requested condition was false. Under TeamCity load, the invalid-archive deploy test therefore asserted a stale partial sequence and failed unrelated pull requests with an event-order message.
+
+## Requirements
+
+- Wake progress waiters when a notification is captured instead of polling every 20 milliseconds.
+- Re-read the queue once at the timeout boundary before deciding that the condition failed.
+- Return only a snapshot that satisfies the caller's condition.
+- Throw an explicit timeout containing secret-safe typed-event summaries when the condition remains false.
+- Keep the corrupt-archive validation non-destructive; no Creatio instance may be installed or uninstalled.
+
+## Exclusions
+
+- No production MCP event schema, ordering, or tool behavior changes.
+- No relaxation of the required terminal `run-completed` assertion.

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
@@ -11,8 +11,8 @@ The MCP E2E progress-capture helper returned its latest snapshot when a timeout 
 - Return only a snapshot that satisfies the caller's condition.
 - Throw an explicit timeout containing secret-safe typed-event summaries when the condition remains false.
 - Isolate captured notification streams by the request's explicit progress token.
-- Replay typed events by protocol sequence because MCP callback scheduling can be concurrent and out of order.
-- Coalesce notification wakeups and bound timeout diagnostics to the latest 20 notifications.
+- Replay typed events by protocol sequence and do not complete a wait until every distinct sequence from zero through terminal is present, because MCP callback scheduling can be concurrent and out of order.
+- Broadcast notification wakeups to concurrent waiters and bound timeout diagnostics to the latest 20 notifications.
 - Keep the corrupt-archive validation non-destructive; no Creatio instance may be installed or uninstalled.
 
 ## Exclusions

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
@@ -1,6 +1,6 @@
 # Story: deterministic MCP progress waiting
 
-Status: review
+Status: done
 
 As a contributor, I want MCP E2E progress waits to fail only after checking the final captured state so unrelated pull requests are not failed by stale partial snapshots.
 

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
@@ -9,5 +9,7 @@ As a contributor, I want MCP E2E progress waits to fail only after checking the 
 - Captured notifications wake waiting tests immediately.
 - A timeout-boundary notification is included in the final condition check.
 - Unsatisfied conditions throw a diagnostic timeout instead of returning partial data.
+- A terminal event captured for another progress token cannot satisfy the wait.
+- Typed event ordering is asserted by protocol sequence rather than callback scheduling order.
 - Timeout diagnostics do not expose configured credentials.
 - The invalid-archive deploy progress test remains non-destructive and passes repeatedly on .NET 8 and .NET 10.

--- a/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
+++ b/spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
@@ -1,0 +1,13 @@
+# Story: deterministic MCP progress waiting
+
+Status: review
+
+As a contributor, I want MCP E2E progress waits to fail only after checking the final captured state so unrelated pull requests are not failed by stale partial snapshots.
+
+## Acceptance criteria
+
+- Captured notifications wake waiting tests immediately.
+- A timeout-boundary notification is included in the final condition check.
+- Unsatisfied conditions throw a diagnostic timeout instead of returning partial data.
+- Timeout diagnostics do not expose configured credentials.
+- The invalid-archive deploy progress test remains non-destructive and passes repeatedly on .NET 8 and .NET 10.

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -26,7 +26,7 @@ stories:
     feature: "mcp-progress-wait-timeout"
     repo: "clio"
     size: S
-    status: review
+    status: done
     issue: 876
     file: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
     prd: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -21,6 +21,20 @@
 # 2026-07-06) is a separate Jira ticket stacked on the same branch; tracked as its own row.
 
 stories:
+  - id: story-mcp-progress-wait-timeout-1
+    title: "Make MCP progress waits notification-driven and timeout-safe"
+    feature: "mcp-progress-wait-timeout"
+    repo: "clio"
+    size: S
+    status: review
+    issue: 876
+    file: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-story.md
+    prd: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-spec.md
+    adr: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-plan.md
+    test_plan: spec/mcp-progress-wait-timeout/mcp-progress-wait-timeout-qa.md
+    depends_on: []
+    blocks: []
+
   - id: story-explorer-deploy-local-defaults-1
     title: "Use local infrastructure preferences and preserve Explorer deployment errors"
     feature: "explorer-deploy-local-defaults"


### PR DESCRIPTION
## Problem

TeamCity could time out while waiting for the terminal typed deploy event, then return a stale partial snapshot as if the condition had succeeded. Concurrent MCP notification callbacks could also enqueue a terminal event before lower sequences, and fixture-wide capture could mix progress streams.

Fixes #876.

## Solution

- replace polling with broadcast notification wakeups and a final timeout-boundary snapshot
- scope captured notifications by typed MCP progress token
- require every distinct sequence from zero through `run-completed` before treating a stream as complete
- throw bounded, secret-safe timeout diagnostics instead of returning partial data
- add deterministic regressions for terminal-first partial streams, typed token identity, cross-token isolation, and token secrecy

## Validation

- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release --filter "FullyQualifiedName~DeployUninstallProgressTests"` — 5/5 passed on net8.0 and 5/5 passed on net10.0
- 10 fresh-process focused fixture runs on net8.0 — all passed
- 10 fresh-process focused fixture runs on net10.0 — all passed
- final comprehensive agentic review — quality/correctness, security/privacy, and testing/reliability clean

The corrupt archive fails during unzip and the uninstall target is deliberately unresolved. No Creatio instance is installed or uninstalled by these tests.

Docs reviewed, no command docs update required. MCP reviewed, production contract unchanged. ClioRing compatibility reviewed, no Ring-consumed contract changed.