### PR TITLE
Add ClioRing app-settings schema and dev-clio guidance

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6331,3 +6331,10 @@ Decision: Ship a Draft 2020-12 schema beside the desktop executable, reference i
 Discovery: `Channel` is only a Ring display label; clio selection is valid `DevClioPath`, then complete `ClioIpc`, then the machine default. Existing local settings can be preserved while refreshing the NativeAOT program files.
 Files: clio-ring/ClioRing.Desktop/app-settings.schema.json, clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs, clio-ring/README.md, spec/ring-app-settings-schema/
 Impact: Editors now catch unknown, incomplete, and whitespace-only settings, developers can intentionally target a trusted local clio build, and `C:\Tools\clio-ring` has been refreshed without losing its IPC configuration.
+
+## 2026-07-16 06:55 – Stabilize unit tests on the dev self-hosted runner
+Context: PR #891 passed on TS1-CORE-DEV24 but two consecutive runs on TS1-MRKT-WEB01 failed in different tests and target frameworks while the Ring-only tests remained green.
+Decision: Join deliberately detached heartbeat test work before disposing its synchronization handles, and use a locked StringWriter for process-wide console capture in CommonProgramTest.
+Discovery: TS1-MRKT-WEB01 is current on .NET SDK 10.0.301/runtime 10.0.9 but its GitHub runner 2.333.0 trails 2.335.1. The first failure was concurrent StringBuilder access; the retry captured a late cancelled-operation fault in the next test, confirming background-work isolation rather than product behavior.
+Files: clio.tests/CommonProgramTest.cs, clio.tests/Command/McpServer/McpProgressHeartbeatTests.cs
+Impact: Core and MCP Server tests no longer dispose gates under detached work or read console buffers during background writes, improving deterministic execution across self-hosted runner speeds.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6324,3 +6324,10 @@ Decision: Extract IIS HTTPS DI registration, evaluate both XML transformations e
 Discovery: `--use-https` is an IIS binding option; allowing it to affect DotNetDeploymentStrategy registration points readiness at an endpoint that the strategy deliberately removes from appsettings. Normalization can turn an all-nonhex explicit thumbprint into an empty value, which must not share interactive-cancellation semantics.
 Files: clio/BindingsModule.cs, clio/Common/IIS/NetFrameworkHttpsConfigurator.cs, clio/Common/DeploymentStrategies/DotNetDeploymentStrategy.cs, clio/Command/PinCertificateCommand.cs, clio.tests/Common/DotNetDeploymentStrategyTests.cs, clio.tests/Command/PinCertificateCommandTests.cs
 Impact: All reported review findings are covered by focused net8.0/net10.0 tests without broadening HTTPS beyond IIS.
+
+## 2026-07-16 06:20 – Add a ClioRing app-settings schema and dev-clio guidance
+Context: Issue #890 requested editor validation for Ring settings and an explanation of how a release-labeled Ring can launch a development clio IPC build.
+Decision: Ship a Draft 2020-12 schema beside the desktop executable, reference it from the sample settings, document launch precedence and trust boundaries, and validate schema/model parity with JsonSchema.Net integration tests.
+Discovery: `Channel` is only a Ring display label; clio selection is valid `DevClioPath`, then complete `ClioIpc`, then the machine default. Existing local settings can be preserved while refreshing the NativeAOT program files.
+Files: clio-ring/ClioRing.Desktop/app-settings.schema.json, clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs, clio-ring/README.md, spec/ring-app-settings-schema/
+Impact: Editors now catch unknown, incomplete, and whitespace-only settings, developers can intentionally target a trusted local clio build, and `C:\Tools\clio-ring` has been refreshed without losing its IPC configuration.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,6 +86,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="$(SIOVersion)" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.0]" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
     <PackageVersion Include="nunit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="ATF.Repository.Mock" Version="2.0.3.1" />

--- a/clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj
+++ b/clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj
@@ -32,6 +32,9 @@
 		<None Update="app-settings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="app-settings.schema.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="actions.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj
+++ b/clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj
@@ -34,6 +34,7 @@
 		</None>
 		<None Update="app-settings.schema.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
 		</None>
 		<None Update="actions.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/clio-ring/ClioRing.Desktop/app-settings.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./app-settings.schema.json",
   "WorkspaceFolder": "C:\\Projects\\Workspaces",
   "Hotkey": "Ctrl+Alt+C",
   "Channel": "dev",

--- a/clio-ring/ClioRing.Desktop/app-settings.schema.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://advance-technologies-foundation.github.io/clio-ring/app-settings.schema.json",
+  "title": "ClioRing application settings",
+  "description": "Local ClioRing desktop settings. This file controls Ring presentation, workspace discovery, and the optional development clio MCP child.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [ "WorkspaceFolder" ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "title": "Schema reference",
+      "description": "Relative path or URL to this JSON Schema for editor validation and hover help."
+    },
+    "WorkspaceFolder": {
+      "type": "string",
+      "title": "Workspace folder",
+      "description": "Absolute folder scanned for clio workspaces.",
+      "minLength": 1,
+      "examples": [ "C:\\Projects\\Workspaces" ]
+    },
+    "Hotkey": {
+      "type": [ "string", "null" ],
+      "title": "Global hotkey",
+      "description": "Optional global gesture used to summon Ring. An absent, blank, or invalid value uses the application default.",
+      "examples": [ "Ctrl+Alt+C" ]
+    },
+    "LogsFolder": {
+      "type": [ "string", "null" ],
+      "title": "Logs folder",
+      "description": "Optional absolute folder for logs and deployment receipts. Blank or absent defaults to the Logs folder beside clio-ring.exe.",
+      "examples": [ "C:\\Tools\\clio-ring\\Logs" ]
+    },
+    "Channel": {
+      "type": [ "string", "null" ],
+      "title": "Ring channel label",
+      "description": "Display/deployment label shown in the Ring build badge, such as release, dev, or preview. This value does not select the clio executable or MCP server.",
+      "default": "dev",
+      "minLength": 1,
+      "pattern": "\\S",
+      "examples": [ "release", "dev", "preview" ]
+    },
+    "Experiments": {
+      "$ref": "#/$defs/experiments"
+    },
+    "ClioIpc": {
+      "$ref": "#/$defs/clioIpc"
+    },
+    "DevClioPath": {
+      "type": [ "string", "null" ],
+      "title": "Development clio override",
+      "description": "Optional absolute path to a trusted local development clio.dll or clio.exe. Ring executes it with your user privileges. A valid value takes precedence over ClioIpc and the machine default; the change applies on the next Ring launch.",
+      "examples": [ "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.dll" ]
+    }
+  },
+  "$defs": {
+    "experiments": {
+      "type": [ "object", "null" ],
+      "title": "Experimental features",
+      "description": "Feature switches that remain off unless explicitly enabled.",
+      "additionalProperties": false,
+      "properties": {
+        "ClioIpc": {
+          "type": "boolean",
+          "title": "Enable clio IPC",
+          "description": "Enables the experimental MCP-over-stdio Clio IPC surface. This must be true to expose the IPC proof UI.",
+          "default": false
+        }
+      }
+    },
+    "clioIpc": {
+      "type": [ "object", "null" ],
+      "title": "Explicit clio MCP launch",
+      "description": "Explicit trusted MCP child-process command used when DevClioPath is absent or invalid. Ring executes it with your user privileges. When omitted or incomplete, Ring uses its machine default.",
+      "additionalProperties": false,
+      "required": [ "Command", "Args" ],
+      "properties": {
+        "Command": {
+          "type": "string",
+          "title": "Executable",
+          "description": "Executable used to launch the clio MCP child, for example dotnet or clio.",
+          "minLength": 1,
+          "pattern": "\\S",
+          "examples": [ "dotnet" ]
+        },
+        "Args": {
+          "type": "array",
+          "title": "Arguments",
+          "description": "Arguments passed to Command. For a framework-dependent build, pass the clio.dll path followed by mcp-server.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "examples": [ [ "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.dll", "mcp-server" ] ]
+        },
+        "WorkingDirectory": {
+          "type": [ "string", "null" ],
+          "title": "Working directory",
+          "description": "Optional working directory for the clio child. Blank or absent uses the Ring launch directory."
+        }
+      }
+    }
+  }
+}

--- a/clio-ring/ClioRing.Desktop/app-settings.schema.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.schema.json
@@ -17,6 +17,7 @@
       "title": "Workspace folder",
       "description": "Absolute folder scanned for clio workspaces.",
       "minLength": 1,
+      "pattern": "\\S",
       "examples": [ "C:\\Projects\\Workspaces" ]
     },
     "Hotkey": {

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -61,13 +61,16 @@ public sealed class AppSettingsSchemaTests {
 		XElement? schemaItem = project.Descendants("None")
 			.SingleOrDefault(item => string.Equals(
 				(string?)item.Attribute("Update"), "app-settings.schema.json", StringComparison.Ordinal));
-		string? copyMode = (string?)schemaItem?.Element("CopyToOutputDirectory");
+		string? outputCopyMode = (string?)schemaItem?.Element("CopyToOutputDirectory");
+		string? publishCopyMode = (string?)schemaItem?.Element("CopyToPublishDirectory");
 
 		// Assert
 		schemaItem.Should().NotBeNull(
 			because: "the schema must be part of the Desktop project's real shipping contract, not only the test output");
-		copyMode.Should().Be("PreserveNewest",
-			because: "build and publish must copy the schema beside app-settings.json");
+		outputCopyMode.Should().Be("PreserveNewest",
+			because: "build output must copy the schema beside app-settings.json");
+		publishCopyMode.Should().Be("PreserveNewest",
+			because: "publish output must explicitly retain the schema beside app-settings.json");
 	}
 
 	[Test]

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -89,6 +89,7 @@ public sealed class AppSettingsSchemaTests {
 	}
 
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Unexpected":true}""")]
+	[TestCase("""{"WorkspaceFolder":"   "}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"dotnet"}}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Channel":"   "}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"   ","Args":["mcp-server"]}}""")]

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ClioRing.Models;
+using FluentAssertions;
+using Json.Schema;
+using NUnit.Framework;
+
+namespace ClioRing.Tests;
+
+/// <summary>
+/// Guards the shipped ClioRing application-settings sample and its editor schema against packaging and documentation drift.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public sealed class AppSettingsSchemaTests {
+	private static readonly Lazy<JsonSchema> Schema = new(LoadSchema);
+	private static string SettingsPath => Path.Combine(AppContext.BaseDirectory, "app-settings.json");
+	private static string SchemaPath => Path.Combine(AppContext.BaseDirectory, "app-settings.schema.json");
+
+	[Test]
+	[Description("The shipped application settings satisfy the valid Draft 2020-12 schema copied beside the Ring test binaries.")]
+	public void ShippedSettings_ShouldSatisfySchema_WhenCopiedToOutput() {
+		// Arrange
+		JsonSchema schema = Schema.Value;
+		using JsonDocument settings = JsonDocument.Parse(File.ReadAllText(SettingsPath));
+
+		// Act
+		EvaluationResults result = schema.Evaluate(settings.RootElement);
+
+		// Assert
+		result.IsValid.Should().BeTrue(
+			because: "building the schema validates its keywords and references, and the shipped sample must satisfy that contract");
+	}
+
+	[Test]
+	[Description("The shipped settings file references the colocated schema used by JSON editors.")]
+	public void Settings_ShouldReferenceColocatedSchema_WhenShipped() {
+		// Arrange
+		JsonObject settings = JsonNode.Parse(File.ReadAllText(SettingsPath))!.AsObject();
+
+		// Act
+		string? schemaReference = settings["$schema"]?.GetValue<string>();
+
+		// Assert
+		schemaReference.Should().Be("./app-settings.schema.json",
+			because: "a relative reference continues to work after build, publish, or local installation");
+	}
+
+	[Test]
+	[Description("The schema covers every supported root setting and explains channel and development-clio selection semantics.")]
+	public void Schema_ShouldDescribeSupportedSettingsAndClioSelection_WhenReadByEditor() {
+		// Arrange
+		JsonObject schema = JsonNode.Parse(File.ReadAllText(SchemaPath))!.AsObject();
+		JsonObject properties = schema["properties"]!.AsObject();
+		JsonObject definitions = schema["$defs"]!.AsObject();
+		string[] expectedProperties = typeof(AppSettings).GetProperties()
+			.Select(property => property.Name).Append("$schema").ToArray();
+		string[] expectedExperimentProperties = typeof(ExperimentSettings).GetProperties()
+			.Select(property => property.Name).ToArray();
+		string[] expectedIpcProperties = typeof(ClioIpcSettingsDto).GetProperties()
+			.Select(property => property.Name).ToArray();
+
+		// Act
+		string[] actualProperties = properties.Select(property => property.Key).ToArray();
+		string[] actualExperimentProperties = definitions["experiments"]!["properties"]!.AsObject()
+			.Select(property => property.Key).ToArray();
+		string[] actualIpcProperties = definitions["clioIpc"]!["properties"]!.AsObject()
+			.Select(property => property.Key).ToArray();
+		string channelDescription = properties["Channel"]!["description"]!.GetValue<string>();
+		string devPathDescription = properties["DevClioPath"]!["description"]!.GetValue<string>();
+		string ipcDescription = definitions["clioIpc"]!["description"]!.GetValue<string>();
+
+		// Assert
+		actualProperties.Should().BeEquivalentTo(expectedProperties,
+			because: "the editor contract must stay aligned with every root AppSettings property plus $schema");
+		actualExperimentProperties.Should().BeEquivalentTo(expectedExperimentProperties,
+			because: "the editor contract must stay aligned with every ExperimentSettings property");
+		actualIpcProperties.Should().BeEquivalentTo(expectedIpcProperties,
+			because: "the editor contract must stay aligned with every ClioIpcSettingsDto property");
+		channelDescription.Should().Contain("does not select the clio executable",
+			because: "Channel is only a Ring display/deployment label");
+		devPathDescription.Should().Contain("takes precedence over ClioIpc",
+			because: "developers need the actual launch-selection precedence");
+		ipcDescription.Should().Contain("when DevClioPath is absent or invalid",
+			because: "the explicit child-process block is the second precedence level");
+	}
+
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Unexpected":true}""")]
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"dotnet"}}""")]
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Channel":"   "}""")]
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"   ","Args":["mcp-server"]}}""")]
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"dotnet","Args":["   "]}}""")]
+	[Description("The schema rejects unknown settings, incomplete or blank child launch configuration, and blank channel labels.")]
+	public void Schema_ShouldRejectInvalidSettings_WhenEditorValidates(string json) {
+		// Arrange
+		JsonSchema schema = Schema.Value;
+		using JsonDocument settings = JsonDocument.Parse(json);
+
+		// Act
+		EvaluationResults result = schema.Evaluate(settings.RootElement);
+
+		// Assert
+		result.IsValid.Should().BeFalse(
+			because: "the schema should catch misspelled properties and incomplete or meaningless configuration before Ring starts");
+	}
+
+	private static JsonSchema LoadSchema() {
+		using JsonDocument schemaDocument = JsonDocument.Parse(File.ReadAllText(SchemaPath));
+		return JsonSchema.Build(schemaDocument.RootElement.Clone());
+	}
+}

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Xml.Linq;
 using ClioRing.Models;
 using FluentAssertions;
 using Json.Schema;
@@ -19,6 +20,7 @@ public sealed class AppSettingsSchemaTests {
 	private static readonly Lazy<JsonSchema> Schema = new(LoadSchema);
 	private static string SettingsPath => Path.Combine(AppContext.BaseDirectory, "app-settings.json");
 	private static string SchemaPath => Path.Combine(AppContext.BaseDirectory, "app-settings.schema.json");
+	private static string DesktopProjectPath => Path.Combine(AppContext.BaseDirectory, "ClioRing.Desktop.csproj");
 
 	[Test]
 	[Description("The shipped application settings satisfy the valid Draft 2020-12 schema copied beside the Ring test binaries.")]
@@ -47,6 +49,25 @@ public sealed class AppSettingsSchemaTests {
 		// Assert
 		schemaReference.Should().Be("./app-settings.schema.json",
 			because: "a relative reference continues to work after build, publish, or local installation");
+	}
+
+	[Test]
+	[Description("The Desktop shipping project copies the application-settings schema into build and publish output.")]
+	public void DesktopProject_ShouldCopySchema_WhenBuiltOrPublished() {
+		// Arrange
+		XDocument project = XDocument.Load(DesktopProjectPath);
+
+		// Act
+		XElement? schemaItem = project.Descendants("None")
+			.SingleOrDefault(item => string.Equals(
+				(string?)item.Attribute("Update"), "app-settings.schema.json", StringComparison.Ordinal));
+		string? copyMode = (string?)schemaItem?.Element("CopyToOutputDirectory");
+
+		// Assert
+		schemaItem.Should().NotBeNull(
+			because: "the schema must be part of the Desktop project's real shipping contract, not only the test output");
+		copyMode.Should().Be("PreserveNewest",
+			because: "build and publish must copy the schema beside app-settings.json");
 	}
 
 	[Test]

--- a/clio-ring/ClioRing.Tests/ClioRing.Tests.csproj
+++ b/clio-ring/ClioRing.Tests/ClioRing.Tests.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="NUnit3TestAdapter" />
 		<PackageReference Include="NSubstitute" />
 		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="JsonSchema.Net" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -28,6 +29,12 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Include="..\ClioRing.Desktop\actions.schema.json" Link="actions.schema.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Include="..\ClioRing.Desktop\app-settings.json" Link="app-settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Include="..\ClioRing.Desktop\app-settings.schema.json" Link="app-settings.schema.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<!-- Cross-repo contract anchor: clio's committed ClioStageEvent fixture copied byte-identically.

--- a/clio-ring/ClioRing.Tests/ClioRing.Tests.csproj
+++ b/clio-ring/ClioRing.Tests/ClioRing.Tests.csproj
@@ -37,6 +37,9 @@
 		<None Include="..\ClioRing.Desktop\app-settings.schema.json" Link="app-settings.schema.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Include="..\ClioRing.Desktop\ClioRing.Desktop.csproj" Link="ClioRing.Desktop.csproj">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<!-- Cross-repo contract anchor: clio's committed ClioStageEvent fixture copied byte-identically.
 		     The parity test round-trips each NDJSON line through the Ring mirror and asserts the bytes
 		     match, guarding against silent drift between the two repos (TC-U-30). -->

--- a/clio-ring/README.md
+++ b/clio-ring/README.md
@@ -48,6 +48,44 @@ clio ring
 
 The bootstrap installs versioned releases under `%LOCALAPPDATA%\Creatio\clio-ring` and verifies every ZIP against the SHA-256 in the GitHub release manifest.
 
+## Application settings and development clio
+
+`ClioRing.Desktop/app-settings.json` references the colocated `app-settings.schema.json`, so JSON-aware editors provide validation and hover descriptions. The `Channel` value is only the label shown in Ring's build badge; values such as `release`, `dev`, or `preview` do **not** select which clio executable Ring starts.
+
+To expose the experimental MCP-over-stdio UI and point it at a development build, use:
+
+```json
+{
+  "$schema": "./app-settings.schema.json",
+  "WorkspaceFolder": "C:\\Projects\\Workspaces",
+  "Channel": "release",
+  "Experiments": {
+    "ClioIpc": true
+  },
+  "DevClioPath": "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.dll"
+}
+```
+
+Clio launch selection uses this precedence on the next Ring launch:
+
+1. A valid `DevClioPath` (`clio.dll` or `clio.exe`).
+2. An explicit `ClioIpc` block with `Command`, `Args`, and optional `WorkingDirectory`.
+3. Ring's machine default.
+
+`DevClioPath` and `ClioIpc.Command` are code-execution trust boundaries: Ring starts the selected program with your user privileges. Use only trusted local builds and commands, prefer absolute paths, and do not point them at downloaded binaries or locations writable by other users.
+
+For example, the equivalent explicit launch block is:
+
+```json
+"ClioIpc": {
+  "Command": "dotnet",
+  "Args": [
+    "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.dll",
+    "mcp-server"
+  ]
+}
+```
+
 ## Deletion boundary
 
 Removing the experiment requires deleting this subtree, `.github/workflows/clio-ring-release.yml`, the `RingCommand` implementation and tests, its DI/dispatch/solution entries, and Ring command docs. No clio environment or settings migration is needed.

--- a/clio.tests/Command/McpServer/McpProgressHeartbeatTests.cs
+++ b/clio.tests/Command/McpServer/McpProgressHeartbeatTests.cs
@@ -232,10 +232,12 @@ public sealed class McpProgressHeartbeatTests {
 		// via cancellation, not completion (no wall-clock sleep, deterministic on any agent).
 		using CancellationTokenSource cts = new CancellationTokenSource();
 		using ManualResetEventSlim workStarted = new ManualResetEventSlim(false);
-		using ManualResetEventSlim neverReleased = new ManualResetEventSlim(false);
+		using ManualResetEventSlim releaseWork = new ManualResetEventSlim(false);
+		using ManualResetEventSlim workCompleted = new ManualResetEventSlim(false);
 		Func<int> work = () => {
 			workStarted.Set();
-			neverReleased.Wait(StopGuard);
+			releaseWork.Wait(StopGuard);
+			workCompleted.Set();
 			return 1;
 		};
 
@@ -252,8 +254,18 @@ public sealed class McpProgressHeartbeatTests {
 		cts.Cancel();
 
 		// Assert
-		await act.Should().ThrowAsync<OperationCanceledException>(
-			because: "a cancelled request (or server shutdown) must surface as cancellation, not a fabricated 150 s deadline whose 'work continues, keep polling' guidance would be false").ConfigureAwait(false);
+		try {
+			await act.Should().ThrowAsync<OperationCanceledException>(
+				because: "a cancelled request (or server shutdown) must surface as cancellation, not a fabricated 150 s deadline whose 'work continues, keep polling' guidance would be false").ConfigureAwait(false);
+		}
+		finally {
+			// RunWithProgressAndDeadlineAsync deliberately detaches work from the request lifetime.
+			// Release and join it before disposing its wait handles so no late fault can leak into
+			// another test's process-wide stderr capture.
+			releaseWork.Set();
+			workCompleted.Wait(StopGuard).Should().BeTrue(
+				because: "the detached test work must finish before its synchronization primitives are disposed");
+		}
 	}
 
 	[Test]

--- a/clio.tests/CommonProgramTest.cs
+++ b/clio.tests/CommonProgramTest.cs
@@ -213,7 +213,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Description("Prints a compatibility version line for legacy callers that still invoke clio with the root --version flag.")]
 	public void Main_WithRootVersionFlag_ShouldReturnZeroAndPrintCompatibilityVersion() {
 		// Arrange
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		string[] args = ["--version"];
 
@@ -230,7 +230,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Prints up to ten alphabetically sorted suggestions and help hints for an unknown top-level command.")]
 	public void ExecuteCommands_WithUnknownVerb_ShouldPrintSuggestionsAndKeepExitCodeOne() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["get-list"];
@@ -262,7 +262,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Surfaces the shortest matching alias instead of the canonical name when the alias is a closer fit.")]
 	public void ExecuteCommands_WithAliasLikeInput_ShouldSuggestShortestMatchingAlias() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["envss"];
@@ -285,7 +285,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Reflects the alias closest to a typo such as 'encvs' instead of forcing the user to read the canonical name.")]
 	public void ExecuteCommands_WithTypoNearShortAlias_ShouldSuggestThatAlias() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["encvs"];
@@ -308,7 +308,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Downweights short aliases for longer unknown commands so relevant skill commands remain visible.")]
 	public void ExecuteCommands_WithSkillInput_ShouldPreferSkillCommandsOverShortAliasMatches() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["skill"];
@@ -337,7 +337,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Renders flat top-level help with canonical commands sorted alphabetically.")]
 	public void ExecuteCommands_WithHelpArgument_ShouldRenderAlphabeticalCanonicalRootHelp() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -373,7 +373,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Shows canonical command help when help is requested through an alias.")]
 	public void ExecuteCommands_WithAliasHelp_ShouldRenderCanonicalCommandHelp() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -396,7 +396,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Renders the rich manual add-item help when command help is requested through the built-in help command.")]
 	public void ExecuteCommands_WithBuiltInAddItemHelp_ShouldRenderManualHelpText() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -419,7 +419,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Renders the rich manual add-item help when help is requested through the command parser path.")]
 	public void ExecuteCommands_WithAddItemHelpSwitch_ShouldRenderManualHelpText() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -442,7 +442,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Keeps sparse manual help unchanged instead of appending generated syntax sections at runtime.")]
 	public void ExecuteCommands_WithSparseManualHelp_ShouldPreferManualHelpOnly() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -461,7 +461,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Excludes hidden commands from the unknown-command suggestions.")]
 	public void ExecuteCommands_WithHiddenCommandAlias_ShouldNotSuggestHiddenCommand() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["execc"];
@@ -481,7 +481,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Description("Keeps disabled experimental commands out of unknown-command suggestions.")]
 	public void ExecuteCommands_WithDisabledExperimentalCommand_ShouldNotSuggestExperimentalCommand() {
 		// Arrange
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
@@ -497,7 +497,7 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Falls back to generic help when the input is too dissimilar to any visible command.")]
 	public void ExecuteCommands_WithLowConfidenceUnknownVerb_ShouldShowOnlyHelpHints() {
-		StringWriter consoleOutput = new();
+		ThreadSafeStringWriter consoleOutput = new();
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 		string[] args = ["zzzzzz"];
@@ -545,6 +545,40 @@ internal class CommonProgramTest : BaseClioModuleTests{
 		EnvironmentOptions environmentOptionsFromManifestFile
 			= Program.ReadEnvironmentOptionsFromManifestFile(manifestFilePath, commonFileSystem);
 		environmentOptionsFromManifestFile.Should().BeNull();
+	}
+
+	private sealed class ThreadSafeStringWriter : StringWriter {
+		private readonly object _sync = new();
+
+		public override void Write(char value) {
+			lock (_sync) {
+				base.Write(value);
+			}
+		}
+
+		public override void Write(char[] buffer, int index, int count) {
+			lock (_sync) {
+				base.Write(buffer, index, count);
+			}
+		}
+
+		public override void Write(string value) {
+			lock (_sync) {
+				base.Write(value);
+			}
+		}
+
+		public override void WriteLine(string value) {
+			lock (_sync) {
+				base.WriteLine(value);
+			}
+		}
+
+		public override string ToString() {
+			lock (_sync) {
+				return base.ToString();
+			}
+		}
 	}
 
 	#endregion

--- a/spec/ring-app-settings-schema/ring-app-settings-schema-adr.md
+++ b/spec/ring-app-settings-schema/ring-app-settings-schema-adr.md
@@ -1,0 +1,21 @@
+# ADR: Ship a local JSON Schema beside ClioRing app settings
+
+Status: accepted
+
+## Context
+
+`actions.json` already has a colocated schema, but `app-settings.json` does not. Users therefore cannot discover supported properties or tell whether `Channel` controls the clio child process.
+
+## Decision
+
+Ship `app-settings.schema.json` beside `app-settings.json`, reference it with a relative `$schema`, and copy both files through the desktop project. Keep the schema descriptive rather than executable: Ring continues to deserialize through its source-generated `System.Text.Json` context and retains its tolerant startup behavior.
+
+`Channel` remains an unrestricted non-empty display label. Development clio selection is expressed through `DevClioPath` or `ClioIpc`; `DevClioPath` has precedence when valid. The schema rejects unknown properties in editors to catch typos, while the runtime remains forward-tolerant.
+
+## Consequences
+
+- Editors provide validation and hover documentation without adding a runtime schema dependency.
+- NativeAOT behavior is unchanged.
+- The published directory gains one JSON file.
+- Local refresh must preserve the user's existing settings and add `$schema` only as an intentional configuration migration.
+

--- a/spec/ring-app-settings-schema/ring-app-settings-schema-spec.md
+++ b/spec/ring-app-settings-schema/ring-app-settings-schema-spec.md
@@ -1,0 +1,25 @@
+# ClioRing app-settings schema specification
+
+Issue: #890
+
+## Goal
+
+Provide an editor-discoverable JSON Schema for `clio-ring/ClioRing.Desktop/app-settings.json` and clear guidance for selecting a development clio MCP child without confusing that choice with the Ring `Channel` badge.
+
+## Requirements
+
+- The shipped sample references `./app-settings.schema.json` through `$schema`.
+- The schema covers every property in `AppSettings`, `ExperimentSettings`, and `ClioIpcSettingsDto`.
+- `Channel` is documented as a display/deployment label with a `dev` default; it does not select a clio executable.
+- Development clio selection documents the actual precedence: valid `DevClioPath`, explicit `ClioIpc`, then the machine default.
+- `Experiments.ClioIpc` remains off by default.
+- The schema is copied into build and NativeAOT publish output.
+- Refreshing `C:\Tools\clio-ring` preserves the existing mutable `app-settings.json` and log/measurement directories.
+
+## Acceptance criteria
+
+- The default settings file and schema parse as JSON.
+- Tests prove the schema and settings files are present in Ring test output and that descriptions cover `Channel`, `DevClioPath`, and `ClioIpc`.
+- Ring Release tests pass.
+- Windows x64 NativeAOT publish succeeds without trim/AOT warnings.
+

--- a/spec/ring-app-settings-schema/ring-app-settings-schema-story.md
+++ b/spec/ring-app-settings-schema/ring-app-settings-schema-story.md
@@ -1,0 +1,16 @@
+# ClioRing app-settings schema story
+
+Status: review
+Issue: #890
+
+As a ClioRing developer, I want editor guidance for app settings so I can select a development clio build without mistaking the deployment channel label for executable selection.
+
+## Definition of done
+
+- [x] Schema covers all supported settings and nested objects.
+- [x] Default settings reference the schema.
+- [x] Desktop build/publish includes the schema.
+- [x] README explains `Channel` and dev-clio precedence with examples.
+- [x] Contract tests pass.
+- [x] NativeAOT publish passes.
+- [x] `C:\Tools\clio-ring` is refreshed while preserving local settings.

--- a/spec/ring-app-settings-schema/ring-app-settings-schema-test-plan.md
+++ b/spec/ring-app-settings-schema/ring-app-settings-schema-test-plan.md
@@ -1,0 +1,19 @@
+# ClioRing app-settings schema test plan
+
+## Automated
+
+- Parse the shipped sample and schema as JSON.
+- Assert the sample points to `./app-settings.schema.json`.
+- Assert schema descriptions explain `Channel`, `DevClioPath`, and `ClioIpc` semantics.
+- Assert the schema is copied beside Ring test and publish outputs.
+- Run `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release`.
+- Run the mandatory Windows x64 NativeAOT publish.
+
+## Local installation
+
+- Confirm no Ring process holds the existing executable.
+- Preserve `app-settings.json`, `Logs`, and `measurements`.
+- Replace published program files from the verified NativeAOT output.
+- Add `$schema` to the preserved settings without changing its `Channel` or Clio IPC launch configuration.
+- Run a non-destructive IPC proof or startup harness against the configured development clio build.
+

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -2019,3 +2019,17 @@ stories:
     test_plan: spec/iis-https-deployment/iis-https-deployment-test-plan.md
     depends_on: []
     blocks: []
+
+  - id: story-ring-app-settings-schema-1
+    title: "Ship ClioRing app-settings schema and dev-clio guidance"
+    feature: "ring-app-settings-schema"
+    repo: "clio"
+    size: S
+    status: review
+    issue: 890
+    file: spec/ring-app-settings-schema/ring-app-settings-schema-story.md
+    prd: spec/ring-app-settings-schema/ring-app-settings-schema-spec.md
+    adr: spec/ring-app-settings-schema/ring-app-settings-schema-adr.md
+    test_plan: spec/ring-app-settings-schema/ring-app-settings-schema-test-plan.md
+    depends_on: []
+    blocks: []


### PR DESCRIPTION
## Summary

- ship a Draft 2020-12 `app-settings.schema.json` beside ClioRing settings
- document that `Channel` is a display label and that clio selection uses `DevClioPath`, explicit `ClioIpc`, then the machine default
- add integration coverage for schema validity, model parity, invalid settings, and publish packaging
- refresh `C:\Tools\clio-ring` from the verified NativeAOT artifact while preserving local settings

Closes #890

## Validation

- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 109 passed
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true -p:Version=0.1.0-dev.83` — passed without AOT warnings
- installed settings validated against the installed schema
- installed `C:\Tools\clio-ring\clio-ring.exe --smoke` — exit 0

## Reviews

- comprehensive agentic review: quality, correctness/performance, and security lenses clean
- docs reviewed and updated
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed clio contract changed
