### PR TITLE
Document disabled ESQ filters and group IsNot

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6640,3 +6640,10 @@ Decision: Changed the parsing recipe to compare the exact `LeftExpression.Path` 
 Discovery: `EntitySchemaQueryExpression.Path` retains the complete expression path, while `SchemaColumnName` exposes only its terminal schema column.
 Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
 Impact: Agents following the guide cannot accidentally evaluate an unintended joined column as a same-named root column; focused tests and the full MCP module remain green on net8.0 and net10.0.
+
+## 2026-07-17 14:35 – Validate disabled ESQ nodes and collection IsNot
+Context: Extend the backend ESQ construction and parsing guidance using the VirtualEntityGuidance lab.
+Decision: Document disabled-node transport differences separately from semantic evaluation, and apply collection `IsNot` only after combining enabled children.
+Discovery: Native C# retains disabled leaves/groups while SQL compilation omits them; DataService removes disabled children before the executor boundary. Native C# and DataService preserve collection `IsNot`. ATF.Repository 2.0.3.5 cannot author group negation through LINQ, so the lab used a test-only decorator over its public `ISelectQuery` contract.
+Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents now have lab-verified rules for creating and parsing disabled nodes and negated groups, including the native-versus-DataService shape boundary.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -658,12 +658,16 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "the backend catalog name should preserve the hierarchical backend URI");
 		backend.Article!.Text.Should().Contain("FilterComparisonType.NotEndWith",
 			because: "get-guidance should return the concrete backend scalar Compare recipes");
+		backend.Article!.Text.Should().Contain("disabledLeaf.IsEnabled = false",
+			because: "get-guidance should return the verified native disabled-leaf recipe");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
 			because: "the parsing catalog name should preserve the independent parsing URI");
 		parsing.Article!.Text.Should().Contain("ReadScalarParameter",
 			because: "get-guidance should return the verified runtime scalar parameter parsing recipe");
+		parsing.Article!.Text.Should().Contain("return group.IsNot ? !result : result",
+			because: "get-guidance should return the verified group-negation evaluation rule");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -135,6 +135,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the backend owner should contain the lab-verified nested OR construction");
 		backend.Text.Should().Contain("FilterComparisonType.NotEndWith",
 			because: "the directly readable backend guide should expose the complete verified scalar Compare recipes");
+		backend.Text.Should().Contain("negatedOr.IsNot = true",
+			because: "the directly readable backend guide should expose verified group-IsNot construction");
+		backend.Text.Should().Contain("DataService removes disabled children",
+			because: "the published backend resource should state the disabled-filter transport boundary");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -145,6 +149,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the directly readable parser guide should preserve the verified ATF structural ordering boundary");
 		parsing.Text.Should().Contain("LeftExpression.Path",
 			because: "the published parser guide must validate the complete ESQ column path");
+		parsing.Text.Should().Contain("Exclude disabled items from evaluation",
+			because: "the published parser guide should expose verified disabled-node evaluation");
+		parsing.Text.Should().Contain("return group.IsNot ? !result : result",
+			because: "the published parser guide should negate the combined group result");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1684,8 +1684,10 @@ public sealed class McpGuidanceResourceTests {
 			because: "the guide must apply group negation after combining enabled children");
 		article.Text.Should().Contain("group.EnabledChildren",
 			because: "evaluation should reuse enabled children cached during parsing instead of allocating per record");
-		article.Text.Should().Contain("Reject an empty non-root group",
-			because: "unverified empty-group semantics must remain fail-closed");
+		article.Text.Should().Contain("including an empty root OR",
+			because: "only the verified empty root AND envelope may bypass empty-group rejection");
+		article.Text.Should().Contain("Only the empty root AND envelope is supported.",
+			because: "the sample guard must reject both empty root OR and empty non-root groups");
 		article.Text.Should().Contain("ReadScalarParameter",
 			because: "the parsing owner should show how to validate one typed runtime parameter before evaluation");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1637,9 +1637,19 @@ public sealed class McpGuidanceResourceTests {
 		}
 		article.Text.Should().Contain("C, A, B",
 			because: "the backend guide should preserve the verified three-term ATF shape ordering boundary");
+		article.Text.Should().Contain("disabledLeaf.IsEnabled = false",
+			because: "the backend guide should show the verified native disabled-leaf construction API");
+		article.Text.Should().Contain("disabledGroup.IsEnabled = false",
+			because: "the backend guide should show how to disable a complete native collection");
+		article.Text.Should().Contain("negatedOr.IsNot = true",
+			because: "the backend guide should show group negation on the collection rather than a leaf");
+		article.Text.Should().Contain("DataService removes disabled children",
+			because: "the guide must state the verified structural boundary for disabled filters");
+		article.Text.Should().Contain("ATF.Repository 2.0.3.5 LINQ cannot author group `IsNot`",
+			because: "the guide should distinguish the library authoring limitation from DataService support");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
-		article.Text.Should().Contain("Pending lab validation",
+		article.Text.Should().Contain("Pending lab",
 			because: "unverified filter families should be explicit instead of guessed");
 	}
 
@@ -1666,8 +1676,16 @@ public sealed class McpGuidanceResourceTests {
 			because: "shape tests should compare the full structure rather than only returned rows");
 		article.Text.Should().Contain("maximum depth and total-node limits",
 			because: "runtime filter parsing must bound remotely supplied tree complexity");
-		article.Text.Should().Contain("Reject a disabled item",
-			because: "unverified disabled-filter semantics must fail closed instead of changing query meaning");
+		article.Text.Should().Contain("Exclude disabled items from evaluation",
+			because: "the parser should implement the verified disabled-node semantics");
+		article.Text.Should().Contain("DataService removes disabled",
+			because: "the parser must accept the verified native-versus-DataService shape boundary");
+		article.Text.Should().Contain("return group.IsNot ? !result : result",
+			because: "the guide must apply group negation after combining enabled children");
+		article.Text.Should().Contain("group.EnabledChildren",
+			because: "evaluation should reuse enabled children cached during parsing instead of allocating per record");
+		article.Text.Should().Contain("Reject an empty non-root group",
+			because: "unverified empty-group semantics must remain fail-closed");
 		article.Text.Should().Contain("ReadScalarParameter",
 			because: "the parsing owner should show how to validate one typed runtime parameter before evaluation");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -75,10 +75,48 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       ## Group envelope semantics
 		       Capture these properties before interpreting children:
 		       - `LogicalOperation`: combines direct children as AND or OR.
-		       - `IsEnabled`: disabled-filter semantics are not yet verified; reject a disabled group or leaf
-		         instead of guessing how its parent should combine the remaining children.
-		       - `IsNot`: negates the group's result; this is pending a dedicated lab proof.
+		       - `IsEnabled`: a disabled group or leaf does not contribute to its parent's condition.
+		       - `IsNot`: negates the result after the enabled direct children are combined.
 		       - Items: preserve nesting and order for diagnostics and native-vs-DataService shape tests.
+
+		       Native C# retains disabled nodes in the runtime tree, but DataService removes disabled
+		       child configurations before the query executor receives the ESQ. A parser must therefore
+		       accept both observable shapes. Count every node that is present against the depth/node
+		       budget and preserve it in structural diagnostics, but exclude a disabled node from semantic
+		       evaluation. Do not require native-versus-DataService shape equality for disabled items.
+
+		       The lab verified a disabled leaf and a disabled nested OR group beside one enabled root-AND
+		       sibling: both cases evaluated exactly the enabled sibling. If removing disabled items leaves
+		       a non-root group with zero enabled children, fail closed until that empty-group shape has its
+		       own live proof; do not infer an AND/OR identity from these examples.
+
+		       Apply group negation to the complete combined result:
+		       ```csharp
+		       private static bool EvaluateValidatedGroup(
+		           FilterGroupNode group,
+		           VirtualRecord record) {
+		           IReadOnlyList<FilterNode> enabled = group.EnabledChildren;
+		           if (enabled.Count == 0 && !group.IsRoot) {
+		               throw new NotSupportedException(
+		                   "An empty non-root ESQ group is not supported.");
+		           }
+
+		           bool result = group.LogicalOperation switch {
+		               LogicalOperationStrict.And => enabled.All(child => child.Evaluate(record)),
+		               LogicalOperationStrict.Or => enabled.Any(child => child.Evaluate(record)),
+		               _ => throw new NotSupportedException(
+		                   $"Unsupported logical operation '{group.LogicalOperation}'.")
+		           };
+		           return group.IsNot ? !result : result;
+		       }
+		       ```
+
+		       The node API above is illustrative. During the one-time parse/validation phase, validate
+		       every present node's complete shape, including disabled nodes, and cache each group's
+		       enabled children. Evaluation must reuse that cached list rather than filtering and allocating
+		       an array for every record; combine only enabled children and apply `IsNot` once. Creatio and
+		       DataService both exposed `NOT(B OR C)` as an enabled OR collection with `IsNot == true`;
+		       generated SQL negated the composed group.
 
 		       An empty enabled AND root is the normal no-filter envelope. It has zero items and must
 		       evaluate as true, so every source record remains eligible. Do not treat it as an error or
@@ -121,8 +159,7 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       private static object ReadScalarParameter(
 		           EntitySchemaQueryFilter filter,
 		           string expectedColumn) {
-		           if (!filter.IsEnabled ||
-		               filter.LeftExpression?.ExpressionType !=
+		           if (filter.LeftExpression?.ExpressionType !=
 		                   EntitySchemaQueryExpressionType.SchemaColumn ||
 		               filter.LeftExpression.Path != expectedColumn ||
 		               filter.RightExpressions.Count != 1) {
@@ -136,6 +173,8 @@ public sealed class EsqFilterParsingGuidanceResource {
 		           return right.ParameterValue;
 		       }
 		       ```
+		       `ReadScalarParameter` validates structure for enabled and disabled leaves alike. The parsed
+		       node retains `IsEnabled`; only the cached enabled-child list controls later evaluation.
 
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
@@ -147,16 +186,18 @@ public sealed class EsqFilterParsingGuidanceResource {
 
 		       `EntitySchemaQueryFilter` does not expose a leaf `IsNot`. Negated string predicates arrive
 		       as `NotStartWith`, `NotContain`, or `NotEndWith`; evaluate those operators directly. Group
-		       `IsNot` is a separate, still-unverified concern.
+		       `IsNot` exists only on `EntitySchemaQueryFilterCollection` and negates the combined group.
 
 		       ## Evaluation rules for the verified subset
 		       1. Parse and validate the complete remotely supplied tree once. Reject unsupported nodes even
 		          when an earlier sibling could determine the result; otherwise invalid hidden branches bypass
 		          fail-closed validation.
-		       2. Reject a disabled item; disabled-item and resulting empty-group semantics remain unverified.
+		       2. Exclude disabled items from evaluation. Preserve/count native disabled nodes for structural
+		          diagnostics; expect DataService to omit disabled children before this boundary.
 		       3. Evaluate only the validated tree. Short-circuit AND at the first false child and OR at the
 		          first true child so expensive provider predicates are not evaluated unnecessarily.
-		       4. Empty AND is true. Do not guess empty OR or negation behavior until validated.
+		       4. The normal empty root AND is true. Reject an empty non-root group until its semantics are
+		          independently validated. Apply group `IsNot` only after combining enabled children.
 		       5. Evaluate the leaf using the typed value. Reject unsupported expression or operator shapes
 		          with a diagnostic that includes the runtime item type, operator, and column path.
 		       6. Choose and document comparison semantics for the provider. The lab handler deliberately
@@ -182,9 +223,10 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       and ATF version.
 
 		       ## Coverage boundary
-		       Verified now: group envelope/nesting and all scalar Compare operators using representative
-		       Integer and MediumText values. The frontend guide supplies the remaining validation backlog:
-		       disabled/group IsNot, Boolean/Guid values, IsNull, In, Between, lookups, dates/macros,
+		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
+		       scalar Compare operators using representative Integer and MediumText values. The frontend
+		       guide supplies the remaining validation backlog: Boolean/Guid values, IsNull, In, Between,
+		       lookups, dates/macros,
 		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.
 		       """

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -87,8 +87,8 @@ public sealed class EsqFilterParsingGuidanceResource {
 
 		       The lab verified a disabled leaf and a disabled nested OR group beside one enabled root-AND
 		       sibling: both cases evaluated exactly the enabled sibling. If removing disabled items leaves
-		       a non-root group with zero enabled children, fail closed until that empty-group shape has its
-		       own live proof; do not infer an AND/OR identity from these examples.
+		       any group other than the root AND envelope with zero enabled children, fail closed until that
+		       empty-group shape has its own live proof; do not infer an AND/OR identity from these examples.
 
 		       Apply group negation to the complete combined result:
 		       ```csharp
@@ -96,9 +96,10 @@ public sealed class EsqFilterParsingGuidanceResource {
 		           FilterGroupNode group,
 		           VirtualRecord record) {
 		           IReadOnlyList<FilterNode> enabled = group.EnabledChildren;
-		           if (enabled.Count == 0 && !group.IsRoot) {
+		           if (enabled.Count == 0 &&
+		               !(group.IsRoot && group.LogicalOperation == LogicalOperationStrict.And)) {
 		               throw new NotSupportedException(
-		                   "An empty non-root ESQ group is not supported.");
+		                   "Only the empty root AND envelope is supported.");
 		           }
 
 		           bool result = group.LogicalOperation switch {
@@ -196,8 +197,9 @@ public sealed class EsqFilterParsingGuidanceResource {
 		          diagnostics; expect DataService to omit disabled children before this boundary.
 		       3. Evaluate only the validated tree. Short-circuit AND at the first false child and OR at the
 		          first true child so expensive provider predicates are not evaluated unnecessarily.
-		       4. The normal empty root AND is true. Reject an empty non-root group until its semantics are
-		          independently validated. Apply group `IsNot` only after combining enabled children.
+		       4. The normal empty root AND is true. Reject every other empty group, including an empty root OR,
+		          until its semantics are independently validated. Apply group `IsNot` only after combining
+		          enabled children.
 		       5. Evaluate the leaf using the typed value. Reject unsupported expression or operator shapes
 		          with a diagnostic that includes the runtime item type, operator, and column path.
 		       6. Choose and document comparison semantics for the provider. The lab handler deliberately

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -157,6 +157,58 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Preserve the requirement's explicit grouping. Parentheses determine the collection tree;
 		       do not flatten mixed AND/OR logic even when the leaf expressions are unchanged.
 
+		       ## Disable a leaf or a complete group
+		       Set `IsEnabled` on the exact item that must not contribute a condition:
+		       ```csharp
+		       EntitySchemaQueryFilter disabledLeaf =
+		           (EntitySchemaQueryFilter)esq.CreateFilterWithParameters(
+		               FilterComparisonType.Equal,
+		               "UsrName",
+		               "Blocked");
+		       disabledLeaf.IsEnabled = false;
+		       esq.Filters.Add(disabledLeaf);
+
+		       EntitySchemaQueryFilterCollection disabledGroup =
+		           new(esq, LogicalOperationStrict.Or);
+		       disabledGroup.Add(nameEquals);
+		       disabledGroup.Add(sequenceLess);
+		       disabledGroup.IsEnabled = false;
+		       esq.Filters.Add(disabledGroup);
+		       ```
+
+		       Native C# retains disabled leaves and groups in `esq.Filters`, so a virtual query
+		       executor can observe their complete runtime shape. Creatio SQL compilation skips a
+		       disabled collection and every disabled child; the lab's generated SQL contained only
+		       the enabled sibling predicate.
+
+		       DataService is a different structural boundary: it removes disabled child filter
+		       configurations while building the runtime ESQ. Therefore native and DataService requests
+		       can return the same records while exposing different executor-visible trees. Do not require
+		       shape equality for disabled items, and do not assume a disabled DataService item will be
+		       available to backend parsing code.
+
+		       ## Negate a complete group with IsNot
+		       Set `IsNot` on the collection after adding the predicates that form the group:
+		       ```csharp
+		       EntitySchemaQueryFilterCollection negatedOr =
+		           new(esq, LogicalOperationStrict.Or);
+		       negatedOr.Add(nameEquals);
+		       negatedOr.Add(sequenceLess);
+		       negatedOr.IsNot = true;
+		       esq.Filters.Add(negatedOr);
+		       ```
+
+		       This means `NOT(nameEquals OR sequenceLess)`. `IsNot` negates the combined collection;
+		       it is not a leaf modifier and must not be replaced with a guessed comparison operator.
+		       Native C# and DataService produced the same enabled, negated OR runtime group in the lab,
+		       and generated SQL applied `NOT` to the composed group condition.
+
+		       ATF.Repository 2.0.3.5 LINQ cannot author group `IsNot`: unary NOT over a logical
+		       expression is rejected, and its LINQ query builder does not copy metadata `IsNot` to the
+		       outgoing group. The lab validated DataService transport with a test-only decorator over
+		       the public `ISelectQuery` filter contract. Treat that as a library authoring limitation,
+		       not as a DataService or runtime ESQ limitation.
+
 		       ## Execute
 		       ```csharp
 		       EntityCollection records = esq.GetEntityCollection(userConnection);
@@ -176,14 +228,17 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		         two-term/grouped cases. The verified three-term ATF order is `C, A, B`.
 		       - A scalar created with `CreateFilterWithParameters` is exposed at runtime through the
 		         filter's right-expression collection.
+		       - Native C# retains disabled leaves/groups, but SQL compilation omits their conditions.
+		         DataService removes disabled children before the executor boundary.
+		       - Collection `IsNot` negates the complete combined group and is preserved by DataService.
 		       - The lab provider deliberately used `StringComparison.OrdinalIgnoreCase`; case-variant
 		         results prove that provider policy, not Creatio/PostgreSQL collation behavior.
 
 		       ## Coverage boundary
-		       Verified now: group envelope/nesting and all scalar Compare operators using representative
-		       Integer and MediumText values. Pending lab validation before publishing construction
-		       recipes: disabled filters, group `IsNot`, Boolean/Guid Compare values, IsNull, In, Between,
-		       lookup values, dates and macros, Exists/subqueries/aggregates, and Segment filters. Use the
+		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
+		       scalar Compare operators using representative Integer and MediumText values. Pending lab
+		       validation before publishing construction recipes: Boolean/Guid Compare values, IsNull,
+		       In, Between, lookup values, dates and macros, Exists/subqueries/aggregates, and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.
 		       """


### PR DESCRIPTION
## Summary
- document how native backend ESQ disables leaves and complete groups
- document collection `IsNot` construction and parsing after child combination
- explain the verified native C# versus DataService shape boundary for disabled filters
- add unit and real MCP-process coverage for both published guidance resources

## Lab evidence
Validated in `C:\Projects\Workspaces\VirtualEntityGuidance` against Creatio `std-skill-n8`:
- native C# retains disabled leaves/groups at the virtual executor boundary while SQL compilation skips them
- DataService removes disabled children before the executor boundary
- native C# and DataService preserve collection `IsNot`, and generated SQL negates the composed group
- ATF.Repository 2.0.3.5 LINQ cannot author group negation; the lab used a test-only decorator over its public `ISelectQuery` contract

## Validation
- `dotnet test clio.tests/clio.tests.csproj -c Debug --filter "Category=Unit&Module=McpServer" --no-build` — 2,429 passed on net8.0 and 2,429 passed on net10.0
- focused `McpGuidanceResourceTests` — 43 passed per target framework
- focused `clio.mcp.e2e` resource-read and `get-guidance` tests — 2 passed per target framework
- comprehensive pre-PR agentic review: correctness/testing, code quality, and security/performance; all findings resolved

## Maintenance review
- MCP reviewed and updated: resource text, unit coverage, and MCP E2E coverage are aligned
- docs reviewed: no CLI command behavior or command documentation changed
- ClioRing compatibility reviewed, no Ring-consumed contract changed; only guidance resource text and its tests changed