### PR TITLE
Fix get-info target classification

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6036,3 +6036,10 @@ Decision: Treat only object/array-prefixed parse failures as malformed JSON, req
 Discovery: JSON permits scalar top-level values, but ApplicationInfoService does not; using generic JSON scalar prefixes caused text such as `404 Not Found` to be misclassified.
 Files: clio/Command/GetCreatioInfoCommand.cs, clio.tests/Command/GetInfoCommand.cs, clio/help/en/get-info.txt, spec/sprint-status.yaml
 Impact: Digit-prefixed non-Creatio responses and empty sysValues envelopes now fail with the correct stable classification, while programming defects are no longer swallowed by remote-operation boundaries.
+
+## 2026-07-15 09:44 – Make secret-safe boundaries recoverable by policy
+Context: Final re-review traced real ClioGate compatibility failures through package-list parsing and found recoverable exception types beyond the transport whitelist.
+Decision: Catch every recoverable exception at base and optional remote-operation boundaries while explicitly propagating fatal runtime conditions and clear programming defects; validate optional success tokens by type before conversion.
+Discovery: ClioGate compatibility can throw InvalidOperationException or System.Text.Json parsing errors before GetSysInfo, so a narrow HTTP/Newtonsoft exception list cannot guarantee nonfatal enrichment or secret-safe MCP output.
+Files: clio/Command/GetCreatioInfoCommand.cs, clio.tests/Command/GetInfoCommand.cs
+Impact: Recoverable client/library failures now remain classified and redacted, while fatal or programming-defect exceptions still propagate for diagnosis.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6029,3 +6029,10 @@ Decision: Make ApplicationInfoService the mandatory base probe, map failures to 
 Discovery: Creatio.Client can surface transport failures through nested exceptions and returns non-success response bodies directly, so classification must inspect exception chains while keeping debug output limited to safe metadata.
 Files: clio/Command/GetCreatioInfoCommand.cs, clio.tests/Command/GetInfoCommand.cs, clio/Command/McpServer/, clio.mcp.e2e/GetCreatioInfoToolE2ETests.cs, clio/docs/commands/get-info.md, spec/get-info-target-classification/
 Impact: CLI aliases and MCP now share stable secret-safe errors, valid Creatio instances still report base information without ClioGate, and Ring compatibility remains covered by its consumer tests and NativeAOT publish gate.
+
+## 2026-07-15 09:31 – Close get-info review edge cases
+Context: The comprehensive pre-PR review tested response classification against ambiguous plain text and minimally shaped JSON.
+Decision: Treat only object/array-prefixed parse failures as malformed JSON, require a non-empty coreVersion in the base report, and filter remote-failure catches to known transport, authentication, timeout, and JSON exception families.
+Discovery: JSON permits scalar top-level values, but ApplicationInfoService does not; using generic JSON scalar prefixes caused text such as `404 Not Found` to be misclassified.
+Files: clio/Command/GetCreatioInfoCommand.cs, clio.tests/Command/GetInfoCommand.cs, clio/help/en/get-info.txt, spec/sprint-status.yaml
+Impact: Digit-prefixed non-Creatio responses and empty sysValues envelopes now fail with the correct stable classification, while programming defects are no longer swallowed by remote-operation boundaries.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6022,3 +6022,10 @@ Decision: Broadcast each notification through a versioned task-completion signal
 Discovery: Sorting a partial snapshot cannot recover callbacks that have not arrived; terminal presence proves completeness only when every preceding sequence is already captured. This supersedes the earlier coalescing-semaphore decision.
 Files: clio.mcp.e2e/Support/Mcp/McpServerSession.cs, clio.mcp.e2e/DeployUninstallProgressTests.cs, spec/mcp-progress-wait-timeout/
 Impact: Deterministic terminal-first and typed-token regressions pass, and the five-test fixture passed ten fresh-process runs on each of net8.0 and net10.0 without real Creatio lifecycle operations.
+
+## 2026-07-15 09:16 – Classify get-info target failures safely
+Context: Issue #390 required get-info and its aliases to distinguish invalid URLs, unreachable targets, authentication failures, non-Creatio responses, and malformed Creatio responses without leaking response bodies or parser details.
+Decision: Make ApplicationInfoService the mandatory base probe, map failures to stable user-facing classifications, and run system-info and ClioGate enrichment only after a valid base report and as non-fatal best-effort steps.
+Discovery: Creatio.Client can surface transport failures through nested exceptions and returns non-success response bodies directly, so classification must inspect exception chains while keeping debug output limited to safe metadata.
+Files: clio/Command/GetCreatioInfoCommand.cs, clio.tests/Command/GetInfoCommand.cs, clio/Command/McpServer/, clio.mcp.e2e/GetCreatioInfoToolE2ETests.cs, clio/docs/commands/get-info.md, spec/get-info-target-classification/
+Impact: CLI aliases and MCP now share stable secret-safe errors, valid Creatio instances still report base information without ClioGate, and Ring compatibility remains covered by its consumer tests and NativeAOT publish gate.

--- a/clio.mcp.e2e/GetCreatioInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/GetCreatioInfoToolE2ETests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -18,6 +20,92 @@ namespace Clio.Mcp.E2E;
 [AllureFeature(GetCreatioInfoTool.ToolName)]
 [NonParallelizable]
 public sealed class GetCreatioInfoToolE2ETests : McpContractFixtureBase {
+	private sealed class NonCreatioApplicationStub : IAsyncDisposable {
+		private const string ResponseMarker = "not-creatio-secret-marker";
+		private readonly CancellationTokenSource _cancellationTokenSource = new();
+		private readonly HttpListener _listener;
+		private readonly Task _listenerLoop;
+
+		private NonCreatioApplicationStub(HttpListener listener, string applicationUri) {
+			_listener = listener;
+			ApplicationUri = applicationUri;
+			_listenerLoop = Task.Run(ListenAsync);
+		}
+
+		public string ApplicationUri { get; }
+
+		public static NonCreatioApplicationStub Start() {
+			for (int attempt = 0; attempt < 5; attempt++) {
+				int port = Random.Shared.Next(20_000, 60_000);
+				HttpListener listener = new();
+				listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+				try {
+					listener.Start();
+					return new NonCreatioApplicationStub(listener, $"http://127.0.0.1:{port}");
+				} catch (HttpListenerException) {
+					listener.Close();
+				}
+			}
+			throw new InvalidOperationException("Unable to start the non-Creatio loopback stub.");
+		}
+
+		public async ValueTask DisposeAsync() {
+			_cancellationTokenSource.Cancel();
+			_listener.Stop();
+			try {
+				await _listenerLoop.ConfigureAwait(false);
+			} catch (OperationCanceledException) {
+				// Expected when the fixture stops the listener.
+			} finally {
+				_listener.Close();
+				_cancellationTokenSource.Dispose();
+			}
+		}
+
+		private async Task ListenAsync() {
+			while (!_cancellationTokenSource.IsCancellationRequested) {
+				HttpListenerContext context;
+				try {
+					context = await _listener.GetContextAsync()
+						.WaitAsync(_cancellationTokenSource.Token)
+						.ConfigureAwait(false);
+				} catch (OperationCanceledException) {
+					return;
+				} catch (HttpListenerException) when (_cancellationTokenSource.IsCancellationRequested) {
+					return;
+				} catch (ObjectDisposedException) when (_cancellationTokenSource.IsCancellationRequested) {
+					return;
+				}
+				await RespondAsync(context).ConfigureAwait(false);
+			}
+		}
+
+		private static async Task RespondAsync(HttpListenerContext context) {
+			string path = context.Request.Url?.AbsolutePath ?? string.Empty;
+			string body;
+			if (path.EndsWith("/ServiceModel/AuthService.svc/Login", StringComparison.Ordinal)) {
+				context.Response.SetCookie(new Cookie(".ASPXAUTH", "stub-session", "/"));
+				context.Response.ContentType = "application/json";
+				body = "{\"Code\":0}";
+			} else if (path.EndsWith("/ping", StringComparison.Ordinal)) {
+				context.Response.ContentType = "application/json";
+				body = "{}";
+			} else if (path.EndsWith(
+					"/ServiceModel/ApplicationInfoService.svc/GetApplicationInfo", StringComparison.Ordinal)) {
+				context.Response.ContentType = "text/html";
+				body = $"<html><body>{ResponseMarker}</body></html>";
+			} else {
+				context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+				context.Response.ContentType = "text/plain";
+				body = "Not Found";
+			}
+			byte[] bytes = Encoding.UTF8.GetBytes(body);
+			context.Response.ContentLength64 = bytes.Length;
+			await context.Response.OutputStream.WriteAsync(bytes).ConfigureAwait(false);
+			context.Response.Close();
+		}
+	}
+
 	[Test]
 	[Description("Exposes describe-environment via the get-tool-contract compact index with a non-destructive safety flag on the lazy tool surface.")]
 	[AllureTag(GetCreatioInfoTool.ToolName)]
@@ -65,5 +153,45 @@ public sealed class GetCreatioInfoToolE2ETests : McpContractFixtureBase {
 			because: "valid describe-environment payloads should bind and return a structured execution result, not a protocol error");
 		response.ExitCode.Should().Be(1,
 			because: "an unknown registered environment is an expected, caller-actionable failure (exit code 1)");
+	}
+
+	[Test]
+	[Description("Classifies HTML returned by a reachable non-Creatio loopback target through the real MCP server without leaking parser or body details.")]
+	[AllureTag(GetCreatioInfoTool.ToolName)]
+	[AllureName("describe-environment classifies a reachable non-Creatio target")]
+	[AllureDescription("Starts a local HTTP stub that completes clio's basic-auth handshake and returns HTML from ApplicationInfoService, then verifies the external MCP process returns the stable non-Creatio Error envelope.")]
+	public async Task DescribeEnvironment_ShouldReportNonCreatioError_WhenBaseProbeReturnsHtml() {
+		// Arrange
+		await using NonCreatioApplicationStub stub = NonCreatioApplicationStub.Start();
+		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			GetCreatioInfoTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["uri"] = stub.ApplicationUri,
+					["login"] = "stub-user",
+					["password"] = "stub-password",
+					["timeout"] = 5_000
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		CommandExecutionEnvelope response = McpCommandExecutionParser.Extract(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "a classified command failure should use the standard execution envelope, not a protocol error");
+		response.ExitCode.Should().Be(1,
+			because: "a reachable non-Creatio target cannot produce a valid environment report");
+		response.Output.Should().Contain(message =>
+			message.MessageType == Clio.Common.LogDecoratorType.Error
+			&& (message.Value ?? string.Empty).Contains(
+				"does not appear to be a Creatio application", StringComparison.Ordinal),
+			because: "MCP callers need the actionable non-Creatio classification from the command");
+		response.Output.Should().NotContain(message =>
+			(message.Value ?? string.Empty).Contains("not-creatio-secret-marker", StringComparison.Ordinal)
+			|| (message.Value ?? string.Empty).Contains("JsonReaderException", StringComparison.Ordinal),
+			because: "raw HTML and parser implementation details must not cross the MCP boundary");
 	}
 }

--- a/clio.tests/Command/GetInfoCommand.cs
+++ b/clio.tests/Command/GetInfoCommand.cs
@@ -334,6 +334,65 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 	}
 
 	[Test]
+	[Description("Classifies a truncated quoted JSON scalar as malformed rather than non-Creatio plain text.")]
+	public void Execute_ShouldReportUnexpectedResponse_WhenQuotedBaseJsonIsMalformed()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("\"unterminated");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "a JSON-token prefix with invalid syntax is a malformed response");
+		logger.Received(1).WriteError("The Creatio ApplicationInfoService returned an unexpected response.");
+	}
+
+	[Test]
+	[Description("Maps an unexpected recoverable base-client exception to a stable secret-safe response.")]
+	public void Execute_ShouldKeepUnexpectedBaseFailureSecretSafe_WhenClientThrowsRecoverableException()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new InvalidOperationException("token=base-secret"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "recoverable library failures cannot bypass the classified command boundary");
+		logger.Received(1).WriteError("The Creatio ApplicationInfoService returned an unexpected response.");
+		logger.DidNotReceive().WriteError(Arg.Is<string>(message => message.Contains("base-secret", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Keeps the base report when system-environment enrichment returns an invalid success value.")]
+	public void Execute_ShouldReturnBaseReport_WhenSystemEnvironmentInfoSuccessValueIsMalformed()
+	{
+		// Arrange
+		IApplicationClient client = SubstituteClient();
+		StubSystemEnvironmentInfo(client, """{ "success": "not-a-bool", "dbEngineType": "secret-value" }""");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0, because: "malformed optional enrichment cannot invalidate a valid base report");
+		logger.Received(1).WriteLine(Arg.Is<string>(message =>
+			message.Contains("coreVersion", StringComparison.Ordinal)
+			&& !message.Contains("secret-value", StringComparison.Ordinal)));
+	}
+
+	[Test]
 	[Description("Classifies an HTTP transport exception as an unavailable Creatio target.")]
 	public void Execute_ShouldReportConnectionFailure_WhenBaseProbeThrowsHttpRequestException()
 	{
@@ -504,7 +563,7 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 		// Arrange
 		IApplicationClient client = SubstituteClient();
 		IClioGateway gateway = Substitute.For<IClioGateway>();
-		gateway.IsCompatibleWith(Arg.Any<string>()).Throws(new HttpRequestException("secret cliogate failure"));
+		gateway.IsCompatibleWith(Arg.Any<string>()).Throws(new InvalidOperationException("secret cliogate failure"));
 		ILogger logger = Substitute.For<ILogger>();
 		GetCreatioInfoCommand command = CreateCommand(client, gateway, logger);
 
@@ -516,6 +575,30 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 		logger.Received(1).WriteLine(Arg.Is<string>(message => message.Contains("coreVersion", StringComparison.Ordinal)));
 		logger.Received(1).WriteWarning(Arg.Is<string>(message =>
 			message.Contains("compatibility could not be determined", StringComparison.Ordinal)));
+		logger.DidNotReceive().WriteError(Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Keeps a successful base report when ClioGate package-list JSON cannot be deserialized.")]
+	public void Execute_ShouldReturnBaseReport_WhenCliogateCompatibilityJsonIsMalformed()
+	{
+		// Arrange
+		IApplicationClient client = SubstituteClient();
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		gateway.IsCompatibleWith(Arg.Any<string>())
+			.Throws(new System.Text.Json.JsonException("token=cliogate-json-secret"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0, because: "package-list JSON is optional after the base report succeeds");
+		logger.Received(1).WriteLine(Arg.Is<string>(message => message.Contains("coreVersion", StringComparison.Ordinal)));
+		logger.Received(1).WriteWarning(Arg.Is<string>(message =>
+			message.Contains("compatibility could not be determined", StringComparison.Ordinal)
+			&& !message.Contains("cliogate-json-secret", StringComparison.Ordinal)));
 		logger.DidNotReceive().WriteError(Arg.Any<string>());
 	}
 }

--- a/clio.tests/Command/GetInfoCommand.cs
+++ b/clio.tests/Command/GetInfoCommand.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Clio.Command;
 using Clio.Common;
 using FluentAssertions;
@@ -44,9 +47,10 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 				Arg.Is<string>(u => u.Contains(GetSysInfoMarker)), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(response);
 
-	private static GetCreatioInfoCommand CreateCommand(IApplicationClient client, IClioGateway gateway, ILogger logger = null)
+	private static GetCreatioInfoCommand CreateCommand(IApplicationClient client, IClioGateway gateway,
+		ILogger logger = null, string uri = "https://creatio.test")
 	{
-		EnvironmentSettings env = new() { Uri = "https://creatio.test", IsNetCore = true };
+		EnvironmentSettings env = new() { Uri = uri, IsNetCore = true };
 		return new GetCreatioInfoCommand(client, env, gateway) { Logger = logger ?? Substitute.For<ILogger>() };
 	}
 
@@ -213,7 +217,8 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 				Arg.Is<string>(u => u.Contains(ApplicationInfoMarker)),
 				Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("""{ "applicationInfo": { } }""");
-		GetCreatioInfoCommand command = CreateCommand(client, gateway: null);
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
 
 		// Act
 		int result = command.Execute(new GetCreatioInfoCommandOptions());
@@ -221,5 +226,256 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 		// Assert
 		result.Should().Be(1,
 			because: "an unusable ApplicationInfoService base must surface as a clean failure, not a crash");
+		logger.Received(1).WriteError("The Creatio ApplicationInfoService returned an unexpected response.");
+	}
+
+	[Test]
+	[Description("Classifies an HTML base response as a reachable non-Creatio target without exposing HTML or parser details.")]
+	public void Execute_ShouldReportNonCreatioTarget_WhenBaseResponseIsHtml()
+	{
+		// Arrange
+		const string html = "<html><body>not-creatio-secret-marker</body></html>";
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(html);
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger, "https://google.com");
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "a reachable non-Creatio target cannot produce an environment report");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("does not appear to be a Creatio application", StringComparison.Ordinal)
+			&& message.Contains("https://google.com", StringComparison.Ordinal)));
+		logger.DidNotReceive().WriteError(Arg.Is<string>(message =>
+			message.Contains("Unexpected character", StringComparison.Ordinal)
+			|| message.Contains("not-creatio-secret-marker", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies a plain non-JSON base response as a reachable non-Creatio target.")]
+	public void Execute_ShouldReportNonCreatioTarget_WhenBaseResponseIsPlainText()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("plain text response");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "plain non-JSON content is not a usable Creatio response");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("does not appear to be a Creatio application", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies malformed JSON from ApplicationInfoService with the stable unexpected-response error.")]
+	public void Execute_ShouldReportUnexpectedResponse_WhenBaseJsonIsMalformed()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("{\"applicationInfo\":");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "malformed JSON cannot be trusted as a Creatio report");
+		logger.Received(1).WriteError("The Creatio ApplicationInfoService returned an unexpected response.");
+		logger.DidNotReceive().WriteError(Arg.Is<string>(message => message.Contains("JsonReaderException", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies an HTTP transport exception as an unavailable Creatio target.")]
+	public void Execute_ShouldReportConnectionFailure_WhenBaseProbeThrowsHttpRequestException()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new HttpRequestException("secret transport implementation detail"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "an unreachable target cannot produce a base Creatio report");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Could not connect to the Creatio application", StringComparison.Ordinal)
+			&& !message.Contains("secret transport", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies a request timeout as an unavailable Creatio target.")]
+	public void Execute_ShouldReportConnectionFailure_WhenBaseProbeTimesOut()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new TaskCanceledException("secret timeout detail"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "a timed-out base probe did not establish a Creatio report");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Could not connect to the Creatio application", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies rejected basic-auth credentials separately from non-Creatio and transport failures.")]
+	public void Execute_ShouldReportAuthenticationFailure_WhenBaseProbeRejectsCredentials()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new UnauthorizedAccessException("Unauthorized secret-user for secret-url"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "invalid credentials are a caller-actionable authentication failure");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Authentication failed", StringComparison.Ordinal)
+			&& message.Contains("Verify the credentials", StringComparison.Ordinal)
+			&& !message.Contains("secret-user", StringComparison.Ordinal)));
+	}
+
+	[TestCase(HttpStatusCode.Unauthorized)]
+	[TestCase(HttpStatusCode.Forbidden)]
+	[Description("Classifies HTTP authentication status codes separately from transport and non-Creatio failures.")]
+	public void Execute_ShouldReportAuthenticationFailure_WhenBaseProbeReturnsAuthenticationStatus(
+		HttpStatusCode status)
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new HttpRequestException("secret HTTP detail", null, status));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "HTTP 401/403 means the caller must correct authentication settings");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Authentication failed", StringComparison.Ordinal)
+			&& !message.Contains("secret HTTP detail", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Classifies Creatio's session-expired HTML response as authentication failure before parsing.")]
+	public void Execute_ShouldReportAuthenticationFailure_WhenBaseResponseIsLoginPage()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("<html><form action=\"/0/Login/NuiLogin.aspx\">secret-login-body</form></html>");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "a Creatio login page means authentication failed, not that the URL is non-Creatio");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Authentication failed", StringComparison.Ordinal)));
+		logger.DidNotReceive().WriteError(Arg.Is<string>(message => message.Contains("secret-login-body", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Rejects malformed and unsupported application URIs before sending the base probe.")]
+	public void Execute_ShouldRejectUriBeforeProbe_WhenUriIsNotHttpOrHttps()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger, "ftp://files.example.test");
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "ApplicationInfoService is supported only over absolute HTTP or HTTPS URLs");
+		logger.Received(1).WriteError("The application URL is invalid. Use an absolute HTTP or HTTPS URL.");
+		client.DidNotReceive().ExecutePostRequest(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[NonParallelizable]
+	[Description("Debug diagnostics expose only safe classification metadata and redact URI user-info, query values, exception messages, and response bodies.")]
+	public void Execute_ShouldKeepDebugDiagnosticsSecretSafe_WhenBaseProbeFails()
+	{
+		// Arrange
+		bool originalDebugMode = Program.IsDebugMode;
+		Program.IsDebugMode = true;
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Throws(new AggregateException(new HttpRequestException("token=exception-secret")));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger,
+			"https://user:password@creatio.test/site?token=query-secret#fragment-secret");
+
+		try {
+			// Act
+			int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+			// Assert
+			result.Should().Be(1, because: "the wrapped transport failure is still an unavailable target");
+			logger.Received(1).WriteError(Arg.Is<string>(message =>
+				message.Contains("https://creatio.test", StringComparison.Ordinal)
+				&& !message.Contains("user", StringComparison.Ordinal)
+				&& !message.Contains("password", StringComparison.Ordinal)
+				&& !message.Contains("/site", StringComparison.Ordinal)
+				&& !message.Contains("query-secret", StringComparison.Ordinal)));
+			logger.Received(1).WriteDebug(Arg.Is<string>(message =>
+				message.Contains("classification=Connection", StringComparison.Ordinal)
+				&& message.Contains(nameof(HttpRequestException), StringComparison.Ordinal)
+				&& !message.Contains("exception-secret", StringComparison.Ordinal)
+				&& !message.Contains("query-secret", StringComparison.Ordinal)));
+		} finally {
+			Program.IsDebugMode = originalDebugMode;
+		}
+	}
+
+	[Test]
+	[Description("Keeps a successful base report when the optional ClioGate compatibility check fails.")]
+	public void Execute_ShouldReturnBaseReport_WhenCliogateCompatibilityCheckFails()
+	{
+		// Arrange
+		IApplicationClient client = SubstituteClient();
+		IClioGateway gateway = Substitute.For<IClioGateway>();
+		gateway.IsCompatibleWith(Arg.Any<string>()).Throws(new HttpRequestException("secret cliogate failure"));
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(0, because: "optional ClioGate compatibility cannot invalidate a successful base report");
+		logger.Received(1).WriteLine(Arg.Is<string>(message => message.Contains("coreVersion", StringComparison.Ordinal)));
+		logger.Received(1).WriteWarning(Arg.Is<string>(message =>
+			message.Contains("compatibility could not be determined", StringComparison.Ordinal)));
+		logger.DidNotReceive().WriteError(Arg.Any<string>());
 	}
 }

--- a/clio.tests/Command/GetInfoCommand.cs
+++ b/clio.tests/Command/GetInfoCommand.cs
@@ -294,6 +294,28 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 			message.Contains("does not appear to be a Creatio application", StringComparison.Ordinal)));
 	}
 
+	[TestCase("true story")]
+	[TestCase("null-route")]
+	[TestCase("- backend unavailable")]
+	[Description("Classifies literal-prefixed plain text as a reachable non-Creatio response.")]
+	public void Execute_ShouldReportNonCreatioTarget_WhenPlainTextStartsLikeJsonLiteral(string response)
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(response);
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "literal-prefixed server text is not a JSON Creatio response");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("does not appear to be a Creatio application", StringComparison.Ordinal)));
+	}
+
 	[Test]
 	[Description("Rejects a sysValues object without the required coreVersion base signature.")]
 	public void Execute_ShouldReportUnexpectedResponse_WhenBaseReportHasNoCoreVersion()

--- a/clio.tests/Command/GetInfoCommand.cs
+++ b/clio.tests/Command/GetInfoCommand.cs
@@ -275,6 +275,45 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 	}
 
 	[Test]
+	[Description("Classifies digit-prefixed plain text as a reachable non-Creatio response rather than malformed JSON.")]
+	public void Execute_ShouldReportNonCreatioTarget_WhenBaseResponseStartsWithDigit()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("404 Not Found");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "digit-prefixed server text is non-JSON content from a reachable non-Creatio target");
+		logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("does not appear to be a Creatio application", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Rejects a sysValues object without the required coreVersion base signature.")]
+	public void Execute_ShouldReportUnexpectedResponse_WhenBaseReportHasNoCoreVersion()
+	{
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("""{ "applicationInfo": { "sysValues": { } } }""");
+		ILogger logger = Substitute.For<ILogger>();
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger);
+
+		// Act
+		int result = command.Execute(new GetCreatioInfoCommandOptions());
+
+		// Assert
+		result.Should().Be(1, because: "an empty sysValues object cannot establish a usable Creatio base report");
+		logger.Received(1).WriteError("The Creatio ApplicationInfoService returned an unexpected response.");
+	}
+
+	[Test]
 	[Description("Classifies malformed JSON from ApplicationInfoService with the stable unexpected-response error.")]
 	public void Execute_ShouldReportUnexpectedResponse_WhenBaseJsonIsMalformed()
 	{
@@ -401,14 +440,15 @@ public class GetInfoCommandTests : BaseCommandTests<GetCreatioInfoCommandOptions
 		logger.DidNotReceive().WriteError(Arg.Is<string>(message => message.Contains("secret-login-body", StringComparison.Ordinal)));
 	}
 
-	[Test]
+	[TestCase("ftp://files.example.test")]
+	[TestCase("not-a-uri")]
 	[Description("Rejects malformed and unsupported application URIs before sending the base probe.")]
-	public void Execute_ShouldRejectUriBeforeProbe_WhenUriIsNotHttpOrHttps()
+	public void Execute_ShouldRejectUriBeforeProbe_WhenUriIsNotHttpOrHttps(string uri)
 	{
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		ILogger logger = Substitute.For<ILogger>();
-		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger, "ftp://files.example.test");
+		GetCreatioInfoCommand command = CreateCommand(client, gateway: null, logger, uri);
 
 		// Act
 		int result = command.Execute(new GetCreatioInfoCommandOptions());

--- a/clio.tests/Command/McpServer/GetCreatioInfoToolTests.cs
+++ b/clio.tests/Command/McpServer/GetCreatioInfoToolTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using Clio.Command;
+using Clio.Command.McpServer.Resources;
 using Clio.Command.McpServer.Tools;
 using Clio.Common;
 using FluentAssertions;
@@ -22,12 +23,13 @@ public sealed class GetCreatioInfoToolTests {
 	// Builds the REAL (sealed) GetCreatioInfoCommand backed by a substituted client so the tool's
 	// resolve -> execute path runs end to end without I/O. The cliogate path is disabled (incompatible)
 	// so the command reports the ApplicationInfoService base and returns success.
-	private static GetCreatioInfoCommand CreateRealCommand(out IApplicationClient client) {
+	private static GetCreatioInfoCommand CreateRealCommand(out IApplicationClient client,
+		string applicationInfoResponse = ApplicationInfoResponse) {
 		client = Substitute.For<IApplicationClient>();
 		client.ExecutePostRequest(
 				Arg.Is<string>(url => url.Contains(ApplicationInfoMarker)),
 				Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
-			.Returns(ApplicationInfoResponse);
+			.Returns(applicationInfoResponse);
 		IClioGateway gateway = Substitute.For<IClioGateway>();
 		gateway.IsCompatibleWith(Arg.Any<string>()).Returns(false);
 		EnvironmentSettings env = new() { Uri = "https://creatio.test", IsNetCore = true };
@@ -67,6 +69,41 @@ public sealed class GetCreatioInfoToolTests {
 				because: "the MCP tool should return the real describe-environment command exit code");
 			commandResolver.Received(1).Resolve<GetCreatioInfoCommand>(Arg.Is<EnvironmentOptions>(options =>
 				options.Environment == "sandbox"));
+		} finally {
+			ConsoleLogger.Instance.ClearMessages();
+		}
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Returns the command's actionable non-Creatio classification as an Error log in the standard MCP execution envelope.")]
+	public void GetInfo_ShouldReturnClassifiedError_WhenResolvedCommandReceivesHtml() {
+		// Arrange
+		ConsoleLogger.Instance.ClearMessages();
+		GetCreatioInfoCommand resolvedCommand = CreateRealCommand(
+			out _, "<html><body>not-creatio-secret-marker</body></html>");
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<GetCreatioInfoCommand>(Arg.Any<EnvironmentOptions>())
+			.Returns(resolvedCommand);
+		GetCreatioInfoTool tool = new(ConsoleLogger.Instance, commandResolver);
+
+		try {
+			// Act
+			CommandExecutionResult result = tool.GetInfo(new GetCreatioInfoArgs(EnvironmentName: "sandbox"));
+
+			// Assert
+			result.ExitCode.Should().Be(1,
+				because: "the MCP envelope must preserve the failed get-info command exit code");
+			result.Output.Should().Contain(message =>
+				message.LogDecoratorType == LogDecoratorType.Error
+				&& message.Value != null
+				&& message.Value.ToString()!.Contains(
+					"does not appear to be a Creatio application", System.StringComparison.Ordinal),
+				because: "MCP callers need the same actionable non-Creatio classification as CLI callers");
+			result.Output.Should().NotContain(message =>
+				message.Value != null
+				&& message.Value.ToString()!.Contains("not-creatio-secret-marker", System.StringComparison.Ordinal),
+				because: "raw response bodies must not cross the MCP error envelope");
 		} finally {
 			ConsoleLogger.Instance.ClearMessages();
 		}
@@ -155,5 +192,23 @@ public sealed class GetCreatioInfoToolTests {
 			because: "the description must state the shape is the same with or without cliogate");
 		description.Description.Should().Contain("get-guidance name=describe-environment",
 			because: "the description should point the agent at the field-catalogue guidance");
+		description.Description.Should().Contain("authentication failures",
+			because: "the tool contract should tell agents that required-probe failures are classified actionably");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Keeps describe-environment guidance aligned with the command's classified and secret-safe base-probe failures.")]
+	public void Guide_ShouldDescribeClassifiedFailures_WhenReadByMcpAgent() {
+		// Act
+		string guidance = DescribeEnvironmentGuidanceResource.Guide.Text;
+
+		// Assert
+		guidance.Should().Contain("REQUIRED BASE PROBE FAILURES",
+			because: "agents need a dedicated section for interpreting exit-code-1 base-probe results");
+		guidance.Should().Contain("Authentication",
+			because: "authentication failures must remain distinguishable from non-Creatio targets");
+		guidance.Should().Contain("never contains raw HTML",
+			because: "the guidance must preserve the secret-safe error-envelope contract");
 	}
 }

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -1,5 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using CommandLine;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Clio.Common;
 
@@ -29,6 +35,24 @@ namespace Clio.Command
 		/// <c>ApplicationInfoService</c> instead of failing.
 		/// </summary>
 		private const string ClioGateMinVersion = "2.0.0.32";
+		private const string InvalidApplicationUriMessage =
+			"The application URL is invalid. Use an absolute HTTP or HTTPS URL.";
+		private const string UnexpectedApplicationInfoResponseMessage =
+			"The Creatio ApplicationInfoService returned an unexpected response.";
+
+		private enum BaseProbeFailure {
+			Authentication,
+			Connection,
+			NonCreatio,
+			UnexpectedResponse
+		}
+
+		private enum CliogateEnrichmentState {
+			UnavailableOrIncompatible,
+			CompatibilityUnknown,
+			CompatibleWithoutData,
+			Reported
+		}
 
 		#endregion
 
@@ -56,46 +80,239 @@ namespace Clio.Command
 		/// silently and the command still reports what it has.
 		/// </summary>
 		public override int Execute(GetCreatioInfoCommandOptions options){
-			try {
-				string appInfoUrl = RootPath + CreatioServicePaths.GetApplicationInfo;
-				string appInfoResponse = ApplicationClient.ExecutePostRequest(
-					appInfoUrl, "{}", options.TimeOut, options.MaxAttempts, options.RetryDelay);
-				if (JObject.Parse(appInfoResponse)["applicationInfo"]?["sysValues"] is not JObject report){
-					Logger.WriteError("ApplicationInfoService returned an unexpected response.");
-					return 1;
-				}
-
-				// DbEngineType + framework without cliogate (admin-gated GetSystemEnvironmentInfo).
-				TryEnrichWithSystemEnvironmentInfo(report, options);
-
-				// cliogate-only fields (productName, licenseInfo) + db/framework backfill for older Creatio.
-				bool cliogateCompatible = ClioGateWay is not null
-					&& ClioGateWay.IsCompatibleWith(ClioGateMinVersion);
-				bool cliogateReported = cliogateCompatible && TryEnrichWithCliogateSysInfo(report, options);
-				if (!cliogateReported){
-					// Distinguish "not installed/incompatible" from "installed but GetSysInfo returned nothing"
-					// (typically the caller lacks CanManageSolution) — claiming "not installed" when it is would
-					// be misleading.
-					string reason = cliogateCompatible
-						? $"cliogate {ClioGateMinVersion}+ is installed but GetSysInfo returned no data "
-							+ "(the caller may lack the CanManageSolution permission)"
-						: $"cliogate {ClioGateMinVersion}+ is not installed";
-					Logger.WriteWarning(
-						$"{reason} - ProductName and LicenseInfo are unavailable. All other fields "
-						+ "(incl. DbEngineType and framework when CanManageSolution is granted) are reported.");
-				}
-
-				Logger.WriteLine(report.ToString());
-				return 0;
-			} catch (Exception e){
-				Logger.WriteError(e.GetReadableMessageException(Program.IsDebugMode));
+			if (!TryGetSafeTargetUri(out Uri targetUri)) {
+				Logger.WriteError(InvalidApplicationUriMessage);
 				return 1;
 			}
+			if (!TryGetBaseReport(targetUri, options, out JObject report)) {
+				return 1;
+			}
+
+			// DbEngineType + framework without cliogate (admin-gated GetSystemEnvironmentInfo).
+			TryEnrichWithSystemEnvironmentInfo(report, options);
+
+			// cliogate-only fields (productName, licenseInfo) + db/framework backfill for older Creatio.
+			CliogateEnrichmentState cliogateState = TryEnrichFromCliogate(report, options);
+			if (cliogateState != CliogateEnrichmentState.Reported){
+				string reason = cliogateState switch {
+					CliogateEnrichmentState.CompatibleWithoutData =>
+						$"cliogate {ClioGateMinVersion}+ is installed but GetSysInfo returned no data "
+						+ "(the caller may lack the CanManageSolution permission)",
+					CliogateEnrichmentState.CompatibilityUnknown =>
+						"cliogate compatibility could not be determined",
+					_ => $"cliogate {ClioGateMinVersion}+ is not installed or is incompatible"
+				};
+				Logger.WriteWarning(
+					$"{reason} - ProductName and LicenseInfo are unavailable. All other fields "
+					+ "(incl. DbEngineType and framework when CanManageSolution is granted) are reported.");
+			}
+
+			Logger.WriteLine(report.ToString());
+			return 0;
 		}
 
 		#endregion
 
 		#region Methods: Private
+
+		private static IEnumerable<Exception> EnumerateExceptionChain(Exception exception) {
+			Stack<Exception> pending = new();
+			pending.Push(exception);
+			while (pending.Count > 0) {
+				Exception current = pending.Pop();
+				yield return current;
+				if (current is AggregateException aggregateException) {
+					foreach (Exception inner in aggregateException.InnerExceptions.Reverse()) {
+						pending.Push(inner);
+					}
+				} else if (current.InnerException is not null) {
+					pending.Push(current.InnerException);
+				}
+			}
+		}
+
+		private BaseProbeFailure ClassifyBaseProbeException(Exception exception) {
+			IReadOnlyList<Exception> chain = EnumerateExceptionChain(exception).ToArray();
+			if (chain.Any(item => item is UnauthorizedAccessException)
+					|| TryGetHttpStatus(chain, out HttpStatusCode authStatus)
+					&& authStatus is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden) {
+				return BaseProbeFailure.Authentication;
+			}
+			if (TryGetHttpStatus(chain, out HttpStatusCode status)) {
+				if (status is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed) {
+					return BaseProbeFailure.NonCreatio;
+				}
+				if (status is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests
+						or HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable
+						or HttpStatusCode.GatewayTimeout) {
+					return BaseProbeFailure.Connection;
+				}
+				return BaseProbeFailure.UnexpectedResponse;
+			}
+			if (chain.Any(item => item is TaskCanceledException or TimeoutException or HttpRequestException)) {
+				return BaseProbeFailure.Connection;
+			}
+			if (chain.OfType<WebException>().Any(IsConnectionFailure)) {
+				return BaseProbeFailure.Connection;
+			}
+			return BaseProbeFailure.UnexpectedResponse;
+		}
+
+		private static string GetDisplayUri(Uri uri) {
+			UriBuilder builder = new(uri) {
+				UserName = string.Empty,
+				Password = string.Empty,
+				Path = string.Empty,
+				Query = string.Empty,
+				Fragment = string.Empty
+			};
+			return builder.Uri.GetLeftPart(UriPartial.Authority);
+		}
+
+		private static bool IsClearlyNonCreatioContent(string response) {
+			if (string.IsNullOrWhiteSpace(response)) {
+				return false;
+			}
+			string trimmed = response.TrimStart();
+			char first = trimmed[0];
+			bool hasJsonStart = first is '{' or '[' or '"' or '-' || char.IsDigit(first)
+				|| trimmed.StartsWith("true", StringComparison.Ordinal)
+				|| trimmed.StartsWith("false", StringComparison.Ordinal)
+				|| trimmed.StartsWith("null", StringComparison.Ordinal);
+			return !hasJsonStart;
+		}
+
+		private static bool IsConnectionFailure(WebException exception) => exception.Status is
+			WebExceptionStatus.ConnectFailure or
+			WebExceptionStatus.ConnectionClosed or
+			WebExceptionStatus.KeepAliveFailure or
+			WebExceptionStatus.NameResolutionFailure or
+			WebExceptionStatus.ProxyNameResolutionFailure or
+			WebExceptionStatus.ReceiveFailure or
+			WebExceptionStatus.RequestCanceled or
+			WebExceptionStatus.SecureChannelFailure or
+			WebExceptionStatus.SendFailure or
+			WebExceptionStatus.Timeout or
+			WebExceptionStatus.TrustFailure;
+
+		private void ReportBaseProbeFailure(BaseProbeFailure failure, Uri targetUri, Exception exception = null,
+			int? responseLength = null) {
+			string displayUri = GetDisplayUri(targetUri);
+			string message = failure switch {
+				BaseProbeFailure.Authentication =>
+					$"Authentication failed for the Creatio application at '{displayUri}'. "
+					+ "Verify the credentials and authentication settings.",
+				BaseProbeFailure.Connection =>
+					$"Could not connect to the Creatio application at '{displayUri}'. "
+					+ "Verify the URL and make sure the application is running.",
+				BaseProbeFailure.NonCreatio =>
+					$"The URL '{displayUri}' does not appear to be a Creatio application. "
+					+ "Verify the application URL and try again.",
+				_ => UnexpectedApplicationInfoResponseMessage
+			};
+			Logger.WriteError(message);
+			WriteSafeDebug("base-probe", failure, exception, responseLength);
+		}
+
+		private bool TryGetBaseReport(Uri targetUri, GetCreatioInfoCommandOptions options, out JObject report) {
+			report = null;
+			string response;
+			try {
+				string appInfoUrl = RootPath + CreatioServicePaths.GetApplicationInfo;
+				response = ApplicationClient.ExecutePostRequest(
+					appInfoUrl, "{}", options.TimeOut, options.MaxAttempts, options.RetryDelay);
+			} catch (Exception exception) {
+				ReportBaseProbeFailure(ClassifyBaseProbeException(exception), targetUri, exception);
+				return false;
+			}
+
+			if (ReauthExecutor.IsSessionExpiredResponse(response)) {
+				ReportBaseProbeFailure(BaseProbeFailure.Authentication, targetUri, responseLength: response?.Length);
+				return false;
+			}
+
+			JToken root;
+			try {
+				root = JToken.Parse(response ?? string.Empty);
+			} catch (JsonException exception) {
+				BaseProbeFailure failure = IsClearlyNonCreatioContent(response)
+					? BaseProbeFailure.NonCreatio
+					: BaseProbeFailure.UnexpectedResponse;
+				ReportBaseProbeFailure(failure, targetUri, exception, response?.Length);
+				return false;
+			}
+
+			if (root is not JObject rootObject
+					|| rootObject["applicationInfo"]?["sysValues"] is not JObject baseReport) {
+				ReportBaseProbeFailure(BaseProbeFailure.UnexpectedResponse, targetUri,
+					responseLength: response?.Length);
+				return false;
+			}
+			report = baseReport;
+			return true;
+		}
+
+		private bool TryGetSafeTargetUri(out Uri targetUri) {
+			return Uri.TryCreate(EnvironmentSettings?.Uri, UriKind.Absolute, out targetUri)
+				&& (string.Equals(targetUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+					|| string.Equals(targetUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
+		}
+
+		private static bool TryGetHttpStatus(IEnumerable<Exception> exceptions, out HttpStatusCode status) {
+			foreach (Exception exception in exceptions) {
+				if (exception is HttpRequestException { StatusCode: { } httpStatus }) {
+					status = httpStatus;
+					return true;
+				}
+				if (exception is WebException { Response: HttpWebResponse response }) {
+					status = response.StatusCode;
+					return true;
+				}
+			}
+			status = default;
+			return false;
+		}
+
+		private void WriteSafeDebug(string stage, BaseProbeFailure failure, Exception exception = null,
+			int? responseLength = null) {
+			if (!Program.IsDebugMode) {
+				return;
+			}
+			string exceptionTypes = exception is null
+				? "none"
+				: string.Join(" -> ", EnumerateExceptionChain(exception)
+					.Select(item => item.GetType().FullName)
+					.Distinct(StringComparer.Ordinal));
+			IReadOnlyList<Exception> exceptionChain = exception is null
+				? []
+				: EnumerateExceptionChain(exception).ToArray();
+			string status = TryGetHttpStatus(exceptionChain, out HttpStatusCode httpStatus)
+				? $"{(int)httpStatus} ({httpStatus})"
+				: "none";
+			Logger.WriteDebug(
+				$"get-info {stage}: classification={failure}; exception-types={exceptionTypes}; "
+				+ $"http-status={status}; response-length={responseLength?.ToString() ?? "unknown"}.");
+		}
+
+		private CliogateEnrichmentState TryEnrichFromCliogate(
+			JObject report, GetCreatioInfoCommandOptions options) {
+			if (ClioGateWay is null) {
+				return CliogateEnrichmentState.UnavailableOrIncompatible;
+			}
+			bool compatible;
+			try {
+				compatible = ClioGateWay.IsCompatibleWith(ClioGateMinVersion);
+			} catch (Exception exception) {
+				WriteSafeDebug("cliogate-compatibility", BaseProbeFailure.UnexpectedResponse, exception);
+				return CliogateEnrichmentState.CompatibilityUnknown;
+			}
+			if (!compatible) {
+				return CliogateEnrichmentState.UnavailableOrIncompatible;
+			}
+			return TryEnrichWithCliogateSysInfo(report, options)
+				? CliogateEnrichmentState.Reported
+				: CliogateEnrichmentState.CompatibleWithoutData;
+		}
 
 		/// <summary>
 		/// Best-effort: the admin-gated <c>ApplicationInfoService.GetSystemEnvironmentInfo</c> operation
@@ -126,9 +343,7 @@ namespace Clio.Command
 			} catch (Exception e){
 				// Degrade silently — the ApplicationInfoService base is already reported. Surface the reason
 				// only under --debug so an access/transport failure is diagnosable without polluting normal output.
-				if (Program.IsDebugMode){
-					Logger.WriteWarning($"GetSystemEnvironmentInfo skipped: {e.Message}");
-				}
+				WriteSafeDebug("system-environment-enrichment", BaseProbeFailure.UnexpectedResponse, e);
 			}
 		}
 
@@ -168,9 +383,7 @@ namespace Clio.Command
 			} catch (Exception e){
 				// Degrade silently — the base + GetSystemEnvironmentInfo data is already reported. Surface the
 				// reason only under --debug so an access/transport failure is diagnosable.
-				if (Program.IsDebugMode){
-					Logger.WriteWarning($"cliogate GetSysInfo skipped: {e.Message}");
-				}
+				WriteSafeDebug("cliogate-sysinfo-enrichment", BaseProbeFailure.UnexpectedResponse, e);
 				return false;
 			}
 		}

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -174,13 +174,16 @@ namespace Clio.Command
 				return false;
 			}
 			string trimmed = response.TrimStart();
-			char first = trimmed[0];
-			bool hasJsonStart = first is '{' or '[' or '"' or '-' || char.IsDigit(first)
-				|| trimmed.StartsWith("true", StringComparison.Ordinal)
-				|| trimmed.StartsWith("false", StringComparison.Ordinal)
-				|| trimmed.StartsWith("null", StringComparison.Ordinal);
-			return !hasJsonStart;
+			// ApplicationInfoService must return an object. A broken object/array-shaped payload is
+			// therefore malformed JSON, while text such as "404 Not Found" is plainly a non-Creatio
+			// response even though JSON itself permits a top-level number or string.
+			return trimmed[0] is not ('{' or '[');
 		}
+
+		private static bool IsExpectedRemoteFailure(Exception exception) =>
+			EnumerateExceptionChain(exception).Any(item => item is
+				UnauthorizedAccessException or TaskCanceledException or TimeoutException or
+				HttpRequestException or WebException or JsonException);
 
 		private static bool IsConnectionFailure(WebException exception) => exception.Status is
 			WebExceptionStatus.ConnectFailure or
@@ -221,7 +224,7 @@ namespace Clio.Command
 				string appInfoUrl = RootPath + CreatioServicePaths.GetApplicationInfo;
 				response = ApplicationClient.ExecutePostRequest(
 					appInfoUrl, "{}", options.TimeOut, options.MaxAttempts, options.RetryDelay);
-			} catch (Exception exception) {
+			} catch (Exception exception) when (IsExpectedRemoteFailure(exception)) {
 				ReportBaseProbeFailure(ClassifyBaseProbeException(exception), targetUri, exception);
 				return false;
 			}
@@ -243,7 +246,9 @@ namespace Clio.Command
 			}
 
 			if (root is not JObject rootObject
-					|| rootObject["applicationInfo"]?["sysValues"] is not JObject baseReport) {
+					|| rootObject["applicationInfo"]?["sysValues"] is not JObject baseReport
+					|| baseReport["coreVersion"]?.Type != JTokenType.String
+					|| string.IsNullOrWhiteSpace(baseReport["coreVersion"]?.Value<string>())) {
 				ReportBaseProbeFailure(BaseProbeFailure.UnexpectedResponse, targetUri,
 					responseLength: response?.Length);
 				return false;
@@ -302,7 +307,7 @@ namespace Clio.Command
 			bool compatible;
 			try {
 				compatible = ClioGateWay.IsCompatibleWith(ClioGateMinVersion);
-			} catch (Exception exception) {
+			} catch (Exception exception) when (IsExpectedRemoteFailure(exception)) {
 				WriteSafeDebug("cliogate-compatibility", BaseProbeFailure.UnexpectedResponse, exception);
 				return CliogateEnrichmentState.CompatibilityUnknown;
 			}
@@ -340,7 +345,7 @@ namespace Clio.Command
 						report[field] = value;
 					}
 				}
-			} catch (Exception e){
+			} catch (Exception e) when (IsExpectedRemoteFailure(e)){
 				// Degrade silently — the ApplicationInfoService base is already reported. Surface the reason
 				// only under --debug so an access/transport failure is diagnosable without polluting normal output.
 				WriteSafeDebug("system-environment-enrichment", BaseProbeFailure.UnexpectedResponse, e);
@@ -380,7 +385,7 @@ namespace Clio.Command
 					report["frameworkKind"] = sysInfo["IsNetCore"].Value<bool>() ? "Net" : "NetFramework";
 				}
 				return true;
-			} catch (Exception e){
+			} catch (Exception e) when (IsExpectedRemoteFailure(e)){
 				// Degrade silently — the base + GetSystemEnvironmentInfo data is already reported. Surface the
 				// reason only under --debug so an access/transport failure is diagnosable.
 				WriteSafeDebug("cliogate-sysinfo-enrichment", BaseProbeFailure.UnexpectedResponse, e);

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -174,16 +174,21 @@ namespace Clio.Command
 				return false;
 			}
 			string trimmed = response.TrimStart();
-			// ApplicationInfoService must return an object. A broken object/array-shaped payload is
-			// therefore malformed JSON, while text such as "404 Not Found" is plainly a non-Creatio
-			// response even though JSON itself permits a top-level number or string.
-			return trimmed[0] is not ('{' or '[');
+			// ApplicationInfoService must return an object. Preserve malformed-JSON classification for
+			// every unmistakable JSON token prefix, but treat digit-prefixed text such as "404 Not Found"
+			// as non-Creatio. A valid numeric JSON scalar parses successfully and is rejected by shape.
+			char first = trimmed[0];
+			bool hasJsonStart = first is '{' or '[' or '"' or '-'
+				|| trimmed.StartsWith("true", StringComparison.Ordinal)
+				|| trimmed.StartsWith("false", StringComparison.Ordinal)
+				|| trimmed.StartsWith("null", StringComparison.Ordinal);
+			return !hasJsonStart;
 		}
 
-		private static bool IsExpectedRemoteFailure(Exception exception) =>
-			EnumerateExceptionChain(exception).Any(item => item is
-				UnauthorizedAccessException or TaskCanceledException or TimeoutException or
-				HttpRequestException or WebException or JsonException);
+		private static bool IsRecoverable(Exception exception) =>
+			!EnumerateExceptionChain(exception).Any(item => item is
+				OutOfMemoryException or StackOverflowException or AccessViolationException or
+				NullReferenceException or IndexOutOfRangeException);
 
 		private static bool IsConnectionFailure(WebException exception) => exception.Status is
 			WebExceptionStatus.ConnectFailure or
@@ -224,7 +229,7 @@ namespace Clio.Command
 				string appInfoUrl = RootPath + CreatioServicePaths.GetApplicationInfo;
 				response = ApplicationClient.ExecutePostRequest(
 					appInfoUrl, "{}", options.TimeOut, options.MaxAttempts, options.RetryDelay);
-			} catch (Exception exception) when (IsExpectedRemoteFailure(exception)) {
+			} catch (Exception exception) when (IsRecoverable(exception)) {
 				ReportBaseProbeFailure(ClassifyBaseProbeException(exception), targetUri, exception);
 				return false;
 			}
@@ -307,7 +312,7 @@ namespace Clio.Command
 			bool compatible;
 			try {
 				compatible = ClioGateWay.IsCompatibleWith(ClioGateMinVersion);
-			} catch (Exception exception) when (IsExpectedRemoteFailure(exception)) {
+			} catch (Exception exception) when (IsRecoverable(exception)) {
 				WriteSafeDebug("cliogate-compatibility", BaseProbeFailure.UnexpectedResponse, exception);
 				return CliogateEnrichmentState.CompatibilityUnknown;
 			}
@@ -337,7 +342,7 @@ namespace Clio.Command
 				string response = ApplicationClient.ExecutePostRequest(
 					url, "{}", options.TimeOut, maxAttempts: 1, delaySec: 0);
 				JObject info = JObject.Parse(response);
-				if (info["success"]?.Value<bool>() != true){
+				if (info["success"]?.Type != JTokenType.Boolean || info["success"]?.Value<bool>() != true){
 					return;
 				}
 				foreach (string field in new[] { "dbEngineType", "frameworkKind", "frameworkDescription" }){
@@ -345,7 +350,7 @@ namespace Clio.Command
 						report[field] = value;
 					}
 				}
-			} catch (Exception e) when (IsExpectedRemoteFailure(e)){
+			} catch (Exception e) when (IsRecoverable(e)){
 				// Degrade silently — the ApplicationInfoService base is already reported. Surface the reason
 				// only under --debug so an access/transport failure is diagnosable without polluting normal output.
 				WriteSafeDebug("system-environment-enrichment", BaseProbeFailure.UnexpectedResponse, e);
@@ -385,7 +390,7 @@ namespace Clio.Command
 					report["frameworkKind"] = sysInfo["IsNetCore"].Value<bool>() ? "Net" : "NetFramework";
 				}
 				return true;
-			} catch (Exception e) when (IsExpectedRemoteFailure(e)){
+			} catch (Exception e) when (IsRecoverable(e)){
 				// Degrade silently — the base + GetSystemEnvironmentInfo data is already reported. Surface the
 				// reason only under --debug so an access/transport failure is diagnosable.
 				WriteSafeDebug("cliogate-sysinfo-enrichment", BaseProbeFailure.UnexpectedResponse, e);

--- a/clio/Command/GetCreatioInfoCommand.cs
+++ b/clio/Command/GetCreatioInfoCommand.cs
@@ -174,15 +174,11 @@ namespace Clio.Command
 				return false;
 			}
 			string trimmed = response.TrimStart();
-			// ApplicationInfoService must return an object. Preserve malformed-JSON classification for
-			// every unmistakable JSON token prefix, but treat digit-prefixed text such as "404 Not Found"
-			// as non-Creatio. A valid numeric JSON scalar parses successfully and is rejected by shape.
-			char first = trimmed[0];
-			bool hasJsonStart = first is '{' or '[' or '"' or '-'
-				|| trimmed.StartsWith("true", StringComparison.Ordinal)
-				|| trimmed.StartsWith("false", StringComparison.Ordinal)
-				|| trimmed.StartsWith("null", StringComparison.Ordinal);
-			return !hasJsonStart;
+			// ApplicationInfoService must return an object. Object/array/quoted token prefixes are
+			// unmistakably JSON-like when parsing fails; literal-looking plain text such as
+			// "true story", "null-route", "- backend unavailable", or "404 Not Found" is not.
+			// Valid JSON scalars parse successfully and are rejected later by the required object shape.
+			return trimmed[0] is not ('{' or '[' or '"');
 		}
 
 		private static bool IsRecoverable(Exception exception) =>

--- a/clio/Command/McpServer/Resources/DescribeEnvironmentGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DescribeEnvironmentGuidanceResource.cs
@@ -31,6 +31,16 @@ public sealed class DescribeEnvironmentGuidanceResource {
 		       - Target the environment with environment-name (PREFERRED). uri/login/password is an emergency
 		         fallback only when no environment is registered.
 
+		       REQUIRED BASE PROBE FAILURES (exit 1)
+		       - Invalid URI          -> use an absolute HTTP or HTTPS application URL.
+		       - Unreachable/timeout  -> verify the URL and make sure the application is running.
+		       - Authentication       -> verify credentials and authentication settings.
+		       - Reachable non-Creatio content -> the URL does not appear to be a Creatio application.
+		       - Malformed/unusable ApplicationInfoService response -> stable unexpected-response error.
+		       These classifications are identical through CLI aliases and the MCP error envelope. Normal output
+		       never contains raw HTML, response bodies, parser exceptions, credentials, cookies, or tokens.
+		       Debug output adds only safe classification/type/status metadata.
+
 		       BEST-EFFORT CONTRACT (exit 0 even when an optional source is missing)
 		       The report is assembled from up to three sources, in order. A field's ABSENCE means the source
 		       that supplies it was unavailable (older Creatio, cliogate not installed, or the caller lacks the

--- a/clio/Command/McpServer/Resources/GuidanceCatalog.cs
+++ b/clio/Command/McpServer/Resources/GuidanceCatalog.cs
@@ -141,7 +141,7 @@ internal static class GuidanceCatalog {
 				DeployLifecycleGuidanceResource.Guide),
 			["describe-environment"] = Create(
 				"describe-environment",
-				"Canonical MCP guidance for describe-environment: the single source-independent environment report (coreVersion, db engine, framework, productName, licenseInfo, locale/workspace metadata), which source supplies each field, and the cliogate / CanManageSolution prerequisites.",
+				"Canonical MCP guidance for describe-environment: classified base-probe failures, the single source-independent environment report (coreVersion, db engine, framework, productName, licenseInfo, locale/workspace metadata), which source supplies each field, and the cliogate / CanManageSolution prerequisites.",
 				DescribeEnvironmentGuidanceResource.Guide),
 			["support-mode"] = Create(
 				"support-mode",

--- a/clio/Command/McpServer/Tools/GetCreatioInfoTool.cs
+++ b/clio/Command/McpServer/Tools/GetCreatioInfoTool.cs
@@ -49,7 +49,10 @@ public sealed class GetCreatioInfoTool(
 				 same with or without cliogate, so an agent can reason about every instance the same way.
 
 				 Read get-guidance name=describe-environment for the full field catalogue before interpreting
-				 the output. The report is assembled best-effort from up to three sources and the command still
+				 the output. The required ApplicationInfoService probe classifies invalid/unavailable targets,
+				 authentication failures, non-Creatio content, and malformed Creatio responses separately; these
+				 return exit 1 with an actionable Error log and never expose raw response/parser details or
+				 misleading cliogate guidance. The report is assembled best-effort from up to three sources and the command still
 				 succeeds (exit 0) when an optional source is unavailable:
 				   - ALWAYS (no cliogate, authenticated session): coreVersion plus user / culture / workspace /
 				     maintainer / environmentType metadata, from ApplicationInfoService.

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -61,7 +61,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="describe"></a>
 <a id="describe-creatio"></a>
 <a id="instance-info"></a>
-- [`get-info`](docs/commands/get-info.md) - Show system information for a Creatio instance, `describe`, `describe-creatio`, `instance-info`
+- [`get-info`](docs/commands/get-info.md) - Validate and show system information for a Creatio instance with actionable target/auth/response errors, `describe`, `describe-creatio`, `instance-info`
 <a id="get-webservice-url"></a>
 <a id="gwu"></a>
 - [`get-webservice-url`](docs/commands/get-webservice-url.md) - Show the configured base URL for a web service, `gwu`

--- a/clio/docs/commands/get-info.md
+++ b/clio/docs/commands/get-info.md
@@ -43,6 +43,13 @@ error) it is skipped silently and the command still reports what it has and
 exits 0. The only fields that strictly require cliogate are `productName` and
 `licenseInfo`.
 
+The required base probe classifies invalid URLs, unavailable applications,
+authentication failures, reachable non-Creatio URLs, and malformed Creatio
+responses separately. Normal output never prints raw response bodies, HTML,
+parser exceptions, credentials, cookies, tokens, or stack traces. `--debug`
+adds only safe classification, exception-type, HTTP-status, and response-length
+metadata.
+
 The command returns information such as:
 - Creatio version (available with or without cliogate)
 - Runtime / executing framework (.NET version) — via cliogate, or without
@@ -63,7 +70,7 @@ REQUIREMENTS:
 ## Options
 
 ```bash
--e, --Environment       Environment name from the registered configuration
+-e, --environment       Environment name from the registered configuration
 The environment must be registered using
 'reg-web-app' command (RECOMMENDED)
 
@@ -73,9 +80,9 @@ Alternative authentication (when not using -e):
 -p, --password          Password for basic authentication
 
 OR for OAuth authentication:
---clientid              OAuth Client ID
---clientsecret          OAuth Client Secret
---authappuri            OAuth Authentication App URI
+--client-id             OAuth Client ID
+--client-secret         OAuth Client Secret
+--auth-app-uri          OAuth Authentication App URI
 
 Additional options:
 --timeout               Request timeout in milliseconds (default: 100000)
@@ -90,19 +97,19 @@ clio get-info -e MyEnvironment
 # Short form using environment as positional argument
 clio get-info MyEnvironment
 
-# Using an alias command
-clio get-info -e MyEnvironment
-clio get-info -e MyEnvironment
-clio get-info MyEnvironment
+# Using alias commands
+clio describe -e MyEnvironment
+clio instance-info -e MyEnvironment
+clio describe-creatio MyEnvironment
 
 # Using direct authentication with username/password
 clio get-info -u "https://myapp.creatio.com" -l "admin" -p "password"
 
 # Using OAuth authentication
 clio get-info -u "https://myapp.creatio.com" \
---clientid "your-client-id" \
---clientsecret "your-secret" \
---authappuri "https://oauth.creatio.com"
+--client-id "your-client-id" \
+--client-secret "your-secret" \
+--auth-app-uri "https://oauth.creatio.com"
 
 # With custom timeout (60 seconds)
 clio get-info -e MyEnvironment --timeout 60000
@@ -110,25 +117,28 @@ clio get-info -e MyEnvironment --timeout 60000
 
 ## Behavior
 
-1. Sends a POST request to `ApplicationInfoService.GetApplicationInfo` and uses
-   its `sysValues` as the base report (always; no cliogate required)
-2. Enriches the report from the admin-gated
+1. Validates that the supplied application URI is an absolute HTTP or HTTPS URI
+2. Sends a POST request to `ApplicationInfoService.GetApplicationInfo`,
+   classifies transport, authentication, non-Creatio content, and
+   malformed/unusable responses, and uses valid `sysValues` as the base report
+   (no cliogate required)
+3. Enriches the report from the admin-gated
    `ApplicationInfoService.GetSystemEnvironmentInfo` (POST) — adds `dbEngineType`,
    `frameworkKind` and `frameworkDescription` (requires `CanManageSolution`)
-3. If a compatible cliogate (>= 2.0.0.32) is installed, GETs
+4. If a compatible cliogate (>= 2.0.0.32) is installed, GETs
    `/rest/CreatioApiGateway/GetSysInfo` and merges the cliogate-only `productName`
    and `licenseInfo` into the same object (and backfills db engine / framework if
-   step 2 did not provide them)
-4. Any source in steps 2–3 that is denied, absent, or errors is skipped silently
+   step 3 did not provide them)
+5. Any optional source in steps 3–4 that is denied, absent, or errors is skipped silently
    — the report still includes everything that was available
-5. Displays the single combined report as formatted JSON
+6. Displays the single combined report as formatted JSON
 
 ## Exit Codes
 
     0   Successfully retrieved and displayed system information (regardless of
         which optional sources were available)
-    1   Failed to retrieve information (environment not found, connection error,
-        or ApplicationInfoService returned an unexpected response)
+    1   Invalid URI, unavailable application, authentication failure, reachable
+        non-Creatio target, or unexpected ApplicationInfoService response
 
 ## Notes
 
@@ -146,10 +156,13 @@ clio get-info -e MyEnvironment --timeout 60000
 
     If command fails:
     - Verify environment is registered: clio list-environments
-    - Check cliogate is installed: clio install-gate -e <ENVIRONMENT>
-    - Ensure cliogate version is 2.0.0.32 or higher
-    - Verify network connectivity to Creatio instance
-    - Check credentials are valid for the registered environment
+    - "does not appear to be a Creatio application": verify the application URL
+    - "Could not connect": verify network connectivity and application health
+    - "Authentication failed": verify credentials and authentication settings
+    - "unexpected response": inspect the Creatio ApplicationInfoService health;
+      use --debug for safe diagnostic metadata
+    - Missing ProductName/LicenseInfo on an otherwise successful report: install
+      or update cliogate to 2.0.0.32+ only if those optional fields are required
 
 ## See Also
 

--- a/clio/help/en/get-info.txt
+++ b/clio/help/en/get-info.txt
@@ -104,7 +104,7 @@ BEHAVIOR
        (requires CanManageSolution)
     4. If a compatible cliogate (>= 2.0.0.32) is installed, GET
        /rest/CreatioApiGateway/GetSysInfo and merge productName + licenseInfo into
-       the same object (and backfill db engine / framework if step 2 did not)
+       the same object (and backfill db engine / framework if step 3 did not)
     5. Any optional source in steps 3-4 that is denied / absent / errors is skipped
        silently - the report still includes everything that was available
     6. Display the single combined report as formatted JSON

--- a/clio/help/en/get-info.txt
+++ b/clio/help/en/get-info.txt
@@ -27,6 +27,12 @@ DESCRIPTION
     silently and the command still reports what it has and exits 0. Only
     productName and licenseInfo strictly require cliogate.
 
+    The required base probe classifies invalid URLs, unavailable applications,
+    authentication failures, reachable non-Creatio URLs, and malformed Creatio
+    responses separately. Normal output never prints raw response bodies, HTML,
+    parser exceptions, credentials, cookies, tokens, or stack traces. --debug
+    adds only safe classification, exception-type, status, and length metadata.
+
     The command returns information such as:
     - Creatio version (with or without cliogate)
     - Runtime / executing framework (.NET version) - via cliogate, or without
@@ -45,7 +51,7 @@ DESCRIPTION
     - Valid environment configuration with proper credentials
 
 OPTIONS
-    -e, --Environment       Environment name from the registered configuration
+    -e, --environment       Environment name from the registered configuration
                             The environment must be registered using 
                             'reg-web-app' command (RECOMMENDED)
     
@@ -55,9 +61,9 @@ OPTIONS
     -p, --password          Password for basic authentication
     
     OR for OAuth authentication:
-    --clientid              OAuth Client ID
-    --clientsecret          OAuth Client Secret
-    --authappuri            OAuth Authentication App URI
+    --client-id             OAuth Client ID
+    --client-secret         OAuth Client Secret
+    --auth-app-uri          OAuth Authentication App URI
     
     Additional options:
     --timeout               Request timeout in milliseconds (default: 100000)
@@ -79,32 +85,35 @@ EXAMPLES
 
     # Using OAuth authentication
     clio get-info -u "https://myapp.creatio.com" \
-        --clientid "your-client-id" \
-        --clientsecret "your-secret" \
-        --authappuri "https://oauth.creatio.com"
+        --client-id "your-client-id" \
+        --client-secret "your-secret" \
+        --auth-app-uri "https://oauth.creatio.com"
 
     # With custom timeout (60 seconds)
     clio get-info -e MyEnvironment --timeout 60000
 
 
 BEHAVIOR
-    1. POST ApplicationInfoService.GetApplicationInfo; use its sysValues as the
-       base report (always; no cliogate required)
-    2. Enrich from the admin-gated ApplicationInfoService.GetSystemEnvironmentInfo
+    1. Validate that the supplied application URI is an absolute HTTP or HTTPS
+       URI
+    2. POST ApplicationInfoService.GetApplicationInfo and classify transport,
+       authentication, non-Creatio content, and malformed/unusable responses
+       before using sysValues as the base report (no cliogate required)
+    3. Enrich from the admin-gated ApplicationInfoService.GetSystemEnvironmentInfo
        (POST) - add dbEngineType, frameworkKind, frameworkDescription
        (requires CanManageSolution)
-    3. If a compatible cliogate (>= 2.0.0.32) is installed, GET
+    4. If a compatible cliogate (>= 2.0.0.32) is installed, GET
        /rest/CreatioApiGateway/GetSysInfo and merge productName + licenseInfo into
        the same object (and backfill db engine / framework if step 2 did not)
-    4. Any source in steps 2-3 that is denied / absent / errors is skipped
+    5. Any optional source in steps 3-4 that is denied / absent / errors is skipped
        silently - the report still includes everything that was available
-    5. Display the single combined report as formatted JSON
+    6. Display the single combined report as formatted JSON
 
 EXIT CODES
     0   Successfully retrieved and displayed system information (regardless of
         which optional sources were available)
-    1   Failed to retrieve information (environment not found, connection error,
-        or ApplicationInfoService returned an unexpected response)
+    1   Invalid URI, unavailable application, authentication failure, reachable
+        non-Creatio target, or unexpected ApplicationInfoService response
 
 NOTES
     - cliogate is NOT required: without it the command still reports core
@@ -118,10 +127,13 @@ NOTES
 TROUBLESHOOTING
     If command fails:
     - Verify environment is registered: clio list-environments
-    - Check cliogate is installed: clio install-gate -e <ENVIRONMENT>
-    - Ensure cliogate version is 2.0.0.32 or higher
-    - Verify network connectivity to Creatio instance
-    - Check credentials are valid for the registered environment
+    - "does not appear to be a Creatio application": verify the application URL
+    - "Could not connect": verify network connectivity and application health
+    - "Authentication failed": verify credentials and authentication settings
+    - "unexpected response": inspect the Creatio ApplicationInfoService health;
+      use --debug for safe diagnostic metadata
+    - Missing ProductName/LicenseInfo on an otherwise successful report: install
+      or update cliogate to 2.0.0.32+ only if those optional fields are required
 
 SEE ALSO
     install-gate       - Install cliogate on Creatio instance

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -425,7 +425,9 @@ This part is small but important because many other tools depend on it.
   `frameworkDescription` are added WITHOUT cliogate via the admin-gated
   `GetSystemEnvironmentInfo` (needs `CanManageSolution`); `productName` and `licenseInfo` are added
   only when cliogate `>= 2.0.0.32` is installed. Best-effort: an unavailable source is skipped and
-  the call still succeeds. Read `get-guidance name=describe-environment` for the full field catalogue.
+  the call still succeeds. The required base probe returns classified, secret-safe Error logs for
+  invalid/unavailable targets, authentication failures, non-Creatio content, and unusable Creatio
+  responses. Read `get-guidance name=describe-environment` for the full field catalogue.
 
 What an external AI can practically do here:
 

--- a/spec/get-info-target-classification/get-info-target-classification-plan.md
+++ b/spec/get-info-target-classification/get-info-target-classification-plan.md
@@ -1,0 +1,60 @@
+# get-info target classification - PLAN (ADR)
+
+> GitHub: [#390](https://github.com/Advance-Technologies-Foundation/clio/issues/390)
+
+## Decision
+
+Keep classification inside `GetCreatioInfoCommand`, immediately around the required base probe.
+Private helpers will validate and redact the target URI, inspect response shape without echoing the
+body, walk wrapped exception chains, and emit one stable error. This avoids changing the shared
+transport abstraction or successful output contract.
+
+## Classification order
+
+1. Parse `EnvironmentSettings.Uri` as an absolute HTTP/HTTPS URI. Reject unsupported or malformed
+   input without echoing an unsafe raw value.
+2. Execute `ApplicationInfoService.GetApplicationInfo`.
+3. If the response is Creatio's known authentication envelope/login page, return an
+   authentication-specific error.
+4. If content is clearly HTML or non-JSON, classify the reachable target as non-Creatio.
+5. If JSON is malformed or lacks `applicationInfo.sysValues`, return the stable
+   unexpected-response error.
+6. Only after the base report succeeds, run both optional enrichment paths.
+
+Exception-chain rules:
+
+- `UnauthorizedAccessException`, HTTP 401/403, and known session-expired responses ->
+  authentication.
+- `TaskCanceledException`, `TimeoutException`, transport `HttpRequestException`, and network
+  `WebException` statuses -> unavailable/connection failure.
+- Other required-probe exceptions -> unexpected response, with only exception type metadata under
+  `--debug`.
+
+## Diagnostics and redaction
+
+- User-visible target text is derived from a parsed URI with user-info, query, and fragment removed.
+- Response bodies and exception messages are never logged by this command.
+- Debug output contains classification, response length, exception type chain, and safe HTTP/status
+  metadata only.
+
+## Optional enrichment
+
+`GetSystemEnvironmentInfo`, ClioGate compatibility detection, and ClioGate `GetSysInfo` remain
+best-effort. ClioGate compatibility lookup moves under the same guarded enrichment path so its
+failure cannot replace a successful base report.
+
+## MCP and ClioRing
+
+The existing `describe-environment` MCP tool remains a thin environment-aware adapter. Its
+description/guidance and tests will document and assert that base-probe failures use the same
+classified command envelope. ClioRing invokes `get-info` through `clio-run`; no Ring code or schema
+change is expected, but Ring tests and Windows x64 NativeAOT publish are mandatory compatibility
+checks.
+
+## Rejected alternatives
+
+- Changing `IApplicationClient` to return HTTP status/content metadata: too broad for a scoped bug
+  and would affect many commands.
+- Probing a second endpoint before ApplicationInfoService: adds latency and can introduce a second
+  source of contradictory classification.
+- Matching arbitrary exception messages: unstable and risks leaking credentials or URLs.

--- a/spec/get-info-target-classification/get-info-target-classification-qa.md
+++ b/spec/get-info-target-classification/get-info-target-classification-qa.md
@@ -1,0 +1,48 @@
+# get-info target classification - QA plan
+
+## Unit - Command module
+
+| ID | Case | Expected |
+|---|---|---|
+| U1 | HTML response | exit 1, non-Creatio message, no body/parser detail |
+| U2 | plain non-JSON response | exit 1, non-Creatio message |
+| U3 | malformed JSON beginning as JSON | exit 1, stable unexpected-response message |
+| U4 | valid JSON with missing `applicationInfo.sysValues` | exit 1, stable unexpected-response message |
+| U5 | `HttpRequestException` / connect failure | exit 1, connection message |
+| U6 | `TaskCanceledException` / timeout | exit 1, connection message |
+| U7 | `UnauthorizedAccessException`, HTTP 401/403, or auth envelope | exit 1, authentication message |
+| U8 | malformed or unsupported URI | exit 1 before any request |
+| U9 | debug failure path with secret-like exception/body text | only safe type/classification metadata logged |
+| U10 | valid base response without compatible ClioGate | exit 0 with base report and warning |
+| U11 | valid base response with system/ClioGate enrichment | exit 0 with merged report |
+| U12 | ClioGate compatibility check throws | exit 0 with base report |
+
+## Unit - MCP module
+
+| ID | Case | Expected |
+|---|---|---|
+| M1 | Resolved command receives HTML | exit 1, Error log with non-Creatio message |
+| M2 | Existing environment and timeout mapping | unchanged |
+| M3 | Tool metadata/description | advertises classified actionable failures |
+
+## MCP E2E
+
+Use a local loopback HTTP stub and the real `clio mcp-server` child. The stub accepts the basic
+authentication handshake and returns HTML for the ApplicationInfoService endpoint.
+
+| ID | Case | Expected |
+|---|---|---|
+| E1 | `describe-environment` against loopback non-Creatio stub | structured exit 1, Error message contains non-Creatio guidance and no parser/body detail |
+
+The E2E is `McpE2E.NoEnvironment`; it does not mutate or require a Creatio instance.
+
+## Compatibility and regression
+
+- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=McpServer)"`
+- targeted `GetCreatioInfoToolE2ETests` external-process run
+- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release`
+- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true`
+
+No live Creatio deployment is required because the changed failure classes are deterministic at
+the command boundary and the successful/enrichment contracts are covered with existing substituted
+clients.

--- a/spec/get-info-target-classification/get-info-target-classification-spec.md
+++ b/spec/get-info-target-classification/get-info-target-classification-spec.md
@@ -1,0 +1,52 @@
+# get-info target classification - SPEC
+
+> GitHub: [#390](https://github.com/Advance-Technologies-Foundation/clio/issues/390)
+
+## Problem
+
+`get-info` treats every failure from the required
+`ApplicationInfoService.GetApplicationInfo` probe as a generic exception. Reachable non-Creatio
+HTML therefore exposes a Newtonsoft.Json parser message, while transport failures can be mistaken
+for missing ClioGate support. The broad failure path also lets optional ClioGate compatibility
+checks replace an already successful base report.
+
+## Requirements
+
+R1. Validate that the configured application URI is an absolute HTTP or HTTPS URI before the base
+probe.
+
+R2. Classify required-probe failures into stable user-facing outcomes: invalid URI, unreachable or
+timed-out target, authentication failure, reachable non-Creatio content, and unexpected Creatio
+response.
+
+R3. Normal CLI and MCP output must not expose response bodies, parser messages, stack traces,
+credentials, cookies, tokens, or authorization data. Debug output may identify safe exception and
+classification metadata only.
+
+R4. Perform `GetSystemEnvironmentInfo` and ClioGate enrichment only after a valid base report is
+available. Any optional-enrichment failure must preserve the base report and exit code 0.
+
+R5. Preserve the successful report schema, command aliases, options, and MCP tool arguments.
+
+## Acceptance criteria
+
+- AC1. HTML or other clearly non-JSON content exits 1 with a `does not appear to be a Creatio
+  application` error through `get-info` and every alias.
+- AC2. Transport failures and timeouts exit 1 with a connection/application-unavailable error.
+- AC3. Authentication failures exit 1 with credential/authentication guidance and are not
+  classified as non-Creatio.
+- AC4. Malformed JSON and valid JSON with an unusable ApplicationInfoService shape exit 1 with a
+  stable unexpected-response error.
+- AC5. Valid Creatio responses still return the base report when ClioGate is absent, incompatible,
+  denied, malformed, or unreachable.
+- AC6. CLI unit tests cover every classification and both enrichment paths.
+- AC7. MCP unit and external-process E2E tests assert the same actionable error envelope.
+- AC8. Command help, detailed docs, command index, Wiki anchors, MCP descriptions, guidance, and
+  ClioRing consumption are reviewed and validated.
+
+## Exclusions
+
+- No successful report fields or MCP arguments are added or removed.
+- No new Creatio endpoint, ClioGate package change, or local Creatio deployment is required.
+- The shared `IApplicationClient` transport contract is not changed; classification remains scoped
+  to `get-info` because other commands have different retry and side-effect semantics.

--- a/spec/get-info-target-classification/get-info-target-classification-story.md
+++ b/spec/get-info-target-classification/get-info-target-classification-story.md
@@ -1,0 +1,24 @@
+# get-info target classification - STORY
+
+## Story
+
+As a clio user or MCP agent, I want `get-info` to distinguish invalid, unavailable,
+authentication-failed, non-Creatio, and malformed Creatio targets so I receive one actionable error
+without misleading ClioGate guidance or leaked transport/parser details.
+
+## Implementation tasks
+
+1. Add scoped required-probe classification and safe diagnostics to `GetCreatioInfoCommand`.
+2. Keep ClioGate compatibility and both enrichment calls non-fatal after base success.
+3. Add focused Command-module unit coverage for every issue acceptance case.
+4. Align `describe-environment` MCP description/guidance, unit tests, and external-process E2E.
+5. Update all `get-info` documentation surfaces and verify aliases/options.
+6. Run Command/McpServer tests, targeted MCP E2E, and the ClioRing compatibility/AOT gate.
+
+## Definition of done
+
+- All acceptance criteria in the SPEC pass.
+- No normal or debug output contains raw bodies or secret-bearing values.
+- Docs and MCP surfaces are aligned.
+- Comprehensive agentic review has no unresolved Blocker or High finding.
+- PR is ready, assigned, and armed for auto-merge.

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -26,7 +26,7 @@ stories:
     feature: "get-info-target-classification"
     repo: "clio"
     size: S
-    status: done
+    status: review
     issue: 390
     file: spec/get-info-target-classification/get-info-target-classification-story.md
     prd: spec/get-info-target-classification/get-info-target-classification-spec.md

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -21,6 +21,20 @@
 # 2026-07-06) is a separate Jira ticket stacked on the same branch; tracked as its own row.
 
 stories:
+  - id: story-get-info-target-classification-1
+    title: "Classify get-info target and response failures"
+    feature: "get-info-target-classification"
+    repo: "clio"
+    size: S
+    status: done
+    issue: 390
+    file: spec/get-info-target-classification/get-info-target-classification-story.md
+    prd: spec/get-info-target-classification/get-info-target-classification-spec.md
+    adr: spec/get-info-target-classification/get-info-target-classification-plan.md
+    test_plan: spec/get-info-target-classification/get-info-target-classification-qa.md
+    depends_on: []
+    blocks: []
+
   - id: story-mcp-progress-wait-timeout-1
     title: "Make MCP progress waits notification-driven and timeout-safe"
     feature: "mcp-progress-wait-timeout"


### PR DESCRIPTION
Closes #390

## Summary
- validate get-info target URIs and classify unavailable, authentication, reachable non-Creatio, malformed JSON, and unusable ApplicationInfoService responses with stable secret-safe errors
- preserve the base Creatio report when GetSystemEnvironmentInfo or ClioGate enrichment is absent, malformed, incompatible, or fails recoverably
- align MCP tool/guidance, CLI help/docs, BMAD artifacts, unit coverage, and external-process MCP E2E coverage

## Validation
- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit&(Module=Command|Module=McpServer)" --no-build --no-restore` — 4,413 passed, 15 skipped, 0 failed per target framework
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release --filter "FullyQualifiedName~GetCreatioInfoToolE2ETests" --no-build --no-restore` — 3 passed per target framework
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release --no-restore` — 95 passed
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true --no-restore` — succeeded
- `dotnet build clio/clio.csproj --no-restore` — succeeded (only pre-existing CLIO005 warnings in BindingsModule.cs)
- `make verify-docs` — passed
- live read-only validation: google.com classified as non-Creatio with redacted debug metadata; unreachable and invalid-URI cases returned stable errors; `deloitte` and `deloitte-nf` returned valid base reports without requiring a new instance

## Reviews
- comprehensive agentic review: code quality/testing, security, and performance/correctness — no remaining findings
- docs reviewed and updated; Wiki anchors reviewed, no update required
- MCP reviewed and updated, including unit and local E2E coverage
- ClioRing compatibility reviewed: `actions.json` consumes `get-info`; Ring tests and Windows x64 NativeAOT publish passed, no Ring code update required
- no TeamCity result is required for this delivery; local E2E and consumer compatibility gates are green