### PR TITLE
Document backend ESQ membership filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6653,3 +6653,10 @@ Decision: Teach the dedicated native null-filter APIs and a separate left-only p
 Discovery: Native C# and ATF/DataService shapes matched exactly. For the verified MediumText columns, PostgreSQL SQL compilation used `column = ''` and `NOT column = ''`; the lab provider therefore evaluates null and empty string alike without generalizing to other data types.
 Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents can now construct and parse text null predicates from verified runtime and SQL evidence rather than treating null as an ordinary scalar parameter.
+
+## 2026-07-18 01:25 – Validate backend In cardinality
+Context: Project milestone 5 of the backend ESQ filter validation plan into clio guidance.
+Decision: Document native membership as Equal plus a right-expression collection and keep DataService filterType 4 as a transport-only discriminator.
+Discovery: Zero, one, and two values matched exactly between native and DataService runtime trees. SQL emitted invalid `column = ` for zero, scalar equality for one, and IN for two; Guid arrays require conversion to object[] to avoid one array-valued parameter.
+Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can now construct and parse membership without confusing serialized In metadata with the runtime comparison enum or broadening empty membership.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -662,6 +662,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified native disabled-leaf recipe");
 		backend.Article!.Text.Should().Contain("CreateIsNullFilter(\"UsrDescription\")",
 			because: "get-guidance should return the verified native null-filter recipe");
+		backend.Article!.Text.Should().Contain("object[] sequenceNumbers = { 10, 30 }",
+			because: "get-guidance should return the verified native membership recipe");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -672,6 +674,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified group-negation evaluation rule");
 		parsing.Article!.Text.Should().Contain("ReadNullComparison",
 			because: "get-guidance should return the verified null-filter parsing contract");
+		parsing.Article!.Text.Should().Contain("ReadIntegerMembership",
+			because: "get-guidance should return the verified membership parsing contract");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -143,6 +143,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide should expose the dedicated native null-filter APIs");
 		backend.Text.Should().Contain("not a general null rule for Integer, Guid, lookup, or date columns",
 			because: "the published guide must preserve the verified MediumText-only boundary");
+		backend.Text.Should().Contain("object[] sequenceNumbers = { 10, 30 }",
+			because: "the published backend guide should expose native In construction");
+		backend.Text.Should().Contain("physical SQL compilation emits invalid `column = ` text",
+			because: "the published guide should warn against executing empty membership");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -161,6 +165,12 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser guide should expose the verified left-only null shape");
 		parsing.Text.Should().Contain("empty-string rule to other schema data-value types",
 			because: "the published parser must not apply text semantics to unverified data types");
+		parsing.Text.Should().Contain("ReadIntegerMembership",
+			because: "the published parser should expose the verified membership reader");
+		parsing.Text.Should().Contain("MaxMembershipValues",
+			because: "the published parser must bound remotely supplied membership parameters");
+		parsing.Text.Should().Contain("always false; it must never fall through",
+			because: "the published parser must fail safe for empty membership");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1657,6 +1657,16 @@ public sealed class McpGuidanceResourceTests {
 			because: "the guide must preserve the verified MediumText SQL storage semantics");
 		article.Text.Should().Contain("not a general null rule for Integer, Guid, lookup, or date columns",
 			because: "the MediumText empty-string observation must not be generalized to unverified types");
+		article.Text.Should().Contain("object[] sequenceNumbers = { 10, 30 }",
+			because: "the backend guide should expose the verified native membership recipe");
+		article.Text.Should().Contain("two or more values produce one right expression per value",
+			because: "membership cardinality controls the runtime collection and generated SQL");
+		article.Text.Should().Contain("physical SQL compilation emits invalid `column = ` text",
+			because: "the empty-membership construction boundary must fail safe");
+		article.Text.Should().Contain("ownerIds.Cast<object>().ToArray()",
+			because: "value-type arrays must not become one array-valued parameter");
+		article.Text.Should().Contain("serialized `filterType: 4`",
+			because: "the guide must distinguish the DataService discriminator from runtime ESQ");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
 		article.Text.Should().Contain("Pending lab",
@@ -1708,6 +1718,18 @@ public sealed class McpGuidanceResourceTests {
 			because: "the parser should reproduce the verified MediumText null semantics");
 		article.Text.Should().Contain("empty-string rule to other schema data-value types",
 			because: "the parser must retain the type boundary around text null evaluation");
+		article.Text.Should().Contain("ReadIntegerMembership",
+			because: "the parsing guide should validate the complete membership collection");
+		article.Text.Should().Contain("MaxMembershipValues",
+			because: "remotely supplied membership parameters require an explicit cardinality limit");
+		article.Text.Should().Contain("ToHashSet()",
+			because: "validated membership values should be cached for repeated record evaluation");
+		article.Text.Should().Contain("values.Contains(record.SequenceNumber)",
+			because: "the verified evaluator should implement membership explicitly");
+		article.Text.Should().Contain("always false; it must never fall through",
+			because: "empty membership must never broaden a virtual query");
+		article.Text.Should().Contain("cannot recover whether a one-value Equal leaf was authored",
+			because: "the parser must document one-value Compare/In ambiguity");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -201,6 +201,45 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       with `string.IsNullOrEmpty(value)` and `IsNotNull` with its negation. Do not generalize that
 		       empty-string rule to other schema data-value types without a separate platform proof.
 
+		       Membership leaves use the ordinary `Equal` comparison type at this runtime boundary. Parse the
+		       complete right-expression collection and validate every value before evaluating any record:
+		       ```csharp
+		       private const int MaxMembershipValues = 100;
+
+		       private static HashSet<int> ReadIntegerMembership(
+		           EntitySchemaQueryFilter filter,
+		           string expectedColumn) {
+		           if (filter.ComparisonType != FilterComparisonType.Equal ||
+		               filter.LeftExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               filter.LeftExpression.Path != expectedColumn) {
+		               throw new NotSupportedException("Unsupported membership filter shape.");
+		           }
+		           if (filter.RightExpressions.Count > MaxMembershipValues) {
+		               throw new NotSupportedException(
+		                   $"Membership exceeds the {MaxMembershipValues}-value limit.");
+		           }
+
+		           return filter.RightExpressions.Select(expression => {
+		               if (expression.ExpressionType !=
+		                       EntitySchemaQueryExpressionType.Parameter ||
+		                   expression.ParameterValue is not int value) {
+		                   throw new NotSupportedException("Membership requires Integer parameters.");
+		               }
+		               return value;
+		           }).ToHashSet();
+		       }
+		       ```
+
+		       Count right expressions against a separate conservative parameter budget (or the provider's shared
+		       parse budget), validate them once, and cache the set. Evaluate membership with
+		       `values.Contains(record.SequenceNumber)`. An empty returned set is
+		       always false; it must never fall through to an unfiltered result. One value is structurally the
+		       same runtime leaf as scalar equality, and multiple values are the same leaf with multiple right
+		       expressions. The serialized DataService `filterType: 4` discriminator is consumed before the
+		       executor boundary, so a parser cannot recover whether a one-value Equal leaf was authored as
+		       Compare or In. Support that ambiguity deliberately in the provider contract.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -251,7 +290,8 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
-		       `IsNull`/`IsNotNull`. The frontend guide supplies the remaining validation backlog: Boolean/Guid values, In, Between,
+		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. The frontend guide supplies the remaining
+		       validation backlog: Boolean/Guid values, Between,
 		       lookups, dates/macros,
 		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -125,6 +125,39 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       This is Creatio's empty-string storage semantics, not a reason to rewrite the ESQ operator and
 		       not a general null rule for Integer, Guid, lookup, or date columns.
 
+		       ## Create In membership filters
+		       Native backend ESQ represents membership with `FilterComparisonType.Equal` plus a collection of
+		       parameter values:
+		       ```csharp
+		       object[] sequenceNumbers = { 10, 30 };
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal,
+		           "UsrSequenceNumber",
+		           sequenceNumbers));
+		       ```
+
+		       Cardinality controls SQL generation while the runtime comparison type remains `Equal`:
+		       - one value produces one right expression and SQL `column = value`;
+		       - two or more values produce one right expression per value and SQL `column IN (...)`.
+
+		       Guard empty input before constructing the filter. Handle it as an always-false result in the
+		       owning query/executor contract; do not add no filter, because that would broaden the query. Returning
+		       an empty `EntityCollection` is one executor-specific implementation, not part of filter construction.
+
+		       The lab proved that an empty array remains an executor-visible Equal leaf with zero right
+		       expressions, but physical SQL compilation emits invalid `column = ` text. Do not execute that
+		       shape against the database and never omit it in a way that broadens the query.
+
+		       Always pass an `object[]`. A value-type array such as `Guid[]` can bind as one array-valued
+		       `params object[]` argument instead of several parameters. Convert it explicitly when needed:
+		       ```csharp
+		       object[] ownerIdsAsParameters = ownerIds.Cast<object>().ToArray();
+		       ```
+
+		       DataService uses serialized `filterType: 4` to distinguish In from Compare while building ESQ.
+		       That transport discriminator is not present on the resulting `EntitySchemaQueryFilter`; backend
+		       runtime code must use the right-expression count and its own supported-query contract.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -255,8 +288,9 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
-		       `IsNull`/`IsNotNull`. Pending lab validation before publishing construction recipes: Boolean/Guid Compare values,
-		       In, Between, lookup values, dates and macros, Exists/subqueries/aggregates, and Segment filters. Use the
+		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. Pending lab validation before publishing
+		       construction recipes: Boolean/Guid Compare values, Between, lookup values, dates and macros,
+		       Exists/subqueries/aggregates, and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.
 		       """


### PR DESCRIPTION
## Summary
- document verified backend ESQ In construction and cardinality behavior
- document bounded, typed runtime membership parsing and evaluation
- cover empty, single, and multiple-value behavior in unit and MCP E2E guidance tests

## Validation
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" --no-build` (2,429/2,429 on net8.0 and net10.0)
- focused `clio.mcp.e2e` guidance tests (45/45 on net8.0 and net10.0)
- comprehensive pre-PR agentic review: correctness clean; maintainability and security/performance Medium findings resolved and re-reviewed clean

## Review notes
- MCP guidance reviewed and updated; no command behavior changed
- docs reviewed, no command documentation update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed