### PR TITLE
Document typed and lookup ESQ filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6667,3 +6667,10 @@ Decision: Document first-class Between separately from the equivalent pair of in
 Discovery: Native and DataService first-class shapes matched as one Between leaf with ordered lower/upper Integer parameters and inclusive SQL. DataService counterintuitively requires rightLessExpression for the first/lower value and rightGreaterExpression for the second/upper value; the two-Compare alternative remains two leaves.
 Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents can author and parse both inclusive range representations without reversing DataService bounds or assuming structural normalization.
+
+## 2026-07-18 02:27 – Validate typed primitive and lookup filters
+Context: Project milestones 7 and 8 of the backend ESQ filter validation plan into clio guidance.
+Decision: Validate CLR parameter type together with ParameterValueForcedType and treat lookup Guid values as a schema-specific family distinct from plain Guid columns.
+Discovery: Boolean and plain Guid retained BooleanDataValueType and GuidDataValueType. Native UsrOwner resolved to runtime UsrOwnerId, while its Guid parameters were LookupDataValueType; multi-value lookup requires object[] and compiled to IN. Low-level DataService accepted raw lookup Guid parameters, while designer-owned frontend JSON retains its display-value object contract.
+Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can distinguish Boolean, plain Guid, and lookup Guid parameters without coercion or path-based guessing.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -625,6 +625,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "the family router should expose the runtime parsing owner");
 		response.Article.Text.Should().Contain("inclusive Between ranges",
 			because: "get-guidance should report the current promoted backend validation status");
+		response.Article.Text.Should().Contain("lookup equality/membership",
+			because: "get-guidance should report promoted typed lookup coverage");
 	}
 
 	[Test]
@@ -668,6 +670,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified native membership recipe");
 		backend.Article!.Text.Should().Contain("FilterComparisonType.Between",
 			because: "get-guidance should return the verified native Between recipe");
+		backend.Article!.Text.Should().Contain("LookupDataValueType`, not `GuidDataValueType`",
+			because: "get-guidance should return the verified lookup type distinction");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -676,6 +680,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified runtime scalar parameter parsing recipe");
 		parsing.Article!.Text.Should().Contain("ReadIntegerBetween",
 			because: "get-guidance should return the verified runtime Between parsing recipe");
+		parsing.Article!.Text.Should().Contain("ReadTypedParameter<bool, BooleanDataValueType>",
+			because: "get-guidance should return verified typed parameter parsing");
 		parsing.Article!.Text.Should().Contain("return group.IsNot ? !result : result",
 			because: "get-guidance should return the verified group-negation evaluation rule");
 		parsing.Article!.Text.Should().Contain("ReadNullComparison",

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -127,12 +127,16 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the root resource should route rather than duplicate detailed rules");
 		router.Text.Should().Contain("inclusive Between ranges",
 			because: "the published router must not describe promoted Between guidance as pending");
+		router.Text.Should().Contain("lookup equality/membership",
+			because: "the published router should advertise promoted lookup coverage");
 		TextResourceContents frontend = frontendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",
 			because: "the existing serialized group contract should remain in the frontend owner");
 		frontend.Text.Should().Contain("`rightLessExpression` = first/lower bound",
 			because: "the published frontend resource must expose the verified Between ordering");
+		frontend.Text.Should().Contain("Low-level DataService also accepted a raw GUID parameter",
+			because: "the published frontend guide should distinguish low-level and designer lookup values");
 		TextResourceContents backend = backendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the backend construction resource should resolve to one plain-text article").Subject;
 		backend.Text.Should().Contain("LogicalOperationStrict.Or",
@@ -155,6 +159,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide should expose native Between construction");
 		backend.Text.Should().Contain("rightLessExpression` carries the first/lower value",
 			because: "the published backend guide must not reverse DataService Between bounds");
+		backend.Text.Should().Contain("LookupDataValueType`, not `GuidDataValueType`",
+			because: "the published backend guide must distinguish lookup and plain Guid parameters");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -181,6 +187,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser must fail safe for empty membership");
 		parsing.Text.Should().Contain("ReadIntegerBetween",
 			because: "the published parser should expose the verified two-boundary reader");
+		parsing.Text.Should().Contain("ReadTypedParameter<bool, BooleanDataValueType>",
+			because: "the published parser should validate typed primitive parameters");
+		parsing.Text.Should().Contain("its CLR value is Guid",
+			because: "the published parser must not infer lookup semantics from CLR type alone");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1599,6 +1599,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the family router should point runtime C# consumers to the parsing owner");
 		router.Text.Should().Contain("inclusive Between ranges",
 			because: "the entry router must advertise the backend families already promoted as verified");
+		router.Text.Should().Contain("lookup equality/membership",
+			because: "the router status should include promoted typed lookup coverage");
 		router.Text.Should().NotContain("### Compare (filterType 1)",
 			because: "the router should not duplicate detailed frontend filter rules");
 
@@ -1612,6 +1614,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the frontend guide must preserve the verified counterintuitive Between field ordering");
 		frontend.Text.Should().Contain("`rightGreaterExpression` = second/upper bound",
 			because: "the frontend guide must not reverse the serialized Between bounds");
+		frontend.Text.Should().Contain("Low-level DataService also accepted a raw GUID parameter",
+			because: "the frontend guide should distinguish verified DataService shorthand from designer JSON");
 	}
 
 	[Test]
@@ -1681,6 +1685,16 @@ public sealed class McpGuidanceResourceTests {
 			because: "the backend guide must preserve the verified DataService bound ordering");
 		article.Text.Should().Contain("does not normalize it into a Between leaf",
 			because: "the two-comparison alternative must remain structurally distinct");
+		article.Text.Should().Contain("BooleanDataValueType",
+			because: "the backend guide should retain the verified Boolean forced type");
+		article.Text.Should().Contain("GuidDataValueType",
+			because: "plain Guid parameters must stay distinct from lookup identifiers");
+		article.Text.Should().Contain("runtime `UsrOwnerId`",
+			because: "native logical lookup paths resolve to their runtime Id column path");
+		article.Text.Should().Contain("LookupDataValueType`, not `GuidDataValueType`",
+			because: "lookup Guid parameters require their schema-specific forced type");
+		article.Text.Should().Contain("ownerIds.Cast<object>().ToArray()",
+			because: "lookup membership must avoid one array-valued params argument");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
 		article.Text.Should().Contain("Pending lab",
@@ -1752,6 +1766,14 @@ public sealed class McpGuidanceResourceTests {
 			because: "the verified Between evaluator includes its lower boundary");
 		article.Text.Should().Contain("dispatch the shapes independently",
 			because: "first-class Between and the two-leaf alternative are not structurally interchangeable");
+		article.Text.Should().Contain("ReadTypedParameter<bool, BooleanDataValueType>",
+			because: "the parser should validate the Boolean CLR and forced types together");
+		article.Text.Should().Contain("ReadTypedParameter<Guid, GuidDataValueType>",
+			because: "the parser should reject textual or lookup-typed values for a plain Guid column");
+		article.Text.Should().Contain("Require that complete path and `LookupDataValueType`",
+			because: "lookup parsing must validate path and forced type rather than only Guid CLR type");
+		article.Text.Should().Contain("its CLR value is Guid",
+			because: "the parser must not conflate plain Guid and lookup columns");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -272,6 +272,41 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       remains two leaves in the surrounding AND group. A general tree evaluator can support both, but must
 		       dispatch the shapes independently; do not rewrite or silently accept an exclusive sibling pair.
 
+		       Validate both the CLR value and `ParameterValueForcedType` for typed parameters. The same CLR Guid
+		       represents two different schema families:
+		       ```csharp
+		       private static T ReadTypedParameter<T, TDataValueType>(
+		           EntitySchemaQueryFilter filter,
+		           string expectedPath)
+		           where TDataValueType : DataValueType {
+		           if (filter.ComparisonType != FilterComparisonType.Equal ||
+		               filter.LeftExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               filter.LeftExpression.Path != expectedPath ||
+		               filter.RightExpressions.Count != 1) {
+		               throw new NotSupportedException("Unsupported typed filter shape.");
+		           }
+
+		           EntitySchemaQueryExpression right = filter.RightExpressions.Single();
+		           if (right.ExpressionType != EntitySchemaQueryExpressionType.Parameter ||
+		               right.ParameterValue is not T value ||
+		               right.ParameterValueForcedType is not TDataValueType) {
+		               throw new NotSupportedException("Unexpected parameter value or data type.");
+		           }
+		           return value;
+		       }
+		       ```
+
+		       Use `ReadTypedParameter<bool, BooleanDataValueType>(filter, "UsrIsActive")` for Boolean and
+		       `ReadTypedParameter<Guid, GuidDataValueType>(filter, "UsrExternalRecordId")` for a plain Guid.
+		       Reject textual Guid values instead of coercing them.
+
+		       For the verified `UsrOwner` lookup, native construction resolves the runtime left path to
+		       `UsrOwnerId`. Require that complete path and `LookupDataValueType` while reading the Guid. One right
+		       expression is equality; multiple right expressions are membership and must use the same bounded,
+		       validate-once set strategy as other In filters. Never classify a parameter as a lookup merely because
+		       its CLR value is Guid or its terminal path ends in `Id`.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -323,8 +358,7 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. The frontend guide supplies the remaining
-		       validation backlog: Boolean/Guid values,
-		       lookups, dates/macros,
+		       validation backlog: dates/macros,
 		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.
 		       """

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -188,6 +188,43 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       `rightGreaterExpression` carries the second/upper value. DataService appends them to runtime
 		       `RightExpressions` in that order. Sending only a generic `rightExpressions` array is rejected.
 
+		       ## Create Boolean and plain Guid comparisons
+		       Ordinary typed values use the same scalar native API:
+		       ```csharp
+		       Guid externalRecordId = new("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrIsActive", true));
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrExternalRecordId", externalRecordId));
+		       ```
+
+		       The verified runtime values remained `System.Boolean` and `System.Guid`. Their parameter expressions
+		       carried `BooleanDataValueType` and `GuidDataValueType` respectively. Do not serialize or parse a Guid
+		       as text and do not coerce a string-form Guid in a provider.
+
+		       ## Create lookup equality and membership
+		       Pass the logical lookup column name to native ESQ and a Guid record Id as the value:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrOwner", ownerId));
+		       ```
+
+		       Native ESQ resolves that logical path to runtime `UsrOwnerId`. The parameter CLR value is still
+		       `System.Guid`, but its forced type is `LookupDataValueType`, not `GuidDataValueType`. This distinction
+		       is why lookup Ids must not be parsed as ordinary Guid columns.
+
+		       Multi-value lookup membership uses the same Equal-plus-collection runtime representation as In:
+		       ```csharp
+		       object[] ownerIdsAsParameters = ownerIds.Cast<object>().ToArray();
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrOwner", ownerIdsAsParameters));
+		       ```
+
+		       The verified two-value form produced two Lookup-typed Guid expressions and SQL `IN`. Passing a
+		       `Guid[]` directly to `params object[]` instead creates one array-valued expression. DataService accepted
+		       raw Guid values tagged as Lookup for the verified equality and membership requests; designer-owned
+		       frontend JSON may still require the display-value object documented in `esq-filters-frontend`.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -319,7 +356,7 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. Pending lab validation before publishing
-		       construction recipes: Boolean/Guid Compare values, lookup values, dates and macros,
+		       construction recipes: dates and macros,
 		       Exists/subqueries/aggregates, and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -51,7 +51,8 @@ public sealed class EsqFiltersGuidanceResource {
 		       ## Current backend validation status
 		       The backend construction and parsing guides currently publish the lab-verified group
 		       envelope, nesting, disabled nodes, group negation, primitive Integer/MediumText Compare,
-		       MediumText null checks, Integer membership cardinalities, and inclusive Between ranges.
+		       MediumText null checks, Integer membership cardinalities, inclusive Between ranges, typed
+		       Boolean/Guid comparisons, and lookup equality/membership.
 		       Other filter families remain explicitly marked pending until the same native-vs-DataService
 		       runtime-shape test proves and promotes them.
 		       """
@@ -184,11 +185,12 @@ public sealed class EsqFiltersGuidanceResource {
 		       - Date (8) / DateTime (7) / Time (9): a JSON-encoded date string with its own encoding and macro rules — see Dates: macros & date-parts below.
 
 		       ## Lookups
-		       - A lookup equality is serialized as an IN filter (filterType 4), even for a single value (the current-user macros below are the one exception — they use a CompareFilter):
+		       - The Freedom UI designer serializes lookup equality as an IN filter (filterType 4), even for a single value (the current-user macros below are the one exception — they use a CompareFilter):
 		         - `filterType: 4`, `comparisonType: 3` (Equal), `dataValueType: 10`, `referenceSchemaName: "<LookupTargetSchema>"`.
 		         - `leftExpression`: `{ "expressionType": 0, "columnPath": "<LookupColumn>" }`.
 		         - `rightExpressions`: an ARRAY. Each entry is `{ "expressionType": 2, "parameter": { "dataValueType": 10, "value": { "Id": "<guid>", "value": "<guid>", "displayValue": "<text>", "Name": "<text>" } } }`.
-		       - The parameter `value` is an OBJECT carrying both the record Id (`Id`/`value`) and its `displayValue`. Do not pass a bare GUID for a lookup. Resolve the GUID first (do not fabricate it) — for example via an ESQ select against the lookup schema, or the platform lookup-resolution path.
+		       - For Freedom UI designer round-trip, the parameter `value` is an OBJECT carrying both the record Id (`Id`/`value`) and its `displayValue`. Resolve the GUID first (do not fabricate it) — for example via an ESQ select against the lookup schema, or the platform lookup-resolution path.
+		       - Low-level DataService also accepted a raw GUID parameter tagged with Lookup `dataValueType: 10` in verified ATF requests: Compare for one value and In for multiple values. This shorthand is a DataService transport capability, not proof that every Freedom UI client helper accepts or round-trips it. Use the object form when authoring designer-owned JSON.
 		       - Multi-value lookup ("USA or UK"): keep it ONE lookup IN filter with several objects in `rightExpressions`; do not expand into duplicated scalar filters.
 		       - Current-user / current-user-contact lookups are the exception: they use a CompareFilter (filterType 1) whose `rightExpression` is a macro — `{ "expressionType": 1, "functionType": 1, "macrosType": 1 }` for current user (SysAdminUnit) or `macrosType: 2` for current user's Contact.
 		       - Display-name fallback: if a stable GUID is unavailable, filter on the lookup display path as TEXT instead, e.g. `CreatedBy.Name = "Supervisor"` or `Country.Name = "United States"` (filterType 1, dataValueType 1). Do not mix this text path with GUID value-objects in the same filter.


### PR DESCRIPTION
## Summary
- document Boolean and plain Guid backend ESQ construction and forced runtime types
- document lookup equality/membership, runtime `...Id` path resolution, and LookupDataValueType distinction
- distinguish verified low-level DataService raw-Guid shorthand from Freedom UI designer lookup objects

## Validation
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" --no-build` (2,429/2,429 on net8.0 and net10.0)
- focused `clio.mcp.e2e` guidance tests (45/45 on net8.0 and net10.0)
- comprehensive pre-PR agentic review: clean across correctness, maintainability, and security/performance

## Review notes
- MCP guidance reviewed and updated; no command behavior changed
- docs reviewed, no command documentation update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed