### PR TITLE
fix(mcp): mark odata-create as destructive (GH-953)

### DIFF
--- a/clio.mcp.e2e/ODataWriteToolsE2ETests.cs
+++ b/clio.mcp.e2e/ODataWriteToolsE2ETests.cs
@@ -17,7 +17,7 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ODataWriteToolsE2ETests : McpContractFixtureBase {
 	[Test]
-	[Description("Exposes odata-create via the get-tool-contract compact index with a non-destructive safety flag on the lazy tool surface.")]
+	[Description("Exposes odata-create via the get-tool-contract compact index with a destructive safety flag on the lazy tool surface.")]
 	[AllureTag(ODataCreateTool.ToolName)]
 	[AllureName("odata-create MCP tool is discoverable on the lazy surface")]
 	public async Task ODataCreate_Should_Be_Advertised() {
@@ -29,8 +29,8 @@ public sealed class ODataWriteToolsE2ETests : McpContractFixtureBase {
 		ToolContractIndexEntry entry = index.Should().ContainSingle(entry => entry.Name == ODataCreateTool.ToolName,
 			because: "odata-create must be discoverable via the get-tool-contract compact index on the lazy surface")
 			.Which;
-		entry.Destructive.Should().NotBe(true,
-			because: "odata-create only inserts new rows and must not be flagged destructive");
+		entry.Destructive.Should().BeTrue(
+			because: "odata-create writes durable Creatio records; a data mutation MCP hosts must gate for approval and audit (GH-953)");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/DurableInvocationGateCompletenessTests.cs
+++ b/clio.tests/Command/McpServer/DurableInvocationGateCompletenessTests.cs
@@ -31,6 +31,8 @@ public sealed class DurableInvocationGateCompletenessTests {
 	// decision: reproduce the pre-#743 per-tool gate as-is). If this test fails, either the new tool's
 	// annotation is wrong (a genuinely destructive tool must declare Destructive=true) or the baseline
 	// must be consciously extended in the same PR that adds the tool.
+	// GH-953: odata-create was intentionally REMOVED from this baseline — it is now Destructive=true, so
+	// the durable gate host-confirms it instead of silently executing (the intended mutation-gating change).
 	private static readonly IReadOnlyCollection<string> ReviewedSilentWriteCapableTools = new HashSet<string>(
 		StringComparer.OrdinalIgnoreCase) {
 		"add-package",
@@ -57,7 +59,6 @@ public sealed class DurableInvocationGateCompletenessTests {
 		"new-integration-test-project",
 		"new-test-project",
 		"new-ui-project",
-		"odata-create",
 		"reg-web-app",
 		"send-telemetry",
 		"start-creatio",

--- a/clio.tests/Command/McpServer/ODataCreateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataCreateToolTests.cs
@@ -16,7 +16,7 @@ public sealed class ODataCreateToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Advertises a stable, non-read-only, non-destructive, non-idempotent MCP tool name for odata-create.")]
+	[Description("Advertises a stable, non-read-only, destructive, non-idempotent MCP tool name for odata-create.")]
 	public void Create_Should_Advertise_Stable_Tool_Name() {
 		// Arrange
 		// Act
@@ -28,7 +28,7 @@ public sealed class ODataCreateToolTests {
 		// Assert
 		attribute.Name.Should().Be(ODataCreateTool.ToolName, because: "the tool name is part of the stable MCP contract");
 		attribute.ReadOnly.Should().BeFalse(because: "odata-create mutates state by inserting records");
-		attribute.Destructive.Should().BeFalse(because: "creating a record does not destroy existing state");
+		attribute.Destructive.Should().BeTrue(because: "odata-create inserts durable Creatio records; a data mutation MCP hosts must gate for approval and audit (GH-953)");
 		attribute.Idempotent.Should().BeFalse(because: "repeating a create inserts another record");
 	}
 

--- a/clio/Command/McpServer/Tools/ODataCreateTool.cs
+++ b/clio/Command/McpServer/Tools/ODataCreateTool.cs
@@ -18,7 +18,7 @@ public sealed class ODataCreateTool(IToolCommandResolver commandResolver) {
 	internal const string ToolName = "odata-create";
 
 	/// <summary>Creates one or more Creatio records using OData v4.</summary>
-	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = false, Idempotent = false, OpenWorld = false)]
+	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
 	[Description(
 		"Create one or more Creatio records via OData v4 (POST) in a single call. " +
 		"Provide the entity set name and a 'rows' array of field/value objects; pass all rows for the same " +


### PR DESCRIPTION
Fixes #953.

## What

Flip the `odata-create` MCP tool from `Destructive = false` to `Destructive = true` on its `[McpServerTool]` attribute — the single source that feeds the runtime `DestructiveHint`, the `get-tool-contract` compact index (`ToolContractIndexEntry.Destructive`), `clio-run`, and the durable-call gate (`McpToolInvokerRegistry.IsDestructive`).

## Why

`odata-create` writes durable rows to the Creatio database. Per #953, MCP hosts rely on the destructive flag to apply mutation-approval and audit policies, and a durable data write should carry that signal.

## ⚠️ This reverses a recent, deliberate decision — please confirm

Current `master` intentionally classifies `odata-create` as **non-destructive**, with explicit test rationale ("only inserts new rows"), reviewed **2026-07-10 (ENG-93370)**. That classification reads `destructiveHint` on the MCP *additive-vs-destructive* axis (create = additive; update/delete = destructive), and treats "does it mutate at all" as the separate `readOnlyHint` (already `false` on odata-create).

This PR adopts the broader interpretation from #953: **any durable write is destructive for host-gating purposes.** That is a deliberate semantics choice, so I'd like @Alexandr-Kravchuk (assignee) to confirm it's the intended direction before merge. If the team prefers to keep the additive-vs-destructive reading, the alternative is to close #953 as working-as-intended and have hosts gate on `readOnlyHint`.

## Behavioral consequence

With `Destructive = true`, the **durable-call gate no longer silently executes `odata-create`** — it becomes host-confirmed like `odata-update` / `odata-delete`. `odata-create` is therefore removed from the `ReviewedSilentWriteCapableTools` baseline in `DurableInvocationGateCompletenessTests` (that baseline pins the silently-executable `ReadOnly=false, Destructive=false` set).

## Changes (4 files)

- `clio/Command/McpServer/Tools/ODataCreateTool.cs` — `Destructive = false` → `true`.
- `clio.tests/Command/McpServer/ODataCreateToolTests.cs` — unit assertion `BeFalse` → `BeTrue` + description/rationale.
- `clio.mcp.e2e/ODataWriteToolsE2ETests.cs` — compact-index assertion `NotBe(true)` → `BeTrue` + description.
- `clio.tests/Command/McpServer/DurableInvocationGateCompletenessTests.cs` — remove `odata-create` from the silently-executable baseline + explanatory comment.

No prompt/resource/docs changes: `odata-create` has no MCP prompt/resource, is not a CLI verb (no `help/`, `docs/commands/`, `Commands.md` entry), and is not in `McpCapabilityMap.md`. The `PassthroughToolClassificationRegistry` entry is on the credential-passthrough axis (unrelated to destructive) and is unchanged.

## Verification

- Build: audit-enabled `dotnet build` — 0 errors, 0 NU1903.
- Unit: `dotnet test --filter "Category=Unit&(FullyQualifiedName~ODataCreateToolTests|FullyQualifiedName~DurableInvocationGateCompletenessTests)"` — 14 passed / 0 failed on net8.0 and net10.0. `DurableInvocationGateCompletenessTests` confirms the silently-executable baseline still matches after removing odata-create.
- E2E (`clio.mcp.e2e/ODataWriteToolsE2ETests.ODataCreate_Should_Be_Advertised`): updated to assert `destructive = true`; not run in CI (needs a live Creatio env).

## MCP maintenance policy

- MCP reviewed: tool + unit + e2e + durable-gate baseline updated together; no prompt/resource/doc artifacts apply.
- **ClioRing compatibility reviewed, no Ring-consumed contract changed** — inspected `clio-ring/` (Ipc, Desktop `actions.json`, sources); `odata-create` is not referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
