### PR TITLE
Document backend ESQ null filter behavior

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6647,3 +6647,9 @@ Decision: Document disabled-node transport differences separately from semantic 
 Discovery: Native C# retains disabled leaves/groups while SQL compilation omits them; DataService removes disabled children before the executor boundary. Native C# and DataService preserve collection `IsNot`. ATF.Repository 2.0.3.5 cannot author group negation through LINQ, so the lab used a test-only decorator over its public `ISelectQuery` contract.
 Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents now have lab-verified rules for creating and parsing disabled nodes and negated groups, including the native-versus-DataService shape boundary.
+## 2026-07-18 00:30 – Validate text IsNull and IsNotNull
+Context: Project milestone 4 of the backend ESQ filter validation plan into clio guidance.
+Decision: Teach the dedicated native null-filter APIs and a separate left-only parser contract with zero right expressions.
+Discovery: Native C# and ATF/DataService shapes matched exactly. For the verified MediumText columns, PostgreSQL SQL compilation used `column = ''` and `NOT column = ''`; the lab provider therefore evaluates null and empty string alike without generalizing to other data types.
+Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can now construct and parse text null predicates from verified runtime and SQL evidence rather than treating null as an ordinary scalar parameter.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -660,6 +660,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the concrete backend scalar Compare recipes");
 		backend.Article!.Text.Should().Contain("disabledLeaf.IsEnabled = false",
 			because: "get-guidance should return the verified native disabled-leaf recipe");
+		backend.Article!.Text.Should().Contain("CreateIsNullFilter(\"UsrDescription\")",
+			because: "get-guidance should return the verified native null-filter recipe");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -668,6 +670,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified runtime scalar parameter parsing recipe");
 		parsing.Article!.Text.Should().Contain("return group.IsNot ? !result : result",
 			because: "get-guidance should return the verified group-negation evaluation rule");
+		parsing.Article!.Text.Should().Contain("ReadNullComparison",
+			because: "get-guidance should return the verified null-filter parsing contract");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -159,7 +159,7 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser guide should negate the combined group result");
 		parsing.Text.Should().Contain("ReadNullComparison",
 			because: "the published parser guide should expose the verified left-only null shape");
-		parsing.Text.Should().Contain("Do not generalize that empty-string rule",
+		parsing.Text.Should().Contain("empty-string rule to other schema data-value types",
 			because: "the published parser must not apply text semantics to unverified data types");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -139,6 +139,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the directly readable backend guide should expose verified group-IsNot construction");
 		backend.Text.Should().Contain("DataService removes disabled children",
 			because: "the published backend resource should state the disabled-filter transport boundary");
+		backend.Text.Should().Contain("CreateIsNotNullFilter(\"UsrName\")",
+			because: "the published backend guide should expose the dedicated native null-filter APIs");
+		backend.Text.Should().Contain("not a general null rule for Integer, Guid, lookup, or date columns",
+			because: "the published guide must preserve the verified MediumText-only boundary");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -153,6 +157,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser guide should expose verified disabled-node evaluation");
 		parsing.Text.Should().Contain("return group.IsNot ? !result : result",
 			because: "the published parser guide should negate the combined group result");
+		parsing.Text.Should().Contain("ReadNullComparison",
+			because: "the published parser guide should expose the verified left-only null shape");
+		parsing.Text.Should().Contain("Do not generalize that empty-string rule",
+			because: "the published parser must not apply text semantics to unverified data types");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1706,7 +1706,7 @@ public sealed class McpGuidanceResourceTests {
 			because: "the null parser must reject an unexpected right expression");
 		article.Text.Should().Contain("string.IsNullOrEmpty(value)",
 			because: "the parser should reproduce the verified MediumText null semantics");
-		article.Text.Should().Contain("Do not generalize that empty-string rule",
+		article.Text.Should().Contain("empty-string rule to other schema data-value types",
 			because: "the parser must retain the type boundary around text null evaluation");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1647,6 +1647,16 @@ public sealed class McpGuidanceResourceTests {
 			because: "the guide must state the verified structural boundary for disabled filters");
 		article.Text.Should().Contain("ATF.Repository 2.0.3.5 LINQ cannot author group `IsNot`",
 			because: "the guide should distinguish the library authoring limitation from DataService support");
+		article.Text.Should().Contain("CreateIsNullFilter(\"UsrDescription\")",
+			because: "the backend guide should use the dedicated native IsNull API");
+		article.Text.Should().Contain("CreateIsNotNullFilter(\"UsrName\")",
+			because: "the backend guide should use the dedicated native IsNotNull API");
+		article.Text.Should().Contain("zero right expressions",
+			because: "null comparisons must be documented as left-only runtime leaves");
+		article.Text.Should().Contain("Creatio compiled text `IsNull` as `column = ''`",
+			because: "the guide must preserve the verified MediumText SQL storage semantics");
+		article.Text.Should().Contain("not a general null rule for Integer, Guid, lookup, or date columns",
+			because: "the MediumText empty-string observation must not be generalized to unverified types");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
 		article.Text.Should().Contain("Pending lab",
@@ -1690,6 +1700,14 @@ public sealed class McpGuidanceResourceTests {
 			because: "the sample guard must reject both empty root OR and empty non-root groups");
 		article.Text.Should().Contain("ReadScalarParameter",
 			because: "the parsing owner should show how to validate one typed runtime parameter before evaluation");
+		article.Text.Should().Contain("ReadNullComparison",
+			because: "left-only null leaves require a parser distinct from scalar parameters");
+		article.Text.Should().Contain("filter.RightExpressions.Count != 0",
+			because: "the null parser must reject an unexpected right expression");
+		article.Text.Should().Contain("string.IsNullOrEmpty(value)",
+			because: "the parser should reproduce the verified MediumText null semantics");
+		article.Text.Should().Contain("Do not generalize that empty-string rule",
+			because: "the parser must retain the type boundary around text null evaluation");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -177,6 +177,30 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       `ReadScalarParameter` validates structure for enabled and disabled leaves alike. The parsed
 		       node retains `IsEnabled`; only the cached enabled-child list controls later evaluation.
 
+		       Null comparisons have a different verified leaf contract and must not use the scalar-parameter
+		       reader:
+		       ```csharp
+		       private static FilterComparisonType ReadNullComparison(
+		           EntitySchemaQueryFilter filter,
+		           string expectedColumn) {
+		           bool isNullComparison = filter.ComparisonType == FilterComparisonType.IsNull ||
+		               filter.ComparisonType == FilterComparisonType.IsNotNull;
+		           if (!isNullComparison ||
+		               filter.LeftExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               filter.LeftExpression.Path != expectedColumn ||
+		               filter.RightExpressions.Count != 0) {
+		               throw new NotSupportedException("Unsupported null filter shape.");
+		           }
+		           return filter.ComparisonType;
+		       }
+		       ```
+
+		       Native and DataService text null predicates produced this same left-only runtime shape. For the
+		       verified MediumText columns, the provider matched Creatio's SQL oracle by evaluating `IsNull`
+		       with `string.IsNullOrEmpty(value)` and `IsNotNull` with its negation. Do not generalize that
+		       empty-string rule to other schema data-value types without a separate platform proof.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -226,8 +250,8 @@ public sealed class EsqFilterParsingGuidanceResource {
 
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
-		       scalar Compare operators using representative Integer and MediumText values. The frontend
-		       guide supplies the remaining validation backlog: Boolean/Guid values, IsNull, In, Between,
+		       scalar Compare operators using representative Integer and MediumText values, plus text
+		       `IsNull`/`IsNotNull`. The frontend guide supplies the remaining validation backlog: Boolean/Guid values, In, Between,
 		       lookups, dates/macros,
 		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -107,6 +107,24 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Negated C# string predicates sent through ATF/DataService arrived as the dedicated
 		       negative comparison types. They did not use group `IsNot`.
 
+		       ## Create IsNull and IsNotNull leaves
+		       Null comparisons are left-only filters. Use the dedicated APIs; do not pass a null parameter
+		       to `CreateFilterWithParameters`:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateIsNullFilter("UsrDescription"));
+		       esq.Filters.Add(esq.CreateIsNotNullFilter("UsrName"));
+		       ```
+
+		       Both native leaves matched ATF/DataService predicates `UsrDescription == null` and
+		       `UsrName != null` exactly at the runtime boundary. Each leaf had comparison type `IsNull` or
+		       `IsNotNull`, one schema-column left expression, and zero right expressions. Do not create or
+		       expect a parameter expression for either operator.
+
+		       The SQL oracle exposed type-specific MediumText behavior: on the verified PostgreSQL platform,
+		       Creatio compiled text `IsNull` as `column = ''` and text `IsNotNull` as `NOT column = ''`.
+		       This is Creatio's empty-string storage semantics, not a reason to rewrite the ESQ operator and
+		       not a general null rule for Integer, Guid, lookup, or date columns.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -236,8 +254,8 @@ public sealed class EsqFiltersBackendGuidanceResource {
 
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
-		       scalar Compare operators using representative Integer and MediumText values. Pending lab
-		       validation before publishing construction recipes: Boolean/Guid Compare values, IsNull,
+		       scalar Compare operators using representative Integer and MediumText values, plus text
+		       `IsNull`/`IsNotNull`. Pending lab validation before publishing construction recipes: Boolean/Guid Compare values,
 		       In, Between, lookup values, dates and macros, Exists/subqueries/aggregates, and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.


### PR DESCRIPTION
## Summary
- document native C# IsNull/IsNotNull construction and their left-only runtime shape
- document verified MediumText empty-string SQL semantics without generalizing to other types
- add unit and real MCP E2E coverage for both construction and parsing guides

## Validation
- dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" --no-build (2,429 passed per target framework)
- focused real MCP guidance E2E tests (2 passed per target framework)
- comprehensive pre-PR agentic review: quality, correctness, security/performance; no blocking findings

MCP reviewed and updated. No command documentation change required.

ClioRing compatibility reviewed, no Ring-consumed contract changed.