### PR TITLE
Document backend ESQ Segment filters

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6702,3 +6702,24 @@ Decision: Require the exact lab-proven non-distinct Count(Id) operand after appl
 Discovery: Avoiding one query per root record is insufficient if an implementation instead materializes an unbounded child source; correlation-key, fan-out, timeout, and cancellation limits are part of the parser contract.
 Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: The published parser fails closed on semantically different Count functions and cannot recommend an unbounded preload as an N+1 workaround.
+
+## 2026-07-18 04:35 – Validate saved Segment filters
+Context: Complete milestone 11 of the backend ESQ filter validation plan and promote the final pending frontend family.
+Decision: Publish the native SegmentFilterOptions recipe and parse only the exact expanded current-membership tree, with membership tables restricted by trusted metadata or an allowlist.
+Discovery: Native and DataService IN/NOT IN requests produced identical Exists/NotExists subqueries with RecordId correlation and RemovedOn IsNull. The Segment Id and filterType 7 authoring metadata do not survive into esq.Filters. ATF.Repository 2.0.3.5 can serialize numeric filter type 7 but does not name it in its enum.
+Files: clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs, clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Agents can construct saved Segment membership and safely recognize its executor-visible expansion without trusting dynamic table names or claiming unverified option variants.
+
+## 2026-07-18 04:48 – Require Segment authorization before table access
+Context: Pre-PR adversarial review found that a membership-table allowlist alone could bypass caller/root Segment authorization and that malformed child roots could escape the secret-safe rejection path.
+Decision: Require request-scoped, permission-checked SysDataSegment resolution for the caller and root schema on every access, then use only the exact authorized table identifier through the provider query builder.
+Discovery: Dynamic SQL identifiers cannot be parameterized; authorization must derive the exact identifier from trusted metadata, while every value remains parameterized. Parser guards now null-check the child root and validate the selected RecordId schema-column expression before authorization.
+Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: An expanded Segment-shaped subquery cannot access an allowlisted table without proving caller authorization and target-schema ownership, and malformed subqueries fail through controlled validation.
+
+## 2026-07-18 04:55 – Validate before Segment authorization lookup
+Context: Re-review found that malformed repeated Segment leaves could trigger metadata authorization work before cheap shape rejection and repeat it within one query.
+Decision: Validate the complete in-memory Segment tree first, then authorize each distinct table once using a cache scoped to caller, root-schema UId, table name, and request lifetime.
+Discovery: Authorization results must never be shared across callers or retained globally; query-scoped reuse avoids repeated metadata work without turning stale authorization into ambient trust.
+Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Invalid trees are rejected before external work, while valid repeated Segment leaves reuse only identity-safe request-scoped authorization.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6723,3 +6723,10 @@ Decision: Validate the complete in-memory Segment tree first, then authorize eac
 Discovery: Authorization results must never be shared across callers or retained globally; query-scoped reuse avoids repeated metadata work without turning stale authorization into ambient trust.
 Files: clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs, clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
 Impact: Invalid trees are rejected before external work, while valid repeated Segment leaves reuse only identity-safe request-scoped authorization.
+
+## 2026-07-18 05:03 – Pin Segment validation presence in contracts
+Context: Final comprehensive review found that the validation-order assertion could pass when the validation marker was absent because IndexOf returned -1.
+Decision: Require ValidateCurrentMembershipFilters explicitly in unit and both MCP E2E resource contracts before asserting its order relative to authorization.
+Discovery: Ordering assertions over string indices must independently prove that both ordered markers exist.
+Files: clio.tests/Command/McpServer/McpGuidanceResourceTests.cs, clio.mcp.e2e/McpGuidanceResourceE2ETests.cs, clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+Impact: Removing the fail-closed validation step now fails every relevant published-resource contract instead of accidentally satisfying the order assertion.

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -722,6 +722,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should preserve bounded fallback execution guidance");
 		parsing.Article!.Text.Should().Contain("ReadSegmentMembership",
 			because: "get-guidance should return verified expanded Segment parsing guidance");
+		parsing.Article!.Text.Should().Contain("ValidateCurrentMembershipFilters",
+			because: "get-guidance should preserve complete shape validation before external work");
 		parsing.Article!.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
 			because: "get-guidance should preserve request-scoped Segment authorization");
 		parsing.Article!.Text.Should().Contain("Never reuse a cross-caller",

--- a/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
+++ b/clio.mcp.e2e/GuidanceGetToolE2ETests.cs
@@ -631,6 +631,8 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should report promoted temporal coverage");
 		response.Article.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
 			because: "get-guidance should report promoted subquery coverage");
+		response.Article.Text.Should().Contain("saved Segment membership",
+			because: "get-guidance should report promoted Segment coverage");
 	}
 
 	[Test]
@@ -684,6 +686,10 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should return verified native Exists construction");
 		backend.Article!.Text.Should().Contain("out EntitySchemaQuery activitySubQuery",
 			because: "get-guidance should return verified aggregate child-filter construction");
+		backend.Article!.Text.Should().Contain("new SegmentFilterOptions",
+			because: "get-guidance should return verified native Segment construction");
+		backend.Article!.Text.Should().Contain("UseSegmentFiltering",
+			because: "get-guidance should retain the Segment feature gate");
 		parsing.Success.Should().BeTrue(
 			because: "runtime C# filter interpretation should have one retrievable parsing owner");
 		parsing.Article!.Uri.Should().Be("docs://mcp/guides/esq-filter-parsing",
@@ -714,6 +720,14 @@ public sealed class GuidanceGetToolE2ETests : McpContractFixtureBase {
 			because: "get-guidance should preserve exact aggregate operand validation");
 		parsing.Article!.Text.Should().Contain("materialize an unbounded child source",
 			because: "get-guidance should preserve bounded fallback execution guidance");
+		parsing.Article!.Text.Should().Contain("ReadSegmentMembership",
+			because: "get-guidance should return verified expanded Segment parsing guidance");
+		parsing.Article!.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
+			because: "get-guidance should preserve request-scoped Segment authorization");
+		parsing.Article!.Text.Should().Contain("Never reuse a cross-caller",
+			because: "get-guidance should preserve safe query-scoped authorization caching");
+		parsing.Article!.Text.Should().Contain("SQL table identifiers cannot be parameters",
+			because: "get-guidance should preserve dynamic membership-table identifier safety");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -228,6 +228,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser should reject unbounded child preloading as an N+1 workaround");
 		parsing.Text.Should().Contain("ReadSegmentMembership",
 			because: "the published parser should validate the expanded Segment runtime tree");
+		parsing.Text.Should().Contain("ValidateCurrentMembershipFilters",
+			because: "the published parser should require complete shape validation before external work");
 		parsing.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
 			because: "the published parser should require request-scoped Segment authorization");
 		parsing.Text.Should().Contain("Never reuse a cross-caller",

--- a/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
+++ b/clio.mcp.e2e/McpGuidanceResourceE2ETests.cs
@@ -133,6 +133,8 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published router should advertise promoted temporal coverage");
 		router.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
 			because: "the published router should advertise promoted subquery coverage");
+		router.Text.Should().Contain("saved Segment membership",
+			because: "the published router should advertise promoted Segment coverage");
 		TextResourceContents frontend = frontendResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the frontend construction resource should resolve to one plain-text article").Subject;
 		frontend.Text.Should().Contain("Group envelope (filterType 6)",
@@ -176,6 +178,10 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published backend guide should expose verified native Exists construction");
 		backend.Text.Should().Contain("out EntitySchemaQuery activitySubQuery",
 			because: "the published backend guide should place child aggregate predicates in the returned subquery");
+		backend.Text.Should().Contain("new SegmentFilterOptions",
+			because: "the published backend guide should expose native saved-Segment construction");
+		backend.Text.Should().Contain("RemovedOn IsNull",
+			because: "the published backend guide should preserve default active-membership semantics");
 		TextResourceContents parsing = parsingResult.Contents.Single().Should().BeOfType<TextResourceContents>(
 			because: "the runtime parsing resource should resolve to one plain-text article").Subject;
 		parsing.Text.Should().Contain("Parse a tree, not a flat list",
@@ -220,6 +226,14 @@ public sealed class McpGuidanceResourceE2ETests : McpContractFixtureBase {
 			because: "the published parser should validate the proven aggregation operand and evaluation mode");
 		parsing.Text.Should().Contain("materialize an unbounded child source",
 			because: "the published parser should reject unbounded child preloading as an N+1 workaround");
+		parsing.Text.Should().Contain("ReadSegmentMembership",
+			because: "the published parser should validate the expanded Segment runtime tree");
+		parsing.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
+			because: "the published parser should require request-scoped Segment authorization");
+		parsing.Text.Should().Contain("Never reuse a cross-caller",
+			because: "the published parser should scope authorization caching to one request identity");
+		parsing.Text.Should().Contain("SQL table identifiers cannot be parameters",
+			because: "the published parser should fail safe on dynamic membership-table identifiers");
 		parsing.Text.Should().Contain("never reached PostgreSQL",
 			because: "the published resource must not misattribute virtual-provider case behavior to the database");
 	}

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1605,6 +1605,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the router status should include promoted temporal coverage");
 		router.Text.Should().Contain("Exists/NotExists/aggregate subqueries",
 			because: "the router status should include promoted backward-subquery coverage");
+		router.Text.Should().Contain("saved Segment membership",
+			because: "the router status should include promoted Segment coverage");
 		router.Text.Should().NotContain("### Compare (filterType 1)",
 			because: "the router should not duplicate detailed frontend filter rules");
 
@@ -1726,8 +1728,18 @@ public sealed class McpGuidanceResourceTests {
 			because: "the guide must avoid an existence-boundary optimization when demonstrating aggregates");
 		article.Text.Should().Contain("extra enabled AND collection",
 			because: "the guide should preserve the proven DataService child-filter envelope difference");
-		article.Text.Should().Contain("Pending lab",
-			because: "unverified filter families should be explicit instead of guessed");
+		article.Text.Should().Contain("new SegmentFilterOptions",
+			because: "the backend guide should expose the verified native saved-Segment API");
+		article.Text.Should().Contain("FilterComparisonType.NotExists",
+			because: "the Segment recipe should cover independently verified non-membership");
+		article.Text.Should().Contain("RecordId == root.Id",
+			because: "the guide should preserve the generated membership correlation");
+		article.Text.Should().Contain("RemovedOn IsNull",
+			because: "default Segment membership must exclude soft-removed members");
+		article.Text.Should().Contain("UseSegmentFiltering",
+			because: "the Segment recipe must expose its feature gate");
+		article.Text.Should().Contain("validated only default current-membership options",
+			because: "unverified Segment option variants must remain outside the promoted contract");
 	}
 
 	[Test]
@@ -1841,6 +1853,29 @@ public sealed class McpGuidanceResourceTests {
 			because: "virtual providers must avoid one child query per root record");
 		article.Text.Should().Contain("`RootSchema.IsVirtual` in `finally`",
 			because: "the diagnostic SQL oracle must not leave the shared schema non-virtual");
+		article.Text.Should().Contain("ReadSegmentMembership",
+			because: "the parser should expose the verified expanded Segment tree contract");
+		article.Text.Should().Contain("original Segment Guid cannot be recovered",
+			because: "the parser must not promise authoring metadata that is absent at runtime");
+		article.Text.Should().Contain("child?.RootSchema?.Name",
+			because: "malformed subqueries must fail closed before the parser dereferences their root schema");
+		article.Text.Should().Contain("selectedColumn?.ValueExpression?.ExpressionType",
+			because: "the selected Segment column must be validated as a schema-column expression");
+		article.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
+			because: "membership access must authorize the caller, root schema, and resolved saved segment");
+		article.Text.IndexOf("ValidateCurrentMembershipFilters", System.StringComparison.Ordinal).Should().BeLessThan(
+			article.Text.IndexOf("RequireAuthorizedCurrentSegmentOncePerQuery", System.StringComparison.Ordinal),
+			because: "cheap complete shape validation must precede metadata and permission work");
+		article.Text.Should().Contain("Never reuse a cross-caller",
+			because: "Segment authorization caching must be scoped to the current query and identity");
+		article.Text.Should().Contain("is not authorization by itself",
+			because: "a table-name allowlist must not bypass request-scoped Segment authorization");
+		article.Text.Should().Contain("SQL table identifiers cannot be parameters",
+			because: "the dynamic membership-table name is remotely reachable parser input");
+		article.Text.Should().Contain("RecordId Equal root Id",
+			because: "the parser should validate the complete Segment correlation");
+		article.Text.Should().Contain("additional removal/date predicates",
+			because: "unverified Segment option expansions must fail closed");
 		string[] expectedScalarOperators = [
 			"Equal", "NotEqual", "Less", "LessOrEqual", "Greater", "GreaterOrEqual",
 			"StartWith", "NotStartWith", "Contain", "NotContain", "EndWith", "NotEndWith"

--- a/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceResourceTests.cs
@@ -1863,6 +1863,8 @@ public sealed class McpGuidanceResourceTests {
 			because: "the selected Segment column must be validated as a schema-column expression");
 		article.Text.Should().Contain("RequireAuthorizedCurrentSegmentOncePerQuery",
 			because: "membership access must authorize the caller, root schema, and resolved saved segment");
+		article.Text.Should().Contain("ValidateCurrentMembershipFilters",
+			because: "complete in-memory shape validation must remain part of the published security contract");
 		article.Text.IndexOf("ValidateCurrentMembershipFilters", System.StringComparison.Ordinal).Should().BeLessThan(
 			article.Text.IndexOf("RequireAuthorizedCurrentSegmentOncePerQuery", System.StringComparison.Ordinal),
 			because: "cheap complete shape validation must precede metadata and permission work");

--- a/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFilterParsingGuidanceResource.cs
@@ -432,6 +432,69 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       physical-SQL trick is an oracle only—always restore
 		       `RootSchema.IsVirtual` in `finally` and never execute that SQL for a virtual schema.
 
+		       ## Parse expanded Segment membership
+		       `filterType: 7` and `segmentFilterOptions.segmentId` are DataService authoring fields; they do not survive
+		       into `esq.Filters`. Native and DataService Segment requests reached the executor as the same ordinary
+		       Exists/NotExists subquery tree. Validate that expanded tree fail closed:
+		       ```csharp
+		       private static FilterComparisonType ReadSegmentMembership(
+		           EntitySchemaQueryFilter filter,
+		           ISegmentMembershipAuthorization segmentAuthorization,
+		           UserConnection userConnection,
+		           Guid rootSchemaUId) {
+		           if ((filter.ComparisonType != FilterComparisonType.Exists &&
+		                filter.ComparisonType != FilterComparisonType.NotExists) ||
+		               filter.LeftExpression != null ||
+		               filter.RightExpressions.Count != 1 ||
+		               filter.RightExpressions.Single().ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SubQuery) {
+		               throw new NotSupportedException("Unsupported Segment filter shape.");
+		           }
+
+		           EntitySchemaQuery child = filter.RightExpressions.Single().SubQuery;
+		           string tableName = child?.RootSchema?.Name;
+		           EntitySchemaQueryColumn selectedColumn = child?.Columns.Count == 1
+		               ? child.Columns.Single()
+		               : null;
+		           if (string.IsNullOrEmpty(tableName) ||
+		               selectedColumn?.ValueExpression?.ExpressionType !=
+		                   EntitySchemaQueryExpressionType.SchemaColumn ||
+		               selectedColumn.ValueExpression.Path != "RecordId") {
+		               throw new NotSupportedException("Unknown Segment membership table or selected column.");
+		           }
+		           // Require exactly two enabled leaves:
+		           // RecordId Equal root Id (SchemaColumn), and RemovedOn IsNull with no right values.
+		           ValidateCurrentMembershipFilters(child.Filters);
+		           segmentAuthorization.RequireAuthorizedCurrentSegmentOncePerQuery(
+		               userConnection, rootSchemaUId, tableName);
+		           return filter.ComparisonType;
+		       }
+		       ```
+
+		       Validate the complete correlation, not only terminal column names: the left path is `RecordId`; the one
+		       right expression is a SchemaColumn whose complete path is root `Id`. The active-membership leaf is
+		       `RemovedOn` with comparison `IsNull` and zero right expressions. The verified child group contained
+		       exactly those two enabled leaves and selected exactly one `RecordId` column. Reject extra groups,
+		       predicates, selected columns, comparison types, disabled nodes, or an unknown child table.
+
+		       The original Segment Guid cannot be recovered from the runtime tree. Before every membership access,
+		       validate the complete in-memory tree before performing metadata or permission work. Then unconditionally
+		       resolve the observed table name against permission-checked `SysDataSegment` metadata for the request's
+		       caller and root-schema UId. Authorize each distinct table once per query/request. Scope that positive cache
+		       to the caller, root-schema UId, table name, and current request lifetime. Never reuse a cross-caller, global,
+		       or stale authorization result. Require exactly one authorized, enabled segment whose table name
+		       matches with ordinal semantics; derive the usable identifier from that record. A configured allowlist may
+		       narrow this result but is not authorization by itself. Never accept every `SysDataInSegment*`-looking name.
+		       SQL table identifiers cannot be parameters: do not concatenate the observed name. Use the Creatio query
+		       builder/provider's quoted identifier obtained from the authorized metadata record, and parameterize every
+		       value. Reuse the subquery execution limits above; do not query the membership table once per virtual record.
+
+		       This shape requires the `UseSegmentFiltering` feature. The live proof used Creatio 10.1.298.0; locally
+		       inspected history's earliest containing build tag is `builds-linux/10.0.0.655`. Treat an absent API,
+		       disabled feature, target-schema mismatch, or rejected segment status as unsupported platform/setup—not as
+		       an empty result. Only default current-membership options are verified; reject expanded variants with
+		       additional removal/date predicates until their exact shapes and semantics are tested.
+
 		       Then require the CLR type appropriate to the schema column (`System.Int32` for the verified
 		       Integer example and `System.String` for MediumText) and dispatch explicitly on
 		       `ComparisonType`. Do not coerce an unexpected value or silently treat an unsupported
@@ -483,10 +546,10 @@ public sealed class EsqFilterParsingGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaf/group behavior, group `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and temporal literals,
-		       trim-to-date, relative-period boundaries, Year, HourMinute functions, and Exists/NotExists/Count subqueries
-		       over a mixed forward/backward path. The frontend guide supplies the remaining validation backlog: Segment.
-		       Add parsing rules here only after native C# and
-		       DataService produce an asserted runtime shape and the lab proves result behavior.
+		       trim-to-date, relative-period boundaries, Year, HourMinute functions, Exists/NotExists/Count subqueries over
+		       a mixed forward/backward path, and saved Segment Exists/NotExists membership with default options. Add new
+		       parsing rules only after native C# and DataService produce an asserted runtime shape and the lab proves
+		       result behavior.
 		       """
 	};
 

--- a/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersBackendGuidanceResource.cs
@@ -333,6 +333,37 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       semantics matched. Preserve the complete source shape for diagnostics; normalize only this explicit
 		       transport envelope when a semantic parity test needs to compare the two authoring paths.
 
+		       ## Create saved Segment membership
+		       Segment filtering is feature-gated. Require `UseSegmentFiltering` to be enabled and use a saved
+		       `SysDataSegment` that targets the query's root schema:
+		       ```csharp
+		       var options = new SegmentFilterOptions {
+		           SegmentId = savedSegmentId
+		       };
+		       esq.Filters.Add(esq.CreateSegmentFilter(
+		           options,
+		           userConnection,
+		           FilterComparisonType.Exists));
+		       ```
+
+		       `Exists` means currently IN the segment. Use the same call with `FilterComparisonType.NotExists` for
+		       currently NOT IN it. Do not create an ordinary compare against the segment Guid. Creatio resolves the
+		       `SysDataSegment`, validates that it targets the ESQ root, applies enabled status gates, and expands the
+		       saved segment into a correlated membership-table subquery.
+
+		       With default options, the verified runtime leaf had a null left expression and one right SubQuery. The
+		       child root was the saved segment's physical table, selected `RecordId`, correlated
+		       `RecordId == root.Id`, and added `RemovedOn IsNull`; NotExists retained the same child tree. Native C#
+		       and DataService `filterType: 7` produced exactly the same recursive shape and SQL semantics. The lab
+		       separately proved that a current member matched Exists while a removed member and a never-added record
+		       matched NotExists.
+
+		       The lab validated only default current-membership options. Do not publish shapes for
+		       `IncludeRemovedMembers` or date-bound options until those variants receive their own parity/result tests.
+		       The earliest locally inspected build tag containing the current API is
+		       `builds-linux/10.0.0.655`; the live proof used Creatio 10.1.298.0. Check the target version and feature
+		       instead of assuming Segment filtering exists on older environments.
+
 		       ### Exact ATF shape parity for three-term AND
 		       ATF.Repository 2.0.3.5 translated source `A && B && C` to one flat root AND ordered
 		       `C, A, B`. If a test requires byte-for-byte/shape-for-shape parity, insert the native
@@ -464,9 +495,8 @@ public sealed class EsqFiltersBackendGuidanceResource {
 		       Verified now: group envelope/nesting, disabled leaves/groups, collection `IsNot`, and all
 		       scalar Compare operators using representative Integer and MediumText values, plus text
 		       `IsNull`/`IsNotNull`, Integer In cardinality boundaries, typed/lookup parameters, and Date/DateTime/Time
-		       literals, trim-to-date, relative-period macros, Year, HourMinute, and Exists/NotExists/Count subqueries
-		       over a mixed forward/backward path. Pending lab validation before publishing construction recipes:
-		       Segment filters. Use the
+		       literals, trim-to-date, relative-period macros, Year, HourMinute, Exists/NotExists/Count subqueries over a
+		       mixed forward/backward path, and saved Segment Exists/NotExists membership with default options. Use the
 		       frontend guide as a discovery checklist, but do not translate its JSON fields into guessed
 		       backend APIs.
 		       """

--- a/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/EsqFiltersGuidanceResource.cs
@@ -53,9 +53,9 @@ public sealed class EsqFiltersGuidanceResource {
 		       envelope, nesting, disabled nodes, group negation, primitive Integer/MediumText Compare,
 		       MediumText null checks, Integer membership cardinalities, inclusive Between ranges, typed
 		       Boolean/Guid comparisons, lookup equality/membership, temporal literals/macros/date parts,
-		       and Exists/NotExists/aggregate subqueries over backward paths.
-		       Other filter families remain explicitly marked pending until the same native-vs-DataService
-		       runtime-shape test proves and promotes them.
+		       Exists/NotExists/aggregate subqueries over backward paths, and saved Segment membership.
+		       New filter families remain pending until the same native-vs-DataService runtime-shape test
+		       proves and promotes them.
 		       """
 	};
 


### PR DESCRIPTION
## Summary
- document native backend construction for saved Segment membership and non-membership filters
- document the executor-visible Exists/NotExists expansion and fail-closed parsing contract
- require request-scoped, permission-checked Segment authorization before accessing the resolved membership table
- update the ESQ filter router plus unit and MCP end-to-end contract coverage

## Lab validation
- Creatio 10.1.298.0 (.NET 8 / PostgreSQL), environment `std-skill-n8`
- package tests: 95/95
- live Segment integration: 4/4
- native C# and DataService filter shapes matched for IN and NOT IN

## Local validation
- `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~McpGuidanceResourceTests" --no-build --no-restore` — 43/43 on net8.0 and net10.0
- guidance MCP E2E — 45/45 on net8.0 and net10.0 earlier in this change
- comprehensive pre-PR three-lens review completed; authorization, null-safety, validation-order, and cache-scope findings resolved

## Maintenance review
- MCP resources and MCP unit/E2E contracts updated
- docs reviewed, no CLI command documentation update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed

TeamCity is non-blocking for this PR; merge gate is Unit, Integration, and Sonar plus resolved review threads.
