### PR TITLE
feat(mcp): workplaces guidance for navigation workplace management (ENG-88474)

### DIFF
--- a/clio/Command/McpServer/Resources/DataBindingsGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/DataBindingsGuidanceResource.cs
@@ -37,7 +37,7 @@ public sealed class DataBindingsGuidanceResource {
 			         - `sync-schemas` for inline lookup seed rows
 			         - `create-data-binding-db`, `upsert-data-binding-row-db`, and `remove-data-binding-row-db` for remote DB-first binding work
 			         - `create-data-binding`, `add-data-binding-row`, and `remove-data-binding-row` for local artifact workflows
-			       - When the task depends on current binding or schema context, inspect that context before binding mutations.
+			       - Before creating or removing a binding, inspect what the package already ships: the binding tools have no list mode, so read `SysPackageSchemaData` with `execute-esq` (filter `SysPackage.Name`; columns `Name`, `SysSchema.Name`). `binding-name` defaults to the schema name, so pass it explicitly to target an existing binding (often a suffixed folder) instead of creating a parallel one.
 
 			       Preferred workflows
 			       - Canonical lookup seeding flow: `get-tool-contract` -> `sync-schemas` -> refresh/read-back.

--- a/clio/Command/McpServer/Resources/GuidanceCatalog.cs
+++ b/clio/Command/McpServer/Resources/GuidanceCatalog.cs
@@ -155,6 +155,10 @@ internal static class GuidanceCatalog {
 				"record-rights",
 				"Canonical MCP guidance for record-level access rights: read/change who can access a record or dashboard with get-record-rights / set-record-rights, addressing a dashboard as SysSchemaAdminUnit + schema UId, and the record-level (SysSchemaAdminUnitRight) vs operation-level (SysSchemaOperationRight) distinction.",
 				RecordRightsGuidanceResource.Guide),
+			["workplaces"] = Create(
+				"workplaces",
+				"Canonical MCP guidance for managing Creatio navigation workplaces: create/update/delete a SysWorkplace, grant/remove role access (SysAdminUnitInWorkplace), and add/remove/move sections (SysModuleInWorkplace) via the odata tools, shipping every change as a package data binding.",
+				WorkplacesGuidanceResource.Guide),
 			["related-list"] = Create(
 				"related-list",
 				"Canonical MCP guidance for adding a Freedom UI related/child list and filtering it by the current page record (master-detail \"filter by page data\"): the declarative, dependencies-based scoping — no handler. Fetch the 'Expanded list' composite structure via get-component-info.",

--- a/clio/Command/McpServer/Resources/HomePageGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/HomePageGuidanceResource.cs
@@ -63,11 +63,10 @@ public sealed class HomePageGuidanceResource {
 		          - Reconcile with the requested audience: if the request scopes the page to a role (e.g. "only
 		            Sales Manager"), the target should be a workplace whose audience matches (see Access / roles
 		            below). If the app's own workplace doesn't match that role, surface it and confirm.
-		          - The workplace must ALREADY exist — if a named one is not found, stop and ask rather than
-		            creating it: a workplace spans several tables (`SysWorkplace` + `SysModuleInWorkplace` sections +
-		            `SysAdminUnitInWorkplace` access), clio has no tool to create one, and it is set up in the
-		            Creatio UI. This is the app workplace `SysWorkplace` — NOT clio's `create-workspace` (a local
-		            project folder) and NOT the dev `SysWorkspace` table.
+		          - The workplace must ALREADY exist for this flow — if a named one is not found, stop and ask.
+		            To create or otherwise manage a workplace and its sections, see `workplaces` (which also
+		            disambiguates the navigation `SysWorkplace` from clio's `create-workspace` and the dev
+		            `SysWorkspace`). This is the app workplace `SysWorkplace`.
 		       6. Point each target workplace at the page and persist it as a package data binding so it ships.
 		          You are UPDATING an existing workplace row (not creating one) and then shipping it:
 		          a. `odata-update` `SysWorkplace` with `id` = the workplace `Id`,
@@ -91,11 +90,8 @@ public sealed class HomePageGuidanceResource {
 		       A home page is NOT role-secured on its own — a user sees it because they opened a workplace whose
 		       `HomePageUId` points at it. Its audience therefore equals the audience of the workplace(s) you bind
 		       it to, controlled by `SysAdminUnitInWorkplace` (which roles/users see the workplace). To scope a home
-		       page to specific roles, bind it to a workplace whose audience is those roles. To ADD a role to an
-		       existing workplace, insert a `SysAdminUnitInWorkplace` row via `create-data-binding-db` (schema
-		       `SysAdminUnitInWorkplace`, `rows` a new `{Id, SysWorkplaceId, SysAdminUnitId}`; resolve the role
-		       `Id` from `SysAdminUnit` by name) — a security-relevant write, so confirm with the user first. clio
-		       has no tool to CREATE a workplace or its sections — that stays in the Creatio UI.
+		       page to specific roles, bind it to a workplace whose audience is those roles. To change which roles
+		       see a workplace — or to create a workplace or add its sections — see `workplaces`.
 		       """
 	};
 

--- a/clio/Command/McpServer/Resources/RoutingGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/RoutingGuidanceResource.cs
@@ -47,6 +47,7 @@ public sealed class RoutingGuidanceResource {
 		         - lookup seeding / data bindings -> name=data-bindings
 		       - Applications, deploy & ops: deploy & provisioning -> name=deploy-lifecycle
 		         - integration tests / ATF.Repository / Allure / process tests -> name=integration-testing
+		         - manage navigation workplaces (create/update/delete a workplace, grant/remove role visibility, add/remove/move sections) -> name=workplaces
 		         - environment inspection (version / db engine / framework / product / license) -> name=describe-environment
 		         - executing an approved plan -> name=agent-execution
 		         - identity assertion / Identity Service V3 -> name=identity-assertion

--- a/clio/Command/McpServer/Resources/WorkplacesGuidanceResource.cs
+++ b/clio/Command/McpServer/Resources/WorkplacesGuidanceResource.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Resources;
+
+/// <summary>
+/// The workplaces guide: how to create, update, and delete a Creatio navigation workplace
+/// (<c>SysWorkplace</c>), grant or remove role access, and add, remove, or move its sections with the
+/// generic odata tools, shipping every change as a package data binding.
+/// </summary>
+[McpServerResourceType]
+public sealed class WorkplacesGuidanceResource {
+	private const string DocsScheme = "docs";
+	private const string ResourcePath = "mcp/guides/workplaces";
+	private const string ResourceUri = DocsScheme + "://" + ResourcePath;
+
+	/// <summary>
+	/// Canonical guidance article accessible by name through <c>get-guidance</c>.
+	/// </summary>
+	internal static readonly TextResourceContents Guide = new() {
+		Uri = ResourceUri,
+		MimeType = "text/plain",
+		Text = """
+		       clio MCP workplaces guide
+
+		       A workplace (`SysWorkplace`) is a named container in the Creatio left navigation: it groups
+		       sections and is shown only to the roles granted access to it. Managing one spans three tables —
+		       this guide owns that model. Read `core-rules` first (every write here is destructive and needs
+		       `confirm`), and `data-bindings` for the binding-tool contract this guide relies on.
+
+		       ## The three tables
+		       - `SysWorkplace` — the workplace itself. Key columns: `Name`, `Position` (order in the switcher).
+		       - `SysModuleInWorkplace` — one row per section in the workplace. Required `SysModuleId` (the
+		         section, a `SysModule` row) and `SysWorkplaceId`; `Position` orders the sections.
+		       - `SysAdminUnitInWorkplace` — one row per role that sees the workplace. Required `SysAdminUnitId`
+		         (a role or user, a `SysAdminUnit` row) and `SysWorkplaceId`.
+		       All three key on `Id`. Lookups take a GUID, but the column name differs by tool: in `odata-*` calls
+		       use the `<Field>Id` form (`SysWorkplaceId`, `SysModuleId`, `SysAdminUnitId`); in data-binding calls
+		       use the logical column name (`SysWorkplace`, `SysModule`, `SysAdminUnit`).
+
+		       ## Not to be confused with
+		       Navigation `SysWorkplace` is NOT `SysWorkspace` (the dev configuration workspace) and NOT clio
+		       `create-workspace` (a local project folder). This guide covers navigation `SysWorkplace` only.
+
+		       ## Ship every change as a data binding
+		       Each operation below is TWO steps: write the live row (`odata-create` / `odata-update` /
+		       `odata-delete`), then mirror it into the target package so it transfers — `create-data-binding-db`
+		       (adopts an existing row by `Id`), `upsert-data-binding-row-db`, or `remove-data-binding-row-db`.
+		       Read `data-bindings` for those tool contracts and for how to inspect a package's existing bindings
+		       first. An app ships its workplace under suffixed binding names (e.g. `SysWorkplace_ItRequest`,
+		       `SysModuleInWorkplace_<App>`, `SysAdminUnitInWorkplace_<App>`), so pass that `binding-name`
+		       explicitly to update the app's binding — omitting it creates a parallel binding under the bare
+		       schema name. Deleting a workplace cascades its child rows in the database, but NOT in the package —
+		       remove each child's binding row yourself.
+
+		       ## Operations
+		       - Create / update / delete a workplace: `odata-create` `SysWorkplace` (`Name` + `Position` suffice
+		         to create one), `odata-update` by `Id`, `odata-delete` by `Id`.
+		       - Grant / remove a role's access: `odata-create` / `odata-delete` a `SysAdminUnitInWorkplace` row.
+		         Resolve the role `Id` from `SysAdminUnit` by name first (names are not unique). Changing a role
+		         is a remove of the old row plus a grant of the new one. Access is security-relevant — confirm
+		         with the user first.
+		       - Add / remove / move a section: `odata-create` / `odata-delete` a `SysModuleInWorkplace` row; a
+		         move is an `odata-update` of its `SysWorkplaceId` to the target workplace. Resolve the section
+		         `Id` from `SysModule` by code first.
+
+		       ## New apps start in a default workplace
+		       Creating an app registers its section in the default `My applications` workplace and ships that
+		       placement as a `SysModuleInWorkplace` binding in the app's package — the app does NOT appear in a
+		       business workplace on its own. To surface it where users expect, move its section from
+		       `My applications` to the target workplace (or add it there per Operations), and update the binding
+		       so the new placement transfers with the package.
+
+		       ## Rules that bite
+		       - There is NO unique constraint on (`SysModule`, `SysWorkplace`): adding or moving a section
+		         already present in the target creates a duplicate. Read the target's rows first and skip if the
+		         section is already there.
+		       - `SysModuleInWorkplace.Position` is assigned by the server on write — the value you send is not
+		         honoured. Read the row back for the actual order rather than trusting the number you passed.
+		       - Filter the junction tables by the navigation path `SysWorkplace/Id`, not the scalar
+		         `SysWorkplaceId`.
+
+		       ## When changes appear
+		       A workplace, its sections, and its access become visible to a user only after that user logs in
+		       again — navigation is cached per session. No restart or cache clear is needed; a re-login is.
+
+		       ## Verify
+		       Read back after every mutation with `odata-read` (filter junctions by `SysWorkplace/Id`); do not
+		       treat an install log as proof.
+		       """
+	};
+
+	/// <summary>
+	/// Returns the workplaces guide covering workplace CRUD, role access, and section membership.
+	/// </summary>
+	[McpServerResource(UriTemplate = ResourceUri, Name = "workplaces-guidance")]
+	[Description("Returns the clio MCP workplaces guide: create/update/delete a navigation workplace, grant/remove role access, and add/remove/move sections via the odata tools, shipping each change as a package data binding.")]
+	public ResourceContents GetGuide() => Guide;
+}


### PR DESCRIPTION
## Summary

Adds a `workplaces` clio MCP guidance article so code agents can manage Creatio **navigation workplaces** end to end for [ENG-88474](https://creatio.atlassian.net/browse/ENG-88474) — create/update/delete a workplace, grant/change/remove role visibility, and add/remove/move sections — shipping every change as a package data binding.

No new tools: the acceptance criteria are covered by the existing generic `odata-*` and DB-first `*-data-binding-*-db` tools. The gap was **guidance**, not code.

## Changes

- **New guide** `WorkplacesGuidanceResource` (`get-guidance name=workplaces`): the three-table model (`SysWorkplace` / `SysModuleInWorkplace` / `SysAdminUnitInWorkplace`), per-operation recipes, the "every change ships as a data binding" invariant, and verification discipline.
- **`GuidanceCatalog`**: registers `workplaces`.
- **`RoutingGuidanceResource`**: adds a routing-map row (Applications, deploy & ops) → `name=workplaces`.
- **`HomePageGuidanceResource`**: replaces the duplicated workplace model and the stale "clio has no tool to create a workplace" text with a cross-reference to `workplaces` (removes duplication; the new guide now owns that model).
- **`DataBindingsGuidanceResource`**: documents inspecting a package's existing bindings via `execute-esq` on `SysPackageSchemaData` (the binding tools have no list mode), and that `binding-name` defaults to the schema name.

## Findings baked into the guides (verified on a live environment)

- Lookup column-name differs by tool: `odata-*` uses `<Field>Id`; DB-first bindings use the logical column name (`SysWorkplace` / `SysModule` / `SysAdminUnit`).
- Deleting a workplace **cascades** its child rows in the DB, but **not** in the package — child binding rows must be removed explicitly.
- **No unique constraint** on (`SysModule`, `SysWorkplace`) → read before add/move or you create duplicates.
- `SysModuleInWorkplace.Position` is **server-assigned** on write — read back for the real order.
- Navigation is **cached per session** — changes are visible only after the affected user re-logs in (no restart / cache-clear needed).
- A new app registers its section in the default `My applications` workplace and ships that as a `SysModuleInWorkplace` binding; it must be moved/added to the target workplace.

## MCP review

Guidance-only change — no MCP tool contract, argument, destructive flag, or executor behavior changed. Routing↔catalog consistency is enforced by the existing `McpGuidanceForcingTests` guard (routes only to names that resolve in `GuidanceCatalog`).

**ClioRing compatibility reviewed, no Ring-consumed contract changed** — only guidance resource text + catalog/routing registration were touched.

## Test note

Per request, the final `Category=Unit&Module=McpServer` run was deferred. An earlier run on this branch's tool-surface state passed 2500/2500 (both net8.0 and net10.0), including the routing↔catalog guard. E2E resolve coverage in `clio.mcp.e2e` for the new guide name is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-88474]: https://creatio.atlassian.net/browse/ENG-88474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ