### PR TITLE
Fix uninstall warning MCP E2E without EnvironmentPath

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6338,3 +6338,10 @@ Decision: Join deliberately detached heartbeat test work before disposing its sy
 Discovery: TS1-MRKT-WEB01 is current on .NET SDK 10.0.301/runtime 10.0.9 but its GitHub runner 2.333.0 trails 2.335.1. The first failure was concurrent StringBuilder access; the retry captured a late cancelled-operation fault in the next test, confirming background-work isolation rather than product behavior.
 Files: clio.tests/CommonProgramTest.cs, clio.tests/Command/McpServer/McpProgressHeartbeatTests.cs
 Impact: Core and MCP Server tests no longer dispose gates under detached work or read console buffers during background writes, improving deterministic execution across self-hosted runner speeds.
+
+## 2026-07-16 13:55 – Resolve uninstall warning E2E target without EnvironmentPath
+Context: TeamCity master build 15735619 failed the issue #881 locked-profile MCP E2E before uninstall because the registered `dev` environment had an empty `EnvironmentPath`.
+Decision: Resolve the registered environment URI through the fresh clio process, then fail-closed match its scheme, port, host binding, and application path to exactly one IIS application pool; keep file-reading sandbox helpers path-based.
+Discovery: TeamCity exposes `dev` at `http://<agent>:88/<application>` with a wildcard IIS binding and no path metadata. The disposable 10.0.0.802 Studio NET8 PostgreSQL run proved URI resolution, warning propagation, successful uninstall, and complete cleanup.
+Files: clio.mcp.e2e/Support/Configuration/ClioEnvironmentCommandResolver.cs, clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
+Impact: The warning E2E no longer depends on unrelated `EnvironmentPath` metadata and aborts safely on unmatched, ambiguous, or pool-less IIS targets.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6345,3 +6345,10 @@ Decision: Resolve the registered environment URI through the fresh clio process,
 Discovery: TeamCity exposes `dev` at `http://<agent>:88/<application>` with a wildcard IIS binding and no path metadata. The disposable 10.0.0.802 Studio NET8 PostgreSQL run proved URI resolution, warning propagation, successful uninstall, and complete cleanup.
 Files: clio.mcp.e2e/Support/Configuration/ClioEnvironmentCommandResolver.cs, clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
 Impact: The warning E2E no longer depends on unrelated `EnvironmentPath` metadata and aborts safely on unmatched, ambiguous, or pool-less IIS targets.
+
+## 2026-07-16 14:10 – Bind uninstall warning E2E to the local machine
+Context: Final security review found that a wildcard IIS binding could accept a stale URI hostname for another machine and still select a local pool.
+Decision: Require the registered URI host to identify the current machine by machine name, FQDN, loopback, or DNS/local-interface intersection before IIS matching; reject URI user information and sanitize query/fragment data from diagnostics.
+Discovery: The final worktree code passed 8 resolver/security regressions on net8.0 and net10.0, then the repeated 10.0.0.802 locked-profile E2E passed against the local FQDN and cleaned all recorded resources.
+Files: clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
+Impact: Wildcard bindings no longer authorize foreign-host targets, and secret-bearing URI components cannot leak through failure messages.

--- a/clio.mcp.e2e/Support/Configuration/ClioEnvironmentCommandResolver.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioEnvironmentCommandResolver.cs
@@ -6,6 +6,15 @@ namespace Clio.Mcp.E2E.Support.Configuration;
 
 internal static class ClioEnvironmentCommandResolver {
 	public static string ResolveEnvironmentPath(McpE2ESettings settings, string environmentName) {
+		return ResolveEnvironmentValue(settings, environmentName, "EnvironmentPath");
+	}
+
+	public static string ResolveEnvironmentUri(McpE2ESettings settings, string environmentName) {
+		return ResolveEnvironmentValue(settings, environmentName, "Uri");
+	}
+
+	private static string ResolveEnvironmentValue(McpE2ESettings settings, string environmentName,
+		string fieldName) {
 		ClioProcessDescriptor command = ClioExecutableResolver.Resolve(settings, "envs", environmentName, "--format", "raw");
 		ProcessStartInfo startInfo = new() {
 			FileName = command.Command,
@@ -27,19 +36,23 @@ internal static class ClioEnvironmentCommandResolver {
 		process.WaitForExit();
 
 		process.ExitCode.Should().Be(0,
-			because: $"clio envs {environmentName} must succeed so the E2E suite can resolve the registered environment path. stderr: {stderr}");
+			because: $"clio envs {environmentName} must succeed so the E2E suite can resolve registered environment metadata. stderr: {stderr}");
 
-		string? environmentPath = stdout
-			.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+		return ResolveEnvironmentValue(stdout, fieldName);
+	}
+
+	internal static string ResolveEnvironmentValue(string stdout, string fieldName) {
+		string? value = stdout
+			.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
 			.Select(line => line.Split(':', 2))
 			.Where(parts => parts.Length == 2)
-			.Where(parts => string.Equals(parts[0].Trim(), "EnvironmentPath", StringComparison.OrdinalIgnoreCase))
+			.Where(parts => string.Equals(parts[0].Trim(), fieldName, StringComparison.OrdinalIgnoreCase))
 			.Select(parts => parts[1].Trim())
 			.FirstOrDefault();
 
-		environmentPath.Should().NotBeNullOrWhiteSpace(
-			because: "clio envs must surface EnvironmentPath for a sandbox environment that can be inspected end to end");
+		value.Should().NotBeNullOrWhiteSpace(
+			because: $"clio envs must surface {fieldName} for the configured E2E sandbox environment");
 
-		return environmentPath!;
+		return value!;
 	}
 }

--- a/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
+++ b/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Xml.Linq;
+
+namespace Clio.Mcp.E2E.Support.Configuration;
+
+internal static class IisApplicationPoolResolver {
+	public static string Resolve(string environmentUri) {
+		if (!OperatingSystem.IsWindows()) {
+			throw new PlatformNotSupportedException("IIS application-pool resolution requires Windows.");
+		}
+		if (!Uri.TryCreate(environmentUri, UriKind.Absolute, out Uri? uri)) {
+			throw new InvalidOperationException(
+				$"Registered sandbox URI '{environmentUri}' is not a valid absolute URI.");
+		}
+
+		string appCmd = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+			"System32", "inetsrv", "appcmd.exe");
+		if (!File.Exists(appCmd)) {
+			throw new InvalidOperationException($"IIS AppCmd was not found at '{appCmd}'.");
+		}
+
+		return Resolve(uri, RunAppCmd(appCmd, "list", "site", "/xml"),
+			RunAppCmd(appCmd, "list", "app", "/xml"));
+	}
+
+	internal static string Resolve(Uri environmentUri, string sitesXml, string applicationsXml) {
+		XElement sitesRoot = XElement.Parse(sitesXml);
+		XElement applicationsRoot = XElement.Parse(applicationsXml);
+		HashSet<string> matchingSites = sitesRoot.Elements("SITE")
+			.Where(site => SiteMatches(site, environmentUri))
+			.Select(site => site.Attribute("SITE.NAME")?.Value)
+			.Where(name => !string.IsNullOrWhiteSpace(name))
+			.Cast<string>()
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		string applicationPath = NormalizeApplicationPath(Uri.UnescapeDataString(environmentUri.AbsolutePath));
+		XElement[] matchingApplications = applicationsRoot.Elements("APP")
+			.Where(application => matchingSites.Contains(application.Attribute("SITE.NAME")?.Value ?? string.Empty))
+			.Where(application => string.Equals(
+				NormalizeApplicationPath(application.Attribute("path")?.Value ?? string.Empty),
+				applicationPath, StringComparison.OrdinalIgnoreCase))
+			.ToArray();
+
+		if (matchingApplications.Length != 1) {
+			throw new InvalidOperationException(
+				$"Registered sandbox URI '{environmentUri}' matched {matchingApplications.Length} IIS applications; " +
+				"exactly one match is required before destructive E2E execution.");
+		}
+
+		string? applicationPoolName = matchingApplications[0].Attribute("APPPOOL.NAME")?.Value;
+		if (string.IsNullOrWhiteSpace(applicationPoolName)) {
+			throw new InvalidOperationException(
+				$"The IIS application matched by '{environmentUri}' has no application-pool name.");
+		}
+		return applicationPoolName;
+	}
+
+	private static bool SiteMatches(XElement site, Uri environmentUri) {
+		string? siteName = site.Attribute("SITE.NAME")?.Value;
+		string? bindings = site.Attribute("bindings")?.Value;
+		return !string.IsNullOrWhiteSpace(siteName)
+			&& !string.IsNullOrWhiteSpace(bindings)
+			&& bindings.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+				.Any(binding => BindingMatches(binding, environmentUri));
+	}
+
+	private static bool BindingMatches(string binding, Uri environmentUri) {
+		int protocolSeparator = binding.IndexOf('/');
+		if (protocolSeparator <= 0 || !string.Equals(binding[..protocolSeparator], environmentUri.Scheme,
+				StringComparison.OrdinalIgnoreCase)) {
+			return false;
+		}
+
+		string bindingInformation = binding[(protocolSeparator + 1)..];
+		int hostSeparator = bindingInformation.LastIndexOf(':');
+		int portSeparator = hostSeparator > 0
+			? bindingInformation.LastIndexOf(':', hostSeparator - 1)
+			: -1;
+		if (portSeparator < 0 || hostSeparator < 0
+			|| !int.TryParse(bindingInformation[(portSeparator + 1)..hostSeparator],
+				NumberStyles.None, CultureInfo.InvariantCulture, out int port)
+			|| port != environmentUri.Port) {
+			return false;
+		}
+
+		string boundAddress = bindingInformation[..portSeparator].Trim('[', ']');
+		string hostHeader = bindingInformation[(hostSeparator + 1)..];
+		bool addressMatches = boundAddress is "*" or "0.0.0.0" or "::"
+			|| IPAddress.TryParse(boundAddress, out IPAddress? boundIp)
+			&& IPAddress.TryParse(environmentUri.Host, out IPAddress? environmentIp)
+			&& boundIp.Equals(environmentIp);
+		if (!string.IsNullOrWhiteSpace(hostHeader)) {
+			return addressMatches
+				&& string.Equals(hostHeader, environmentUri.Host, StringComparison.OrdinalIgnoreCase);
+		}
+		return addressMatches;
+	}
+
+	private static string NormalizeApplicationPath(string path) {
+		string normalized = string.IsNullOrWhiteSpace(path) ? "/" : path.Trim();
+		if (!normalized.StartsWith('/')) {
+			normalized = "/" + normalized;
+		}
+		return normalized.Length == 1 ? normalized : normalized.TrimEnd('/');
+	}
+
+	private static string RunAppCmd(string appCmd, params string[] arguments) {
+		ProcessStartInfo startInfo = new(appCmd) {
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			CreateNoWindow = true
+		};
+		foreach (string argument in arguments) {
+			startInfo.ArgumentList.Add(argument);
+		}
+		using Process process = Process.Start(startInfo)
+			?? throw new InvalidOperationException("Could not start IIS appcmd.exe.");
+		string output = process.StandardOutput.ReadToEnd();
+		string error = process.StandardError.ReadToEnd();
+		process.WaitForExit();
+		if (process.ExitCode != 0) {
+			throw new InvalidOperationException(
+				$"appcmd.exe failed with exit code {process.ExitCode}: {error}");
+		}
+		return output;
+	}
+}

--- a/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
+++ b/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Xml.Linq;
 
 namespace Clio.Mcp.E2E.Support.Configuration;
@@ -11,8 +13,7 @@ internal static class IisApplicationPoolResolver {
 			throw new PlatformNotSupportedException("IIS application-pool resolution requires Windows.");
 		}
 		if (!Uri.TryCreate(environmentUri, UriKind.Absolute, out Uri? uri)) {
-			throw new InvalidOperationException(
-				$"Registered sandbox URI '{environmentUri}' is not a valid absolute URI.");
+			throw new InvalidOperationException("The registered sandbox URI is not a valid absolute URI.");
 		}
 
 		string appCmd = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows),
@@ -22,10 +23,22 @@ internal static class IisApplicationPoolResolver {
 		}
 
 		return Resolve(uri, RunAppCmd(appCmd, "list", "site", "/xml"),
-			RunAppCmd(appCmd, "list", "app", "/xml"));
+			RunAppCmd(appCmd, "list", "app", "/xml"), HostIdentifiesCurrentMachine);
 	}
 
-	internal static string Resolve(Uri environmentUri, string sitesXml, string applicationsXml) {
+	internal static string Resolve(Uri environmentUri, string sitesXml, string applicationsXml,
+		Func<string, bool> hostIdentifiesCurrentMachine) {
+		string safeTarget = FormatSafeTarget(environmentUri);
+		if (!string.IsNullOrWhiteSpace(environmentUri.UserInfo)) {
+			throw new InvalidOperationException(
+				$"Registered sandbox URI '{safeTarget}' must not contain user information.");
+		}
+		if (!hostIdentifiesCurrentMachine(environmentUri.Host)) {
+			throw new InvalidOperationException(
+				$"Registered sandbox URI '{safeTarget}' does not identify the current machine; " +
+				"destructive E2E execution is refused.");
+		}
+
 		XElement sitesRoot = XElement.Parse(sitesXml);
 		XElement applicationsRoot = XElement.Parse(applicationsXml);
 		HashSet<string> matchingSites = sitesRoot.Elements("SITE")
@@ -44,16 +57,49 @@ internal static class IisApplicationPoolResolver {
 
 		if (matchingApplications.Length != 1) {
 			throw new InvalidOperationException(
-				$"Registered sandbox URI '{environmentUri}' matched {matchingApplications.Length} IIS applications; " +
+				$"Registered sandbox URI '{safeTarget}' matched {matchingApplications.Length} IIS applications; " +
 				"exactly one match is required before destructive E2E execution.");
 		}
 
 		string? applicationPoolName = matchingApplications[0].Attribute("APPPOOL.NAME")?.Value;
 		if (string.IsNullOrWhiteSpace(applicationPoolName)) {
 			throw new InvalidOperationException(
-				$"The IIS application matched by '{environmentUri}' has no application-pool name.");
+				$"The IIS application matched by '{safeTarget}' has no application-pool name.");
 		}
 		return applicationPoolName;
+	}
+
+	internal static bool HostIdentifiesCurrentMachine(string host) {
+		if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(host, Environment.MachineName, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(host, Dns.GetHostName(), StringComparison.OrdinalIgnoreCase)) {
+			return true;
+		}
+
+		IPGlobalProperties properties = IPGlobalProperties.GetIPGlobalProperties();
+		if (!string.IsNullOrWhiteSpace(properties.DomainName)
+			&& string.Equals(host, $"{properties.HostName}.{properties.DomainName}",
+				StringComparison.OrdinalIgnoreCase)) {
+			return true;
+		}
+
+		HashSet<IPAddress> localAddresses = NetworkInterface.GetAllNetworkInterfaces()
+			.SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
+			.Select(address => address.Address)
+			.ToHashSet();
+		IPAddress[] targetAddresses;
+		try {
+			if (IPAddress.TryParse(host, out IPAddress? literal)) {
+				targetAddresses = [literal];
+			}
+			else {
+				targetAddresses = Dns.GetHostAddresses(host);
+			}
+		}
+		catch (SocketException) {
+			return false;
+		}
+		return targetAddresses.Any(address => IPAddress.IsLoopback(address) || localAddresses.Contains(address));
 	}
 
 	private static bool SiteMatches(XElement site, Uri environmentUri) {
@@ -103,6 +149,17 @@ internal static class IisApplicationPoolResolver {
 			normalized = "/" + normalized;
 		}
 		return normalized.Length == 1 ? normalized : normalized.TrimEnd('/');
+	}
+
+	private static string FormatSafeTarget(Uri environmentUri) {
+		UriBuilder safeTarget = new(environmentUri.Scheme, environmentUri.Host, environmentUri.Port,
+			environmentUri.AbsolutePath) {
+			UserName = string.Empty,
+			Password = string.Empty,
+			Query = string.Empty,
+			Fragment = string.Empty
+		};
+		return safeTarget.Uri.AbsoluteUri.TrimEnd('/');
 	}
 
 	private static string RunAppCmd(string appCmd, params string[] arguments) {

--- a/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
+++ b/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Xml.Linq;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Progress;
 using Clio.Command.McpServer.Tools;
@@ -44,10 +43,9 @@ public sealed class UninstallCreatioWarningE2ETests {
 			Assert.Fail("Configure McpE2E:Sandbox:EnvironmentName for the explicitly opted-in disposable uninstall sandbox.");
 		}
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		string environmentPath = string.IsNullOrWhiteSpace(settings.Sandbox.EnvironmentPath)
-			? ClioEnvironmentCommandResolver.ResolveEnvironmentPath(settings, settings.Sandbox.EnvironmentName!)
-			: Path.GetFullPath(settings.Sandbox.EnvironmentPath);
-		string appPoolName = ResolveAppPoolName(environmentPath);
+		string environmentUri = ClioEnvironmentCommandResolver.ResolveEnvironmentUri(
+			settings, settings.Sandbox.EnvironmentName!);
+		string appPoolName = IisApplicationPoolResolver.Resolve(environmentUri);
 		using ServiceProvider services = new ServiceCollection()
 			.AddSingleton<IWindowsUserProfileApi, WindowsUserProfileApi>()
 			.BuildServiceProvider();
@@ -199,47 +197,6 @@ public sealed class UninstallCreatioWarningE2ETests {
 			File.Delete(entry);
 		}
 		Directory.Delete(path, recursive: false);
-	}
-
-	private static string ResolveAppPoolName(string environmentPath) {
-		string appCmd = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows),
-			"System32", "inetsrv", "appcmd.exe");
-		string vdirsXml = RunAppCmd(appCmd, "list", "vdir", "/xml");
-		XElement root = XElement.Parse(vdirsXml);
-		string normalizedTarget = Path.GetFullPath(environmentPath).TrimEnd(Path.DirectorySeparatorChar);
-		XElement vdir = root.Elements("VDIR").Single(element => {
-			string physicalPath = element.Attribute("physicalPath")?.Value ?? string.Empty;
-			return string.Equals(Path.GetFullPath(physicalPath).TrimEnd(Path.DirectorySeparatorChar),
-				normalizedTarget, StringComparison.OrdinalIgnoreCase);
-		});
-		string appName = vdir.Attribute("APP.NAME")?.Value
-			?? throw new InvalidOperationException("The sandbox IIS virtual directory has no APP.NAME.");
-		return RunAppCmd(appCmd, "list", "app", appName, "/text:applicationPool").Trim();
-	}
-
-	private static string RunAppCmd(string appCmd, params string[] arguments) {
-		return RunProcess(appCmd, arguments);
-	}
-
-	private static string RunProcess(string executable, IEnumerable<string> arguments) {
-		ProcessStartInfo startInfo = new(executable) {
-			UseShellExecute = false,
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			CreateNoWindow = true
-		};
-		foreach (string argument in arguments) {
-			startInfo.ArgumentList.Add(argument);
-		}
-		using Process process = Process.Start(startInfo)
-			?? throw new InvalidOperationException("Could not start IIS appcmd.exe.");
-		string output = process.StandardOutput.ReadToEnd();
-		string error = process.StandardError.ReadToEnd();
-		process.WaitForExit();
-		if (process.ExitCode != 0) {
-			throw new InvalidOperationException($"{Path.GetFileName(executable)} failed with exit code {process.ExitCode}: {error}");
-		}
-		return output;
 	}
 
 	private static bool HasWarningTerminalStream(IReadOnlyList<JsonNode> rawParams) {

--- a/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
+++ b/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
@@ -49,7 +49,8 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 			""";
 
 		// Act
-		string result = IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, ApplicationsXml);
+		string result = IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, ApplicationsXml, host => host == "ts1-agent80");
 
 		// Assert
 		result.Should().Be("studio-pool",
@@ -62,7 +63,7 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 	[AllureName("Uninstall warning harness rejects unmatched IIS binding")]
 	public void Resolve_ShouldThrow_WhenBindingDoesNotMatch() {
 		// Arrange
-		Uri environmentUri = new("http://ts1-agent80:88/studio");
+		Uri environmentUri = new("http://ts1-agent80:88/studio?access_token=secret-sentinel");
 		const string sitesXml = """
 			<appcmd>
 			  <SITE SITE.NAME="Default Web Site" bindings="http/*:88:other-agent" state="Started" />
@@ -70,12 +71,15 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 			""";
 
 		// Act
-		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, ApplicationsXml);
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, ApplicationsXml, host => host == "ts1-agent80");
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
 				because: "an unmatched target must fail before the destructive MCP call")
-			.WithMessage("*matched 0 IIS applications*");
+			.WithMessage("*matched 0 IIS applications*")
+			.And.Message.Should().NotContain("secret-sentinel",
+				because: "query credentials must not be written into TeamCity failure diagnostics");
 	}
 
 	[Test]
@@ -99,7 +103,8 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 			""";
 
 		// Act
-		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, applicationsXml);
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, applicationsXml, host => host == "ts1-agent80");
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
@@ -126,11 +131,74 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 			""";
 
 		// Act
-		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, applicationsXml);
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, applicationsXml, host => host == "ts1-agent80");
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
 				because: "a target without an explicit pool must fail before the destructive MCP call")
 			.WithMessage("*has no application-pool name*");
+	}
+
+	[Test]
+	[Description("Rejects a foreign registered hostname even when a wildcard IIS binding and application path match.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness rejects foreign host on wildcard binding")]
+	public void Resolve_ShouldThrow_WhenRegisteredHostIsNotLocal() {
+		// Arrange
+		Uri environmentUri = new("http://other-agent:88/studio");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="Default Web Site" bindings="http/*:88:" state="Started" />
+			</appcmd>
+			""";
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, ApplicationsXml, _ => false);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "a wildcard binding must not authorize a stale URI for another machine")
+			.WithMessage("*does not identify the current machine*");
+	}
+
+	[Test]
+	[Description("Recognizes the current machine name as a local destructive E2E target.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness recognizes current machine name")]
+	public void HostIdentifiesCurrentMachine_ShouldReturnTrue_WhenHostIsMachineName() {
+		// Arrange
+		string host = Environment.MachineName;
+
+		// Act
+		bool result = IisApplicationPoolResolver.HostIdentifiesCurrentMachine(host);
+
+		// Assert
+		result.Should().BeTrue(
+			because: "TeamCity registers the sandbox with the build agent machine name");
+	}
+
+	[Test]
+	[Description("Rejects user information in the registered sandbox URI without leaking it into diagnostics.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness rejects URI user information safely")]
+	public void Resolve_ShouldThrowWithoutSecret_WhenUriContainsUserInformation() {
+		// Arrange
+		Uri environmentUri = new("http://secret-user:secret-password@ts1-agent80:88/studio");
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, "<appcmd />", "<appcmd />", host => host == "ts1-agent80");
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "IIS target URIs never require embedded credentials")
+			.WithMessage("*must not contain user information*")
+			.Which;
+		exception.Message.Should().NotContain("secret-user",
+			because: "URI usernames must not be written into TeamCity failure diagnostics");
+		exception.Message.Should().NotContain("secret-password",
+			because: "URI passwords must not be written into TeamCity failure diagnostics");
 	}
 }

--- a/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
+++ b/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
@@ -1,0 +1,136 @@
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E;
+
+[TestFixture]
+[Category("McpE2E.NoEnvironment")]
+[AllureNUnit]
+[AllureFeature("uninstall-creatio")]
+public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
+	private const string ToolName = UninstallCreatioTool.UninstallCreatioToolName;
+	private const string ApplicationsXml = """
+		<?xml version="1.0" encoding="UTF-8"?>
+		<appcmd>
+		  <APP path="/studio" APP.NAME="Default Web Site/studio" APPPOOL.NAME="studio-pool" SITE.NAME="Default Web Site" />
+		</appcmd>
+		""";
+
+	[Test]
+	[Description("Reads Uri from raw clio environment output when EnvironmentPath is empty.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness reads URI without EnvironmentPath")]
+	public void ResolveEnvironmentValue_ShouldReturnUri_WhenEnvironmentPathIsEmpty() {
+		// Arrange
+		const string rawEnvironment = "EnvironmentPath: \r\nUri: http://ts1-agent80:88/studio\r\n";
+
+		// Act
+		string result = ClioEnvironmentCommandResolver.ResolveEnvironmentValue(rawEnvironment, "Uri");
+
+		// Assert
+		result.Should().Be("http://ts1-agent80:88/studio",
+			because: "the warning scenario needs the registered URI and must not require unrelated path metadata");
+	}
+
+	[Test]
+	[Description("Matches a registered sandbox URI to one IIS application behind a wildcard binding.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness resolves wildcard IIS binding")]
+	public void Resolve_ShouldReturnApplicationPool_WhenWildcardBindingAndPathMatch() {
+		// Arrange
+		Uri environmentUri = new("http://ts1-agent80:88/studio/");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="Default Web Site" bindings="http/*:88:" state="Started" />
+			</appcmd>
+			""";
+
+		// Act
+		string result = IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, ApplicationsXml);
+
+		// Assert
+		result.Should().Be("studio-pool",
+			because: "TeamCity exposes the sandbox through a wildcard IIS binding and application path");
+	}
+
+	[Test]
+	[Description("Rejects a sandbox URI whose IIS binding does not match.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness rejects unmatched IIS binding")]
+	public void Resolve_ShouldThrow_WhenBindingDoesNotMatch() {
+		// Arrange
+		Uri environmentUri = new("http://ts1-agent80:88/studio");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="Default Web Site" bindings="http/*:88:other-agent" state="Started" />
+			</appcmd>
+			""";
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, ApplicationsXml);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "an unmatched target must fail before the destructive MCP call")
+			.WithMessage("*matched 0 IIS applications*");
+	}
+
+	[Test]
+	[Description("Rejects a sandbox URI that ambiguously matches applications in more than one IIS site.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness rejects ambiguous IIS target")]
+	public void Resolve_ShouldThrow_WhenApplicationMatchIsAmbiguous() {
+		// Arrange
+		Uri environmentUri = new("http://ts1-agent80:88/studio");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="First" bindings="http/*:88:" state="Started" />
+			  <SITE SITE.NAME="Second" bindings="http/*:88:" state="Started" />
+			</appcmd>
+			""";
+		const string applicationsXml = """
+			<appcmd>
+			  <APP path="/studio" APP.NAME="First/studio" APPPOOL.NAME="first-pool" SITE.NAME="First" />
+			  <APP path="/studio" APP.NAME="Second/studio" APPPOOL.NAME="second-pool" SITE.NAME="Second" />
+			</appcmd>
+			""";
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, applicationsXml);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "an ambiguous target must fail before the destructive MCP call")
+			.WithMessage("*matched 2 IIS applications*");
+	}
+
+	[Test]
+	[Description("Rejects a matched IIS application that has no application-pool name.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness rejects application without pool")]
+	public void Resolve_ShouldThrow_WhenApplicationPoolNameIsMissing() {
+		// Arrange
+		Uri environmentUri = new("http://ts1-agent80:88/studio");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="Default Web Site" bindings="http/*:88:" state="Started" />
+			</appcmd>
+			""";
+		const string applicationsXml = """
+			<appcmd>
+			  <APP path="/studio" APP.NAME="Default Web Site/studio" SITE.NAME="Default Web Site" />
+			</appcmd>
+			""";
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(environmentUri, sitesXml, applicationsXml);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "a target without an explicit pool must fail before the destructive MCP call")
+			.WithMessage("*has no application-pool name*");
+	}
+}

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -1991,6 +1991,20 @@ stories:
     depends_on: []
     blocks: []
 
+  - id: story-uninstall-warning-e2e-uri-resolution-1
+    title: "Resolve uninstall warning E2E IIS target without EnvironmentPath"
+    feature: "uninstall-warning-e2e-uri-resolution"
+    repo: "clio"
+    size: S
+    status: done
+    issue: 893
+    file: spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-story.md
+    prd: spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
+    adr: spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
+    test_plan: spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
+    depends_on: [story-apppool-profile-cleanup-1]
+    blocks: []
+
   - id: story-dbhub-integration-1
     title: "Deliver dbHub installation and automatic Creatio source synchronization"
     feature: "dbhub-integration"

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
@@ -15,10 +15,12 @@ or inspect `EnvironmentPath`, because that path is not part of the behavior unde
 ## Safety
 
 - Destructive execution remains explicitly opted in and bound to the configured sandbox name.
+- The registered URI host must identify the current machine before wildcard IIS bindings are considered.
 - URI-to-IIS resolution requires exactly one application match and a non-empty pool name.
 - Host-specific bindings must match the URI host; wildcard IP and empty host-header bindings remain
   valid for TeamCity's agent-host URL.
 - Any malformed IIS XML or ambiguous topology fails before the MCP uninstall call.
+- URI user information is rejected, and query/fragment data is removed from failure diagnostics.
 
 ## Compatibility
 

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
@@ -1,0 +1,26 @@
+# Uninstall warning E2E URI resolution ADR
+
+Status: accepted for issue #893
+
+## Decision
+
+Extend the E2E environment command resolver so it can read the registered `Uri` field from
+`clio envs <name> --format raw`. Add a Windows-only E2E harness resolver that reads IIS site and
+application XML from AppCmd, selects sites whose binding matches the URI scheme, port, and host, then
+selects exactly one application whose path matches the URI path.
+
+The locked-profile fixture will use the resulting `APPPOOL.NAME` directly. It will no longer resolve
+or inspect `EnvironmentPath`, because that path is not part of the behavior under test.
+
+## Safety
+
+- Destructive execution remains explicitly opted in and bound to the configured sandbox name.
+- URI-to-IIS resolution requires exactly one application match and a non-empty pool name.
+- Host-specific bindings must match the URI host; wildcard IP and empty host-header bindings remain
+  valid for TeamCity's agent-host URL.
+- Any malformed IIS XML or ambiguous topology fails before the MCP uninstall call.
+
+## Compatibility
+
+This is test-harness-only. MCP tool names, arguments, output, progress events, docs, guidance, and
+ClioRing contracts are unchanged.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
@@ -1,0 +1,32 @@
+# Uninstall warning E2E URI resolution PRD
+
+Issue: [#893](https://github.com/Advance-Technologies-Foundation/clio/issues/893)
+
+## Problem
+
+The destructive uninstall warning E2E requires `EnvironmentPath` only to discover the sandbox IIS
+application pool. TeamCity registers the disposable environment by URI without `EnvironmentPath`, so
+the test fails before invoking `uninstall-creatio`.
+
+## Requirements
+
+- Resolve the registered sandbox URI through the same fresh clio executable used by the E2E run.
+- Match that URI to exactly one IIS site application and return its application-pool name.
+- Support IIS bindings with wildcard IPs and empty host headers.
+- Fail before destructive execution when the URI is invalid, unmatched, ambiguous, or lacks a pool.
+- Keep `SandboxEnvironmentResolver` and its `EnvironmentPath` contract unchanged for tests that read
+  files from the deployed Creatio root.
+- Add no production CLI, MCP, or ClioRing contract changes.
+
+## Acceptance criteria
+
+- The TeamCity shape `http://<agent>:<port>/<application>` resolves without `EnvironmentPath`.
+- Resolver tests cover a successful wildcard binding plus unmatched and ambiguous safety failures.
+- The existing locked-profile test still proves warning output, exit code 0, `IsError=false`, the
+  warning stage, and the `success-with-warnings` terminal.
+
+## Exclusions
+
+- Changing TeamCity configuration.
+- Weakening destructive-test opt-in or target validation.
+- Changing production uninstall behavior.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
@@ -12,11 +12,13 @@ the test fails before invoking `uninstall-creatio`.
 
 - Resolve the registered sandbox URI through the same fresh clio executable used by the E2E run.
 - Match that URI to exactly one IIS site application and return its application-pool name.
+- Require the registered URI host to identify the current machine before considering IIS bindings.
 - Support IIS bindings with wildcard IPs and empty host headers.
 - Fail before destructive execution when the URI is invalid, unmatched, ambiguous, or lacks a pool.
 - Keep `SandboxEnvironmentResolver` and its `EnvironmentPath` contract unchanged for tests that read
   files from the deployed Creatio root.
 - Add no production CLI, MCP, or ClioRing contract changes.
+- Keep URI credentials and query/fragment data out of failure diagnostics.
 
 ## Acceptance criteria
 

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-story.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-story.md
@@ -1,0 +1,17 @@
+# Story: resolve the uninstall warning sandbox by URI
+
+Status: done
+
+Issue: #893
+
+As a Clio maintainer, I want the locked-profile MCP E2E to resolve its IIS application pool from the
+registered sandbox URI so the master TeamCity suite validates uninstall warnings without requiring
+unrelated `EnvironmentPath` metadata.
+
+## Definition of done
+
+- The fixture resolves the environment URI through the fresh clio executable.
+- IIS URI matching is strict, deterministic, and covered by no-environment E2E harness tests.
+- The existing destructive warning scenario passes against an explicitly opted-in disposable stand.
+- Documentation, MCP production surface, and ClioRing compatibility are reviewed and recorded.
+- Final comprehensive agentic review has no unresolved Blocker or High findings.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
@@ -7,6 +7,8 @@
 - Reject unmatched URI bindings before any destructive action.
 - Reject ambiguous IIS application matches before any destructive action.
 - Reject a matched application with no application-pool name.
+- Reject foreign hosts even when a wildcard IIS binding and application path match.
+- Reject URI user information and redact query/fragment values from failure diagnostics.
 
 ## End to end
 
@@ -26,8 +28,8 @@
 
 - `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --no-restore`: passed for
   `net8.0` and `net10.0`; only pre-existing warnings outside the changed files were emitted.
-- Resolver regression filter: 5 passed, 0 failed, 0 skipped on both `net8.0` and `net10.0`.
-- Disposable `10.0.0.802` Studio NET8 PostgreSQL deployment returned HTTP 200 and `get-info` exit 0.
+- Resolver regression filter: 8 passed, 0 failed, 0 skipped on both `net8.0` and `net10.0`.
+- Disposable `10.0.0.802` Studio NET8 PostgreSQL deployment returned HTTP 200.
 - The exact locked-profile MCP E2E passed on `net10.0` and verified the warning terminal contract.
 - Cleanup verification found no remaining environment, IIS site, application pool, files, database,
-  or profile registration for `clio893_20260716_1430`.
+  or profile registration for both disposable validation targets.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
@@ -1,0 +1,33 @@
+# Uninstall warning E2E URI resolution test plan
+
+## Harness regression
+
+- Parse a raw clio environment output whose `EnvironmentPath` is empty but whose `Uri` is populated.
+- Resolve an IIS application behind a wildcard-IP, empty-host-header binding by scheme, port, and path.
+- Reject unmatched URI bindings before any destructive action.
+- Reject ambiguous IIS application matches before any destructive action.
+- Reject a matched application with no application-pool name.
+
+## End to end
+
+- Run the locked application-pool profile scenario against an explicitly opted-in disposable Windows
+  sandbox and verify warning output, exit code 0, `IsError=false`, warning stage, and
+  `success-with-warnings` terminal.
+- Use `F:\CreatioBuilds\10.0.0\10.0.0.802_StudioNet8_Softkey_PostgreSQL_ENU.zip` only if a fresh
+  disposable stand is required.
+
+## Compatibility review
+
+- Docs reviewed: no command behavior or user-facing documentation changes.
+- MCP reviewed: no production MCP contract changes.
+- ClioRing compatibility reviewed: no Ring-consumed contract changes.
+
+## Validation results
+
+- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --no-restore`: passed for
+  `net8.0` and `net10.0`; only pre-existing warnings outside the changed files were emitted.
+- Resolver regression filter: 5 passed, 0 failed, 0 skipped on both `net8.0` and `net10.0`.
+- Disposable `10.0.0.802` Studio NET8 PostgreSQL deployment returned HTTP 200 and `get-info` exit 0.
+- The exact locked-profile MCP E2E passed on `net10.0` and verified the warning terminal contract.
+- Cleanup verification found no remaining environment, IIS site, application pool, files, database,
+  or profile registration for `clio893_20260716_1430`.


### PR DESCRIPTION
## Problem

TeamCity master build 15735619 failed `UninstallCreatioWarningE2ETests.UninstallCreatio_ShouldCompleteWithWarnings_WhenAppPoolProfileContainsLockedFile` before invoking `uninstall-creatio`. The CI sandbox is registered by URI and intentionally has an empty `EnvironmentPath`, but the fixture required that unrelated field only to find its IIS application pool.

Fixes #893.

## Solution

- resolve the registered sandbox `Uri` through the same fresh clio executable used by the E2E run;
- map scheme, port, host binding, and application path to exactly one IIS application pool;
- require the URI host to identify the current machine before considering wildcard IIS bindings;
- fail closed on foreign, unmatched, ambiguous, or pool-less targets;
- reject URI user information and remove query/fragment data from diagnostics;
- keep existing path-based sandbox helpers unchanged for tests that read deployment files.

Scope is test harness only. The production `uninstall-creatio` CLI/MCP contract is unchanged.

## Validation

- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --no-restore` — passed for `net8.0` and `net10.0` (only pre-existing warnings outside changed files).
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net8.0 --no-build --filter "FullyQualifiedName~UninstallWarningIisApplicationPoolResolverE2ETests"` — 8 passed, 0 failed, 0 skipped.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net10.0 --no-build --filter "FullyQualifiedName~UninstallWarningIisApplicationPoolResolverE2ETests"` — 8 passed, 0 failed, 0 skipped.
- Final-code disposable run using `F:\CreatioBuilds\10.0.0\10.0.0.802_StudioNet8_Softkey_PostgreSQL_ENU.zip` — HTTP 200, exact locked-profile MCP E2E passed 1/1 on `net10.0`.
- Disposable cleanup verified: environment unregistered; IIS site and pool absent; application files absent; PostgreSQL database absent; profile registration absent.
- `git diff --check` — clean.

## Reviews

- Docs reviewed, no update required: no command behavior or user-facing contract changed.
- MCP reviewed, no production update required: only MCP E2E harness/test code changed.
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`.
- Initial comprehensive agentic review found one High wildcard-host binding risk; fixed in `2cd5df1b` with local-machine verification and secret-safe diagnostics.
- Repeated comprehensive agentic review over the complete final diff: code quality/maintainability — no findings; correctness/performance/testing/edge cases — no findings; security/best practices — no findings. No unresolved Blocker or High findings.

## Delivery

Ready for review and auto-merge. The linked issue worktree is retained until GitHub merges the PR; TeamCity MCP E2E is intentionally not awaited by this workflow.