### PR TITLE
Fix read-only Codex toolkit cache cleanup

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -6823,3 +6823,17 @@ Decision: Move the existing direct System.Security.Cryptography.Xml pin outside 
 Discovery: The net10 target had only the vulnerable transitive cryptography package, while a fresh audited restore also exposed a pre-existing NU1605 downgrade from Microsoft.Data.SqlClient 7.0.2. On net10, the cryptography package is supplied by Microsoft.AspNetCore.App, so the installed shared runtime must also be current.
 Files: Directory.Packages.props, clio/clio.csproj, clio/docs/commands/mcp-http.md, clio/help/en/mcp-http.txt
 Impact: Audited restores succeed for both clio target frameworks; full unit tests, Ring tests, and Windows x64 NativeAOT publish pass.
+
+## 2026-07-23 12:16 – Handle read-only Codex toolkit cache files (#962)
+Context: `clio update-toolkit` failed before invoking Codex because legacy cache cleanup recursively deleted a read-only Git pack index.
+Decision: Keep the repair scoped to `CodexAgent` and route only its installer-owned legacy directories through the existing read-only-safe deletion path.
+Discovery: `System.IO.Abstractions.TestingHelpers` reproduces the Windows `UnauthorizedAccessException`, so a unit test can pin both ordinary directory cleanup and nested read-only Git pack cleanup without physical filesystem I/O.
+Files: clio/Common/Skills/Agents/CodexAgent.cs, clio.tests/Common/Skills/SkillAgentTests.cs
+Impact: Codex toolkit install/update can refresh caches containing read-only Git objects without changing cleanup behavior for other agents.
+
+## 2026-07-23 12:31 – Bound Codex cache cleanup at reparse points (#962)
+Context: Comprehensive pre-PR review found that the first repair reused a helper that follows directory links and can spin indefinitely after deletion.
+Decision: Clear read-only attributes only within ordinary directories, treat file and directory reparse points as leaves, then use recursive directory deletion, which unlinks reparse points without traversing them.
+Discovery: The legacy delete primitive already preserves the link boundary; only its read-only preparation was missing. A substitute-backed unit test pins that no file or directory enumeration occurs beneath a reparse-point child.
+Files: clio/Common/Skills/Agents/CodexAgent.cs, clio.tests/Common/Skills/SkillAgentTests.cs
+Impact: The update handles read-only Git objects without following cache links or inheriting the existing unbounded post-delete spin.

--- a/clio.tests/Common/Skills/SkillAgentTests.cs
+++ b/clio.tests/Common/Skills/SkillAgentTests.cs
@@ -174,6 +174,183 @@ public sealed class SkillAgentTests {
 		_toml.Received(1).MergeClioMcpServer(Arg.Any<string>());
 	}
 
+	[Test]
+	[Description("Codex update removes installer-owned directories containing ordinary and nested read-only files.")]
+	public void CodexUpdate_ShouldRemoveLegacyDirectories_WhenFilesAreOrdinaryOrReadOnly() {
+		// Arrange
+		string codexHome = _home.GetAgentHome("codex");
+		string legacyMarketplace = Path.Combine(codexHome, "plugins", "marketplaces",
+			ToolkitDistribution.MarketplaceName);
+		string legacyCache = Path.Combine(codexHome, "plugins", "cache", ToolkitDistribution.MarketplaceName);
+		string readOnlyPack = Path.Combine(legacyCache, ToolkitDistribution.PluginName, "1.4.0", ".git",
+			"objects", "pack", "pack-test.idx");
+		_mockFileSystem.AddFile(Path.Combine(legacyMarketplace, "marketplace.json"), new MockFileData("{}"));
+		_mockFileSystem.AddFile(readOnlyPack, new MockFileData("git index") {
+			Attributes = FileAttributes.ReadOnly
+		});
+		CodexAgent agent = new(_fileSystem, _home, _cli, _toml, _json);
+
+		// Act
+		AgentOutcome outcome = agent.Update(new AgentOperationContext(SkillOperationKind.Update, null));
+
+		// Assert
+		outcome.Status.Should().Be(AgentOutcomeStatus.Succeeded,
+			because: "read-only files in a legacy Codex cache should not prevent the toolkit update");
+		_mockFileSystem.Directory.Exists(legacyMarketplace).Should().BeFalse(
+			because: "an ordinary installer-owned marketplace directory should still be removed");
+		_mockFileSystem.Directory.Exists(legacyCache).Should().BeFalse(
+			because: "the installer-owned legacy cache should be removed before reinstalling the plugin");
+	}
+
+	[Test]
+	[Description("Codex update treats a directory reparse point as a leaf while preparing a legacy cache for deletion.")]
+	public void CodexUpdate_ShouldNotTraverseDirectory_WhenDirectoryIsReparsePoint() {
+		// Arrange
+		Clio.Common.IFileSystem fileSystem = Substitute.For<Clio.Common.IFileSystem>();
+		fileSystem.Combine(Arg.Any<string[]>())
+			.Returns(call => Path.Combine(call.Arg<string[]>()));
+		string codexHome = _home.GetAgentHome("codex");
+		string legacyCache = Path.Combine(codexHome, "plugins", "cache", ToolkitDistribution.MarketplaceName);
+		string linkedDirectory = Path.Combine(legacyCache, "linked-directory");
+		fileSystem.ExistsDirectory(Arg.Any<string>())
+			.Returns(call => string.Equals(call.Arg<string>(), legacyCache, StringComparison.Ordinal));
+		System.IO.Abstractions.IDirectoryInfo cacheInfo =
+			Substitute.For<System.IO.Abstractions.IDirectoryInfo>();
+		cacheInfo.Attributes.Returns(FileAttributes.Directory);
+		System.IO.Abstractions.IDirectoryInfo linkInfo =
+			Substitute.For<System.IO.Abstractions.IDirectoryInfo>();
+		linkInfo.Attributes.Returns(FileAttributes.Directory | FileAttributes.ReparsePoint);
+		fileSystem.GetDirectoryInfo(legacyCache).Returns(cacheInfo);
+		fileSystem.GetDirectoryInfo(linkedDirectory).Returns(linkInfo);
+		fileSystem.GetFilesInfos(legacyCache, "*", SearchOption.TopDirectoryOnly)
+			.Returns([]);
+		fileSystem.GetDirectories(legacyCache).Returns([linkedDirectory]);
+		CodexAgent agent = new(fileSystem, _home, _cli, _toml, _json);
+
+		// Act
+		AgentOutcome outcome = agent.Update(new AgentOperationContext(SkillOperationKind.Update, null));
+
+		// Assert
+		outcome.Status.Should().Be(AgentOutcomeStatus.Succeeded,
+			because: "a linked directory should be unlinked by recursive deletion without traversing its target");
+		fileSystem.DidNotReceive().GetFilesInfos(linkedDirectory, "*", SearchOption.TopDirectoryOnly);
+		fileSystem.DidNotReceive().GetDirectories(linkedDirectory);
+		fileSystem.Received(1).DeleteDirectoryIfExists(legacyCache);
+	}
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("Codex update tolerates a root or child legacy directory disappearing during read-only preparation.")]
+	public void CodexUpdate_ShouldContinueCleanup_WhenDirectoryDisappearsDuringReadOnlyPreparation(
+		bool rootDisappears) {
+		// Arrange
+		Clio.Common.IFileSystem fileSystem = Substitute.For<Clio.Common.IFileSystem>();
+		fileSystem.Combine(Arg.Any<string[]>())
+			.Returns(call => Path.Combine(call.Arg<string[]>()));
+		string codexHome = _home.GetAgentHome("codex");
+		string legacyCache = Path.Combine(codexHome, "plugins", "cache", ToolkitDistribution.MarketplaceName);
+		string childDirectory = Path.Combine(legacyCache, "concurrently-removed");
+		fileSystem.ExistsDirectory(Arg.Any<string>())
+			.Returns(call => string.Equals(call.Arg<string>(), legacyCache, StringComparison.Ordinal));
+		System.IO.Abstractions.IDirectoryInfo cacheInfo =
+			Substitute.For<System.IO.Abstractions.IDirectoryInfo>();
+		cacheInfo.Attributes.Returns(FileAttributes.Directory);
+		fileSystem.GetFilesInfos(legacyCache, "*", SearchOption.TopDirectoryOnly)
+			.Returns([]);
+		if (rootDisappears) {
+			fileSystem.GetDirectoryInfo(legacyCache)
+				.Returns(_ => throw new DirectoryNotFoundException(legacyCache));
+		}
+		else {
+			fileSystem.GetDirectoryInfo(legacyCache).Returns(cacheInfo);
+			fileSystem.GetDirectories(legacyCache).Returns([childDirectory]);
+			fileSystem.GetDirectoryInfo(childDirectory)
+				.Returns(_ => throw new DirectoryNotFoundException(childDirectory));
+		}
+		CodexAgent agent = new(fileSystem, _home, _cli, _toml, _json);
+
+		// Act
+		AgentOutcome outcome = agent.Update(new AgentOperationContext(SkillOperationKind.Update, null));
+
+		// Assert
+		outcome.Status.Should().Be(AgentOutcomeStatus.Succeeded,
+			because: "a legacy directory already removed by another installer process is a successful cleanup");
+		fileSystem.Received(1).DeleteDirectoryIfExists(legacyCache);
+	}
+
+	[Test]
+	[Description("Codex update continues preparing sibling files when one legacy cache file disappears.")]
+	public void CodexUpdate_ShouldContinuePreparingSiblings_WhenFileDisappears() {
+		// Arrange
+		Clio.Common.IFileSystem fileSystem = Substitute.For<Clio.Common.IFileSystem>();
+		fileSystem.Combine(Arg.Any<string[]>())
+			.Returns(call => Path.Combine(call.Arg<string[]>()));
+		string codexHome = _home.GetAgentHome("codex");
+		string legacyCache = Path.Combine(codexHome, "plugins", "cache", ToolkitDistribution.MarketplaceName);
+		string readOnlyFilePath = Path.Combine(legacyCache, "remaining-read-only.idx");
+		fileSystem.ExistsDirectory(Arg.Any<string>())
+			.Returns(call => string.Equals(call.Arg<string>(), legacyCache, StringComparison.Ordinal));
+		System.IO.Abstractions.IDirectoryInfo cacheInfo =
+			Substitute.For<System.IO.Abstractions.IDirectoryInfo>();
+		cacheInfo.Attributes.Returns(FileAttributes.Directory);
+		System.IO.Abstractions.IFileInfo disappearedFile =
+			Substitute.For<System.IO.Abstractions.IFileInfo>();
+		disappearedFile.Attributes.Returns(_ => throw new FileNotFoundException());
+		System.IO.Abstractions.IFileInfo readOnlyFile =
+			Substitute.For<System.IO.Abstractions.IFileInfo>();
+		readOnlyFile.Attributes.Returns(FileAttributes.ReadOnly);
+		readOnlyFile.FullName.Returns(readOnlyFilePath);
+		fileSystem.GetDirectoryInfo(legacyCache).Returns(cacheInfo);
+		fileSystem.GetFilesInfos(legacyCache, "*", SearchOption.TopDirectoryOnly)
+			.Returns([disappearedFile, readOnlyFile]);
+		fileSystem.GetDirectories(legacyCache).Returns([]);
+		CodexAgent agent = new(fileSystem, _home, _cli, _toml, _json);
+
+		// Act
+		AgentOutcome outcome = agent.Update(new AgentOperationContext(SkillOperationKind.Update, null));
+
+		// Assert
+		outcome.Status.Should().Be(AgentOutcomeStatus.Succeeded,
+			because: "one concurrently removed file should not prevent cleanup of its remaining siblings");
+		fileSystem.Received(1).ResetFileReadOnlyAttribute(readOnlyFilePath);
+		fileSystem.Received(1).DeleteDirectoryIfExists(legacyCache);
+	}
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("Codex update tolerates its legacy cache disappearing immediately before recursive deletion.")]
+	public void CodexUpdate_ShouldSucceed_WhenLegacyCacheDisappearsBeforeDelete(bool directoryDisappears) {
+		// Arrange
+		Clio.Common.IFileSystem fileSystem = Substitute.For<Clio.Common.IFileSystem>();
+		fileSystem.Combine(Arg.Any<string[]>())
+			.Returns(call => Path.Combine(call.Arg<string[]>()));
+		string codexHome = _home.GetAgentHome("codex");
+		string legacyCache = Path.Combine(codexHome, "plugins", "cache", ToolkitDistribution.MarketplaceName);
+		fileSystem.ExistsDirectory(Arg.Any<string>())
+			.Returns(call => string.Equals(call.Arg<string>(), legacyCache, StringComparison.Ordinal));
+		System.IO.Abstractions.IDirectoryInfo cacheInfo =
+			Substitute.For<System.IO.Abstractions.IDirectoryInfo>();
+		cacheInfo.Attributes.Returns(FileAttributes.Directory);
+		fileSystem.GetDirectoryInfo(legacyCache).Returns(cacheInfo);
+		fileSystem.GetFilesInfos(legacyCache, "*", SearchOption.TopDirectoryOnly)
+			.Returns([]);
+		fileSystem.GetDirectories(legacyCache).Returns([]);
+		Exception disappearance = directoryDisappears
+			? new DirectoryNotFoundException(legacyCache)
+			: new FileNotFoundException(null, legacyCache);
+		fileSystem.When(fs => fs.DeleteDirectoryIfExists(legacyCache))
+			.Do(_ => throw disappearance);
+		CodexAgent agent = new(fileSystem, _home, _cli, _toml, _json);
+
+		// Act
+		AgentOutcome outcome = agent.Update(new AgentOperationContext(SkillOperationKind.Update, null));
+
+		// Assert
+		outcome.Status.Should().Be(AgentOutcomeStatus.Succeeded,
+			because: "a legacy cache already removed before deletion is a successful cleanup");
+		_cli.Received().Run("codex", Arg.Is<string[]>(args => args.Contains("add")));
+	}
+
 	// ---- CursorAgent ----
 
 	[Test]

--- a/clio/Common/Skills/Agents/CodexAgent.cs
+++ b/clio/Common/Skills/Agents/CodexAgent.cs
@@ -1,3 +1,5 @@
+using System.IO;
+using System.IO.Abstractions;
 using Clio.Common.Skills;
 
 namespace Clio.Common.Skills.Agents;
@@ -69,10 +71,10 @@ public sealed class CodexAgent(
 	/// </summary>
 	private void CleanLegacyState() {
 		string marketplace = ToolkitDistribution.MarketplaceName;
-		FileSystem.DeleteDirectoryIfExists(FileSystem.Combine(AgentHome, "plugins", "marketplaces", marketplace));
-		FileSystem.DeleteDirectoryIfExists(FileSystem.Combine(AgentHome, "plugins", "cache", marketplace));
-		FileSystem.DeleteDirectoryIfExists(FileSystem.Combine(HomeProvider.GetAgentsDir(), "plugins", ToolkitDistribution.PluginName));
-		FileSystem.DeleteDirectoryIfExists(FileSystem.Combine(AgentHome, "skills", ToolkitDistribution.SkillName));
+		DeleteLegacyDirectoryIfExists(FileSystem.Combine(AgentHome, "plugins", "marketplaces", marketplace));
+		DeleteLegacyDirectoryIfExists(FileSystem.Combine(AgentHome, "plugins", "cache", marketplace));
+		DeleteLegacyDirectoryIfExists(FileSystem.Combine(HomeProvider.GetAgentsDir(), "plugins", ToolkitDistribution.PluginName));
+		DeleteLegacyDirectoryIfExists(FileSystem.Combine(AgentHome, "skills", ToolkitDistribution.SkillName));
 
 		_jsonConfigEditor.RemovePersonalMarketplacePluginEntry(
 			FileSystem.Combine(HomeProvider.GetAgentsDir(), "plugins", "marketplace.json"),
@@ -84,6 +86,58 @@ public sealed class CodexAgent(
 		_tomlConfigEditor.RemovePluginSection(configPath, ToolkitDistribution.PluginName, marketplace);
 		_tomlConfigEditor.RemoveSkillConfigOverride(configPath,
 			$"{ToolkitDistribution.PluginName}:{ToolkitDistribution.SkillName}");
+	}
+
+	private void DeleteLegacyDirectoryIfExists(string path) {
+		try {
+			if (!FileSystem.ExistsDirectory(path)) {
+				return;
+			}
+
+			ClearReadOnlyAttributes(path);
+			FileSystem.DeleteDirectoryIfExists(path);
+		}
+		catch (DirectoryNotFoundException) {
+			// Another installer process already removed this legacy path.
+		}
+		catch (FileNotFoundException) {
+			// Another installer process already removed an entry from this legacy path.
+		}
+	}
+
+	private void ClearReadOnlyAttributes(string path) {
+		try {
+			IDirectoryInfo directory = FileSystem.GetDirectoryInfo(path);
+			if ((directory.Attributes & FileAttributes.ReparsePoint) != 0) {
+				return;
+			}
+
+			foreach (IFileInfo file in FileSystem.GetFilesInfos(path, "*", SearchOption.TopDirectoryOnly)) {
+				try {
+					if ((file.Attributes & (FileAttributes.ReadOnly | FileAttributes.ReparsePoint))
+						== FileAttributes.ReadOnly) {
+						FileSystem.ResetFileReadOnlyAttribute(file.FullName);
+					}
+				}
+				catch (FileNotFoundException) {
+					// Another installer process removed this file; continue with its siblings.
+				}
+			}
+
+			foreach (string childDirectory in FileSystem.GetDirectories(path)) {
+				ClearReadOnlyAttributes(childDirectory);
+			}
+
+			if ((directory.Attributes & FileAttributes.ReadOnly) != 0) {
+				directory.Attributes &= ~FileAttributes.ReadOnly;
+			}
+		}
+		catch (DirectoryNotFoundException) {
+			// A concurrently running installer already removed this directory.
+		}
+		catch (FileNotFoundException) {
+			// A concurrently running installer already removed an entry from this directory.
+		}
 	}
 
 	private string ConfigPath() => FileSystem.Combine(AgentHome, "config.toml");


### PR DESCRIPTION
## Summary
- clear read-only attributes before deleting Codex installer-owned legacy toolkit directories
- preserve the deletion boundary by treating file and directory reparse points as leaves
- tolerate only concurrent already-removed file/directory races
- add regression coverage for ordinary files, nested read-only Git pack files, reparse points, and cleanup races

## Validation
- `dotnet test clio.tests/clio.tests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~SkillAgentTests.Codex"` (8 passed)
- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit"` (passed)
- comprehensive five-perspective agentic review: no remaining findings

## Contract review
- docs reviewed, no update required
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed

Fixes #962