### PR TITLE
feat(ring): select release or development clio runtime

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6365,3 +6365,9 @@ Decision: Keep pool resolution fail-closed and report the locked-profile test ig
 Discovery: A disposable 10.0.0.802 site with a synthetic same-site `/0` application reproduced the two-assignment skip; removing only that application let the exact warning E2E pass and uninstall cleanly.
 Files: clio.mcp.e2e/Support/Configuration/IisApplicationPoolResolver.cs, clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs, clio.mcp.e2e/UninstallWarningIisApplicationPoolResolverE2ETests.cs, spec/uninstall-warning-e2e-uri-resolution/
 Impact: TeamCity no longer fails a warning-path test on a topology where the production behavior correctly cannot delete the pool profile, while exclusive disposable pools retain full warning-contract coverage.
+## 2026-07-17 09:29 – Prototype ClioRing runtime switch
+Context: Issue #903 requests release clio as the ordinary Ring runtime and an unavoidable main-surface warning when a development/custom clio is running.
+Decision: Separate persisted runtime selection from the saved development target, reserve banner space above the radial control for Development, and keep Release as a compact green identity strip; runtime changes are represented as next-launch choices until the owned IPC child can be safely retargeted.
+Discovery: The prior "machine default" is a hard-coded repository Debug DLL, and the existing settings warning only recognizes DevClioPath, so an explicit ClioIpc Debug DLL is mislabeled as normal and invisible on the main surface.
+Files: clio-ring/ClioRing/Views/RingView.axaml, clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs, clio-ring/ClioRing/Services/ClioSettingsStore.cs, spec/ring-clio-runtime-switch/
+Impact: The requester can approve the rendered Development and Release states before comprehensive review, full tests, or NativeAOT publish.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6371,3 +6371,10 @@ Decision: Separate persisted runtime selection from the saved development target
 Discovery: The prior "machine default" is a hard-coded repository Debug DLL, and the existing settings warning only recognizes DevClioPath, so an explicit ClioIpc Debug DLL is mislabeled as normal and invisible on the main surface.
 Files: clio-ring/ClioRing/Views/RingView.axaml, clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs, clio-ring/ClioRing/Services/ClioSettingsStore.cs, spec/ring-clio-runtime-switch/
 Impact: The requester can approve the rendered Development and Release states before comprehensive review, full tests, or NativeAOT publish.
+
+## 2026-07-17 10:13 – Complete ClioRing runtime selection
+Context: The approved issue #903 design needed production-safe runtime propagation, persistence, and final validation.
+Decision: Resolve one immutable runtime for IPC workflows, environment discovery, and radial commands; trust Release only from dotnet-owned user roots; preserve next-launch selection in Ring's own settings with atomic writes and an actionable invalid-Development fallback.
+Discovery: Runtime identity cannot be inferred from a command name or saved development path, and ordinary Ring actions previously bypassed the IPC runtime target entirely.
+Files: clio-ring/ClioRing.Ipc/ClioIpcModels.cs, clio-ring/ClioRing/Models/ResolvedClioRuntime.cs, clio-ring/ClioRing/Services/ClioAdapter.cs, clio-ring/ClioRing/Services/ClioSettingsStore.cs, clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs, clio-ring/ClioRing/Views/RingView.axaml, clio-ring/ClioRing.Tests/, spec/ring-clio-runtime-switch/
+Impact: Release and Development choices now govern the full Ring surface consistently; 129 focused tests, final three-lens review, and Windows x64 NativeAOT publish pass.

--- a/clio-ring/ClioRing.Desktop/app-settings.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.json
@@ -3,6 +3,7 @@
   "WorkspaceFolder": "C:\\Projects\\Workspaces",
   "Hotkey": "Ctrl+Alt+C",
   "Channel": "dev",
+  "ClioRuntimeMode": "release",
   "Experiments": {
     "ClioIpc": false
   },

--- a/clio-ring/ClioRing.Desktop/app-settings.schema.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.schema.json
@@ -44,7 +44,7 @@
     "ClioRuntimeMode": {
       "type": [ "string", "null" ],
       "title": "Active clio runtime",
-      "description": "Selects the clio child used on the next Ring launch. release starts the installed clio dotnet tool from PATH. development uses the saved DevClioPath or ClioIpc target without deleting it.",
+      "description": "Selects the clio child used on the next Ring launch. release starts a verified installed clio dotnet-tool shim from a dotnet-owned user directory. development uses the saved DevClioPath or ClioIpc target without deleting it.",
       "enum": [ "release", "development", null ],
       "default": "release"
     },

--- a/clio-ring/ClioRing.Desktop/app-settings.schema.json
+++ b/clio-ring/ClioRing.Desktop/app-settings.schema.json
@@ -41,6 +41,13 @@
       "pattern": "\\S",
       "examples": [ "release", "dev", "preview" ]
     },
+    "ClioRuntimeMode": {
+      "type": [ "string", "null" ],
+      "title": "Active clio runtime",
+      "description": "Selects the clio child used on the next Ring launch. release starts the installed clio dotnet tool from PATH. development uses the saved DevClioPath or ClioIpc target without deleting it.",
+      "enum": [ "release", "development", null ],
+      "default": "release"
+    },
     "Experiments": {
       "$ref": "#/$defs/experiments"
     },
@@ -50,7 +57,7 @@
     "DevClioPath": {
       "type": [ "string", "null" ],
       "title": "Development clio override",
-      "description": "Optional absolute path to a trusted local development clio.dll or clio.exe. Ring executes it with your user privileges. A valid value takes precedence over ClioIpc and the machine default; the change applies on the next Ring launch.",
+      "description": "Optional absolute path to a trusted local development clio.dll or clio.exe. Ring executes it with your user privileges. In development mode, a valid value takes precedence over ClioIpc. Switching to release preserves this target.",
       "examples": [ "C:\\Projects\\clio\\clio\\bin\\Debug\\net10.0\\clio.dll" ]
     }
   },
@@ -72,7 +79,7 @@
     "clioIpc": {
       "type": [ "object", "null" ],
       "title": "Explicit clio MCP launch",
-      "description": "Explicit trusted MCP child-process command used when DevClioPath is absent or invalid. Ring executes it with your user privileges. When omitted or incomplete, Ring uses its machine default.",
+      "description": "Explicit trusted development child-process command used in development mode when DevClioPath is absent or invalid. Ring executes it with your user privileges. Switching to release preserves this target.",
       "additionalProperties": false,
       "required": [ "Command", "Args" ],
       "properties": {

--- a/clio-ring/ClioRing.Ipc/ClioIpcClient.cs
+++ b/clio-ring/ClioRing.Ipc/ClioIpcClient.cs
@@ -62,12 +62,15 @@ public sealed class ClioIpcClient : IClioIpcClient {
 
 	// The most meaningful launch identity: the clio dll argument if present, else the raw command.
 	private static string ResolveTargetPath(ClioIpcSettings settings) {
-		string? dll = settings.Args.FirstOrDefault(a => a.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
+		string? dll = settings.Args.FirstOrDefault(a => a?.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) == true);
 		return dll ?? settings.Command;
 	}
 
 	/// <inheritdoc />
 	public event EventHandler? Disconnected;
+
+	/// <inheritdoc />
+	public event EventHandler? ConnectionChanged;
 
 	/// <inheritdoc />
 	public async Task<ClioServerHandshake> ConnectAsync(CancellationToken cancellationToken = default) {
@@ -323,6 +326,7 @@ public sealed class ClioIpcClient : IClioIpcClient {
 			Capabilities = caps,
 			Instructions = client.ServerInstructions
 		};
+		ConnectionChanged?.Invoke(this, EventArgs.Empty);
 
 		// Invalidate the contract/catalog caches when the (executable path + version) key changes — for
 		// example after a RestartAsync that picked up a newer clio build.
@@ -340,7 +344,11 @@ public sealed class ClioIpcClient : IClioIpcClient {
 	private async Task TeardownLockedAsync() {
 		McpClient? client = _client;
 		_client = null;
+		bool hadHandshake = _handshake is not null;
 		_handshake = null;
+		if (hadHandshake) {
+			ConnectionChanged?.Invoke(this, EventArgs.Empty);
+		}
 
 		if (client is null) {
 			return;
@@ -354,6 +362,7 @@ public sealed class ClioIpcClient : IClioIpcClient {
 
 	private void MarkDisconnected() {
 		_handshake = null;
+		ConnectionChanged?.Invoke(this, EventArgs.Empty);
 		Disconnected?.Invoke(this, EventArgs.Empty);
 	}
 

--- a/clio-ring/ClioRing.Ipc/ClioIpcModels.cs
+++ b/clio-ring/ClioRing.Ipc/ClioIpcModels.cs
@@ -18,15 +18,12 @@ public sealed record ClioIpcSettings {
 	public string? WorkingDirectory { get; init; }
 
 	/// <summary>
-	/// A conventional default for this machine: the framework-dependent clio dll driven by <c>dotnet</c>.
-	/// Used only when <c>app-settings.json</c> supplies no <c>ClioIpc</c> section. The Debug build is
-	/// preferred here because on this machine it is newer (8.1.0.77) and matches the documented
-	/// <c>get-tool-contract</c> compact-index contract, whereas the Release dll (8.1.0.64) predates it.
-	/// Override freely in app-settings.
+	/// The released clio dotnet tool available on <c>PATH</c>. Development configurations are resolved by
+	/// ClioRing before constructing this IPC settings record.
 	/// </summary>
 	public static ClioIpcSettings Default { get; } = new() {
-		Command = "dotnet",
-		Args = new[] { @"C:\Projects\clio\clio\bin\Debug\net10.0\clio.dll", "mcp-server" }
+		Command = "clio",
+		Args = new[] { "mcp-server" }
 	};
 }
 

--- a/clio-ring/ClioRing.Ipc/ClioIpcModels.cs
+++ b/clio-ring/ClioRing.Ipc/ClioIpcModels.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace ClioRing.Ipc;
 
@@ -18,13 +21,35 @@ public sealed record ClioIpcSettings {
 	public string? WorkingDirectory { get; init; }
 
 	/// <summary>
-	/// The released clio dotnet tool available on <c>PATH</c>. Development configurations are resolved by
-	/// ClioRing before constructing this IPC settings record.
+	/// The released clio dotnet tool installed in the current user's standard global-tool directory.
+	/// Using the absolute shim path prevents an unrelated executable earlier on <c>PATH</c> from being launched.
 	/// </summary>
 	public static ClioIpcSettings Default { get; } = new() {
-		Command = "clio",
+		Command = ResolveReleaseToolPath(Environment.GetEnvironmentVariable("DOTNET_CLI_HOME"),
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
 		Args = new[] { "mcp-server" }
 	};
+
+	/// <summary>
+	/// Resolves a trusted clio dotnet-tool shim from DOTNET_CLI_HOME or the normal user profile.
+	/// Custom tool paths remain explicit Development targets rather than being trusted implicitly from PATH.
+	/// </summary>
+	/// <param name="dotnetCliHome">Optional DOTNET_CLI_HOME value.</param>
+	/// <param name="userProfile">Current user profile directory.</param>
+	/// <returns>An absolute trusted shim path, or the standard user shim path before installation.</returns>
+	public static string ResolveReleaseToolPath(string? dotnetCliHome, string userProfile) {
+		string shimName = OperatingSystem.IsWindows() ? "clio.exe" : "clio";
+		IEnumerable<string> globalHomes = new[] { dotnetCliHome, userProfile }
+			.Where(home => !string.IsNullOrWhiteSpace(home))
+			.Select(home => Path.Combine(home!, ".dotnet", "tools"));
+		foreach (string directory in globalHomes.Distinct(StringComparer.OrdinalIgnoreCase)) {
+			string candidate = Path.GetFullPath(Path.Combine(directory, shimName));
+			if (File.Exists(candidate) && Directory.Exists(Path.Combine(directory, ".store", "clio"))) {
+				return candidate;
+			}
+		}
+		return Path.GetFullPath(Path.Combine(userProfile, ".dotnet", "tools", shimName));
+	}
 }
 
 /// <summary>

--- a/clio-ring/ClioRing.Ipc/IClioIpcClient.cs
+++ b/clio-ring/ClioRing.Ipc/IClioIpcClient.cs
@@ -34,6 +34,9 @@ public interface IClioIpcClient : IAsyncDisposable {
 	/// <summary>Raised when the child process exits unexpectedly (marks the client disconnected).</summary>
 	event EventHandler? Disconnected;
 
+	/// <summary>Raised whenever the negotiated handshake becomes available or is cleared.</summary>
+	event EventHandler? ConnectionChanged;
+
 	/// <summary>
 	/// Ensures the child is spawned and the <c>initialize</c> handshake has completed, returning the
 	/// negotiated <see cref="ClioServerHandshake"/>. Idempotent: a second call while already connected

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -94,6 +94,7 @@ public sealed class AppSettingsSchemaTests {
 		string[] actualIpcProperties = definitions["clioIpc"]!["properties"]!.AsObject()
 			.Select(property => property.Key).ToArray();
 		string channelDescription = properties["Channel"]!["description"]!.GetValue<string>();
+		string runtimeDescription = properties["ClioRuntimeMode"]!["description"]!.GetValue<string>();
 		string devPathDescription = properties["DevClioPath"]!["description"]!.GetValue<string>();
 		string ipcDescription = definitions["clioIpc"]!["description"]!.GetValue<string>();
 
@@ -106,16 +107,21 @@ public sealed class AppSettingsSchemaTests {
 			because: "the editor contract must stay aligned with every ClioIpcSettingsDto property");
 		channelDescription.Should().Contain("does not select the clio executable",
 			because: "Channel is only a Ring display/deployment label");
+		runtimeDescription.Should().Contain("installed clio dotnet tool from PATH",
+			because: "Release must unambiguously mean the installed clio tool");
+		runtimeDescription.Should().Contain("without deleting it",
+			because: "switching modes must preserve the saved development target");
 		devPathDescription.Should().Contain("takes precedence over ClioIpc",
-			because: "developers need the actual launch-selection precedence");
-		ipcDescription.Should().Contain("when DevClioPath is absent or invalid",
-			because: "the explicit child-process block is the second precedence level");
+			because: "Development mode keeps the existing target precedence");
+		ipcDescription.Should().Contain("development mode",
+			because: "the explicit child-process block is a saved Development target");
 	}
 
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Unexpected":true}""")]
 	[TestCase("""{"WorkspaceFolder":"   "}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"dotnet"}}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","Channel":"   "}""")]
+	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioRuntimeMode":"custom"}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"   ","Args":["mcp-server"]}}""")]
 	[TestCase("""{"WorkspaceFolder":"C:\\Workspaces","ClioIpc":{"Command":"dotnet","Args":["   "]}}""")]
 	[Description("The schema rejects unknown settings, incomplete or blank child launch configuration, and blank channel labels.")]

--- a/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
+++ b/clio-ring/ClioRing.Tests/AppSettingsSchemaTests.cs
@@ -107,7 +107,7 @@ public sealed class AppSettingsSchemaTests {
 			because: "the editor contract must stay aligned with every ClioIpcSettingsDto property");
 		channelDescription.Should().Contain("does not select the clio executable",
 			because: "Channel is only a Ring display/deployment label");
-		runtimeDescription.Should().Contain("installed clio dotnet tool from PATH",
+		runtimeDescription.Should().Contain("verified installed clio dotnet-tool shim",
 			because: "Release must unambiguously mean the installed clio tool");
 		runtimeDescription.Should().Contain("without deleting it",
 			because: "switching modes must preserve the saved development target");

--- a/clio-ring/ClioRing.Tests/ClioAdapterRuntimeTests.cs
+++ b/clio-ring/ClioRing.Tests/ClioAdapterRuntimeTests.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using ClioRing.Ipc;
+using ClioRing.Models;
+using ClioRing.Services;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ClioRing.Tests;
+
+/// <summary>Verifies ordinary Ring actions use the same resolved clio runtime as IPC workflows.</summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class ClioAdapterRuntimeTests {
+	[Test]
+	[Description("Release radial actions execute the resolved release shim with the requested command instead of mcp-server.")]
+	public void BuildStartInfo_ShouldUseReleaseRuntime_WhenReleaseSelected() {
+		// Arrange
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
+		var sut = new ClioAdapter(runtime);
+		var invocation = new ClioInvocation { Verb = "get-info", EnvName = "ve" };
+
+		// Act
+		ProcessStartInfo result = sut.BuildStartInfo(invocation);
+
+		// Assert
+		result.FileName.Should().Be(ClioIpcSettings.Default.Command,
+			"because ordinary actions and IPC must share the resolved release executable");
+		result.ArgumentList.Should().Equal(new[] { "get-info", "-e", "ve" },
+			"because mcp-server is replaced by the selected radial action command");
+	}
+
+	[Test]
+	[Description("Development DLL radial actions execute dotnet with the same DLL before the requested command.")]
+	public void BuildStartInfo_ShouldUseDevelopmentDll_WhenDevelopmentSelected() {
+		// Arrange
+		const string devDll = @"C:\Projects\clio\clio\bin\Debug\net10.0\clio.dll";
+		var launch = new ClioIpcSettings { Command = "dotnet", Args = new[] { devDll, "mcp-server" } };
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Development, launch);
+		var sut = new ClioAdapter(runtime);
+		var invocation = new ClioInvocation { Verb = "show-web-app-list" };
+
+		// Act
+		ProcessStartInfo result = sut.BuildStartInfo(invocation);
+
+		// Assert
+		result.FileName.Should().Be("dotnet", "because a framework-dependent development build uses dotnet");
+		result.ArgumentList.Should().Equal(new[] { devDll, "show-web-app-list" },
+			"because the development DLL stays before the ordinary clio verb");
+	}
+
+	[Test]
+	[Description("Ordinary radial actions preserve the explicit development working directory used by IPC workflows.")]
+	public void BuildStartInfo_ShouldPreserveWorkingDirectory_WhenDevelopmentTargetRequiresIt() {
+		// Arrange
+		const string workingDirectory = @"C:\Projects\clio";
+		var launch = new ClioIpcSettings {
+			Command = "dotnet", Args = new[] { @"clio\bin\Debug\net10.0\clio.dll", "mcp-server" },
+			WorkingDirectory = workingDirectory
+		};
+		var sut = new ClioAdapter(new ResolvedClioRuntime(ClioRuntimeMode.Development, launch));
+
+		// Act
+		ProcessStartInfo result = sut.BuildStartInfo(new ClioInvocation { Verb = "get-info" });
+
+		// Assert
+		result.WorkingDirectory.Should().Be(workingDirectory,
+			"because radial actions must resolve relative development arguments exactly like IPC");
+	}
+}

--- a/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
+++ b/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
@@ -94,7 +94,8 @@ public sealed class ClioSettingsViewModelTests {
 		persisted.Should().BeNull("because a blank override removes the persisted value");
 		sut.IsDevOverrideActive.Should().BeFalse("because no override is active after clearing");
 		resolved.Should().BeSameAs(ClioIpcSettings.Default, "because empty override resolves to the default clio");
-		resolved.Command.Should().Be("clio", "because Release uses the installed dotnet tool from PATH");
+		Path.IsPathFullyQualified(resolved.Command).Should().BeTrue(
+			"because Release uses the absolute global-tool shim instead of trusting PATH ordering");
 		resolved.Args.Should().ContainSingle().Which.Should().Be("mcp-server",
 			"because Ring starts the installed tool as an MCP server");
 	}
@@ -113,7 +114,8 @@ public sealed class ClioSettingsViewModelTests {
 		// Assert
 		resolved.Should().BeSameAs(ClioIpcSettings.Default,
 			"because Release ignores the saved development targets without deleting them");
-		resolved.Command.Should().Be("clio", "because the released dotnet tool is resolved from PATH");
+		resolved.Command.Should().Be(ClioIpcSettings.Default.Command,
+			"because Release uses the standard global-tool shim");
 	}
 
 	[Test]
@@ -284,7 +286,9 @@ public sealed class ClioSettingsViewModelTests {
 		IClioIpcClient client = Substitute.For<IClioIpcClient>();
 		client.TargetPath.Returns(_devClioDll);
 		client.Handshake.Returns((ClioServerHandshake?)null);
-		var sut = new ClioSettingsViewModel(_store, client);
+		ResolvedClioRuntime runtime = Startup.ResolveClioRuntime(runtimeMode: null, devClioPath: null,
+			new ClioIpcSettingsDto { Command = "dotnet", Args = [_devClioDll, "mcp-server"] });
+		var sut = new ClioSettingsViewModel(_store, client, runtime);
 
 		// Act
 		sut.IsDevelopmentSelected = false;
@@ -300,5 +304,197 @@ public sealed class ClioSettingsViewModelTests {
 			"because selecting Release preserves the explicit development target");
 		sut.RuntimeSelectionRestartRequired.Should().BeTrue(
 			"because the running development child remains active until Ring restarts");
+		sut.RefreshConnectionIdentity();
+		sut.IsDevelopmentSelected.Should().BeFalse(
+			"because refresh must retain the persisted pending Release selection");
+	}
+
+	[Test]
+	[Description("An explicit development configuration that happens to use the command name clio is still identified from the resolved startup mode, not from path heuristics.")]
+	public void RuntimeIdentity_ShouldRemainDevelopment_WhenExplicitDevelopmentCommandIsClio() {
+		// Arrange
+		IClioIpcClient client = Substitute.For<IClioIpcClient>();
+		client.TargetPath.Returns("clio");
+		var launch = new ClioIpcSettings { Command = "clio", Args = new[] { "mcp-server" } };
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Development, launch);
+
+		// Act
+		var sut = new ClioSettingsViewModel(_store, client, runtime);
+
+		// Assert
+		sut.IsDevelopmentRuntimeRunning.Should().BeTrue(
+			"because the immutable startup decision is authoritative even when target names overlap");
+		sut.RuntimeSummary.Should().Contain("development clio build",
+			"because the main interface must warn about the actual selected mode");
+	}
+
+	[TestCase(null)]
+	[TestCase("")]
+	[TestCase("   ")]
+	[Description("An explicit IPC target with a null or blank argument is rejected instead of reaching child-process construction.")]
+	public void ResolveClioRuntime_ShouldFallBackToRelease_WhenExplicitArgumentIsInvalid(string? invalidArgument) {
+		// Arrange
+		var ipc = new ClioIpcSettingsDto { Command = "dotnet", Args = [invalidArgument!, "mcp-server"] };
+
+		// Act
+		ResolvedClioRuntime resolved = Startup.ResolveClioRuntime(runtimeMode: "development", devClioPath: null, ipc);
+
+		// Assert
+		resolved.Mode.Should().Be(ClioRuntimeMode.Release,
+			"because every explicit child-process argument must be usable");
+		resolved.LaunchSettings.Should().BeSameAs(ClioIpcSettings.Default,
+			"because invalid development configuration fails closed to the trusted release target");
+		resolved.ConfigurationWarning.Should().Contain("Open Settings",
+			"because an explicit Development request must not fail over silently");
+	}
+
+	[Test]
+	[Description("A valid clio dotnet-tool shim under DOTNET_CLI_HOME is supported without trusting arbitrary PATH entries.")]
+	public void ResolveReleaseToolPath_ShouldUseDotnetCliHome_WhenConfigured() {
+		// Arrange
+		string dotnetCliHome = Path.Combine(_tempDir, "dotnet-cli-home");
+		string toolPath = Path.Combine(dotnetCliHome, ".dotnet", "tools");
+		string storePath = Path.Combine(toolPath, ".store", "clio");
+		Directory.CreateDirectory(storePath);
+		string shimPath = Path.Combine(toolPath, OperatingSystem.IsWindows() ? "clio.exe" : "clio");
+		File.WriteAllText(shimPath, string.Empty);
+
+		// Act
+		string resolved = ClioIpcSettings.ResolveReleaseToolPath(dotnetCliHome,
+			userProfile: Path.Combine(_tempDir, "empty-profile"));
+
+		// Assert
+		resolved.Should().Be(Path.GetFullPath(shimPath),
+			"because DOTNET_CLI_HOME is an explicit dotnet-owned global-tool root");
+	}
+
+	[Test]
+	[Description("An explicit Development selection without a valid target safely runs Release and draws attention to the configuration problem.")]
+	public void RuntimeIdentity_ShouldWarn_WhenRequestedDevelopmentTargetIsInvalid() {
+		// Arrange
+		ResolvedClioRuntime runtime = Startup.ResolveClioRuntime("development", devClioPath: null, ipc: null);
+
+		// Act
+		var sut = new ClioSettingsViewModel(_store, runtime: runtime);
+
+		// Assert
+		sut.IsReleaseRuntimeRunning.Should().BeTrue("because invalid development configuration fails closed");
+		sut.HasRuntimeConfigurationWarning.Should().BeTrue(
+			"because fallback must be conspicuous on the main interface");
+		sut.IsDevelopmentSelected.Should().BeTrue(
+			"because the UI must preserve the requested next-launch mode instead of pretending Release was selected");
+		sut.CanChangeRuntimeSelection.Should().BeTrue(
+			"because the user must be able to switch the invalid request back to Release");
+		sut.RuntimeConfigurationWarning.Should().Contain("Open Settings",
+			"because the warning gives the user a concrete recovery action");
+
+		// Act - recover by selecting Release, then simulate a later connection refresh.
+		sut.IsDevelopmentSelected = false;
+		sut.RefreshConnectionIdentity();
+
+		// Assert
+		sut.IsDevelopmentSelected.Should().BeFalse(
+			"because refresh must not restore the invalid startup request after Release is persisted");
+		sut.HasRuntimeConfigurationWarning.Should().BeFalse(
+			"because the invalid Development warning is resolved by selecting Release");
+	}
+
+	[Test]
+	[Description("Saving a valid development target clears the invalid-request warning while keeping Development selected.")]
+	public void RuntimeIdentity_ShouldClearWarning_WhenValidDevelopmentTargetIsSaved() {
+		// Arrange
+		ResolvedClioRuntime runtime = Startup.ResolveClioRuntime("development", devClioPath: null, ipc: null);
+		var sut = new ClioSettingsViewModel(_store, runtime: runtime) { DevClioPathInput = _devClioDll };
+
+		// Act
+		sut.SaveDevClioOverrideCommand.Execute(null);
+
+		// Assert
+		sut.HasRuntimeConfigurationWarning.Should().BeFalse(
+			"because the requested Development mode now has a valid saved target");
+		sut.IsDevelopmentSelected.Should().BeTrue(
+			"because configuring the missing target fulfills rather than clears the Development request");
+	}
+
+	[Test]
+	[Description("Release identity remains release when a development path is preserved for later switching.")]
+	public void ConnectedIdentity_ShouldRemainRelease_WhenDevelopmentPathIsPreserved() {
+		// Arrange
+		_store.SaveDevClioPath(_devClioDll);
+		IClioIpcClient client = Substitute.For<IClioIpcClient>();
+		client.TargetPath.Returns(ClioIpcSettings.Default.Command);
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
+
+		// Act
+		var sut = new ClioSettingsViewModel(_store, client, runtime);
+
+		// Assert
+		sut.ConnectedClioIdentity.Should().Contain("release build",
+			"because a saved development target is not the source used by the current process");
+		sut.ConnectedClioIdentity.Should().NotContain("development build",
+			"because only the immutable active mode determines connected identity");
+	}
+
+	[Test]
+	[Description("Selecting Development while Release is active persists the next mode and exposes the restart-required state.")]
+	public void RuntimeSwitch_ShouldRequireRestart_WhenDevelopmentSelectedFromRelease() {
+		// Arrange
+		_store.SaveDevClioPath(_devClioDll);
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
+		var sut = new ClioSettingsViewModel(_store, runtime: runtime);
+
+		// Act
+		sut.IsDevelopmentSelected = true;
+
+		// Assert
+		sut.IsReleaseRuntimeRunning.Should().BeTrue("because the current child cannot change during this session");
+		sut.RuntimeSelectionRestartRequired.Should().BeTrue(
+			"because the newly persisted Development choice applies at next launch");
+		_store.ReadRuntimeMode().Should().Be("development", "because the toggle controls the next startup mode");
+		sut.RefreshConnectionIdentity();
+		sut.IsDevelopmentSelected.Should().BeTrue(
+			"because refresh must retain the persisted pending Development selection");
+	}
+
+	[Test]
+	[Description("A malformed settings file is never overwritten when a runtime selection save is attempted.")]
+	public void RuntimeSwitch_ShouldPreserveMalformedSettings_WhenPersistenceFails() {
+		// Arrange
+		const string malformed = "{ this is not valid json";
+		File.WriteAllText(_settingsPath, malformed);
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Development,
+			new ClioIpcSettings { Command = _devClioExe, Args = new[] { "mcp-server" } });
+		var sut = new ClioSettingsViewModel(_store, runtime: runtime);
+
+		// Act
+		sut.IsDevelopmentSelected = false;
+
+		// Assert
+		File.ReadAllText(_settingsPath).Should().Be(malformed,
+			"because unreadable settings must be left byte-for-byte unchanged");
+		sut.IsDevelopmentSelected.Should().BeTrue("because the selection is reverted when persistence fails");
+		sut.ValidationMessage.Should().Contain("left unchanged",
+			"because the save failure must be visible without exposing technical details");
+	}
+
+	[Test]
+	[Description("The main runtime identity refreshes when the lazy clio handshake becomes available.")]
+	public void RuntimeIdentity_ShouldRefresh_WhenConnectionChanges() {
+		// Arrange
+		IClioIpcClient client = Substitute.For<IClioIpcClient>();
+		client.TargetPath.Returns(ClioIpcSettings.Default.Command);
+		client.Handshake.Returns((ClioServerHandshake?)null);
+		var runtime = new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
+		var sut = new ClioSettingsViewModel(_store, client, runtime);
+		client.Handshake.Returns(new ClioServerHandshake {
+			ServerName = "clio", ServerVersion = "8.1.0.84", Capabilities = Array.Empty<string>()
+		});
+
+		// Act
+		client.ConnectionChanged += Raise.Event<EventHandler>(client, EventArgs.Empty);
+
+		// Assert
+		sut.RuntimeSummary.Should().Be("clio 8.1.0.84",
+			"because negotiated identity replaces the pre-handshake configured summary");
 	}
 }

--- a/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
+++ b/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Linq;
 using ClioRing;
 using ClioRing.Ipc;
+using ClioRing.Models;
 using ClioRing.Services;
 using ClioRing.ViewModels;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace ClioRing.Tests;
@@ -92,6 +94,45 @@ public sealed class ClioSettingsViewModelTests {
 		persisted.Should().BeNull("because a blank override removes the persisted value");
 		sut.IsDevOverrideActive.Should().BeFalse("because no override is active after clearing");
 		resolved.Should().BeSameAs(ClioIpcSettings.Default, "because empty override resolves to the default clio");
+		resolved.Command.Should().Be("clio", "because Release uses the installed dotnet tool from PATH");
+		resolved.Args.Should().ContainSingle().Which.Should().Be("mcp-server",
+			"because Ring starts the installed tool as an MCP server");
+	}
+
+	[Test]
+	[Description("An explicit Release selection uses the installed clio command while preserving a valid development target for later use.")]
+	public void ResolveClioIpcSettings_ShouldUseInstalledTool_WhenReleaseSelected() {
+		// Arrange
+		var explicitIpc = new ClioIpcSettingsDto {
+			Command = "dotnet", Args = [_devClioDll, "mcp-server"]
+		};
+
+		// Act
+		ClioIpcSettings resolved = Startup.ResolveClioIpcSettings("release", _devClioDll, explicitIpc);
+
+		// Assert
+		resolved.Should().BeSameAs(ClioIpcSettings.Default,
+			"because Release ignores the saved development targets without deleting them");
+		resolved.Command.Should().Be("clio", "because the released dotnet tool is resolved from PATH");
+	}
+
+	[Test]
+	[Description("Legacy settings with an explicit clio IPC target remain on Development when no runtime mode has been persisted.")]
+	public void ResolveClioIpcSettings_ShouldPreserveDevelopmentTarget_WhenLegacyModeIsMissing() {
+		// Arrange
+		var explicitIpc = new ClioIpcSettingsDto {
+			Command = "dotnet", Args = [_devClioDll, "mcp-server"]
+		};
+
+		// Act
+		ClioIpcSettings resolved = Startup.ResolveClioIpcSettings(runtimeMode: null, devClioPath: null,
+			explicitIpc);
+
+		// Assert
+		resolved.Command.Should().Be("dotnet",
+			"because migration must not silently retarget an existing development setup");
+		resolved.Args.Should().Contain(_devClioDll,
+			"because the saved explicit development target remains selected");
 	}
 
 	[Test]
@@ -186,7 +227,8 @@ public sealed class ClioSettingsViewModelTests {
 		// Assert
 		sut.ConnectedClioIdentity.Should().Contain("clio 8.1.0.77",
 			"because the identity uses the handshake name + version, not a hardcoded label");
-		sut.ConnectedClioIdentity.Should().Contain("dev build", "because the dev override is the active source");
+		sut.ConnectedClioIdentity.Should().Contain("development build",
+			"because the development override is the active source");
 		sut.ConnectedClioIdentity.Should().Contain(_devClioDll, "because the resolved path is shown");
 	}
 
@@ -203,13 +245,13 @@ public sealed class ClioSettingsViewModelTests {
 		sut.SetConnectedIdentity(handshake, @"C:\Tools\clio\clio.dll", isDevOverride: false);
 
 		// Assert
-		sut.ConnectedClioIdentity.Should().Contain("normal build", "because no dev override is active");
+		sut.ConnectedClioIdentity.Should().Contain("release build", "because no development override is active");
 		sut.ConnectedClioIdentity.Should().Contain("8.1.0.77", "because the handshake version is surfaced");
 	}
 
 	[Test]
-	[Description("Before a handshake exists the identity says it is not connected yet, without protocol jargon.")]
-	public void SetConnectedIdentity_ShouldSayNotConnected_WhenHandshakeAbsent() {
+	[Description("Before a handshake exists the identity states the configured build instead of claiming Ring is disconnected.")]
+	public void SetConnectedIdentity_ShouldStateConfiguredBuild_WhenHandshakeAbsent() {
 		// Arrange
 		var sut = new ClioSettingsViewModel(_store);
 
@@ -217,8 +259,46 @@ public sealed class ClioSettingsViewModelTests {
 		sut.SetConnectedIdentity(handshake: null, @"C:\Tools\clio\clio.dll", isDevOverride: false);
 
 		// Assert
-		sut.ConnectedClioIdentity.Should().Contain("not connected",
-			"because there is no negotiated handshake to report yet");
+		sut.ConnectedClioIdentity.Should().Contain("release build",
+			"because the configured runtime is truthful before the lazy handshake occurs");
+		sut.ConnectedClioIdentity.Should().NotContain("not connected",
+			"because Ring already knows which configured runtime it is using");
+		sut.ConnectedClioIdentity.Should().NotContain("—",
+			"because runtime identity uses ordinary hyphens instead of em dashes");
 		sut.ConnectedClioIdentity.Should().NotContain("MCP", "because the identity must stay jargon-free");
+	}
+
+	[Test]
+	[Description("The main runtime warning recognizes an explicit Debug DLL target and selecting Release persists the mode without deleting that target.")]
+	public void RuntimeSwitch_ShouldPersistReleaseAndPreserveTarget_WhenDevelopmentRuntimeIsRunning() {
+		// Arrange
+		File.WriteAllText(_settingsPath, $$"""
+			{
+			  "WorkspaceFolder": "{{_tempDir.Replace("\\", "\\\\")}}",
+			  "ClioIpc": {
+			    "Command": "dotnet",
+			    "Args": ["{{_devClioDll.Replace("\\", "\\\\")}}", "mcp-server"]
+			  }
+			}
+			""");
+		IClioIpcClient client = Substitute.For<IClioIpcClient>();
+		client.TargetPath.Returns(_devClioDll);
+		client.Handshake.Returns((ClioServerHandshake?)null);
+		var sut = new ClioSettingsViewModel(_store, client);
+
+		// Act
+		sut.IsDevelopmentSelected = false;
+
+		// Assert
+		sut.IsDevelopmentRuntimeRunning.Should().BeTrue(
+			"because an explicit Debug DLL is a development runtime even without DevClioPath");
+		sut.RuntimeSummary.Should().Be("Ring is using a development clio build",
+			"because lazy handshake state must not be presented as disconnected");
+		_store.ReadRuntimeMode().Should().Be("release",
+			"because the main toggle persists the next-launch runtime mode");
+		_store.HasDevelopmentTarget().Should().BeTrue(
+			"because selecting Release preserves the explicit development target");
+		sut.RuntimeSelectionRestartRequired.Should().BeTrue(
+			"because the running development child remains active until Ring restarts");
 	}
 }

--- a/clio-ring/ClioRing/Models/AppSettings.cs
+++ b/clio-ring/ClioRing/Models/AppSettings.cs
@@ -26,6 +26,13 @@ public class AppSettings
 	public string? Channel { get; init; }
 
 	/// <summary>
+	/// Selected clio runtime: <c>release</c> uses the installed dotnet tool; <c>development</c> uses the
+	/// saved <see cref="DevClioPath"/> or <see cref="ClioIpc"/> target. When absent, legacy settings with
+	/// a development target remain on Development while clean settings select Release.
+	/// </summary>
+	public string? ClioRuntimeMode { get; init; }
+
+	/// <summary>
 	/// Experimental feature switches (default OFF). When an experiment is off the app behaves exactly
 	/// as today; the corresponding proof UI/behaviour is never wired.
 	/// </summary>
@@ -33,7 +40,7 @@ public class AppSettings
 
 	/// <summary>
 	/// Optional override for how the EXPERIMENTAL clio MCP child process is launched. Absent = a
-	/// machine-sensible default (the clio Release dll driven by <c>dotnet</c>).
+	/// saved development runtime. Release mode ignores this target without deleting it.
 	/// </summary>
 	public ClioIpcSettingsDto? ClioIpc { get; init; }
 

--- a/clio-ring/ClioRing/Models/ResolvedClioRuntime.cs
+++ b/clio-ring/ClioRing/Models/ResolvedClioRuntime.cs
@@ -1,0 +1,36 @@
+using ClioRing.Ipc;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClioRing.Models;
+
+/// <summary>Identifies the clio runtime selected for the current Ring process.</summary>
+public enum ClioRuntimeMode {
+	/// <summary>The installed clio dotnet tool.</summary>
+	Release,
+
+	/// <summary>An explicitly configured development build.</summary>
+	Development
+}
+
+/// <summary>
+/// Immutable startup decision shared by process launch and UI identity so the visible mode cannot diverge
+/// from the child Ring is configured to start.
+/// </summary>
+/// <param name="Mode">The runtime mode selected for this Ring process.</param>
+/// <param name="LaunchSettings">The exact child-process launch settings for that mode.</param>
+/// <param name="RequestedMode">The persisted user choice when it differs from the safe resolved mode.</param>
+/// <param name="ConfigurationWarning">Actionable warning when the requested runtime could not be used.</param>
+public sealed record ResolvedClioRuntime(ClioRuntimeMode Mode, ClioIpcSettings LaunchSettings,
+	ClioRuntimeMode? RequestedMode = null, string? ConfigurationWarning = null);
+
+/// <summary>Shared validation rules for explicit development child-process configuration.</summary>
+public static class ClioRuntimeConfiguration {
+	/// <summary>Validates a complete explicit IPC target consistently across startup and settings discovery.</summary>
+	/// <param name="command">Executable command.</param>
+	/// <param name="args">Command arguments.</param>
+	/// <returns>True only when the command and every required argument are nonblank.</returns>
+	public static bool IsValidExplicitIpc(string? command, IEnumerable<string?>? args) =>
+		!string.IsNullOrWhiteSpace(command) && args is not null && args.Any()
+		&& args.All(argument => !string.IsNullOrWhiteSpace(argument));
+}

--- a/clio-ring/ClioRing/Properties/AssemblyInfo.cs
+++ b/clio-ring/ClioRing/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ClioRing.Tests")]

--- a/clio-ring/ClioRing/Services/ClioAdapter.cs
+++ b/clio-ring/ClioRing/Services/ClioAdapter.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using ClioRing.Ipc;
+using ClioRing.Models;
 
 namespace ClioRing.Services;
 
@@ -14,7 +17,16 @@ namespace ClioRing.Services;
 /// full process tree on cancellation.
 /// </summary>
 public sealed class ClioAdapter : IClioAdapter {
-	private const string ClioExecutable = "clio";
+	private readonly ResolvedClioRuntime _runtime;
+
+	/// <summary>Creates an adapter using the installed release clio.</summary>
+	public ClioAdapter() : this(new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default)) { }
+
+	/// <summary>Creates an adapter using the same immutable runtime selected for IPC workflows.</summary>
+	/// <param name="runtime">Resolved runtime and child-process launch settings.</param>
+	public ClioAdapter(ResolvedClioRuntime runtime) {
+		_runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+	}
 
 	/// <inheritdoc />
 	public event EventHandler<ClioOutputLine>? OutputReceived;
@@ -45,25 +57,7 @@ public sealed class ClioAdapter : IClioAdapter {
 		CancellationToken cancellationToken = default) {
 		ArgumentNullException.ThrowIfNull(invocation);
 
-		var startInfo = new ProcessStartInfo {
-			FileName = ClioExecutable, // NOSONAR: clio is a user-installed dotnet tool intentionally resolved via PATH
-			RedirectStandardOutput = true,
-			RedirectStandardError = true,
-			UseShellExecute = false,
-			CreateNoWindow = true,
-			StandardOutputEncoding = Encoding.UTF8,
-			StandardErrorEncoding = Encoding.UTF8
-		};
-
-		startInfo.ArgumentList.Add(invocation.Verb);
-		foreach (string arg in invocation.Args) {
-			startInfo.ArgumentList.Add(arg);
-		}
-
-		if (!string.IsNullOrWhiteSpace(invocation.EnvName)) {
-			startInfo.ArgumentList.Add("-e");
-			startInfo.ArgumentList.Add(invocation.EnvName);
-		}
+		ProcessStartInfo startInfo = BuildStartInfo(invocation);
 
 		using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
 
@@ -77,7 +71,7 @@ public sealed class ClioAdapter : IClioAdapter {
 			process.Start();
 		}
 		catch (Exception ex) {
-			string message = $"Failed to start '{ClioExecutable}': {ex.Message}";
+			string message = $"Failed to start '{startInfo.FileName}': {ex.Message}";
 			var line = new ClioOutputLine(ClioStream.Stderr, message, Stopwatch.GetTimestamp());
 			stderr.AppendLine(message);
 			onOutput?.Invoke(line);
@@ -106,6 +100,35 @@ public sealed class ClioAdapter : IClioAdapter {
 		}
 
 		return new ClioRunResult(exitCode, stdout.ToString(), stderr.ToString(), cancelled);
+	}
+
+	internal ProcessStartInfo BuildStartInfo(ClioInvocation invocation) {
+		var startInfo = new ProcessStartInfo {
+			FileName = _runtime.LaunchSettings.Command,
+			WorkingDirectory = _runtime.LaunchSettings.WorkingDirectory ?? string.Empty,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+			CreateNoWindow = true,
+			StandardOutputEncoding = Encoding.UTF8,
+			StandardErrorEncoding = Encoding.UTF8
+		};
+
+		foreach (string argument in _runtime.LaunchSettings.Args.TakeWhile(argument =>
+			!string.Equals(argument, "mcp-server", StringComparison.OrdinalIgnoreCase))) {
+			startInfo.ArgumentList.Add(argument);
+		}
+		startInfo.ArgumentList.Add(invocation.Verb);
+		foreach (string arg in invocation.Args) {
+			startInfo.ArgumentList.Add(arg);
+		}
+
+		if (!string.IsNullOrWhiteSpace(invocation.EnvName)) {
+			startInfo.ArgumentList.Add("-e");
+			startInfo.ArgumentList.Add(invocation.EnvName);
+		}
+
+		return startInfo;
 	}
 
 	private void HandleLine(string? data, ClioStream stream, StringBuilder sink, Action<ClioOutputLine>? onOutput) {

--- a/clio-ring/ClioRing/Services/ClioSettingsStore.cs
+++ b/clio-ring/ClioRing/Services/ClioSettingsStore.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using ClioRing.Models;
 
 namespace ClioRing.Services;
 
@@ -10,7 +11,7 @@ namespace ClioRing.Services;
 /// Default <see cref="IClioSettingsStore"/> backed by <c>app-settings.json</c> beside the executable.
 /// Reads/writes through <see cref="JsonNode"/> (no reflection-based serialization) so it stays AOT-safe
 /// and preserves any settings the strongly-typed model does not know about. A read-modify-write updates
-/// only the <c>DevClioPath</c> field; every other key is left byte-for-byte in place.
+/// only the requested field while preserving every other JSON value.
 /// </summary>
 public sealed class ClioSettingsStore : IClioSettingsStore {
 	private const string DevClioPathKey = "DevClioPath";
@@ -19,6 +20,7 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 	private const string DevelopmentMode = "development";
 
 	private readonly string _settingsPath;
+	private readonly object _writeSync = new();
 
 	/// <summary>Creates a store over the default <c>app-settings.json</c> beside the executable.</summary>
 	public ClioSettingsStore() : this(AppSettingsReader.SettingsPath) { }
@@ -41,16 +43,14 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 
 	/// <inheritdoc />
 	public void SaveDevClioPath(string? path) {
-		JsonObject root = TryReadRoot() ?? new JsonObject();
-		if (string.IsNullOrWhiteSpace(path)) {
-			root.Remove(DevClioPathKey);
-		}
-		else {
-			root[DevClioPathKey] = path.Trim();
-		}
-
-		string json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
-		File.WriteAllText(_settingsPath, json);
+		UpdateRoot(root => {
+			if (string.IsNullOrWhiteSpace(path)) {
+				root.Remove(DevClioPathKey);
+			}
+			else {
+				root[DevClioPathKey] = path.Trim();
+			}
+		});
 	}
 
 	/// <inheritdoc />
@@ -68,10 +68,7 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 			throw new ArgumentOutOfRangeException(nameof(mode), mode,
 				"Clio runtime mode must be release or development.");
 		}
-		JsonObject root = TryReadRoot() ?? new JsonObject();
-		root[RuntimeModeKey] = normalized;
-		string json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
-		File.WriteAllText(_settingsPath, json);
+		UpdateRoot(root => root[RuntimeModeKey] = normalized);
 	}
 
 	/// <inheritdoc />
@@ -85,8 +82,7 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 		JsonObject? ipc = root?["ClioIpc"] as JsonObject;
 		string? command = ReadString(ipc?["Command"]);
 		JsonArray? args = ipc?["Args"] as JsonArray;
-		return !string.IsNullOrWhiteSpace(command) && args is { Count: > 0 }
-			&& args.All(value => !string.IsNullOrWhiteSpace(ReadString(value)));
+		return ClioRuntimeConfiguration.IsValidExplicitIpc(command, args?.Select(ReadString));
 	}
 
 	private static string? ReadString(JsonNode? node) =>
@@ -100,8 +96,52 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 			return JsonNode.Parse(File.ReadAllText(_settingsPath)) as JsonObject;
 		}
 		catch (Exception) {
-			// A missing/unreadable/invalid file behaves like "no override"; a subsequent save rewrites it.
+			// Reads fail closed. Mutation uses ReadRootForWrite and refuses to overwrite invalid content.
 			return null;
+		}
+	}
+
+	private JsonObject ReadRootForWrite() {
+		if (!File.Exists(_settingsPath)) {
+			return new JsonObject();
+		}
+		try {
+			return JsonNode.Parse(File.ReadAllText(_settingsPath)) as JsonObject
+				?? throw new InvalidDataException("Ring settings must contain a JSON object.");
+		}
+		catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException or InvalidDataException) {
+			throw new InvalidDataException("Ring settings could not be read and were not changed.", ex);
+		}
+	}
+
+	private void UpdateRoot(Action<JsonObject> update) {
+		lock (_writeSync) {
+			JsonObject root = ReadRootForWrite();
+			update(root);
+			WriteRootAtomically(root);
+		}
+	}
+
+	private void WriteRootAtomically(JsonObject root) {
+		string? directory = Path.GetDirectoryName(_settingsPath);
+		if (!string.IsNullOrEmpty(directory)) {
+			Directory.CreateDirectory(directory);
+		}
+		string tempPath = _settingsPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+		try {
+			string json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+			using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) {
+				using var writer = new StreamWriter(stream);
+				writer.Write(json);
+				writer.Flush();
+				stream.Flush(flushToDisk: true);
+			}
+			File.Move(tempPath, _settingsPath, overwrite: true);
+		}
+		finally {
+			if (File.Exists(tempPath)) {
+				File.Delete(tempPath);
+			}
 		}
 	}
 }

--- a/clio-ring/ClioRing/Services/ClioSettingsStore.cs
+++ b/clio-ring/ClioRing/Services/ClioSettingsStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -13,6 +14,9 @@ namespace ClioRing.Services;
 /// </summary>
 public sealed class ClioSettingsStore : IClioSettingsStore {
 	private const string DevClioPathKey = "DevClioPath";
+	private const string RuntimeModeKey = "ClioRuntimeMode";
+	private const string ReleaseMode = "release";
+	private const string DevelopmentMode = "development";
 
 	private readonly string _settingsPath;
 
@@ -31,7 +35,7 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 	/// <inheritdoc />
 	public string? ReadDevClioPath() {
 		JsonObject? root = TryReadRoot();
-		string? value = root?[DevClioPathKey]?.GetValue<string>();
+		string? value = ReadString(root?[DevClioPathKey]);
 		return string.IsNullOrWhiteSpace(value) ? null : value;
 	}
 
@@ -48,6 +52,45 @@ public sealed class ClioSettingsStore : IClioSettingsStore {
 		string json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
 		File.WriteAllText(_settingsPath, json);
 	}
+
+	/// <inheritdoc />
+	public string? ReadRuntimeMode() {
+		JsonObject? root = TryReadRoot();
+		string? value = ReadString(root?[RuntimeModeKey]);
+		return string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToLowerInvariant();
+	}
+
+	/// <inheritdoc />
+	public void SaveRuntimeMode(string mode) {
+		ArgumentException.ThrowIfNullOrWhiteSpace(mode);
+		string normalized = mode.Trim().ToLowerInvariant();
+		if (normalized is not ReleaseMode and not DevelopmentMode) {
+			throw new ArgumentOutOfRangeException(nameof(mode), mode,
+				"Clio runtime mode must be release or development.");
+		}
+		JsonObject root = TryReadRoot() ?? new JsonObject();
+		root[RuntimeModeKey] = normalized;
+		string json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+		File.WriteAllText(_settingsPath, json);
+	}
+
+	/// <inheritdoc />
+	public bool HasDevelopmentTarget() {
+		JsonObject? root = TryReadRoot();
+		string? devPath = ReadString(root?[DevClioPathKey]);
+		if (!string.IsNullOrWhiteSpace(devPath) && DevClioLaunch.Validate(devPath).IsValid) {
+			return true;
+		}
+
+		JsonObject? ipc = root?["ClioIpc"] as JsonObject;
+		string? command = ReadString(ipc?["Command"]);
+		JsonArray? args = ipc?["Args"] as JsonArray;
+		return !string.IsNullOrWhiteSpace(command) && args is { Count: > 0 }
+			&& args.All(value => !string.IsNullOrWhiteSpace(ReadString(value)));
+	}
+
+	private static string? ReadString(JsonNode? node) =>
+		node is JsonValue value && value.TryGetValue(out string? result) ? result : null;
 
 	private JsonObject? TryReadRoot() {
 		try {

--- a/clio-ring/ClioRing/Services/IClioSettingsStore.cs
+++ b/clio-ring/ClioRing/Services/IClioSettingsStore.cs
@@ -19,4 +19,14 @@ public interface IClioSettingsStore {
 	/// </summary>
 	/// <param name="path">The dev-clio build path, or null/blank to clear the override.</param>
 	void SaveDevClioPath(string? path);
+
+	/// <summary>Reads the selected clio runtime mode, or null for legacy settings.</summary>
+	string? ReadRuntimeMode();
+
+	/// <summary>Persists the selected clio runtime mode without changing either saved runtime target.</summary>
+	/// <param name="mode">The normalized <c>release</c> or <c>development</c> mode.</param>
+	void SaveRuntimeMode(string mode);
+
+	/// <summary>Gets whether a valid development runtime target is saved.</summary>
+	bool HasDevelopmentTarget();
 }

--- a/clio-ring/ClioRing/Startup.cs
+++ b/clio-ring/ClioRing/Startup.cs
@@ -63,13 +63,13 @@ public static class Startup {
 		AppSettingsReader.TryRead()?.Experiments?.ClioIpc == true;
 
 	/// <summary>
-	/// Resolves the clio MCP child launch configuration from <c>app-settings.json</c>. Precedence: a valid
-	/// <c>DevClioPath</c> dev-build override wins; then an explicit <c>ClioIpc</c> section; otherwise the
-	/// machine <see cref="ClioIpcSettings.Default"/>.
+	/// Resolves the clio MCP child launch configuration from <c>app-settings.json</c>. Release mode uses the
+	/// installed clio dotnet tool. Development mode uses a valid <c>DevClioPath</c>, then an explicit
+	/// <c>ClioIpc</c> target. Legacy settings infer Development when either target is present.
 	/// </summary>
 	public static ClioIpcSettings ResolveClioIpcSettings() {
 		AppSettings? settings = AppSettingsReader.TryRead();
-		return ResolveClioIpcSettings(settings?.DevClioPath, settings?.ClioIpc);
+		return ResolveClioIpcSettings(settings?.ClioRuntimeMode, settings?.DevClioPath, settings?.ClioIpc);
 	}
 
 	/// <summary>
@@ -81,16 +81,36 @@ public static class Startup {
 	/// <param name="ipc">The optional explicit <c>ClioIpc</c> section.</param>
 	/// <returns>The resolved launch configuration.</returns>
 	public static ClioIpcSettings ResolveClioIpcSettings(string? devClioPath, ClioIpcSettingsDto? ipc) {
-		if (DevClioLaunch.Validate(devClioPath).IsValid && !string.IsNullOrWhiteSpace(devClioPath)) {
-			return DevClioLaunch.Build(devClioPath);
+		return ResolveClioIpcSettings(runtimeMode: null, devClioPath, ipc);
+	}
+
+	/// <summary>Pure runtime-mode resolution used by startup and tests.</summary>
+	/// <param name="runtimeMode">Explicit <c>release</c>/<c>development</c> choice, or null for migration inference.</param>
+	/// <param name="devClioPath">The optional development clio build path.</param>
+	/// <param name="ipc">The optional explicit development child-process configuration.</param>
+	/// <returns>The selected child-process launch settings.</returns>
+	public static ClioIpcSettings ResolveClioIpcSettings(string? runtimeMode, string? devClioPath,
+		ClioIpcSettingsDto? ipc) {
+		bool hasValidPath = DevClioLaunch.Validate(devClioPath).IsValid
+			&& !string.IsNullOrWhiteSpace(devClioPath);
+		bool hasExplicitIpc = ipc is not null && !string.IsNullOrWhiteSpace(ipc.Command)
+			&& ipc.Args is { Length: > 0 };
+		bool useDevelopment = string.Equals(runtimeMode, "development", System.StringComparison.OrdinalIgnoreCase)
+			|| (string.IsNullOrWhiteSpace(runtimeMode) && (hasValidPath || hasExplicitIpc));
+		if (!useDevelopment || string.Equals(runtimeMode, "release", System.StringComparison.OrdinalIgnoreCase)) {
+			return ClioIpcSettings.Default;
 		}
 
-		if (ipc is null || string.IsNullOrWhiteSpace(ipc.Command) || ipc.Args is not { Length: > 0 }) {
+		if (hasValidPath) {
+			return DevClioLaunch.Build(devClioPath!);
+		}
+
+		if (!hasExplicitIpc) {
 			return ClioIpcSettings.Default;
 		}
 		return new ClioIpcSettings {
-			Command = ipc.Command,
-			Args = new List<string>(ipc.Args),
+			Command = ipc!.Command!,
+			Args = new List<string>(ipc.Args!),
 			WorkingDirectory = string.IsNullOrWhiteSpace(ipc.WorkingDirectory) ? null : ipc.WorkingDirectory
 		};
 	}

--- a/clio-ring/ClioRing/Startup.cs
+++ b/clio-ring/ClioRing/Startup.cs
@@ -17,13 +17,15 @@ public static class Startup {
 	public static ServiceProvider BuildServiceProvider() {
 		var services = new ServiceCollection();
 
-		services.AddSingleton<IClioAdapter, ClioAdapter>();
 		services.AddSingleton<IActionCatalogLoader, ActionCatalogLoader>();
 		services.AddSingleton<IEnvStateStore, EnvStateStore>();
 		services.AddSingleton<IWindowPlacementStore, WindowPlacementStore>();
 		services.AddSingleton<IActionCatalogWatcher, ActionCatalogWatcher>();
 		services.AddSingleton<IEnvironmentSettingsWatcher, EnvironmentSettingsWatcher>();
 		services.AddSingleton<IClioSettingsStore, ClioSettingsStore>();
+		ResolvedClioRuntime clioRuntime = ResolveClioRuntime();
+		services.AddSingleton(clioRuntime);
+		services.AddSingleton<IClioAdapter, ClioAdapter>();
 
 		// Per-run deployment/uninstall RECEIPT (story 10, ADR D6): NDJSON of the same authoritative
 		// ClioStageEvent stream the pipeline UI renders, written to the active logs folder. Wired as a
@@ -34,7 +36,7 @@ public static class Startup {
 		// EXPERIMENTAL clio MCP-over-stdio client. Always registered but lazy: the child is not spawned
 		// until first use, and only the experiment-gated catalog view triggers that use. Off by default,
 		// so a normal launch never contacts clio over IPC.
-		services.AddSingleton<IClioIpcClient>(_ => new ClioIpcClient(ResolveClioIpcSettings(), StartupLog.Log));
+		services.AddSingleton<IClioIpcClient>(_ => new ClioIpcClient(clioRuntime.LaunchSettings, StartupLog.Log));
 
 		services.AddTransient<RingViewModel>();
 		services.AddTransient<ClioIpcViewModel>();
@@ -68,8 +70,14 @@ public static class Startup {
 	/// <c>ClioIpc</c> target. Legacy settings infer Development when either target is present.
 	/// </summary>
 	public static ClioIpcSettings ResolveClioIpcSettings() {
+		return ResolveClioRuntime().LaunchSettings;
+	}
+
+	/// <summary>Resolves the immutable runtime decision used by both process launch and the main UI.</summary>
+	/// <returns>The active runtime mode and its exact launch settings.</returns>
+	public static ResolvedClioRuntime ResolveClioRuntime() {
 		AppSettings? settings = AppSettingsReader.TryRead();
-		return ResolveClioIpcSettings(settings?.ClioRuntimeMode, settings?.DevClioPath, settings?.ClioIpc);
+		return ResolveClioRuntime(settings?.ClioRuntimeMode, settings?.DevClioPath, settings?.ClioIpc);
 	}
 
 	/// <summary>
@@ -91,27 +99,39 @@ public static class Startup {
 	/// <returns>The selected child-process launch settings.</returns>
 	public static ClioIpcSettings ResolveClioIpcSettings(string? runtimeMode, string? devClioPath,
 		ClioIpcSettingsDto? ipc) {
+		return ResolveClioRuntime(runtimeMode, devClioPath, ipc).LaunchSettings;
+	}
+
+	/// <summary>Pure runtime decision used by startup and tests.</summary>
+	/// <param name="runtimeMode">Explicit release/development choice, or null for migration inference.</param>
+	/// <param name="devClioPath">Optional validated development clio path.</param>
+	/// <param name="ipc">Optional explicit development IPC target.</param>
+	/// <returns>The selected mode and exact launch settings.</returns>
+	public static ResolvedClioRuntime ResolveClioRuntime(string? runtimeMode, string? devClioPath,
+		ClioIpcSettingsDto? ipc) {
 		bool hasValidPath = DevClioLaunch.Validate(devClioPath).IsValid
 			&& !string.IsNullOrWhiteSpace(devClioPath);
-		bool hasExplicitIpc = ipc is not null && !string.IsNullOrWhiteSpace(ipc.Command)
-			&& ipc.Args is { Length: > 0 };
+		bool hasExplicitIpc = ClioRuntimeConfiguration.IsValidExplicitIpc(ipc?.Command, ipc?.Args);
 		bool useDevelopment = string.Equals(runtimeMode, "development", System.StringComparison.OrdinalIgnoreCase)
 			|| (string.IsNullOrWhiteSpace(runtimeMode) && (hasValidPath || hasExplicitIpc));
 		if (!useDevelopment || string.Equals(runtimeMode, "release", System.StringComparison.OrdinalIgnoreCase)) {
-			return ClioIpcSettings.Default;
+			return new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
 		}
 
 		if (hasValidPath) {
-			return DevClioLaunch.Build(devClioPath!);
+			return new ResolvedClioRuntime(ClioRuntimeMode.Development, DevClioLaunch.Build(devClioPath!));
 		}
 
 		if (!hasExplicitIpc) {
-			return ClioIpcSettings.Default;
+			return new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default,
+				ClioRuntimeMode.Development,
+				"Development was selected, but its saved clio target is invalid. Open Settings to configure it.");
 		}
-		return new ClioIpcSettings {
+		var settings = new ClioIpcSettings {
 			Command = ipc!.Command!,
 			Args = new List<string>(ipc.Args!),
 			WorkingDirectory = string.IsNullOrWhiteSpace(ipc.WorkingDirectory) ? null : ipc.WorkingDirectory
 		};
+		return new ResolvedClioRuntime(ClioRuntimeMode.Development, settings);
 	}
 }

--- a/clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs
+++ b/clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs
@@ -7,14 +7,17 @@ using CommunityToolkit.Mvvm.Input;
 namespace ClioRing.ViewModels;
 
 /// <summary>
-/// Settings sub-view-model for the ring's clio connection: it defaults to the normal clio build, accepts
+	/// Settings sub-view-model for the Ring's clio connection: it defaults to the release clio, accepts
 /// an explicit dev-clio path override (persisted to <c>app-settings.json</c>), and surfaces which clio is
 /// actually connected using the negotiated handshake identity (name + version + resolved path). The
 /// override applies on the next ring launch, consistent with the hotkey settings.
 /// </summary>
 public sealed partial class ClioSettingsViewModel : ViewModelBase {
+	private const string ReleaseMode = "release";
+	private const string DevelopmentMode = "development";
 	private readonly IClioSettingsStore _store;
 	private readonly IClioIpcClient? _client;
+	private bool _suppressRuntimePersistence;
 
 	/// <summary>Creates the view-model bound to the persistence store and (optionally) the live IPC client.</summary>
 	/// <param name="store">Where the dev-clio override is read from / written to.</param>
@@ -25,7 +28,7 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 		Refresh();
 	}
 
-	/// <summary>The dev-clio build path the user is editing (a <c>clio.dll</c> or <c>clio.exe</c>). Blank = normal clio.</summary>
+	/// <summary>The development clio path the user is editing (a <c>clio.dll</c> or <c>clio.exe</c>).</summary>
 	[ObservableProperty]
 	private string _devClioPathInput = string.Empty;
 
@@ -54,6 +57,34 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 	[ObservableProperty]
 	private bool _restartRequired;
 
+	/// <summary>Whether the clio child used by this Ring session is a development/custom runtime.</summary>
+	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(IsReleaseRuntimeRunning))]
+	private bool _isDevelopmentRuntimeRunning;
+
+	/// <summary>Whether Development is selected for the next Ring launch.</summary>
+	[ObservableProperty]
+	private bool _isDevelopmentSelected;
+
+	/// <summary>Connected clio name/version shown in the main runtime notice.</summary>
+	[ObservableProperty]
+	private string _runtimeSummary = "Installed dotnet tool from PATH";
+
+	/// <summary>Resolved child command/path shown in the main runtime notice.</summary>
+	[ObservableProperty]
+	private string _runtimeTarget = "clio";
+
+	/// <summary>Whether the selected runtime differs from the child running in this session.</summary>
+	[ObservableProperty]
+	private bool _runtimeSelectionRestartRequired;
+
+	/// <summary>Whether the Development side of the runtime switch has a valid saved target.</summary>
+	[ObservableProperty]
+	private bool _hasDevelopmentTarget;
+
+	/// <summary>Whether the running clio child is the released dotnet tool.</summary>
+	public bool IsReleaseRuntimeRunning => !IsDevelopmentRuntimeRunning;
+
 	/// <summary>The path to the config file that owns these settings (shown in the panel).</summary>
 	public string SettingsPath => _store.SettingsPath;
 
@@ -70,16 +101,32 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 		StatusMessage = string.Empty;
 
 		// A persisted-but-invalid override (e.g. hand-edited into the file) is ignored at launch; say so
-		// rather than falling back to the normal clio silently.
+		// rather than falling back to Release silently.
 		DevClioValidation validation = DevClioLaunch.Validate(persisted);
 		ValidationMessage = validation.IsValid ? string.Empty : validation.Message;
 
 		UpdateIdentity(persisted);
+		UpdateRuntimeState();
+	}
+
+	partial void OnIsDevelopmentSelectedChanged(bool value) {
+		if (_suppressRuntimePersistence) {
+			return;
+		}
+		if (value && !HasDevelopmentTarget) {
+			_suppressRuntimePersistence = true;
+			IsDevelopmentSelected = false;
+			_suppressRuntimePersistence = false;
+			StatusMessage = "Configure a development clio target in Settings first.";
+			return;
+		}
+		_store.SaveRuntimeMode(value ? DevelopmentMode : ReleaseMode);
+		RuntimeSelectionRestartRequired = value != IsDevelopmentRuntimeRunning;
 	}
 
 	/// <summary>
 	/// Validates and persists the dev-clio override. A blank path clears the override (reverts to the
-	/// normal clio). An invalid path is NOT persisted and surfaces a friendly message.
+	/// saved development target). An invalid path is NOT persisted and surfaces a friendly message.
 	/// </summary>
 	[RelayCommand]
 	private void SaveDevClioOverride() {
@@ -94,12 +141,13 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 		ValidationMessage = string.Empty;
 		_store.SaveDevClioPath(input);
 		StatusMessage = input is null
-			? "Cleared. Restart the ring to connect to the normal clio."
-			: "Saved. Restart the ring to connect to the dev clio.";
+			? "Development path cleared. Select Release before restarting Ring."
+			: "Development path saved. Select Development before restarting Ring.";
 		UpdateIdentity(input);
+		UpdateRuntimeState();
 	}
 
-	/// <summary>Clears the dev-clio override, reverting the ring to the normal clio on the next launch.</summary>
+	/// <summary>Clears the development path without changing the selected runtime mode.</summary>
 	[RelayCommand]
 	private void ClearDevClioOverride() {
 		DevClioPathInput = string.Empty;
@@ -124,22 +172,63 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 			&& !string.Equals(liveTarget, resolvedTarget, StringComparison.OrdinalIgnoreCase);
 
 		string displayTarget = string.IsNullOrEmpty(liveTarget) ? resolvedTarget : liveTarget;
-		SetConnectedIdentity(handshake, displayTarget, isDevOverride);
+		SetConnectedIdentity(handshake, displayTarget, isDevOverride || IsDevelopmentTarget(liveTarget));
+	}
+
+	private void UpdateRuntimeState() {
+		string target = _client?.TargetPath ?? string.Empty;
+		IsDevelopmentRuntimeRunning = IsDevelopmentTarget(target);
+		RuntimeTarget = string.IsNullOrWhiteSpace(target) ? "clio" : target;
+		HasDevelopmentTarget = _store.HasDevelopmentTarget() || IsDevelopmentRuntimeRunning;
+		ClioServerHandshake? handshake = _client?.Handshake;
+		RuntimeSummary = handshake is null
+			? IsDevelopmentRuntimeRunning
+				? "Ring is using a development clio build"
+				: "Installed dotnet tool from PATH"
+			: $"{handshake.ServerName} {handshake.ServerVersion}";
+
+		string? persistedMode = _store.ReadRuntimeMode();
+		_suppressRuntimePersistence = true;
+		IsDevelopmentSelected = HasDevelopmentTarget && (
+			string.Equals(persistedMode, DevelopmentMode, StringComparison.OrdinalIgnoreCase)
+			|| (persistedMode is null && IsDevelopmentRuntimeRunning));
+		_suppressRuntimePersistence = false;
+		RuntimeSelectionRestartRequired = IsDevelopmentSelected != IsDevelopmentRuntimeRunning;
+	}
+
+	private static bool IsDevelopmentTarget(string? target) =>
+		!string.IsNullOrWhiteSpace(target)
+		&& !string.Equals(target, "clio", StringComparison.OrdinalIgnoreCase)
+		&& !string.Equals(target, "clio.exe", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>Populates the runtime notice without starting a clio process (screenshot/design seam).</summary>
+	/// <param name="developmentRunning">Whether the rendered session represents a development runtime.</param>
+	/// <param name="summary">The representative clio name/version.</param>
+	/// <param name="target">The representative command or path.</param>
+	public void DesignSetRuntime(bool developmentRunning, string summary, string target) {
+		IsDevelopmentRuntimeRunning = developmentRunning;
+		HasDevelopmentTarget = true;
+		_suppressRuntimePersistence = true;
+		IsDevelopmentSelected = developmentRunning;
+		_suppressRuntimePersistence = false;
+		RuntimeSummary = summary;
+		RuntimeTarget = target;
+		RuntimeSelectionRestartRequired = false;
 	}
 
 	/// <summary>
 	/// Builds the human-readable connected-clio identity line from the handshake identity (never a
-	/// hardcoded label): "<c>name version — dev build — path</c>", or a "not connected yet" form when the
+	/// hardcoded label): "<c>name version - dev build - path</c>", or a configured-target form when the
 	/// handshake is absent. Pure and directly testable.
 	/// </summary>
 	/// <param name="handshake">The negotiated handshake, or null when not connected.</param>
 	/// <param name="targetPath">The resolved clio path to display.</param>
 	/// <param name="isDevOverride">Whether the dev-clio override is the active source.</param>
 	public void SetConnectedIdentity(ClioServerHandshake? handshake, string? targetPath, bool isDevOverride) {
-		string source = isDevOverride ? "dev build" : "normal build";
+		string source = isDevOverride ? "development build" : "release build";
 		string path = string.IsNullOrWhiteSpace(targetPath) ? "unknown path" : targetPath!;
 		ConnectedClioIdentity = handshake is null
-			? $"{source} — {path} (not connected yet)"
-			: $"{handshake.ServerName} {handshake.ServerVersion} — {source} — {path}";
+			? $"clio - {source} - {path}"
+			: $"{handshake.ServerName} {handshake.ServerVersion} - {source} - {path}";
 	}
 }

--- a/clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs
+++ b/clio-ring/ClioRing/ViewModels/ClioSettingsViewModel.cs
@@ -1,5 +1,9 @@
 using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using ClioRing.Ipc;
+using ClioRing.Models;
 using ClioRing.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -17,14 +21,23 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 	private const string DevelopmentMode = "development";
 	private readonly IClioSettingsStore _store;
 	private readonly IClioIpcClient? _client;
+	private readonly ResolvedClioRuntime _runtime;
+	private readonly SynchronizationContext? _uiContext;
 	private bool _suppressRuntimePersistence;
 
 	/// <summary>Creates the view-model bound to the persistence store and (optionally) the live IPC client.</summary>
 	/// <param name="store">Where the dev-clio override is read from / written to.</param>
 	/// <param name="client">The live clio IPC client whose handshake identity is displayed; null in design/tests.</param>
-	public ClioSettingsViewModel(IClioSettingsStore store, IClioIpcClient? client = null) {
+	/// <param name="runtime">The immutable runtime decision made during startup.</param>
+	public ClioSettingsViewModel(IClioSettingsStore store, IClioIpcClient? client = null,
+		ResolvedClioRuntime? runtime = null) {
 		_store = store ?? throw new ArgumentNullException(nameof(store));
 		_client = client;
+		_runtime = runtime ?? new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default);
+		_uiContext = SynchronizationContext.Current;
+		if (_client is not null) {
+			_client.ConnectionChanged += OnConnectionChanged;
+		}
 		Refresh();
 	}
 
@@ -64,15 +77,16 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 
 	/// <summary>Whether Development is selected for the next Ring launch.</summary>
 	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(CanChangeRuntimeSelection))]
 	private bool _isDevelopmentSelected;
 
 	/// <summary>Connected clio name/version shown in the main runtime notice.</summary>
 	[ObservableProperty]
-	private string _runtimeSummary = "Installed dotnet tool from PATH";
+	private string _runtimeSummary = "Installed dotnet tool";
 
 	/// <summary>Resolved child command/path shown in the main runtime notice.</summary>
 	[ObservableProperty]
-	private string _runtimeTarget = "clio";
+	private string _runtimeTarget = ClioIpcSettings.Default.Command;
 
 	/// <summary>Whether the selected runtime differs from the child running in this session.</summary>
 	[ObservableProperty]
@@ -80,7 +94,13 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 
 	/// <summary>Whether the Development side of the runtime switch has a valid saved target.</summary>
 	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(CanChangeRuntimeSelection))]
 	private bool _hasDevelopmentTarget;
+
+	/// <summary>Actionable startup warning when the persisted runtime choice could not be used safely.</summary>
+	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(HasRuntimeConfigurationWarning))]
+	private string _runtimeConfigurationWarning = string.Empty;
 
 	/// <summary>Whether the running clio child is the released dotnet tool.</summary>
 	public bool IsReleaseRuntimeRunning => !IsDevelopmentRuntimeRunning;
@@ -93,6 +113,12 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 
 	/// <summary>Whether a non-error status/confirmation line is showing.</summary>
 	public bool HasStatusMessage => !string.IsNullOrEmpty(StatusMessage);
+
+	/// <summary>Whether the main runtime strip must show a startup configuration warning.</summary>
+	public bool HasRuntimeConfigurationWarning => !string.IsNullOrEmpty(RuntimeConfigurationWarning);
+
+	/// <summary>Whether the selector can switch to a valid target or clear an invalid Development request.</summary>
+	public bool CanChangeRuntimeSelection => HasDevelopmentTarget || IsDevelopmentSelected;
 
 	/// <summary>Re-reads the persisted override and refreshes the connected-clio identity from the live client.</summary>
 	public void Refresh() {
@@ -120,8 +146,20 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 			StatusMessage = "Configure a development clio target in Settings first.";
 			return;
 		}
-		_store.SaveRuntimeMode(value ? DevelopmentMode : ReleaseMode);
-		RuntimeSelectionRestartRequired = value != IsDevelopmentRuntimeRunning;
+		try {
+			_store.SaveRuntimeMode(value ? DevelopmentMode : ReleaseMode);
+			RuntimeSelectionRestartRequired = value != IsDevelopmentRuntimeRunning;
+			ValidationMessage = string.Empty;
+			if (!value) {
+				RuntimeConfigurationWarning = string.Empty;
+			}
+		}
+		catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException) {
+			_suppressRuntimePersistence = true;
+			IsDevelopmentSelected = !value;
+			_suppressRuntimePersistence = false;
+			ValidationMessage = "Ring settings could not be updated. The existing file was left unchanged.";
+		}
 	}
 
 	/// <summary>
@@ -139,7 +177,14 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 		}
 
 		ValidationMessage = string.Empty;
-		_store.SaveDevClioPath(input);
+		try {
+			_store.SaveDevClioPath(input);
+		}
+		catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException) {
+			ValidationMessage = "Ring settings could not be updated. The existing file was left unchanged.";
+			StatusMessage = string.Empty;
+			return;
+		}
 		StatusMessage = input is null
 			? "Development path cleared. Select Release before restarting Ring."
 			: "Development path saved. Select Development before restarting Ring.";
@@ -166,53 +211,78 @@ public sealed partial class ClioSettingsViewModel : ViewModelBase {
 
 		// The override applies at launch; if a valid override is configured but the running connection is
 		// pointed elsewhere, tell the user a relaunch is needed rather than showing a stale label.
-		string resolvedTarget = isDevOverride ? persistedOverride!.Trim() : liveTarget;
+		string resolvedTarget = _runtime.Mode == ClioRuntimeMode.Development && isDevOverride
+			? persistedOverride!.Trim()
+			: liveTarget;
 		RestartRequired = _client is { IsConnected: true }
 			&& !string.IsNullOrEmpty(liveTarget)
 			&& !string.Equals(liveTarget, resolvedTarget, StringComparison.OrdinalIgnoreCase);
 
 		string displayTarget = string.IsNullOrEmpty(liveTarget) ? resolvedTarget : liveTarget;
-		SetConnectedIdentity(handshake, displayTarget, isDevOverride || IsDevelopmentTarget(liveTarget));
+		SetConnectedIdentity(handshake, displayTarget, _runtime.Mode == ClioRuntimeMode.Development);
 	}
 
 	private void UpdateRuntimeState() {
-		string target = _client?.TargetPath ?? string.Empty;
-		IsDevelopmentRuntimeRunning = IsDevelopmentTarget(target);
-		RuntimeTarget = string.IsNullOrWhiteSpace(target) ? "clio" : target;
+		string target = _client?.TargetPath ?? ResolveTargetPath(_runtime.LaunchSettings);
+		IsDevelopmentRuntimeRunning = _runtime.Mode == ClioRuntimeMode.Development;
+		RuntimeTarget = string.IsNullOrWhiteSpace(target) ? _runtime.LaunchSettings.Command : target;
 		HasDevelopmentTarget = _store.HasDevelopmentTarget() || IsDevelopmentRuntimeRunning;
 		ClioServerHandshake? handshake = _client?.Handshake;
 		RuntimeSummary = handshake is null
 			? IsDevelopmentRuntimeRunning
 				? "Ring is using a development clio build"
-				: "Installed dotnet tool from PATH"
+				: "Installed dotnet tool"
 			: $"{handshake.ServerName} {handshake.ServerVersion}";
-
 		string? persistedMode = _store.ReadRuntimeMode();
+		RuntimeConfigurationWarning = _runtime.ConfigurationWarning is not null
+			&& !string.Equals(persistedMode, ReleaseMode, StringComparison.OrdinalIgnoreCase)
+			&& !_store.HasDevelopmentTarget()
+				? _runtime.ConfigurationWarning
+				: string.Empty;
 		_suppressRuntimePersistence = true;
-		IsDevelopmentSelected = HasDevelopmentTarget && (
-			string.Equals(persistedMode, DevelopmentMode, StringComparison.OrdinalIgnoreCase)
-			|| (persistedMode is null && IsDevelopmentRuntimeRunning));
+		IsDevelopmentSelected = persistedMode is not null
+			? string.Equals(persistedMode, DevelopmentMode, StringComparison.OrdinalIgnoreCase)
+			: _runtime.RequestedMode.HasValue
+				? _runtime.RequestedMode == ClioRuntimeMode.Development
+				: HasDevelopmentTarget && IsDevelopmentRuntimeRunning;
 		_suppressRuntimePersistence = false;
 		RuntimeSelectionRestartRequired = IsDevelopmentSelected != IsDevelopmentRuntimeRunning;
 	}
 
-	private static bool IsDevelopmentTarget(string? target) =>
-		!string.IsNullOrWhiteSpace(target)
-		&& !string.Equals(target, "clio", StringComparison.OrdinalIgnoreCase)
-		&& !string.Equals(target, "clio.exe", StringComparison.OrdinalIgnoreCase);
+	private static string ResolveTargetPath(ClioIpcSettings settings) =>
+		settings.Args.FirstOrDefault(argument => argument.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+		?? settings.Command;
+
+	private void OnConnectionChanged(object? sender, EventArgs e) {
+		if (_uiContext is null || ReferenceEquals(SynchronizationContext.Current, _uiContext)) {
+			RefreshConnectionIdentity();
+			return;
+		}
+		_uiContext.Post(_ => RefreshConnectionIdentity(), null);
+	}
+
+	/// <summary>Refreshes displayed identity after the lazy clio handshake changes.</summary>
+	public void RefreshConnectionIdentity() {
+		UpdateIdentity(_store.ReadDevClioPath());
+		UpdateRuntimeState();
+	}
 
 	/// <summary>Populates the runtime notice without starting a clio process (screenshot/design seam).</summary>
 	/// <param name="developmentRunning">Whether the rendered session represents a development runtime.</param>
 	/// <param name="summary">The representative clio name/version.</param>
 	/// <param name="target">The representative command or path.</param>
-	public void DesignSetRuntime(bool developmentRunning, string summary, string target) {
+	/// <param name="configurationWarning">Optional startup warning to render.</param>
+	/// <param name="developmentSelected">Optional next-launch selector state when it differs from the running mode.</param>
+	public void DesignSetRuntime(bool developmentRunning, string summary, string target,
+		string? configurationWarning = null, bool? developmentSelected = null) {
 		IsDevelopmentRuntimeRunning = developmentRunning;
 		HasDevelopmentTarget = true;
 		_suppressRuntimePersistence = true;
-		IsDevelopmentSelected = developmentRunning;
+		IsDevelopmentSelected = developmentSelected ?? developmentRunning;
 		_suppressRuntimePersistence = false;
 		RuntimeSummary = summary;
 		RuntimeTarget = target;
+		RuntimeConfigurationWarning = configurationWarning ?? string.Empty;
 		RuntimeSelectionRestartRequired = false;
 	}
 

--- a/clio-ring/ClioRing/ViewModels/RingViewModel.cs
+++ b/clio-ring/ClioRing/ViewModels/RingViewModel.cs
@@ -344,12 +344,13 @@ public partial class RingViewModel : ViewModelBase {
 
 	/// <summary>Primary DI constructor. The IPC client and settings store are optional so lightweight
 	/// design-time / test constructions keep working; DI supplies both at runtime.</summary>
-	public RingViewModel(IClioAdapter clio, IActionCatalogLoader catalogLoader, IEnvStateStore stateStore, IActionCatalogWatcher catalogWatcher, IClioIpcClient? ipcClient = null, IClioSettingsStore? settingsStore = null, IEnvironmentSettingsWatcher? environmentSettingsWatcher = null) {
+	public RingViewModel(IClioAdapter clio, IActionCatalogLoader catalogLoader, IEnvStateStore stateStore, IActionCatalogWatcher catalogWatcher, IClioIpcClient? ipcClient = null, IClioSettingsStore? settingsStore = null, IEnvironmentSettingsWatcher? environmentSettingsWatcher = null, ResolvedClioRuntime? clioRuntime = null) {
 		_clio = clio;
 		_catalogLoader = catalogLoader;
 		_stateStore = stateStore;
 		_catalogWatcher = catalogWatcher;
-		ClioSettings = new ClioSettingsViewModel(settingsStore ?? new ClioSettingsStore(), ipcClient);
+		ClioSettings = new ClioSettingsViewModel(settingsStore ?? new ClioSettingsStore(), ipcClient,
+			clioRuntime ?? new ResolvedClioRuntime(ClioRuntimeMode.Release, ClioIpcSettings.Default));
 		_state = _stateStore.Load();
 		_channel = ResolveChannel();
 		SelectedEnvironmentName = string.IsNullOrEmpty(_state.Selected) ? "—" : _state.Selected!;

--- a/clio-ring/ClioRing/Views/RingView.axaml
+++ b/clio-ring/ClioRing/Views/RingView.axaml
@@ -268,11 +268,75 @@
     </UserControl.Styles>
 
     <Grid>
-        <!-- Main layout: fixed ring region (row 0) + drawer reserved below (row 1). -->
-        <Grid RowDefinitions="Auto,Auto">
+        <!-- Main layout: runtime identity + fixed ring region + drawer reserved below. -->
+        <Grid RowDefinitions="Auto,Auto,Auto">
+
+            <!-- Development runtime is intentionally impossible to miss. It reserves layout space instead
+                 of covering ring actions. The selector persists the next-launch choice. -->
+            <Border Grid.Row="0"
+                    IsVisible="{Binding ClioSettings.IsDevelopmentRuntimeRunning}"
+                    Margin="14,14,14,0" Padding="12,10"
+                    Background="#34200A" BorderBrush="#F59E0B" BorderThickness="1.5"
+                    CornerRadius="10" BoxShadow="0 8 24 0 #70000000">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+                    <Border Grid.Column="0" Width="28" Height="28" CornerRadius="14"
+                            Background="#33F59E0B" BorderBrush="#AAF59E0B" BorderThickness="1"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="!" FontSize="17" FontWeight="Bold" Foreground="#FFD58A"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                        <TextBlock Text="Development clio is active" FontSize="13" FontWeight="Bold"
+                                   Foreground="#FFE0A8" />
+                        <TextBlock Text="{Binding ClioSettings.RuntimeSummary}" FontSize="11"
+                                   Foreground="#F1C98D" />
+                        <TextBlock Text="{Binding ClioSettings.RuntimeTarget}" FontSize="10"
+                                   FontFamily="Cascadia Mono, Consolas, monospace" Foreground="#BFA373"
+                                   MaxWidth="270" TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding ClioSettings.RuntimeTarget}" />
+                        <TextBlock IsVisible="{Binding ClioSettings.RuntimeSelectionRestartRequired}"
+                                   Text="Restart Ring to apply this selection" FontSize="10"
+                                   FontWeight="SemiBold" Foreground="#FFF0C7" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Spacing="3" VerticalAlignment="Center">
+                        <TextBlock Text="Clio runtime" FontSize="9" Foreground="#C8A872"
+                                   HorizontalAlignment="Center" />
+                        <ToggleSwitch IsChecked="{Binding ClioSettings.IsDevelopmentSelected, Mode=TwoWay}"
+                                      IsEnabled="{Binding ClioSettings.HasDevelopmentTarget}"
+                                      OffContent="Release" OnContent="Development"
+                                      Foreground="#FFE0A8"
+                                      AutomationProperties.Name="Use development clio runtime" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Release mode stays calm but keeps the active runtime and switch discoverable. -->
+            <Border Grid.Row="0"
+                    IsVisible="{Binding ClioSettings.IsReleaseRuntimeRunning}"
+                    Margin="14,10,14,0" Padding="10,6"
+                    Background="#101B16" BorderBrush="#345E49" BorderThickness="1"
+                    CornerRadius="9">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <Border Grid.Column="0" Width="7" Height="7" CornerRadius="4"
+                            Background="#3FB950" VerticalAlignment="Center" />
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"
+                                VerticalAlignment="Center">
+                        <TextBlock Text="Release clio" FontSize="11" FontWeight="SemiBold"
+                                   Foreground="#A9D7B6" />
+                        <TextBlock Text="{Binding ClioSettings.RuntimeSummary}" FontSize="10"
+                                   Foreground="#71977D" />
+                    </StackPanel>
+                    <ToggleSwitch Grid.Column="2"
+                                  IsChecked="{Binding ClioSettings.IsDevelopmentSelected, Mode=TwoWay}"
+                                  IsEnabled="{Binding ClioSettings.HasDevelopmentTarget}"
+                                  OffContent="Release" OnContent="Development"
+                                  Foreground="#A9D7B6"
+                                  AutomationProperties.Name="Use development clio runtime" />
+                </Grid>
+            </Border>
 
             <!-- Fixed-geometry ring region -->
-            <Border Grid.Row="0"
+            <Border Grid.Row="1"
                     Width="{Binding Diameter}"
                     Height="{Binding Diameter}"
                     HorizontalAlignment="Center">
@@ -322,7 +386,7 @@
             </Border>
 
             <!-- Output bottom-sheet: expands into reserved space, never reflows the ring -->
-            <Border Grid.Row="1"
+            <Border Grid.Row="2"
                     IsVisible="{Binding IsOutputOpen}"
                     Margin="14,0,14,14"
                     Background="#0D1117"
@@ -377,7 +441,7 @@
 
             <!-- Collapsed output bar: keeps the last output reachable (fixes the lost-output bug).
                  Click / Enter re-expands the SAME buffer; Cancel + state stay reachable while running. -->
-            <Border Grid.Row="1"
+            <Border Grid.Row="2"
                     IsVisible="{Binding IsOutputCollapsed}"
                     Margin="14,0,14,14"
                     Background="#0D1117"
@@ -544,10 +608,10 @@
                             <Border IsVisible="{Binding ClioSettings.IsDevOverrideActive}"
                                     Background="#2A1C0B" BorderBrush="#F5A524" BorderThickness="1"
                                     CornerRadius="6" Padding="8,4" HorizontalAlignment="Left">
-                                <TextBlock Text="Using your dev clio build" FontSize="11"
+                                <TextBlock Text="Development path is configured" FontSize="11"
                                            FontWeight="SemiBold" Foreground="#F5D9A8" />
                             </Border>
-                            <TextBlock Text="Point the ring at a dev clio build (clio.dll or clio.exe). Leave blank to use the normal clio."
+                            <TextBlock Text="Save a development clio build (clio.dll or clio.exe). Use the main runtime switch to choose Release or Development."
                                        FontSize="11" Foreground="#8B97A5" TextWrapping="Wrap" />
                             <TextBox x:Name="DevClioPathBox"
                                      Text="{Binding ClioSettings.DevClioPathInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -562,7 +626,7 @@
                                                  Text="{Binding ClioSettings.StatusMessage}"
                                                  FontSize="11" Foreground="#8FCF9A" TextWrapping="Wrap" />
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-                                <Button x:Name="DevClioClearButton" Classes="pill strong" Content="Use normal clio"
+                                <Button x:Name="DevClioClearButton" Classes="pill strong" Content="Clear development path"
                                         Command="{Binding ClioSettings.ClearDevClioOverrideCommand}" />
                                 <Button x:Name="DevClioSaveButton" Classes="pill primary" Content="Save"
                                         Command="{Binding ClioSettings.SaveDevClioOverrideCommand}" />

--- a/clio-ring/ClioRing/Views/RingView.axaml
+++ b/clio-ring/ClioRing/Views/RingView.axaml
@@ -302,7 +302,7 @@
                         <TextBlock Text="Clio runtime" FontSize="9" Foreground="#C8A872"
                                    HorizontalAlignment="Center" />
                         <ToggleSwitch IsChecked="{Binding ClioSettings.IsDevelopmentSelected, Mode=TwoWay}"
-                                      IsEnabled="{Binding ClioSettings.HasDevelopmentTarget}"
+                                      IsEnabled="{Binding ClioSettings.CanChangeRuntimeSelection}"
                                       OffContent="Release" OnContent="Development"
                                       Foreground="#FFE0A8"
                                       AutomationProperties.Name="Use development clio runtime" />
@@ -319,16 +319,24 @@
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Grid.Column="0" Width="7" Height="7" CornerRadius="4"
                             Background="#3FB950" VerticalAlignment="Center" />
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"
-                                VerticalAlignment="Center">
-                        <TextBlock Text="Release clio" FontSize="11" FontWeight="SemiBold"
-                                   Foreground="#A9D7B6" />
-                        <TextBlock Text="{Binding ClioSettings.RuntimeSummary}" FontSize="10"
-                                   Foreground="#71977D" />
+                    <StackPanel Grid.Column="1" Spacing="1" VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <TextBlock Text="Release clio" FontSize="11" FontWeight="SemiBold"
+                                       Foreground="#A9D7B6" />
+                            <TextBlock Text="{Binding ClioSettings.RuntimeSummary}" FontSize="10"
+                                       Foreground="#71977D" />
+                        </StackPanel>
+                        <TextBlock IsVisible="{Binding ClioSettings.RuntimeSelectionRestartRequired}"
+                                   Text="Restart Ring to apply this selection" FontSize="9"
+                                   FontWeight="SemiBold" Foreground="#A9D7B6" />
+                        <TextBlock IsVisible="{Binding ClioSettings.HasRuntimeConfigurationWarning}"
+                                   Text="{Binding ClioSettings.RuntimeConfigurationWarning}" FontSize="9"
+                                   FontWeight="SemiBold" Foreground="#FFD58A" TextWrapping="Wrap"
+                                   MaxWidth="300" />
                     </StackPanel>
                     <ToggleSwitch Grid.Column="2"
                                   IsChecked="{Binding ClioSettings.IsDevelopmentSelected, Mode=TwoWay}"
-                                  IsEnabled="{Binding ClioSettings.HasDevelopmentTarget}"
+                                  IsEnabled="{Binding ClioSettings.CanChangeRuntimeSelection}"
                                   OffContent="Release" OnContent="Development"
                                   Foreground="#A9D7B6"
                                   AutomationProperties.Name="Use development clio runtime" />

--- a/clio-ring/README.md
+++ b/clio-ring/README.md
@@ -48,9 +48,18 @@ clio ring
 
 The bootstrap installs versioned releases under `%LOCALAPPDATA%\Creatio\clio-ring` and verifies every ZIP against the SHA-256 in the GitHub release manifest.
 
-## Application settings and development clio
+## Application settings and clio runtime
 
 `ClioRing.Desktop/app-settings.json` references the colocated `app-settings.schema.json`, so JSON-aware editors provide validation and hover descriptions. The `Channel` value is only the label shown in Ring's build badge; values such as `release`, `dev`, or `preview` do **not** select which clio executable Ring starts.
+
+Ring has a separate `ClioRuntimeMode` setting:
+
+- `release` starts `clio mcp-server` from `PATH`, using the clio installed through `dotnet tool install clio`.
+- `development` starts the saved local development target.
+
+The main Ring surface always shows the active mode. Development mode uses a prominent warning with a
+Release/Development switch. The switch updates `app-settings.json`, preserves the development target,
+and takes effect after Ring restarts.
 
 To expose the experimental MCP-over-stdio UI and point it at a development build, use:
 
@@ -59,6 +68,7 @@ To expose the experimental MCP-over-stdio UI and point it at a development build
   "$schema": "./app-settings.schema.json",
   "WorkspaceFolder": "C:\\Projects\\Workspaces",
   "Channel": "release",
+  "ClioRuntimeMode": "development",
   "Experiments": {
     "ClioIpc": true
   },
@@ -66,11 +76,14 @@ To expose the experimental MCP-over-stdio UI and point it at a development build
 }
 ```
 
-Clio launch selection uses this precedence on the next Ring launch:
+In Development mode, target selection uses this precedence on the next Ring launch:
 
 1. A valid `DevClioPath` (`clio.dll` or `clio.exe`).
 2. An explicit `ClioIpc` block with `Command`, `Args`, and optional `WorkingDirectory`.
-3. Ring's machine default.
+
+With legacy settings that do not contain `ClioRuntimeMode`, Ring keeps using Development when either
+target exists. Clean settings select Release. This migration prevents an existing development setup from
+changing silently while making Release the default for ordinary installations.
 
 `DevClioPath` and `ClioIpc.Command` are code-execution trust boundaries: Ring starts the selected program with your user privileges. Use only trusted local builds and commands, prefer absolute paths, and do not point them at downloaded binaries or locations writable by other users.
 

--- a/clio-ring/README.md
+++ b/clio-ring/README.md
@@ -54,12 +54,13 @@ The bootstrap installs versioned releases under `%LOCALAPPDATA%\Creatio\clio-rin
 
 Ring has a separate `ClioRuntimeMode` setting:
 
-- `release` starts `clio mcp-server` from `PATH`, using the clio installed through `dotnet tool install clio`.
+- `release` starts a verified dotnet-tool shim from the standard user directory or `DOTNET_CLI_HOME`; custom paths remain explicit Development targets.
 - `development` starts the saved local development target.
 
 The main Ring surface always shows the active mode. Development mode uses a prominent warning with a
 Release/Development switch. The switch updates `app-settings.json`, preserves the development target,
 and takes effect after Ring restarts.
+The same selected runtime drives deployment workflows, environment discovery, and ordinary radial actions.
 
 To expose the experimental MCP-over-stdio UI and point it at a development build, use:
 

--- a/clio-ring/tools/ScreenshotTool/Program.cs
+++ b/clio-ring/tools/ScreenshotTool/Program.cs
@@ -80,6 +80,22 @@ internal static class Program {
 		// 1) DEFAULT — compact, ring only, calm.
 		count += CaptureState(outDir, "default", _ => { });
 
+		// 1b) DEVELOPMENT RUNTIME — prominent main-surface warning with release/development switch.
+		count += Capture(outDir, "development-runtime", 1.0, window => {
+			Vm(window).ClioSettings.DesignSetRuntime(
+				developmentRunning: true,
+				"clio 8.1.0.83",
+				@"C:\Projects\clio\clio\bin\Debug\net10.0\clio.dll");
+		});
+
+		// 1c) RELEASE RUNTIME — calm, compact identity with the same selector discoverable.
+		count += Capture(outDir, "release-runtime", 1.0, window => {
+			Vm(window).ClioSettings.DesignSetRuntime(
+				developmentRunning: false,
+				"clio 8.1.0.84",
+				"clio");
+		});
+
 		// 2) FOCUSED — keyboard focus on an action node (strong accent ring).
 		count += CaptureState(outDir, "focused", (window) => {
 			View(window).SetKeyboardFocusNode(2);

--- a/clio-ring/tools/ScreenshotTool/Program.cs
+++ b/clio-ring/tools/ScreenshotTool/Program.cs
@@ -11,6 +11,7 @@ using Avalonia.Platform;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using ClioRing;
+using ClioRing.Ipc;
 using ClioRing.Services;
 using ClioRing.ViewModels;
 using ClioRing.Views;
@@ -94,6 +95,16 @@ internal static class Program {
 				developmentRunning: false,
 				"clio 8.1.0.84",
 				"clio");
+		});
+
+		// 1d) INVALID DEVELOPMENT TARGET — safe Release fallback with an actionable main-surface warning.
+		count += Capture(outDir, "invalid-development-runtime", 1.0, window => {
+			Vm(window).ClioSettings.DesignSetRuntime(
+				developmentRunning: false,
+				"Installed dotnet tool",
+				ClioIpcSettings.Default.Command,
+				"Development was selected, but its saved clio target is invalid. Open Settings to configure it.",
+				developmentSelected: true);
 		});
 
 		// 2) FOCUSED — keyboard focus on an action node (strong accent ring).

--- a/clio-ring/tools/ScreenshotTool/WorkflowCaptures.cs
+++ b/clio-ring/tools/ScreenshotTool/WorkflowCaptures.cs
@@ -156,6 +156,7 @@ internal sealed class StubIpcClient : IClioIpcClient {
 	public bool LastCatalogIsModern => true;
 #pragma warning disable CS0067 // event never used in the stub
 	public event EventHandler? Disconnected;
+	public event EventHandler? ConnectionChanged;
 #pragma warning restore CS0067
 
 	public Task<ClioServerHandshake> ConnectAsync(CancellationToken cancellationToken = default) =>

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md
@@ -1,0 +1,38 @@
+# ADR: Separate ClioRing runtime selection from runtime configuration
+
+Status: accepted
+
+## Context
+
+ClioRing currently resolves a valid `DevClioPath`, then an explicit `ClioIpc` command, then a hard-coded
+repository Debug DLL. The Settings overlay calls the last two cases a "normal build", and the main Ring
+does not disclose the active source. A user can therefore perform destructive work with an unintended
+development clio.
+
+## Decision
+
+Persist an explicit `ClioRuntimeMode` value with `release` and `development` choices. Keep the existing
+`DevClioPath` and `ClioIpc` fields as the saved development target; changing modes does not erase them.
+
+Release resolves to `Command = "clio"`, `Args = ["mcp-server"]`, using the dotnet tool on `PATH`.
+Development resolves through the existing valid `DevClioPath` then explicit `ClioIpc` precedence. For
+backwards compatibility, settings that have a development target but no `ClioRuntimeMode` migrate in
+memory to Development; clean settings migrate to Release.
+
+Expose the resolved source as a small immutable runtime-selection model consumed by startup and UI.
+The first implementation applies changes on Ring restart because the registered IPC client owns one
+immutable child launch configuration for the app session. The main warning must distinguish "running"
+from "selected for next launch" and provide a restart action before it may claim Release is active.
+
+Render a reserved-height banner above the radial control when Development is running. This avoids
+covering action nodes and makes the warning part of the main visual hierarchy. Release uses a compact
+status pill in the same reserved region.
+
+## Consequences
+
+- Ordinary installs use the released dotnet tool instead of a machine-specific repository path.
+- Existing developer configurations remain active and become conspicuous rather than breaking silently.
+- A selector can switch modes without destroying the development target.
+- The Ring window grows vertically while the development warning is present; the radial geometry remains
+  unchanged.
+- Immediate in-process retargeting is deferred; a future change may add it behind the same selection model.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md
@@ -14,12 +14,15 @@ development clio.
 Persist an explicit `ClioRuntimeMode` value with `release` and `development` choices. Keep the existing
 `DevClioPath` and `ClioIpc` fields as the saved development target; changing modes does not erase them.
 
-Release resolves to `Command = "clio"`, `Args = ["mcp-server"]`, using the dotnet tool on `PATH`.
+Release resolves to the verified clio dotnet-tool shim with `Args = ["mcp-server"]`. Resolution supports the
+standard user tool directory and `DOTNET_CLI_HOME`. Custom tool paths require the user's explicit Development
+configuration and are never promoted to trusted Release merely because they appear on `PATH`.
 Development resolves through the existing valid `DevClioPath` then explicit `ClioIpc` precedence. For
 backwards compatibility, settings that have a development target but no `ClioRuntimeMode` migrate in
 memory to Development; clean settings migrate to Release.
 
-Expose the resolved source as a small immutable runtime-selection model consumed by startup and UI.
+Expose the resolved source as a small immutable runtime-selection model consumed by startup, the UI, IPC
+workflows, environment discovery, and ordinary radial commands.
 The first implementation applies changes on Ring restart because the registered IPC client owns one
 immutable child launch configuration for the app session. The main warning must distinguish "running"
 from "selected for next launch" and provide a restart action before it may claim Release is active.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
@@ -9,7 +9,8 @@ development runtime easy to select and impossible to overlook on the main Ring s
 
 ## Requirements
 
-- Release mode launches `clio mcp-server` from `PATH`.
+- Release mode launches a verified `clio mcp-server` dotnet-tool shim from the standard user tool directory
+  or `DOTNET_CLI_HOME`. Custom paths remain explicit Development targets.
 - A valid `DevClioPath` or explicit `ClioIpc` command remains a saved development target.
 - Existing settings with a development target and no mode retain that target during migration and are
   classified as Development rather than silently switching.
@@ -21,6 +22,8 @@ development runtime easy to select and impossible to overlook on the main Ring s
 - A mode change must never claim the running child changed before it actually did. The first delivery may
   require a Ring restart, but the UI must say so clearly and offer the next action.
 - The Settings overlay uses the same Release and Development terminology.
+- Deployment workflows, environment discovery, and ordinary radial actions all use the same resolved runtime.
+- If Development is selected without a valid target, Ring safely runs Release and shows an actionable warning.
 
 ## Acceptance criteria
 

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
@@ -1,0 +1,33 @@
+# ClioRing clio-runtime switch specification
+
+Issue: #903
+
+## Goal
+
+Make the installed `clio` dotnet tool the ordinary ClioRing runtime while keeping an explicit local
+development runtime easy to select and impossible to overlook on the main Ring surface.
+
+## Requirements
+
+- Release mode launches `clio mcp-server` from `PATH`.
+- A valid `DevClioPath` or explicit `ClioIpc` command remains a saved development target.
+- Existing settings with a development target and no mode retain that target during migration and are
+  classified as Development rather than silently switching.
+- The selected mode is persisted independently from the saved development target.
+- The main Ring surface shows a prominent amber warning whenever the running runtime is Development.
+- The warning identifies the runtime and provides a Release/Development selector without requiring the
+  Settings overlay.
+- Release mode uses a compact, calm identity indicator instead of a warning.
+- A mode change must never claim the running child changed before it actually did. The first delivery may
+  require a Ring restart, but the UI must say so clearly and offer the next action.
+- The Settings overlay uses the same Release and Development terminology.
+
+## Acceptance criteria
+
+- With no explicit development target, Ring resolves to `clio mcp-server` and selects Release.
+- With the current explicit Debug-DLL `ClioIpc` settings, Ring selects Development and shows the main warning.
+- Selecting Release persists the choice without deleting the development target.
+- Selecting Development later reuses the saved target.
+- The UI design is rendered and approved before comprehensive review or NativeAOT validation.
+- Focused tests cover resolution, migration, persistence, and both main-surface states.
+- The final Windows x64 NativeAOT publish is clean.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
@@ -1,6 +1,6 @@
 # ClioRing clio-runtime switch story
 
-Status: in-progress
+Status: done
 Issue: #903
 
 As a ClioRing user, I want the released clio to be the normal runtime and any development runtime to be
@@ -9,10 +9,11 @@ obvious, so I do not accidentally manage Creatio with an unintended local build.
 ## Definition of done
 
 - [x] UI design is rendered and approved by the requester.
-- [x] Release mode resolves to `clio mcp-server` from `PATH`.
+- [x] Release mode resolves to a verified `clio mcp-server` dotnet-tool shim from standard dotnet-owned directories.
 - [x] Existing development settings migrate without losing their target.
 - [x] Main-surface warning and Release/Development selector are implemented.
+- [x] IPC workflows, environment discovery, and ordinary radial actions share the selected runtime.
 - [x] Settings, schema, and README use consistent terminology.
 - [x] Focused Ring tests pass.
-- [ ] Comprehensive agentic review has no unresolved Blocker/High findings.
+- [x] Comprehensive agentic review has no unresolved findings.
 - [x] Windows x64 NativeAOT publish passes without trim/AOT warnings.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
@@ -1,0 +1,18 @@
+# ClioRing clio-runtime switch story
+
+Status: in-progress
+Issue: #903
+
+As a ClioRing user, I want the released clio to be the normal runtime and any development runtime to be
+obvious, so I do not accidentally manage Creatio with an unintended local build.
+
+## Definition of done
+
+- [x] UI design is rendered and approved by the requester.
+- [x] Release mode resolves to `clio mcp-server` from `PATH`.
+- [x] Existing development settings migrate without losing their target.
+- [x] Main-surface warning and Release/Development selector are implemented.
+- [x] Settings, schema, and README use consistent terminology.
+- [x] Focused Ring tests pass.
+- [ ] Comprehensive agentic review has no unresolved Blocker/High findings.
+- [x] Windows x64 NativeAOT publish passes without trim/AOT warnings.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-test-plan.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-test-plan.md
@@ -1,0 +1,20 @@
+# ClioRing clio-runtime switch test plan
+
+## Design checkpoint
+
+- Render the main Ring with the current Debug-DLL configuration.
+- Verify the Development warning is the first visual emphasis and does not cover ring nodes.
+- Render Release mode and verify it is calm but still identifiable.
+- Stop before comprehensive review and Windows x64 NativeAOT publish for requester approval.
+
+## Automated
+
+- Default resolution selects Release and launches `clio mcp-server`.
+- Legacy explicit `ClioIpc` and valid `DevClioPath` settings select Development.
+- Explicit Release ignores but preserves the saved development target.
+- Explicit Development rejects a missing/invalid target with an actionable UI state.
+- Store round-trips runtime mode without altering unrelated JSON fields.
+- View-model states distinguish running mode, pending mode, and restart requirement.
+- Release and Development banner controls have accessible names and keyboard focus.
+- Run `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` after UI approval.
+- Run the mandatory Windows x64 NativeAOT publish after UI approval.

--- a/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-test-plan.md
+++ b/spec/ring-clio-runtime-switch/ring-clio-runtime-switch-test-plan.md
@@ -13,6 +13,8 @@
 - Legacy explicit `ClioIpc` and valid `DevClioPath` settings select Development.
 - Explicit Release ignores but preserves the saved development target.
 - Explicit Development rejects a missing/invalid target with an actionable UI state.
+- Release resolution supports `DOTNET_CLI_HOME` without trusting arbitrary PATH executables.
+- Ordinary radial actions and IPC workflows use the same Release or Development launch target.
 - Store round-trips runtime mode without altering unrelated JSON fields.
 - View-model states distinguish running mode, pending mode, and restart requirement.
 - Release and Development banner controls have accessible names and keyboard focus.

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -2119,8 +2119,8 @@ stories:
     feature: "ring-clio-runtime-switch"
     repo: "clio (clio-ring/)"
     size: M
-    status: in-progress
-    note: "Issue #903. UI design approval is required before comprehensive agentic review or NativeAOT publish."
+    status: done
+    note: "Issue #903. UI approved; 129 focused tests, comprehensive review, and Windows x64 NativeAOT publish passed."
     file: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
     prd: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
     adr: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -2114,3 +2114,15 @@ stories:
       - story-entity-schema-authoring-gaps-2
       - story-entity-schema-authoring-gaps-3
     blocks: []
+  - id: story-ring-clio-runtime-switch-1
+    title: "Make release clio the default and surface the active runtime switch"
+    feature: "ring-clio-runtime-switch"
+    repo: "clio (clio-ring/)"
+    size: M
+    status: in-progress
+    note: "Issue #903. UI design approval is required before comprehensive agentic review or NativeAOT publish."
+    file: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-story.md
+    prd: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-spec.md
+    adr: spec/ring-clio-runtime-switch/ring-clio-runtime-switch-adr.md
+    depends_on: []
+    blocks: []


### PR DESCRIPTION
## Summary
- add a main-surface Release/Development clio runtime selector with the approved prominent Development warning
- persist `ClioRuntimeMode` in Ring's `app-settings.json` while preserving the saved development target
- resolve Release from trusted dotnet-owned user tool roots and use one immutable runtime for IPC workflows, environment discovery, and radial actions
- fail safely with an actionable warning when Development is selected without a valid target
- make settings updates atomic and preserve malformed/unreadable files instead of overwriting them

## Validation
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release --no-restore` - 129 passed
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` - passed, no trim/AOT warnings
- ScreenshotTool rendered Development, Release, and invalid-Development fallback states
- comprehensive three-lens agentic review - clean, no unresolved findings

## Maintenance review
- docs reviewed and updated: Ring README, settings schema, feature spec/ADR/story/test plan
- MCP reviewed, no clio provider command or MCP contract changed
- ClioRing compatibility reviewed: the existing clio MCP invocation and progress contracts are unchanged; Ring unit tests and Windows x64 NativeAOT publish passed

Fixes #903
