### PR TITLE
Document backend ESQ Between filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6660,3 +6660,10 @@ Decision: Document native membership as Equal plus a right-expression collection
 Discovery: Zero, one, and two values matched exactly between native and DataService runtime trees. SQL emitted invalid `column = ` for zero, scalar equality for one, and IN for two; Guid arrays require conversion to object[] to avoid one array-valued parameter.
 Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents can now construct and parse membership without confusing serialized In metadata with the runtime comparison enum or broadening empty membership.
+
+## 2026-07-18 01:53 – Validate backend Between filters
+Context: Project milestone 6 of the backend ESQ filter validation plan into clio guidance.
+Decision: Document first-class Between separately from the equivalent pair of inclusive Compare leaves and correct the frontend serialized-bound ordering.
+Discovery: Native and DataService first-class shapes matched as one Between leaf with ordered lower/upper Integer parameters and inclusive SQL. DataService counterintuitively requires rightLessExpression for the first/lower value and rightGreaterExpression for the second/upper value; the two-Compare alternative remains two leaves.
+Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can author and parse both inclusive range representations without reversing DataService bounds or assuming structural normalization.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -623,6 +623,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "the family router should expose the backend construction owner");
 		response.Article.Text.Should().Contain("esq-filter-parsing",
 			because: "the family router should expose the runtime parsing owner");
+		response.Article.Text.Should().Contain("inclusive Between ranges",
+			because: "get-guidance should report the current promoted backend validation status");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -664,12 +664,16 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified native null-filter recipe");
 		backend.Article!.Text.Should().Contain("object[] sequenceNumbers = { 10, 30 }",
 			because: "get-guidance should return the verified native membership recipe");
+		backend.Article!.Text.Should().Contain("FilterComparisonType.Between",
+			because: "get-guidance should return the verified native Between recipe");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
 			because: "the parsing catalog name should preserve the independent parsing URI");
 		parsing.Article!.Text.Should().Contain("ReadScalarParameter",
 			because: "get-guidance should return the verified runtime scalar parameter parsing recipe");
+		parsing.Article!.Text.Should().Contain("ReadIntegerBetween",
+			because: "get-guidance should return the verified runtime Between parsing recipe");
 		parsing.Article!.Text.Should().Contain("return group.IsNot ? !result : result",
 			because: "get-guidance should return the verified group-negation evaluation rule");
 		parsing.Article!.Text.Should().Contain("ReadNullComparison",

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -125,6 +125,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the family router should resolve to one plain-text article").Subject;
 		router.Text.Should().Contain("GATE: choose the owner",
 			because: "the root resource should route rather than duplicate detailed rules");
+		router.Text.Should().Contain("inclusive Between ranges",
+			because: "the published router must not describe promoted Between guidance as pending");
 		TextResourceContents frontend = frontendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -129,6 +129,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",
 			because: "the existing serialized group contract should remain in the frontend owner");
+		frontend.Text.Should().Contain("`rightLessExpression` = first/lower bound",
+			because: "the published frontend resource must expose the verified Between ordering");
 		TextResourceContents backend = backendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the backend construction resource should resolve to one plain-text article").Subject;
 		backend.Text.Should().Contain("LogicalOperationStrict.Or",
@@ -147,6 +149,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide should expose native In construction");
 		backend.Text.Should().Contain("physical SQL compilation emits invalid `column = ` text",
 			because: "the published guide should warn against executing empty membership");
+		backend.Text.Should().Contain("FilterComparisonType.Between",
+			because: "the published backend guide should expose native Between construction");
+		backend.Text.Should().Contain("rightLessExpression` carries the first/lower value",
+			because: "the published backend guide must not reverse DataService Between bounds");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -171,6 +177,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser must bound remotely supplied membership parameters");
 		parsing.Text.Should().Contain("always false; it must never fall through",
 			because: "the published parser must fail safe for empty membership");
+		parsing.Text.Should().Contain("ReadIntegerBetween",
+			because: "the published parser should expose the verified two-boundary reader");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1597,6 +1597,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the family router should point native C# filter authors to the backend owner");
 		router.Text.Should().Contain("esq-filter-parsing",
 			because: "the family router should point runtime C# consumers to the parsing owner");
+		router.Text.Should().Contain("inclusive Between ranges",
+			because: "the entry router must advertise the backend families already promoted as verified");
 		router.Text.Should().NotContain("### Compare (filterType 1)",
 			because: "the router should not duplicate detailed frontend filter rules");
 

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1606,6 +1606,10 @@ public sealed class McpGuidanceResourceTests {
 			because: "frontend JSON guidance should have a stable child URI");
 		frontend.Text.Should().Contain("### Compare (filterType 1)",
 			because: "the detailed serialized Compare contract should live only in the frontend guide");
+		frontend.Text.Should().Contain("`rightLessExpression` = first/lower bound",
+			because: "the frontend guide must preserve the verified counterintuitive Between field ordering");
+		frontend.Text.Should().Contain("`rightGreaterExpression` = second/upper bound",
+			because: "the frontend guide must not reverse the serialized Between bounds");
 	}
 
 	[Test]
@@ -1667,6 +1671,14 @@ public sealed class McpGuidanceResourceTests {
 			because: "value-type arrays must not become one array-valued parameter");
 		article.Text.Should().Contain("serialized `filterType: 4`",
 			because: "the guide must distinguish the DataService discriminator from runtime ESQ");
+		article.Text.Should().Contain("FilterComparisonType.Between",
+			because: "the backend guide should expose first-class native Between construction");
+		article.Text.Should().Contain("`BETWEEN 10 AND 30`",
+			because: "the guide should retain the verified inclusive SQL behavior");
+		article.Text.Should().Contain("rightLessExpression` carries the first/lower value",
+			because: "the backend guide must preserve the verified DataService bound ordering");
+		article.Text.Should().Contain("does not normalize it into a Between leaf",
+			because: "the two-comparison alternative must remain structurally distinct");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
 		article.Text.Should().Contain("Pending lab",
@@ -1730,6 +1742,14 @@ public sealed class McpGuidanceResourceTests {
 			because: "empty membership must never broaden a virtual query");
 		article.Text.Should().Contain("cannot recover whether a one-value Equal leaf was authored",
 			because: "the parser must document one-value Compare/In ambiguity");
+		article.Text.Should().Contain("ReadIntegerBetween",
+			because: "the parser should validate the first-class two-boundary runtime leaf");
+		article.Text.Should().Contain("filter.RightExpressions.Count != 2",
+			because: "a Between leaf must contain exactly two ordered parameters");
+		article.Text.Should().Contain("record.SequenceNumber >= range.Lower",
+			because: "the verified Between evaluator includes its lower boundary");
+		article.Text.Should().Contain("dispatch the shapes independently",
+			because: "first-class Between and the two-leaf alternative are not structurally interchangeable");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -240,6 +240,38 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       executor boundary, so a parser cannot recover whether a one-value Equal leaf was authored as
 		       Compare or In. Support that ambiguity deliberately in the provider contract.
 
+		       A first-class Between leaf is distinct: require `ComparisonType.Between`, the exact allowed column
+		       path, and exactly two ordered parameter expressions. Parse them once as lower then upper:
+		       ```csharp
+		       private static (int Lower, int Upper) ReadIntegerBetween(
+		           EntitySchemaQueryFilter filter,
+		           string expectedColumn) {
+		           if (filter.ComparisonType != FilterComparisonType.Between ||
+		               filter.LeftExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               filter.LeftExpression.Path != expectedColumn ||
+		               filter.RightExpressions.Count != 2) {
+		               throw new NotSupportedException("Unsupported Integer Between shape.");
+		           }
+
+		           int[] boundaries = filter.RightExpressions.Select(expression => {
+		               if (expression.ExpressionType !=
+		                       EntitySchemaQueryExpressionType.Parameter ||
+		                   expression.ParameterValue is not int value) {
+		                   throw new NotSupportedException(
+		                       "Between boundaries must be Integer parameters.");
+		               }
+		               return value;
+		           }).ToArray();
+		           return (boundaries[0], boundaries[1]);
+		       }
+		       ```
+
+		       Evaluate it inclusively: `record.SequenceNumber >= range.Lower &&
+		       record.SequenceNumber <= range.Upper`. The alternative `GreaterOrEqual` plus `LessOrEqual` form
+		       remains two leaves in the surrounding AND group. A general tree evaluator can support both, but must
+		       dispatch the shapes independently; do not rewrite or silently accept an exclusive sibling pair.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -291,7 +323,7 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. The frontend guide supplies the remaining
-		       validation backlog: Boolean/Guid values, Between,
+		       validation backlog: Boolean/Guid values,
 		       lookups, dates/macros,
 		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -158,6 +158,36 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       That transport discriminator is not present on the resulting `EntitySchemaQueryFilter`; backend
 		       runtime code must use the right-expression count and its own supported-query contract.
 
+		       ## Create Between filters
+		       Native backend ESQ has a first-class inclusive two-boundary form:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Between,
+		           "UsrSequenceNumber",
+		           10,
+		           30));
+		       ```
+
+		       The runtime result is one `Between` leaf whose `RightExpressions` contain the lower value first and
+		       the upper value second. Both are included; the verified SQL was `BETWEEN 10 AND 30`.
+
+		       An equivalent inclusive range can be authored as two ordinary leaves under AND:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.GreaterOrEqual, "UsrSequenceNumber", 10));
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.LessOrEqual, "UsrSequenceNumber", 30));
+		       ```
+
+		       That alternative remains two independent Compare leaves and compiled to `>= 10 AND <= 30`; Creatio
+		       does not normalize it into a Between leaf. Choose the representation required by the owning contract
+		       and test its complete shape rather than treating the two forms as structurally interchangeable.
+
+		       Serialized DataService Between uses `filterType: 3`, `comparisonType: 0`, and dedicated bound fields.
+		       Counterintuitively, `rightLessExpression` carries the first/lower value and
+		       `rightGreaterExpression` carries the second/upper value. DataService appends them to runtime
+		       `RightExpressions` in that order. Sending only a generic `rightExpressions` array is rejected.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -289,7 +319,7 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. Pending lab validation before publishing
-		       construction recipes: Boolean/Guid Compare values, Between, lookup values, dates and macros,
+		       construction recipes: Boolean/Guid Compare values, lookup values, dates and macros,
 		       Exists/subqueries/aggregates, and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -50,10 +50,10 @@ public sealed class EsqFiltersGuidanceResource {
 
 		       ## Current backend validation status
 		       The backend construction and parsing guides currently publish the lab-verified group
-		       envelope, empty root, flat AND, nested OR, and mixed nesting shapes. Compare leaves are
-		       verified for string equality and integer greater/less operations. Other filter families
-		       remain explicitly marked pending until the same native-vs-DataService runtime-shape test
-		       proves them.
+		       envelope, nesting, disabled nodes, group negation, primitive Integer/MediumText Compare,
+		       MediumText null checks, Integer membership cardinalities, and inclusive Between ranges.
+		       Other filter families remain explicitly marked pending until the same native-vs-DataService
+		       runtime-shape test proves and promotes them.
 		       """
 	};
 

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -116,8 +116,8 @@ public sealed class EsqFiltersGuidanceResource {
 		       - Null test with only `leftExpression` (no right side). Is null: `comparisonType: 1`, `isNull: true`. Is not null: `comparisonType: 2`, `isNull: false`.
 
 		       ### Between (filterType 3)
-		       - `comparisonType: 0`. Bounds are two separate expressions: `rightGreaterExpression` = lower bound, `rightLessExpression` = upper bound.
-		       - Example (age 5..25): `{ "filterType": 3, "comparisonType": 0, "isEnabled": true, "leftExpression": { "expressionType": 0, "columnPath": "Age" }, "rightGreaterExpression": { "expressionType": 2, "parameter": { "dataValueType": 4, "value": 5 } }, "rightLessExpression": { "expressionType": 2, "parameter": { "dataValueType": 4, "value": 25 } } }`.
+		       - `comparisonType: 0`. The platform's field names are counterintuitive: `rightLessExpression` = first/lower bound and `rightGreaterExpression` = second/upper bound. This ordering is required by DataService and was verified against native C# runtime shape; do not reinterpret the names as comparison directions.
+		       - Example (age 5..25): `{ "filterType": 3, "comparisonType": 0, "isEnabled": true, "leftExpression": { "expressionType": 0, "columnPath": "Age" }, "rightLessExpression": { "expressionType": 2, "parameter": { "dataValueType": 4, "value": 5 } }, "rightGreaterExpression": { "expressionType": 2, "parameter": { "dataValueType": 4, "value": 25 } } }`.
 		       - Alternative many surfaces prefer: model the range as two CompareFilters (Greater_or_equal lower bound + Less_or_equal upper bound) joined by an AND group. Use the first-class Between only when the surface expects it.
 
 		       ### In (filterType 4) — multi-value membership


### PR DESCRIPTION
## Summary
- document first-class backend ESQ Between construction and strict runtime parsing
- document the structurally distinct inclusive two-Compare alternative
- correct the frontend DataService contract: rightLessExpression is lower and rightGreaterExpression is upper

## Validation
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" --no-build` (2,429/2,429 on net8.0 and net10.0)
- focused `clio.mcp.e2e` guidance tests (45/45 on net8.0 and net10.0)
- comprehensive pre-PR agentic review: clean across correctness, maintainability, and security/performance

## Review notes
- MCP guidance reviewed and updated; no command behavior changed
- docs reviewed, no command documentation update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed