### PR TITLE
Document backend ESQ subquery filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6688,3 +6688,17 @@ Decision: Use the stable column-path overload for HourMinute and strengthen both
 Discovery: The expression-based DateTime overload has a different signature on documented Creatio API versions, so a lab-compiling overload must not be generalized when a cross-version column-path overload expresses the same intent.
 Files: clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
 Impact: Agents copying the published HourMinute example receive a valid native C# call, guarded on both in-process and real MCP resource paths.
+
+## 2026-07-18 04:02 – Validate backward-path subquery filters
+Context: Project milestone 10 of the backend ESQ filter validation plan into clio guidance.
+Decision: Document Exists, NotExists, and Count subqueries together because they share the same generated mixed-path correlation but differ at the outer expression boundary.
+Discovery: Exists and NotExists use a null left expression plus one right Activity subquery. Count uses the subquery on the left and retains both Id and aggregate columns. DataService preserves its serialized child filters as one extra AND envelope; only that validated wrapper is safe to normalize for semantic parity.
+Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can construct and recursively parse verified relationship subqueries without confusing schema-column correlations with parameters, assuming one child column, or introducing N+1 execution.
+
+## 2026-07-18 04:12 – Bound subquery parser execution
+Context: Pre-PR adversarial review of the promoted subquery guidance identified aggregate-shape and fallback-execution gaps.
+Decision: Require the exact lab-proven non-distinct Count(Id) operand after applying the selected-expression budget, and require bounded batched fallback execution when provider pushdown is unavailable.
+Discovery: Avoiding one query per root record is insufficient if an implementation instead materializes an unbounded child source; correlation-key, fan-out, timeout, and cancellation limits are part of the parser contract.
+Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: The published parser fails closed on semantically different Count functions and cannot recommend an unbounded preload as an N+1 workaround.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -629,6 +629,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should report promoted typed lookup coverage");
 		response.Article.Text.Should().Contain("temporal literals/macros/date parts",
 			because: "get-guidance should report promoted temporal coverage");
+		response.Article.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
+			because: "get-guidance should report promoted subquery coverage");
 	}
 
 	[Test]
@@ -678,6 +680,10 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return verified native temporal macro construction");
 		backend.Article!.Text.Should().Contain("createdOnDate.TrimDateTimeParameterToDate = true",
 			because: "get-guidance should return verified date-only construction");
+		backend.Article!.Text.Should().Contain("esq.CreateExistsFilter(ownerActivities)",
+			because: "get-guidance should return verified native Exists construction");
+		backend.Article!.Text.Should().Contain("out EntitySchemaQuery activitySubQuery",
+			because: "get-guidance should return verified aggregate child-filter construction");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -700,6 +706,14 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return recursive temporal function parsing rules");
 		parsing.Article!.Text.Should().Contain("Capture one provider-clock snapshot",
 			because: "get-guidance should return query-scoped temporal boundary caching guidance");
+		parsing.Article!.Text.Should().Contain("ReadActivityExistenceSubquery",
+			because: "get-guidance should return verified existence-subquery parsing guidance");
+		parsing.Article!.Text.Should().Contain("Do not call `child.Columns.Single()`",
+			because: "get-guidance should return verified aggregate-column parsing guidance");
+		parsing.Article!.Text.Should().Contain("Count(Id) without Distinct",
+			because: "get-guidance should preserve exact aggregate operand validation");
+		parsing.Article!.Text.Should().Contain("materialize an unbounded child source",
+			because: "get-guidance should preserve bounded fallback execution guidance");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -131,6 +131,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published router should advertise promoted lookup coverage");
 		router.Text.Should().Contain("temporal literals/macros/date parts",
 			because: "the published router should advertise promoted temporal coverage");
+		router.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
+			because: "the published router should advertise promoted subquery coverage");
 		TextResourceContents frontend = frontendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",
@@ -170,6 +172,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 		backend.Text.Should().Contain(
 			"FilterComparisonType.Equal, \"UsrLocalTime\", EntitySchemaQueryMacrosType.HourMinute",
 			because: "the published backend guide should expose a compiling column-path overload for date-part construction");
+		backend.Text.Should().Contain("esq.CreateExistsFilter(ownerActivities)",
+			because: "the published backend guide should expose verified native Exists construction");
+		backend.Text.Should().Contain("out EntitySchemaQuery activitySubQuery",
+			because: "the published backend guide should place child aggregate predicates in the returned subquery");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -206,6 +212,14 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser should recursively validate temporal function arguments");
 		parsing.Text.Should().Contain("Capture one provider-clock snapshot",
 			because: "the published parser should cache relative temporal boundaries once per query");
+		parsing.Text.Should().Contain("ReadActivityExistenceSubquery",
+			because: "the published parser should validate right-side existence subqueries");
+		parsing.Text.Should().Contain("Do not call `child.Columns.Single()`",
+			because: "the published parser should locate aggregate function columns explicitly");
+		parsing.Text.Should().Contain("Count(Id) without Distinct",
+			because: "the published parser should validate the proven aggregation operand and evaluation mode");
+		parsing.Text.Should().Contain("materialize an unbounded child source",
+			because: "the published parser should reject unbounded child preloading as an N+1 workaround");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1603,6 +1603,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the router status should include promoted typed lookup coverage");
 		router.Text.Should().Contain("temporal literals/macros/date parts",
 			because: "the router status should include promoted temporal coverage");
+		router.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
+			because: "the router status should include promoted backward-subquery coverage");
 		router.Text.Should().NotContain("### Compare (filterType 1)",
 			because: "the router should not duplicate detailed frontend filter rules");
 
@@ -1712,6 +1714,18 @@ public sealed class McpGuidanceResourceTests {
 			because: "the guide must preserve the verified DateTime Kind transport boundary");
 		article.Text.Should().Contain("not Creatio/PostgreSQL collation behavior",
 			because: "in-memory provider case policy must not be published as database-collation evidence");
+		article.Text.Should().Contain("esq.CreateExistsFilter(ownerActivities)",
+			because: "the backend guide should expose native Exists construction over the verified mixed path");
+		article.Text.Should().Contain("esq.CreateNotExistsFilter(ownerActivities)",
+			because: "the backend guide should expose native NotExists construction independently");
+		article.Text.Should().Contain("out EntitySchemaQuery activitySubQuery",
+			because: "aggregate child predicates must be authored through the returned subquery");
+		article.Text.Should().Contain("AggregationTypeStrict.Count",
+			because: "the backend guide should preserve the verified Count aggregate recipe");
+		article.Text.Should().Contain("Count > 1",
+			because: "the guide must avoid an existence-boundary optimization when demonstrating aggregates");
+		article.Text.Should().Contain("extra enabled AND collection",
+			because: "the guide should preserve the proven DataService child-filter envelope difference");
 		article.Text.Should().Contain("Pending lab",
 			because: "unverified filter families should be explicit instead of guessed");
 	}
@@ -1807,6 +1821,26 @@ public sealed class McpGuidanceResourceTests {
 			because: "the parser must validate the full ESQ path instead of only its terminal schema column");
 		article.Text.Should().Contain("can collapse `Account.Name` to",
 			because: "the guide should explain why terminal SchemaColumnName matching can accept an unintended lookup path");
+		article.Text.Should().Contain("ReadActivityExistenceSubquery",
+			because: "the parser should validate Exists and NotExists as right-side subqueries");
+		article.Text.Should().Contain("Owner.Id == root UsrOwnerId",
+			because: "the parser must validate the generated mixed-path correlation");
+		article.Text.Should().Contain("column.ValueExpression?.Function is EntitySchemaAggregationQueryFunction",
+			because: "aggregate parsing must select the function column instead of assuming one subquery column");
+		article.Text.Should().Contain("Do not call `child.Columns.Single()`",
+			because: "the guide must preserve the live failure caused by the retained Id plus Count columns");
+		article.Text.Should().Contain("Count(Id) without Distinct",
+			because: "aggregate parsing must validate the exact operand and evaluation mode proved by the lab");
+		article.Text.Should().Contain("ConsumeSelectedExpressionBudget(child.Columns.Count)",
+			because: "the selected-expression budget must be applied before aggregate-column enumeration");
+		article.Text.Should().Contain("materialize an unbounded child source",
+			because: "avoiding literal N+1 queries must not permit unbounded child preloading");
+		article.Text.Should().Contain("child-row/fan-out, timeout",
+			because: "fallback batching must remain bounded and cancellable");
+		article.Text.Should().Contain("Do not execute one",
+			because: "virtual providers must avoid one child query per root record");
+		article.Text.Should().Contain("`RootSchema.IsVirtual` in `finally`",
+			because: "the diagnostic SQL oracle must not leave the shared schema non-virtual");
 		string[] expectedScalarOperators = [
 			"Equal", "NotEqual", "Less", "LessOrEqual", "Greater", "GreaterOrEqual",
 			"StartWith", "NotStartWith", "Contain", "NotContain", "EndWith", "NotEndWith"

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -363,6 +363,75 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       compare it with the cached bounds. Recomputing `now` or traversing the function tree per row is both
 		       unnecessarily expensive and inconsistent when a query crosses midnight or a year boundary.
 
+		       ## Parse Exists, NotExists, and aggregate subqueries
+		       Existence leaves do not follow the ordinary left-column/right-parameter contract. Validate the comparison,
+		       null left expression, one right SubQuery, child root schema, and generated correlation together:
+		       ```csharp
+		       private static EntitySchemaQuery ReadActivityExistenceSubquery(
+		           EntitySchemaQueryFilter filter,
+		           FilterComparisonType expectedComparison) {
+		           if (filter.ComparisonType != expectedComparison ||
+		               filter.LeftExpression != null ||
+		               filter.RightExpressions.Count != 1 ||
+		               filter.RightExpressions.Single().ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SubQuery) {
+		               throw new NotSupportedException("Unsupported existence filter shape.");
+		           }
+
+		           EntitySchemaQuery child = filter.RightExpressions.Single().SubQuery;
+		           if (child?.RootSchema?.Name != "Activity") {
+		               throw new NotSupportedException("Expected an Activity subquery.");
+		           }
+		           // Recursively validate child.Filters, including the generated
+		           // Owner.Id == root UsrOwnerId schema-column correlation.
+		           return child;
+		       }
+		       ```
+
+		       Call it only for explicitly supported `Exists` or `NotExists` leaves. The verified mixed path generated
+		       `Owner.Id` on the Activity side and a schema-column right expression whose complete path was
+		       `UsrOwnerId` on the root side. A schema-column correlation is not a parameter: do not read
+		       `ParameterValue`, coerce it to Guid, or compare only the terminal `Id` column name.
+
+		       Aggregate filters invert the expression placement: the SubQuery is the outer leaf's left expression and
+		       the scalar threshold is on the right. Validate `Greater`, `LeftExpression.ExpressionType == SubQuery`,
+		       exactly one Integer threshold, the Activity root, and the complete child filter tree. Apply the
+		       selected-column/expression budget before enumerating child columns, then locate the aggregate
+		       column by function type:
+		       ```csharp
+		       ConsumeSelectedExpressionBudget(child.Columns.Count);
+		       EntitySchemaQueryColumn countColumn = child.Columns.SingleOrDefault(column =>
+		           column.ValueExpression?.Function is EntitySchemaAggregationQueryFunction);
+		       EntitySchemaAggregationQueryFunction countFunction =
+		           countColumn?.ValueExpression?.Function as EntitySchemaAggregationQueryFunction;
+		       if (countFunction?.AggregationType != AggregationTypeStrict.Count ||
+		           countFunction.AggregationEvalType != AggregationEvalType.None ||
+		           countFunction.Expression?.ExpressionType != EntitySchemaQueryExpressionType.SchemaColumn ||
+		           countFunction.Expression.Path != "Id") {
+		           throw new NotSupportedException("Expected Count(Id) without Distinct in the child subquery.");
+		       }
+		       ```
+
+		       Do not call `child.Columns.Single()` or assume the aggregation replaces the ordinary selected column. The
+		       verified Count subquery retained Id and the Count function. Reject an unknown aggregation, threshold,
+		       correlation, child schema, or Title predicate instead of treating every subquery as existence.
+
+		       Native and DataService child-filter envelopes differ. Native C# placed the verified Title leaf directly in
+		       `child.Filters`; DataService retained serialized `subFilters` as a one-item nested AND collection. An empty
+		       serialized Exists `subFilters` remained an empty nested AND next to the correlation. Accept only the
+		       direct and nested forms your provider has proved. Preserve/count the envelope for structural diagnostics;
+		       a semantic comparison may remove only this known transport wrapper after validating it is enabled,
+		       non-negated, AND, and contains the expected zero or one child.
+
+		       Extend depth, node, expression, and parameter budgets into every subquery, selected expression, and child
+		       filter collection. Parse and compile the validated tree once. Prefer a correlated Exists/aggregate pushed
+		       into the backing provider. If pushdown is unavailable, collect a bounded set of root correlation keys and use
+		       chunked batch queries plus provider-side aggregation. Enforce explicit root-key, child-row/fan-out, timeout,
+		       and cancellation limits; reject the request when those bounds cannot preserve semantics. Do not execute one
+		       child query per root record or materialize an unbounded child source merely to pre-index it. The diagnostic
+		       physical-SQL trick is an oracle only—always restore
+		       `RootSchema.IsVirtual` in `finally` and never execute that SQL for a virtual schema.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -414,9 +483,9 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and temporal literals,
-		       trim-to-date, relative-period boundaries, Year, and HourMinute functions. The frontend guide supplies
-		       the remaining validation backlog: Exists/subqueries/aggregates and Segment. Add parsing rules here only
-		       after native C# and
+		       trim-to-date, relative-period boundaries, Year, HourMinute functions, and Exists/NotExists/Count subqueries
+		       over a mixed forward/backward path. The frontend guide supplies the remaining validation backlog: Segment.
+		       Add parsing rules here only after native C# and
 		       DataService produce an asserted runtime shape and the lab proves result behavior.
 		       """
 	};

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -280,6 +280,59 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Construct the semantic API call and let Creatio calculate period boundaries. Do not expect the runtime
 		       tree to retain a macro enum or remain one leaf.
 
+		       ## Create Exists and NotExists over backward paths
+		       Use the relationship path overloads for child-record existence. A mixed path may traverse a forward
+		       lookup before a backward collection:
+		       ```csharp
+		       const string ownerActivities = "UsrOwner.[Activity:Owner].Id";
+		       esq.Filters.Add(esq.CreateExistsFilter(ownerActivities));
+		       // Or, independently:
+		       esq.Filters.Add(esq.CreateNotExistsFilter(ownerActivities));
+		       ```
+
+		       Read the path from the query root: `UsrOwner` moves forward from the virtual record to Contact;
+		       `[Activity:Owner]` moves backward to Activities whose `Owner` points at that Contact; `.Id` is the
+		       child column selected by the subquery. Do not flatten this into a fake root column path.
+
+		       Both calls create one runtime leaf with `LeftExpression == null` and one right expression of type
+		       SubQuery rooted at `Activity`. Creatio adds the correlation
+		       `Activity.Owner.Id == root.UsrOwnerId` inside that subquery. `NotExists` has the same recursive shape
+		       with comparison type `NotExists`; verified SQL changed from `EXISTS` to `NOT EXISTS`.
+
+		       ## Create an aggregate subquery with child filters
+		       Use the aggregate overload with its `out EntitySchemaQuery` when child conditions belong to the
+		       related records:
+		       ```csharp
+		       EntitySchemaQueryFilter activityCount = esq.CreateFilter(
+		           FilterComparisonType.Greater,
+		           ownerActivities,
+		           AggregationTypeStrict.Count,
+		           1,
+		           out EntitySchemaQuery activitySubQuery);
+
+		       activitySubQuery.Filters.Add(activitySubQuery.CreateFilterWithParameters(
+		           FilterComparisonType.Equal,
+		           "Title",
+		           "Lab activity"));
+		       esq.Filters.Add(activityCount);
+		       ```
+
+		       The child `Title` predicate must be added to `activitySubQuery.Filters`, not to the root ESQ and not
+		       copied onto the outer aggregate leaf. The runtime outer leaf is `Greater`; its left expression is an
+		       Activity SubQuery and its right expression is the Integer threshold. The subquery contains the generated
+		       owner correlation plus the Title predicate and selects both its ordinary Id column and a Count function
+		       over Id.
+
+		       Keep an actual aggregate boundary when validating aggregate behavior. Creatio may optimize `Count > 0`,
+		       `Count >= 1`, and `Count == 0` into Exists/NotExists. The lab used `Count > 1` so Count remained observable.
+
+		       DataService `subFilters` have one proven structural difference from direct native construction. The
+		       serialized group survives as an extra enabled AND collection inside the generated subquery: an empty
+		       Exists `subFilters` becomes an empty child group, and one aggregate child predicate becomes a one-item
+		       child group. Native construction has no empty group and adds the Title leaf directly. The generated SQL
+		       semantics matched. Preserve the complete source shape for diagnostics; normalize only this explicit
+		       transport envelope when a semantic parity test needs to compare the two authoring paths.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -411,8 +464,9 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and Date/DateTime/Time
-		       literals, trim-to-date, relative-period macros, Year, and HourMinute. Pending lab validation before
-		       publishing construction recipes: Exists/subqueries/aggregates and Segment filters. Use the
+		       literals, trim-to-date, relative-period macros, Year, HourMinute, and Exists/NotExists/Count subqueries
+		       over a mixed forward/backward path. Pending lab validation before publishing construction recipes:
+		       Segment filters. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.
 		       """

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -52,7 +52,8 @@ public sealed class EsqFiltersGuidanceResource {
 		       The backend construction and parsing guides currently publish the lab-verified group
 		       envelope, nesting, disabled nodes, group negation, primitive Integer/MediumText Compare,
 		       MediumText null checks, Integer membership cardinalities, inclusive Between ranges, typed
-		       Boolean/Guid comparisons, lookup equality/membership, and temporal literals/macros/date parts.
+		       Boolean/Guid comparisons, lookup equality/membership, temporal literals/macros/date parts,
+		       and Exists/NotExists/aggregate subqueries over backward paths.
 		       Other filter families remain explicitly marked pending until the same native-vs-DataService
 		       runtime-shape test proves and promotes them.
 		       """


### PR DESCRIPTION
## Summary
- document native Exists and NotExists construction over mixed forward/backward paths
- document Count subquery construction, exact runtime parsing, and the proven DataService child-group envelope
- require exact Count(Id) validation and bounded provider execution
- pin the guidance through direct resource and get-guidance MCP tests

## Validation
- dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter FullyQualifiedName~McpGuidanceResourceTests
- dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter FullyQualifiedName~McpGuidanceResourceE2ETests|FullyQualifiedName~GuidanceGetToolE2ETests
- same focused filters on net8.0
- comprehensive three-lens agentic review; two scalability hardening findings resolved, re-review clean

## Compatibility
- MCP resource and resource tests updated together
- ClioRing compatibility reviewed, no Ring-consumed contract changed
- docs reviewed: no CLI command documentation update required