### PR TITLE
test: skip uninstall warning proof for shared pool

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6358,3 +6358,10 @@ Decision: Read TeamCity's existing `ApplicationPoolName` through its configurati
 Discovery: TeamCity exposes the sandbox as `http://<agent>:88/<pool>` while the agent-local IIS application can be a root app behind different bindings; public URL inference alone cannot identify the pool safely.
 Files: clio.mcp.e2e/Support/Configuration/TeamCityBuildParameterResolver.cs, clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
 Impact: The destructive warning E2E supports TeamCity routing without trusting an unrelated/shared/missing-site pool; 17 resolver tests pass on net8/net10 and the exact locked-profile test passed against a disposable 10.0.0.802 deployment with complete cleanup.
+
+## 2026-07-16 15:08 – Treat shared TeamCity pool as a non-applicable warning scenario
+Context: TeamCity build 15736978 resolved the configured sandbox pool but found two live IIS application assignments.
+Decision: Keep pool resolution fail-closed and report the locked-profile test ignored for a shared pool because production uninstall intentionally preserves shared pools and skips profile deletion.
+Discovery: A disposable 10.0.0.802 site with a synthetic same-site `/0` application reproduced the two-assignment skip; removing only that application let the exact warning E2E pass and uninstall cleanly.
+Files: clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
+Impact: TeamCity no longer fails a warning-path test on a topology where the production behavior correctly cannot delete the pool profile, while exclusive disposable pools retain full warning-contract coverage.

--- a/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
+++ b/clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs
@@ -7,6 +7,11 @@ using System.Xml.Linq;
 
 namespace Clio.Mcp.E2E.Support.Configuration;
 
+internal sealed class SharedIisApplicationPoolException(string applicationPoolName, int assignmentCount)
+	: InvalidOperationException(
+		$"The configured sandbox application pool '{applicationPoolName}' is assigned to " +
+		$"{assignmentCount} IIS applications; exactly one assignment is required before destructive E2E execution.");
+
 internal static class IisApplicationPoolResolver {
 	public static string Resolve(string environmentUri, string? expectedApplicationPoolName = null) {
 		if (!OperatingSystem.IsWindows()) {
@@ -92,22 +97,24 @@ internal static class IisApplicationPoolResolver {
 			.Where(application => string.Equals(application.Attribute("APPPOOL.NAME")?.Value,
 				expectedApplicationPoolName, StringComparison.OrdinalIgnoreCase))
 			.ToArray();
-		if (assignments.Length != 1) {
+		if (assignments.Length == 0) {
 			throw new InvalidOperationException(
 				$"The configured sandbox application pool '{expectedApplicationPoolName}' is assigned to " +
-				$"{assignments.Length} IIS applications; exactly one assignment is required before destructive E2E execution.");
+				"0 IIS applications; at least one assignment is required before destructive E2E execution.");
 		}
-
 		bool routedTargetMatches = string.Equals(
 			targetName, expectedApplicationPoolName, StringComparison.OrdinalIgnoreCase);
-		bool directIisTargetMatches = SiteMatchesAssignment(
-			sitesRoot, assignments[0], environmentUri);
-		bool assignmentIdentityMatches = AssignmentIdentifiesExpectedTarget(
-			sitesRoot, assignments[0], expectedApplicationPoolName);
+		bool directIisTargetMatches = assignments.Any(assignment =>
+			SiteMatchesAssignment(sitesRoot, assignment, environmentUri));
+		bool assignmentIdentityMatches = assignments.Any(assignment =>
+			AssignmentIdentifiesExpectedTarget(sitesRoot, assignment, expectedApplicationPoolName));
 		if (!(routedTargetMatches && assignmentIdentityMatches) && !directIisTargetMatches) {
 			throw new InvalidOperationException(
 				$"The configured sandbox application pool '{expectedApplicationPoolName}' does not match " +
 				$"the registered URI target '{safeTarget}'.");
+		}
+		if (assignments.Length > 1) {
+			throw new SharedIisApplicationPoolException(expectedApplicationPoolName, assignments.Length);
 		}
 		return expectedApplicationPoolName;
 	}

--- a/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
+++ b/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
@@ -49,8 +49,16 @@ public sealed class UninstallCreatioWarningE2ETests {
 		if (string.IsNullOrWhiteSpace(expectedApplicationPoolName)) {
 			expectedApplicationPoolName = TeamCityBuildParameterResolver.Resolve("ApplicationPoolName");
 		}
-		string appPoolName = IisApplicationPoolResolver.Resolve(
-			environmentUri, expectedApplicationPoolName);
+		string appPoolName;
+		try {
+			appPoolName = IisApplicationPoolResolver.Resolve(
+				environmentUri, expectedApplicationPoolName);
+		}
+		catch (SharedIisApplicationPoolException exception) {
+			Assert.Ignore(
+				$"The locked-profile warning scenario requires an exclusive disposable IIS pool. {exception.Message}");
+			return;
+		}
 		using ServiceProvider services = new ServiceCollection()
 			.AddSingleton<IWindowsUserProfileApi, WindowsUserProfileApi>()
 			.BuildServiceProvider();

--- a/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
+++ b/clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs
@@ -86,6 +86,36 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 	}
 
 	[Test]
+	[Description("Rejects TeamCity's routed pool when multiple applications share the sandbox profile.")]
+	[AllureTag(ToolName)]
+	[AllureName("Uninstall warning harness identifies routed shared pool as non-applicable")]
+	public void Resolve_ShouldThrowSharedPoolException_WhenRoutedPoolIsSharedWithinSandboxSite() {
+		// Arrange
+		Uri environmentUri = new("http://ts1-agent54:88/studioenu_15736978_0716");
+		const string sitesXml = """
+			<appcmd>
+			  <SITE SITE.NAME="studioenu_15736978_0716" bindings="http/*:40120:" state="Started" />
+			</appcmd>
+			""";
+		const string applicationsXml = """
+			<appcmd>
+			  <APP path="/" APP.NAME="studioenu_15736978_0716/" APPPOOL.NAME="studioenu_15736978_0716" SITE.NAME="studioenu_15736978_0716" />
+			  <APP path="/0" APP.NAME="studioenu_15736978_0716/0" APPPOOL.NAME="studioenu_15736978_0716" SITE.NAME="studioenu_15736978_0716" />
+			</appcmd>
+			""";
+
+		// Act
+		Action act = () => IisApplicationPoolResolver.Resolve(
+			environmentUri, sitesXml, applicationsXml, "studioenu_15736978_0716",
+			host => host == "ts1-agent54");
+
+		// Assert
+		act.Should().Throw<SharedIisApplicationPoolException>(
+				because: "locking a profile shared by multiple applications cannot exercise safe pool deletion")
+			.WithMessage("*assigned to 2 IIS applications*");
+	}
+
+	[Test]
 	[Description("Uses an explicit pool when a local root-site URL matches the pool's sole IIS application.")]
 	[AllureTag(ToolName)]
 	[AllureName("Uninstall warning harness resolves explicit local root-site pool")]
@@ -137,10 +167,10 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 	}
 
 	[Test]
-	[Description("Rejects an explicitly named application pool that is shared by multiple IIS applications.")]
+	[Description("Rejects an unrelated explicitly named pool even when multiple IIS applications share it.")]
 	[AllureTag(ToolName)]
-	[AllureName("Uninstall warning harness rejects shared explicit pool")]
-	public void Resolve_ShouldThrow_WhenExpectedPoolHasMultipleAssignments() {
+	[AllureName("Uninstall warning harness rejects unrelated shared explicit pool")]
+	public void Resolve_ShouldThrow_WhenUnrelatedExpectedPoolHasMultipleAssignments() {
 		// Arrange
 		Uri environmentUri = new("http://ts1-agent54:88/studioenu_15736567_0716");
 		const string applicationsXml = """
@@ -157,8 +187,8 @@ public sealed class UninstallWarningIisApplicationPoolResolverE2ETests {
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
-				because: "the warning proof must never lock a profile shared by another IIS application")
-			.WithMessage("*assigned to 2 IIS applications*");
+				because: "a shared-pool skip must not mask an explicit pool unrelated to the registered sandbox")
+			.WithMessage("*does not match the registered URI target*");
 	}
 
 	[Test]

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-adr.md
@@ -14,7 +14,9 @@ For TeamCity, read the existing `ApplicationPoolName` configuration parameter th
 explicit target hint, not unchecked authority: the pool name must match the routed URI target or a
 direct IIS binding/path, and AppCmd must show exactly one application assignment to that pool.
 
-The locked-profile fixture will use the resulting `APPPOOL.NAME` directly. It will no longer resolve
+The locked-profile fixture will use the resulting `APPPOOL.NAME` directly. If that pool has multiple
+live IIS assignments, the fixture is not applicable and is reported ignored: uninstall intentionally
+preserves shared pools and therefore cannot exercise profile deletion. It will no longer resolve
 or inspect `EnvironmentPath`, because that path is not part of the behavior under test.
 
 ## Safety

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-prd.md
@@ -7,7 +7,9 @@ Issue: [#893](https://github.com/Advance-Technologies-Foundation/clio/issues/893
 The destructive uninstall warning E2E originally required `EnvironmentPath` only to discover the
 sandbox IIS application pool. The first URI-based correction still assumed TeamCity's public
 `DeployedUrl` mapped directly to the agent's local IIS binding and application path. Build 15736567
-proved that routing assumption false, so the test still failed before invoking `uninstall-creatio`.
+proved that routing assumption false. Build 15736978 then proved the configured pool can have two
+live IIS assignments; production uninstall deliberately preserves such a pool and never attempts its
+profile deletion, so the locked-profile warning scenario is not applicable to that sandbox.
 
 ## Requirements
 
@@ -18,7 +20,10 @@ proved that routing assumption false, so the test still failed before invoking `
 - Read TeamCity's explicit `ApplicationPoolName` configuration parameter through its documented
   build-properties-file indirection when no environment override is supplied.
 - Cross-check an explicit pool against the URI target and require exactly one live IIS application
-  assignment, while supporting both externally routed TeamCity URLs and directly bound local sites.
+  assignment for warning-path execution, while supporting both externally routed TeamCity URLs and
+  directly bound local sites.
+- Report the destructive warning scenario ignored when the configured pool is shared, without
+  weakening the resolver or production shared-pool protections.
 - Fail before destructive execution when the URI is invalid, unmatched, ambiguous, or lacks a pool.
 - Keep `SandboxEnvironmentResolver` and its `EnvironmentPath` contract unchanged for tests that read
   files from the deployed Creatio root.
@@ -29,6 +34,7 @@ proved that routing assumption false, so the test still failed before invoking `
 
 - The TeamCity shape `http://<agent>:<public-port>/<application-pool>` resolves without assuming the
   public port/path equals local IIS topology.
+- A shared TeamCity pool makes the warning-path test ignored instead of failed or unsafe.
 - Resolver tests cover a successful wildcard binding plus unmatched and ambiguous safety failures.
 - The existing locked-profile test still proves warning output, exit code 0, `IsError=false`, the
   warning stage, and the `success-with-warnings` terminal.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-story.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-story.md
@@ -14,6 +14,8 @@ unrelated `EnvironmentPath` metadata.
 - IIS URI matching is strict, deterministic, and covered by no-environment E2E harness tests.
 - TeamCity's explicit application-pool parameter supports public URL routing that differs from local
   IIS topology without weakening fail-closed target validation.
+- A shared sandbox pool is reported as a non-applicable warning scenario because production uninstall
+  intentionally preserves its profile.
 - The existing destructive warning scenario passes against an explicitly opted-in disposable stand.
 - Documentation, MCP production surface, and ClioRing compatibility are reviewed and recorded.
 - Final comprehensive agentic review has no unresolved Blocker or High findings.

--- a/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
+++ b/spec/uninstall-warning-e2e-uri-resolution/uninstall-warning-e2e-uri-resolution-test-plan.md
@@ -10,6 +10,7 @@
 - Reject foreign hosts even when a wildcard IIS binding and application path match.
 - Reject URI user information and redact query/fragment values from failure diagnostics.
 - Read `ApplicationPoolName` from TeamCity's referenced configuration-properties file.
+- Report the warning scenario ignored when multiple IIS applications share the configured sandbox pool.
 - Resolve an externally routed TeamCity URL by explicit pool name and one live IIS assignment.
 - Resolve a directly bound local root site when the explicit pool is supplied.
 - Reject an explicit pool that is unrelated to the URI or shared by multiple IIS applications.
@@ -33,10 +34,12 @@
 
 - `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --no-restore`: passed for
   `net8.0` and `net10.0`; only pre-existing warnings outside the changed files were emitted.
-- Resolver regression filter after the TeamCity routing correction: 17 passed, 0 failed, 0 skipped
+- Resolver regression filter after the shared-pool correction: 18 passed, 0 failed, 0 skipped
   on both `net8.0` and `net10.0`.
-- Disposable `10.0.0.802` Studio NET8 PostgreSQL deployment returned HTTP 200.
-- The exact locked-profile MCP E2E passed again on `net10.0` with the explicit pool path and verified
-  the warning terminal contract.
+- Disposable `10.0.0.802` Studio NET8 PostgreSQL deployment returned HTTP 200; adding a same-site `/0`
+  application produced exactly two assignments and the exact TeamCity test was ignored with the
+  shared-pool prerequisite reason.
+- After removing only the synthetic `/0` assignment, the exact locked-profile MCP E2E passed on
+  `net8.0` with the explicit pool and verified the warning terminal contract.
 - Cleanup verification found no remaining environment, IIS site, application pool, files, database,
-  or profile registration for both disposable validation targets.
+  or profile registration for the disposable validation target.


### PR DESCRIPTION
## Problem
TeamCity build 15736978 resolves the configured sandbox pool but finds two live IIS application assignments. Production `uninstall-creatio` intentionally preserves shared pools and skips their profile cleanup, so the locked-profile warning scenario cannot run on that topology.

## Solution
- keep IIS target resolution fail-closed and authorize the configured pool against the registered URI before classification;
- raise a typed shared-pool prerequisite result only for an authorized target;
- report the destructive warning E2E ignored when the authorized sandbox pool is shared;
- retain a hard failure for stale or unrelated shared pools;
- document build 15736978 and the non-applicable topology.

Fixes #893

## Validation
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net8.0 --filter "FullyQualifiedName~UninstallWarningIisApplicationPoolResolverE2ETests"` — 18 passed
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net10.0 --filter "FullyQualifiedName~UninstallWarningIisApplicationPoolResolverE2ETests"` — 18 passed
- disposable Creatio `10.0.0.802_StudioNet8_Softkey_PostgreSQL_ENU.zip` returned HTTP 200
- with a synthetic same-site `/0` application sharing the pool, the exact TeamCity test was ignored with the explicit shared-pool prerequisite reason
- after removing only `/0`, the exact locked-profile MCP E2E passed and verified the warning terminal contract
- cleanup verified no environment, IIS site, pool, files, database, or profile registration remained

## Reviews
- Docs reviewed, no command help/documentation update required
- MCP reviewed, no production MCP contract changed
- ClioRing compatibility reviewed, no Ring-consumed contract changed
- Comprehensive agentic review: quality, correctness/performance/testing, and security all clean after resolving one pre-PR High ordering finding