### PR TITLE
Document temporal ESQ filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6681,3 +6681,10 @@ Decision: Document temporal literals by schema path, trim-to-date as an explicit
 Discovery: Date, DateTime, and Time arrive as CLR DateTime. DataService preserved ticks but changed UTC Kind to Unspecified and reordered flat AND siblings. CurrentYear and PreviousNDays expanded to half-open boundary groups; Year became a date-part leaf; HourMinute equality became a one-minute half-open range.
 Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents can author and recursively parse verified temporal filter shapes without inferring date-only semantics, timezone policy, or macro boundaries.
+
+## 2026-07-18 03:36 – Correct HourMinute backend recipe overload
+Context: The Codex connector found that the temporal guidance combined an expression argument with the four-argument DateTime overload shape.
+Decision: Use the stable column-path overload for HourMinute and strengthen both resource contract tests to assert that exact compiling recipe.
+Discovery: The expression-based DateTime overload has a different signature on documented Creatio API versions, so a lab-compiling overload must not be generalized when a cross-version column-path overload expresses the same intent.
+Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+Impact: Agents copying the published HourMinute example receive a valid native C# call, guarded on both in-process and real MCP resource paths.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6674,3 +6674,10 @@ Decision: Validate CLR parameter type together with ParameterValueForcedType and
 Discovery: Boolean and plain Guid retained BooleanDataValueType and GuidDataValueType. Native UsrOwner resolved to runtime UsrOwnerId, while its Guid parameters were LookupDataValueType; multi-value lookup requires object[] and compiled to IN. Low-level DataService accepted raw lookup Guid parameters, while designer-owned frontend JSON retains its display-value object contract.
 Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Agents can distinguish Boolean, plain Guid, and lookup Guid parameters without coercion or path-based guessing.
+
+## 2026-07-18 03:15 – Validate temporal ESQ filters
+Context: Project milestone 9 of the backend ESQ filter validation plan into clio guidance.
+Decision: Document temporal literals by schema path, trim-to-date as an explicit leaf flag, and macros/date parts by their expanded recursive runtime trees.
+Discovery: Date, DateTime, and Time arrive as CLR DateTime. DataService preserved ticks but changed UTC Kind to Unspecified and reordered flat AND siblings. CurrentYear and PreviousNDays expanded to half-open boundary groups; Year became a date-part leaf; HourMinute equality became a one-minute half-open range.
+Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can author and recursively parse verified temporal filter shapes without inferring date-only semantics, timezone policy, or macro boundaries.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -627,6 +627,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should report the current promoted backend validation status");
 		response.Article.Text.Should().Contain("lookup equality/membership",
 			because: "get-guidance should report promoted typed lookup coverage");
+		response.Article.Text.Should().Contain("temporal literals/macros/date parts",
+			because: "get-guidance should report promoted temporal coverage");
 	}
 
 	[Test]
@@ -672,6 +674,10 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified native Between recipe");
 		backend.Article!.Text.Should().Contain("LookupDataValueType`, not `GuidDataValueType`",
 			because: "get-guidance should return the verified lookup type distinction");
+		backend.Article!.Text.Should().Contain("EntitySchemaQueryMacrosType.CurrentYear",
+			because: "get-guidance should return verified native temporal macro construction");
+		backend.Article!.Text.Should().Contain("createdOnDate.TrimDateTimeParameterToDate = true",
+			because: "get-guidance should return verified date-only construction");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -688,6 +694,12 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return the verified null-filter parsing contract");
 		parsing.Article!.Text.Should().Contain("ReadIntegerMembership",
 			because: "get-guidance should return the verified membership parsing contract");
+		parsing.Article!.Text.Should().Contain("ReadTrimmedDate",
+			because: "get-guidance should return the verified trim-to-date parsing contract");
+		parsing.Article!.Text.Should().Contain("Function.GetArguments()",
+			because: "get-guidance should return recursive temporal function parsing rules");
+		parsing.Article!.Text.Should().Contain("Capture one provider-clock snapshot",
+			because: "get-guidance should return query-scoped temporal boundary caching guidance");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -167,8 +167,9 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide should expose explicit date-only comparison");
 		backend.Text.Should().Contain("EntitySchemaQueryMacrosType.PreviousNDays, 7",
 			because: "the published backend guide should expose parameterized temporal macros");
-		backend.Text.Should().Contain("EntitySchemaQueryMacrosType.HourMinute",
-			because: "the published backend guide should expose date-part construction");
+		backend.Text.Should().Contain(
+			"FilterComparisonType.Equal, \"UsrLocalTime\", EntitySchemaQueryMacrosType.HourMinute",
+			because: "the published backend guide should expose a compiling column-path overload for date-part construction");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -129,6 +129,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published router must not describe promoted Between guidance as pending");
 		router.Text.Should().Contain("lookup equality/membership",
 			because: "the published router should advertise promoted lookup coverage");
+		router.Text.Should().Contain("temporal literals/macros/date parts",
+			because: "the published router should advertise promoted temporal coverage");
 		TextResourceContents frontend = frontendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",
@@ -161,6 +163,12 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide must not reverse DataService Between bounds");
 		backend.Text.Should().Contain("LookupDataValueType`, not `GuidDataValueType`",
 			because: "the published backend guide must distinguish lookup and plain Guid parameters");
+		backend.Text.Should().Contain("createdOnDate.TrimDateTimeParameterToDate = true",
+			because: "the published backend guide should expose explicit date-only comparison");
+		backend.Text.Should().Contain("EntitySchemaQueryMacrosType.PreviousNDays, 7",
+			because: "the published backend guide should expose parameterized temporal macros");
+		backend.Text.Should().Contain("EntitySchemaQueryMacrosType.HourMinute",
+			because: "the published backend guide should expose date-part construction");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -191,6 +199,12 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser should validate typed primitive parameters");
 		parsing.Text.Should().Contain("its CLR value is Guid",
 			because: "the published parser must not infer lookup semantics from CLR type alone");
+		parsing.Text.Should().Contain("ReadTrimmedDate",
+			because: "the published parser should expose explicit trim-to-date validation");
+		parsing.Text.Should().Contain("Function.GetArguments()",
+			because: "the published parser should recursively validate temporal function arguments");
+		parsing.Text.Should().Contain("Capture one provider-clock snapshot",
+			because: "the published parser should cache relative temporal boundaries once per query");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1601,6 +1601,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the entry router must advertise the backend families already promoted as verified");
 		router.Text.Should().Contain("lookup equality/membership",
 			because: "the router status should include promoted typed lookup coverage");
+		router.Text.Should().Contain("temporal literals/macros/date parts",
+			because: "the router status should include promoted temporal coverage");
 		router.Text.Should().NotContain("### Compare (filterType 1)",
 			because: "the router should not duplicate detailed frontend filter rules");
 
@@ -1695,6 +1697,18 @@ public sealed class McpGuidanceResourceTests {
 			because: "lookup Guid parameters require their schema-specific forced type");
 		article.Text.Should().Contain("ownerIds.Cast<object>().ToArray()",
 			because: "lookup membership must avoid one array-valued params argument");
+		article.Text.Should().Contain("createdOnDate.TrimDateTimeParameterToDate = true",
+			because: "date-only DateTime intent must use the explicit native leaf flag");
+		article.Text.Should().Contain("EntitySchemaQueryMacrosType.CurrentYear",
+			because: "the backend guide should expose native relative-period construction");
+		article.Text.Should().Contain("EntitySchemaQueryMacrosType.PreviousNDays, 7",
+			because: "the backend guide should expose parameterized relative-period construction");
+		article.Text.Should().Contain("EntitySchemaQueryMacrosType.Year, 2026",
+			because: "the backend guide should expose native fixed-year date-part construction");
+		article.Text.Should().Contain("EntitySchemaQueryMacrosType.HourMinute",
+			because: "the backend guide should expose native exact-minute construction");
+		article.Text.Should().Contain("DataService preserved DateTime ticks",
+			because: "the guide must preserve the verified DateTime Kind transport boundary");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
 		article.Text.Should().Contain("Pending lab",
@@ -1774,6 +1788,20 @@ public sealed class McpGuidanceResourceTests {
 			because: "lookup parsing must validate path and forced type rather than only Guid CLR type");
 		article.Text.Should().Contain("its CLR value is Guid",
 			because: "the parser must not conflate plain Guid and lookup columns");
+		article.Text.Should().Contain("ReadTrimmedDate",
+			because: "the parser should validate trim-to-date as an explicit leaf contract");
+		article.Text.Should().Contain("EntitySchemaStartOfCurrentYearQueryFunction",
+			because: "the parser should recognize expanded CurrentYear boundaries");
+		article.Text.Should().Contain("EntitySchemaCurrentDateQueryFunction",
+			because: "the parser should recognize expanded PreviousNDays boundaries");
+		article.Text.Should().Contain("Function.GetArguments()",
+			because: "nested temporal function expressions require recursive argument traversal");
+		article.Text.Should().Contain("DateTimeKind.Unspecified",
+			because: "the parser must account for the verified DataService Kind normalization");
+		article.Text.Should().Contain("ParameterValueForcedType is not",
+			because: "temporal readers must validate the forced data-value-type family as well as CLR DateTime");
+		article.Text.Should().Contain("Capture one provider-clock snapshot",
+			because: "relative temporal boundaries must remain consistent and allocation-free across records");
 		article.Text.Should().Contain("filter.LeftExpression.Path != expectedColumn",
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1705,8 +1705,9 @@ public sealed class McpGuidanceResourceTests {
 			because: "the backend guide should expose parameterized relative-period construction");
 		article.Text.Should().Contain("EntitySchemaQueryMacrosType.Year, 2026",
 			because: "the backend guide should expose native fixed-year date-part construction");
-		article.Text.Should().Contain("EntitySchemaQueryMacrosType.HourMinute",
-			because: "the backend guide should expose native exact-minute construction");
+		article.Text.Should().Contain(
+			"FilterComparisonType.Equal, \"UsrLocalTime\", EntitySchemaQueryMacrosType.HourMinute",
+			because: "the backend guide should expose a compiling column-path overload for native exact-minute construction");
 		article.Text.Should().Contain("DataService preserved DateTime ticks",
 			because: "the guide must preserve the verified DateTime Kind transport boundary");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -307,6 +307,62 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       validate-once set strategy as other In filters. Never classify a parameter as a lookup merely because
 		       its CLR value is Guid or its terminal path ends in `Id`.
 
+		       ## Parse temporal values, trimming, macros, and date parts
+		       Date, DateTime, and Time parameters all arrive as CLR `System.DateTime`. Also require a temporal
+		       `ParameterValueForcedType` (`DateTimeDataValueType` or its Date/Time subtype), then validate the complete
+		       left path against the schema contract; neither the CLR value nor the temporal forced-type family alone
+		       can distinguish those three Creatio types. The lab also observed DataService preserving ticks while
+		       changing a native UTC value to
+		       `DateTimeKind.Unspecified`, so compare or normalize `Kind` according to an explicit provider timezone
+		       policy rather than using it as the column-type discriminator.
+
+		       Date-only intent on a DateTime column is an explicit leaf property:
+		       ```csharp
+		       private static DateTime ReadTrimmedDate(
+		           EntitySchemaQueryFilter filter,
+		           string expectedPath) {
+		           if (filter.ComparisonType != FilterComparisonType.Equal ||
+		               !filter.TrimDateTimeParameterToDate ||
+		               filter.LeftExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               filter.LeftExpression.Path != expectedPath ||
+		               filter.RightExpressions.Count != 1 ||
+		               filter.RightExpressions.Single().ExpressionType !=
+		                   EntitySchemaQueryExpressionType.Parameter ||
+		               filter.RightExpressions.Single().ParameterValue is not DateTime value ||
+		               filter.RightExpressions.Single().ParameterValueForcedType is not
+		                   DateTimeDataValueType) {
+		               throw new NotSupportedException("Unsupported trim-to-date filter shape.");
+		           }
+		           return value.Date;
+		       }
+		       ```
+
+		       Do not infer trimming from `00:00:00`; an untrimmed midnight DateTime equality remains an exact instant.
+
+		       Relative macros are already expanded when a virtual query executor sees `esq.Filters`. Parse the
+		       resulting tree recursively:
+		       - CurrentYear is a nested AND with two boundary leaves using
+		         `EntitySchemaStartOfCurrentYearQueryFunction`;
+		       - PreviousNDays is a nested AND with `EntitySchemaCurrentDateQueryFunction` boundaries;
+		       - Year is a leaf with `EntitySchemaDatePartQueryFunction.Interval == Year`, a schema-column function
+		         argument, and one `System.Int32` parameter;
+		       - HourMinute equality is a nested `>=` / `<` one-minute range. Both sides are
+		         `EntitySchemaDatePartQueryFunction(Interval == HourMinute)`; the right-side function wraps a DateTime
+		         parameter.
+
+		       Function expressions are recursive. Inspect `expression.Function.GetArguments()` under the same depth,
+		       node, and parameter budgets as groups and leaves. Validate the concrete supported function type,
+		       `EntitySchemaDatePartQueryFunction.Interval`, argument count, argument expression type, column path, and
+		       parameter type before evaluating. Never treat an unknown function as a scalar parameter or silently
+		       drop one boundary of a half-open range.
+
+		       Compile the validated temporal tree once per query. Capture one provider-clock snapshot, resolve all
+		       record-independent CurrentYear/PreviousNDays boundaries from that same instant, and cache those bounds in
+		       the parsed predicate. Per-record evaluation should read only the record's temporal value/date part and
+		       compare it with the cached bounds. Recomputing `now` or traversing the function tree per row is both
+		       unnecessarily expensive and inconsistent when a query crosses midnight or a year boundary.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -357,9 +413,10 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
-		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. The frontend guide supplies the remaining
-		       validation backlog: dates/macros,
-		       Exists/subqueries/aggregates, and Segment. Add parsing rules here only after native C# and
+		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and temporal literals,
+		       trim-to-date, relative-period boundaries, Year, and HourMinute functions. The frontend guide supplies
+		       the remaining validation backlog: Exists/subqueries/aggregates and Segment. Add parsing rules here only
+		       after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.
 		       """
 	};

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -265,7 +265,7 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       esq.Filters.Add(esq.CreateFilter(
 		           FilterComparisonType.Equal, createdOn, EntitySchemaQueryMacrosType.Year, 2026));
 		       esq.Filters.Add(esq.CreateFilter(
-		           FilterComparisonType.Equal, createdOn, EntitySchemaQueryMacrosType.HourMinute,
+		           FilterComparisonType.Equal, "UsrLocalTime", EntitySchemaQueryMacrosType.HourMinute,
 		           new DateTime(1, 1, 1, 13, 45, 0)));
 		       ```
 

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -225,6 +225,61 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       raw Guid values tagged as Lookup for the verified equality and membership requests; designer-owned
 		       frontend JSON may still require the display-value object documented in `esq-filters-frontend`.
 
+		       ## Create Date, DateTime, and Time filters
+		       Creatio Date, DateTime, and Time column parameters are all CLR `System.DateTime` values. The schema
+		       column carries the semantic type, so use the exact logical column path and do not turn a temporal value
+		       into text:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrEffectiveDate", new DateTime(2026, 7, 18)));
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrGeneratedOn",
+		           new DateTime(2026, 7, 18, 13, 45, 30, DateTimeKind.Utc)));
+		       esq.Filters.Add(esq.CreateFilterWithParameters(
+		           FilterComparisonType.Equal, "UsrLocalTime", new DateTime(1, 1, 1, 13, 45, 0)));
+		       ```
+
+		       DataService preserved DateTime ticks in the verified request but reconstructed a native UTC value with
+		       `DateTimeKind.Unspecified`. Treat `Kind` as transport metadata unless the provider contract explicitly
+		       requires timezone conversion; do not reject the same ticks merely because one path retains `Utc`.
+
+		       A midnight parameter does not enable date-only comparison on a DateTime column. Set the leaf flag:
+		       ```csharp
+		       EntitySchemaQueryFilter createdOnDate =
+		           (EntitySchemaQueryFilter)esq.CreateFilterWithParameters(
+		               FilterComparisonType.Equal, "CreatedOn", new DateTime(2026, 7, 18));
+		       createdOnDate.TrimDateTimeParameterToDate = true;
+		       esq.Filters.Add(createdOnDate);
+		       ```
+
+		       ## Create relative-period macros and date-part filters
+		       Use `CreateFilter` with `EntitySchemaQueryMacrosType` rather than calculating relative boundaries in
+		       application code:
+		       ```csharp
+		       esq.Filters.Add(esq.CreateFilter(
+		           FilterComparisonType.Equal, "CreatedOn", EntitySchemaQueryMacrosType.CurrentYear));
+		       esq.Filters.Add(esq.CreateFilter(
+		           FilterComparisonType.Equal, "CreatedOn", EntitySchemaQueryMacrosType.PreviousNDays, 7));
+
+		       EntitySchemaQueryExpression createdOn = esq.CreateSchemaColumnExpression("CreatedOn");
+		       esq.Filters.Add(esq.CreateFilter(
+		           FilterComparisonType.Equal, createdOn, EntitySchemaQueryMacrosType.Year, 2026));
+		       esq.Filters.Add(esq.CreateFilter(
+		           FilterComparisonType.Equal, createdOn, EntitySchemaQueryMacrosType.HourMinute,
+		           new DateTime(1, 1, 1, 13, 45, 0)));
+		       ```
+
+		       These calls expand before the executor boundary:
+		       - `CurrentYear` becomes a nested AND containing `>=` the start of this year and `<` the start of next year;
+		       - `PreviousNDays, 7` becomes a nested half-open range from seven days ago through exclusive today;
+		       - `Year, 2026` becomes one Equal leaf whose left expression is
+		         `EntitySchemaDatePartQueryFunction(Year)` and whose right value is `System.Int32`;
+		       - HourMinute equality becomes a nested AND from the requested minute (inclusive) to the next minute
+		         (exclusive), with HourMinute functions on both sides.
+
+		       Construct the semantic API call and let Creatio calculate period boundaries. Do not expect the runtime
+		       tree to retain a macro enum or remain one leaf.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -355,9 +410,9 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       ## Coverage boundary
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
-		       `IsNull`/`IsNotNull` and Integer In cardinality boundaries. Pending lab validation before publishing
-		       construction recipes: dates and macros,
-		       Exists/subqueries/aggregates, and Segment filters. Use the
+		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and Date/DateTime/Time
+		       literals, trim-to-date, relative-period macros, Year, and HourMinute. Pending lab validation before
+		       publishing construction recipes: Exists/subqueries/aggregates and Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.
 		       """

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -52,7 +52,7 @@ public sealed class EsqFiltersGuidanceResource {
 		       The backend construction and parsing guides currently publish the lab-verified group
 		       envelope, nesting, disabled nodes, group negation, primitive Integer/MediumText Compare,
 		       MediumText null checks, Integer membership cardinalities, inclusive Between ranges, typed
-		       Boolean/Guid comparisons, and lookup equality/membership.
+		       Boolean/Guid comparisons, lookup equality/membership, and temporal literals/macros/date parts.
 		       Other filter families remain explicitly marked pending until the same native-vs-DataService
 		       runtime-shape test proves and promotes them.
 		       """


### PR DESCRIPTION
## Summary
- document lab-verified Date, DateTime, and Time literal construction
- document explicit trim-to-date and expanded CurrentYear/PreviousNDays/Year/HourMinute runtime shapes
- require recursive, bounded, query-scoped temporal parsing with forced-type validation and cached clock boundaries
- update ESQ family routing status and MCP resource contracts

## Validation
- VirtualEntityGuidance lab: 88/88 package tests and 4/4 temporal E2E tests against `std-skill-n8` (Creatio 10.1.298.0, .NET 8, PostgreSQL)
- `dotnet test clio.tests/clio.tests.csproj -f net8.0 --filter <3 affected guidance tests> --no-build --no-restore` (3 passed)
- same focused unit contracts on `net10.0` (3 passed)
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net8.0 --filter <3 ESQ guidance retrieval tests> --no-build --no-restore` (3 passed)
- same focused MCP E2E contracts on `net10.0` (3 passed)
- broader MCP module execution completed 2,326/2,326 tests before an existing test-host shutdown hang aborted the runner

## Review
- Comprehensive pre-PR three-lens agentic review completed
- correctness/security: clean
- quality/maintainability: clean
- performance/robustness: two Medium findings fixed (forced temporal type validation; query-scoped clock/boundary caching), re-review clean

MCP reviewed and updated with unit and E2E coverage.
Docs reviewed, no command documentation update required.
ClioRing compatibility reviewed, no Ring-consumed contract changed (guidance text only).
TeamCity is not part of the requested merge gate for this PR.