### PR TITLE
ENG-93876 update request registry snapshots

### DIFF
--- a/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/ComponentInfoToolE2ETests.cs
@@ -552,6 +552,76 @@ public sealed class ComponentInfoToolE2ETests : McpContractFixtureBase {
 		}
 	}
 
+	[Test]
+	[Description("Type-reference closure over the wire on the component flavor: a component detail must inline a type definition reachable ONLY through a keyType/valueType string. The fixture's input is a Record whose valueType names AttributeConfigProbe, a shape the live catalog uses for attribute-config and filter maps, so a response that omits that definition would name a type it never defines. UnreferencedProbe is published but unreachable, pinning that the closure stays scoped. Mandatory MCP e2e for the changed tool result content (AGENTS.md).")]
+	[AllureTag(ToolName)]
+	[AllureName("get-component-info inlines valueType-referenced type definitions over the wire")]
+	[AllureDescription("Points the real clio process at a local component-registry fixture whose input references a type only through a valueType union, then verifies references.typeDefinitions inlines it while an unreferenced global stays out.")]
+	public async Task ComponentInfoTool_Should_Inline_ValueType_Referenced_TypeDefinitions_Over_The_Wire() {
+		// Arrange — a wrapped-shape catalog: the component's only type reference to
+		// AttributeConfigProbe lives in a valueType string, never in a `type` one.
+		string fixturePath = Path.Combine(Path.GetTempPath(), $"clio-e2e-valuetype-closure-{Guid.NewGuid():N}.json");
+		const string registryJson = """
+		{
+		  "components": [
+		    {
+		      "componentType": "crt.ValueTypeProbe",
+		      "category": "containers",
+		      "description": "Fixture component whose attribute map names its value type through valueType.",
+		      "inputs": {
+		        "attributes": { "type": "Record", "keyType": "string", "valueType": "AttributeConfigProbe" }
+		      },
+		      "outputs": {}
+		    }
+		  ],
+		  "references": {
+		    "typeDefinitions": {
+		      "AttributeConfigProbe": {
+		        "fields": {
+		          "path": { "type": "string", "required": true }
+		        }
+		      },
+		      "UnreferencedProbe": {
+		        "fields": {
+		          "unused": { "type": "string" }
+		        }
+		      }
+		    }
+		  }
+		}
+		""";
+		await File.WriteAllTextAsync(fixturePath, registryJson);
+		try {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			// Documented Tier-0 override, read before the disk cache and CDN.
+			settings.ProcessEnvironmentVariables["CLIO_COMPONENT_REGISTRY_LOCAL_FILE"] = fixturePath;
+			using CancellationTokenSource closureCts = new(TimeSpan.FromMinutes(3));
+			await using McpServerSession closureSession = await McpServerSession.StartAsync(settings, closureCts.Token);
+
+			// Act
+			ComponentInfoResponse response = await CallComponentInfoAsync(
+				closureSession,
+				closureCts.Token,
+				new Dictionary<string, object?> { ["component-type"] = "crt.ValueTypeProbe" });
+
+			// Assert
+			response.Success.Should().BeTrue(
+				because: "the fixture publishes crt.ValueTypeProbe, so the detail lookup succeeds over the wire");
+			response.References.Should().NotBeNull(
+				because: "the component references a named type, so the detail carries a typeDefinitions block");
+			response.References!.TypeDefinitions.Should().NotBeNull(
+				because: "the resolved closure is what the response surfaces as references.typeDefinitions");
+			response.References.TypeDefinitions!.Should().ContainKey("AttributeConfigProbe",
+				because: "the input names it only through a valueType string - the hop this closure follows");
+			response.References.TypeDefinitions.Should().NotContainKey("UnreferencedProbe",
+				because: "no input or output reaches it, so the closure must leave it out of the response");
+		}
+		finally {
+			TryDeleteFixture(fixturePath);
+		}
+	}
+
 	private static async Task<ComponentInfoResponse> CallComponentInfoAsync(
 		McpServerSession session,
 		CancellationToken cancellationToken,

--- a/clio.mcp.e2e/RequestInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/RequestInfoToolE2ETests.cs
@@ -39,6 +39,10 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 	/// Offline registry fixture: the pilot parameterless request (no docs, so the detail
 	/// path never touches the docs CDN) plus a parameterised request for search coverage,
 	/// with the base-parameter and wiring-contract globals the detail response surfaces.
+	/// The wiring contract deliberately names its value type through a <c>valueType</c> string
+	/// (never a <c>type</c> one) so the type-reference closure's keyType/valueType hop is
+	/// exercised over the wire; <c>SortColumnOptions</c> is the unreferenced global that proves
+	/// the closure stays scoped instead of inlining the whole bag.
 	/// </summary>
 	private const string RegistryFixtureJson = """
 	{
@@ -63,8 +67,16 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 	    "typeDefinitions": {
 	      "RequestBindingConfig": {
 	        "fields": {
-	          "params": { "type": "Record", "keyType": "string", "valueType": "string | boolean | number" },
+	          "params": { "type": "Record", "keyType": "string", "valueType": "string | boolean | number | RequestParamBindingConfigValue" },
 	          "request": { "type": "string", "required": true }
+	        }
+	      },
+	      "RequestParamBindingConfigValue": {
+	        "type": "string | boolean | number | null"
+	      },
+	      "SortColumnOptions": {
+	        "fields": {
+	          "columnName": { "type": "string", "required": true }
 	        }
 	      }
 	    }
@@ -315,6 +327,32 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 			because: "the wiring contract is reachable from the closure seed");
 		response.References!.TypeDefinitions.Should().ContainKey("RequestBindingConfig",
 			because: "every request is wired through RequestBindingConfig, so the detail inlines its schema");
+	}
+
+	[Test]
+	[Description("Type-reference closure over the wire: a detail response must inline a type definition that is reachable ONLY through a keyType/valueType string, not through a `type` one. The fixture's RequestBindingConfig.params names RequestParamBindingConfigValue in its valueType union, so a response that omits that definition would name a type it never defines - the non-self-contained schema this closure hop fixes. SortColumnOptions is published but unreferenced, pinning that the widened tokenizer did not turn into a merge-everything.")]
+	[AllureTag(ToolName)]
+	[AllureName("get-request-info inlines valueType-referenced type definitions over the wire")]
+	[AllureDescription("Requests crt.ClosePageRequest detail against the local registry fixture and verifies references.typeDefinitions carries the type reachable only through the wiring contract's valueType union, while an unreferenced global stays out.")]
+	public async Task RequestInfoTool_Should_Inline_ValueType_Referenced_TypeDefinitions_When_Detail_Is_Returned() {
+		// Arrange
+		await using var context = Arrange();
+
+		// Act
+		RequestInfoResponse response = await CallRequestInfoAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> { ["request-type"] = "crt.ClosePageRequest" });
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "crt.ClosePageRequest exists in the fixture registry");
+		response.References.Should().NotBeNull(
+			because: "the wiring contract is reachable from the closure seed, so the detail carries typeDefinitions");
+		response.References!.TypeDefinitions.Should().ContainKey("RequestParamBindingConfigValue",
+			because: "RequestBindingConfig.params names it only through a valueType string - the hop this closure follows");
+		response.References.TypeDefinitions.Should().NotContainKey("SortColumnOptions",
+			because: "nothing reachable from this request references it, so the closure must leave it out of the response");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/Fixtures/MobileRequestRegistry.live-snapshot.json
+++ b/clio.tests/Command/McpServer/Fixtures/MobileRequestRegistry.live-snapshot.json
@@ -3,7 +3,7 @@
 		{
 			"requestType": "crt.CancelRecordChangesRequest",
 			"parameters": {},
-			"description": "Discards unsaved changes to the current record and reloads its last saved values. Bound to Cancel buttons on record pages; on a mini page, or for a new record that was never saved, it closes the page instead.",
+			"description": "Discards unsaved changes to the current record and reloads its last saved values; the page stays open and the revert shows no confirmation. For a record opened in add or copy mode that was never saved, it closes the page instead of reverting; the close surfaces the built-in discard-changes confirmation when the record has edits. Bound to Cancel buttons on record pages.",
 			"references": {
 				"docs": [
 					"mobile-request-docs/mobile-cancel-record-changes.request.md"
@@ -13,7 +13,7 @@
 		{
 			"requestType": "crt.ClosePageRequest",
 			"parameters": {},
-			"description": "Closes the currently open page. Bound to buttons, menu items, and page commands to dismiss a record page or mini page, prompting to discard any unsaved changes before the page is closed.",
+			"description": "Closes the currently open page by popping the navigation stack. Bound to back and close buttons; when the page has unsaved changes, a discard-changes confirmation must be accepted before the page is closed.",
 			"references": {
 				"docs": [
 					"mobile-request-docs/mobile-close-page.request.md"
@@ -21,42 +21,61 @@
 			}
 		},
 		{
-			"requestType": "crt.PrintablesRequest",
+			"requestType": "crt.CreateRecordRequest",
 			"parameters": {
-				"convertInPDF": {
+				"defaultValues": {
+					"type": "array",
+					"items": {
+						"type": "ModelDefaultValue"
+					},
+					"description": "Column values pre-filled on the new record; each entry is `{ attributeName, value }` where `value` may be a constant, a lookup record Id, or an `$Attribute` binding. Optional. On a binding whose entity resolves to the page's primary object, the platform also injects the page's relation context (e.g. the master record link) as a default value, so a detail's new record is linked automatically."
+				},
+				"entityName": {
+					"type": "string",
+					"description": "Schema name of the entity to create a new record of (e.g. \"Activity\"). When omitted, a page preprocessor fills it with the page's primary data source entity, so set it only for a record that belongs to a different entity - a detail, nested collection, or list of another object. If it is still missing after preprocessing the request does nothing (an error is logged). There is no `itemsAttributeName` resolution on mobile: name the entity explicitly for non-primary collections."
+				},
+				"preventCardClose": {
 					"type": "boolean",
-					"description": "Whether to convert the generated report to PDF."
-				},
-				"dataSourceName": {
-					"type": "string",
-					"required": true,
-					"description": "Data source whose records are printed: the page's primary data source when printing the current record, or the selected list/view element data source when printing a records list. The handler always requires `templateId`, `printableCaption` and `dataSourceName` together; in the designer's menu mode only `dataSourceName` (optionally with `filters`) is authored, while `templateId` and `printableCaption` are filled at runtime by the generated menu items."
-				},
-				"filters": {
-					"type": "FilterGroup | JsonObject",
-					"description": "Collection-filter binding that limits the print to the records selected in the list. When set, records are printed by filter. When not set, the handler prints the active record resolved from dataSourceName; if that record is unsaved (Add state) or cannot be resolved, nothing is printed and an info message is shown. Canonical list-page shape (designer parity, prints the checked rows and falls back to the active row when nothing is checked): \"$<GridItems> | crt.ToCollectionFilters : '<GridItems>' : $<Grid>_SelectionState | crt.SkipIfSelectionEmpty : $<Grid>_SelectionState\" - substitute the page's real grid collection and selection-state attribute names from its bundle."
-				},
-				"printableCaption": {
-					"type": "string",
-					"valueSource": {
-						"kind": "environment",
-						"tool": "list-printables"
-					},
-					"description": "Caption of the printable (SysModuleReport.Caption); also used as the downloaded file name. Validation-required on direct calls. In menu mode it is stamped automatically onto each generated menu item from SysModuleReport.Caption; the Interface Designer never writes it."
-				},
-				"templateId": {
-					"type": "string",
-					"valueSource": {
-						"kind": "environment",
-						"tool": "list-printables"
-					},
-					"description": "Id of the SysModuleReport printable to generate; on direct/programmatic calls it is validation-required together with printableCaption and dataSourceName. Omitting it (with dataSourceName set) switches the button into the declarative menu mode: the platform expands it into a menu of every printable available for the data source's entity, stamping templateId and printableCaption onto each menu item at runtime. The Interface Designer only ever authors the menu-mode shape (dataSourceName, optionally filters) and never writes templateId itself."
+					"description": "Controls what happens after the new record is saved. When `true` (the default), the saved record is reopened in edit mode - the add page closes and the record's edit page is pushed. When `false`, the flow ends when the add page closes and the record is not reopened. Omit it for the standard add-then-edit behavior."
 				}
 			},
-			"description": "Generates and downloads a report (printable) for the current record or a filtered set of records, optionally converting it to PDF. Bound to print buttons and their generated report menu items.",
+			"description": "Opens a blank add page to create a new record of an entity, optionally pre-filling column values; by default the saved record is then reopened in edit mode. Bound to list add buttons and row/menu actions. The add page is pushed onto the navigation stack; creating a record does not prompt to discard unsaved changes on the current page.",
 			"references": {
 				"docs": [
-					"mobile-request-docs/mobile-printables.request.md"
+					"mobile-request-docs/mobile-create-record.request.md"
+				]
+			}
+		},
+		{
+			"requestType": "crt.OpenPageRequest",
+			"parameters": {
+				"modelInitConfigs": {
+					"type": "array",
+					"items": {
+						"type": "ModelInitConfig"
+					},
+					"description": "Initial model configuration for the opened page: for each entry, which model to seed (`name`), the record to load (`recordId`), the mode (`action`: `edit` / `add` / `copy`), and `defaultValues` to pre-fill. Honored by the mobile runtime and forwarded to the opened page's route."
+				},
+				"parameters": {
+					"type": "Record",
+					"keyType": "string",
+					"valueType": "unknown",
+					"description": "Page parameters passed to the opened page, keyed by parameter name; values may be constants or `$Attribute` bindings. The opened page reads them through a `crt.PageParametersDataSource` bound as `PageParameters.<key>`. Not declared on the TS request class but honored by the mobile runtime."
+				},
+				"schemaName": {
+					"type": "string",
+					"required": true,
+					"valueSource": {
+						"kind": "environment",
+						"tool": "list-pages"
+					},
+					"description": "Schema name (code) of the mobile Freedom UI page to open, not its display caption. Required: the handler does nothing (no navigation) when it is not set. Usually a literal; an `$Attribute` binding is also accepted."
+				}
+			},
+			"description": "Opens a mobile Freedom UI page by its schema name, pushing it onto the navigation stack, optionally passing page parameters and initial model configuration. Bound to buttons and row/menu actions. Opening a page does not prompt to discard unsaved changes on the current page.",
+			"references": {
+				"docs": [
+					"mobile-request-docs/mobile-open-page.request.md"
 				]
 			}
 		},
@@ -65,29 +84,29 @@
 			"parameters": {
 				"activeRow": {
 					"type": "string",
-					"description": "Mobile-only: current row context on a mobile list."
+					"description": "Identifier of the record used to build a single-record fallback filter when `filters` resolves to no selection, i.e. nothing is checked in the list (`ForTheSelectedRecords` run type). Populated automatically at page load from the data grid whose `selectionState` the `filters` expression references; author it only to override that default."
 				},
 				"activeRowAttributeName": {
 					"type": "string",
-					"description": "Mobile-only: name of the view-model attribute holding the current row on a mobile list."
+					"description": "Name of the view-model attribute holding the active row; reset together with `selectionStateAttributeName` after the run for the selected records. Populated automatically at page load alongside `activeRow`."
 				},
 				"dataSourceName": {
 					"type": "string",
-					"description": "Data source of the list whose selected records the process runs for (`ForTheSelectedRecords` run type)."
+					"description": "Data source of the list whose records the process runs for (`ForTheSelectedRecords` run type); required for that run type. This is the data source name from `modelConfigDiff`, not the list's collection attribute. When it is missing or does not resolve on the page, nothing is run and an info message is shown. Its entity schema becomes the entity the process runs against."
 				},
 				"filters": {
-					"type": "JsonObject",
-					"description": "Collection-filter binding selecting the records to run the process for; paired with `dataSourceName` (`ForTheSelectedRecords` run type)."
+					"type": "string | JsonObject",
+					"description": "Collection-filter binding that limits the run to the records selected in the list (`ForTheSelectedRecords` run type). Canonical list-page shape: \"$<GridItems> | crt.ToCollectionFilters : '<GridItems>' : $<Grid>_SelectionState | crt.SkipIfSelectionEmpty : $<Grid>_SelectionState\" - substitute the page's real collection and selection-state attribute names. When the expression resolves to no selection, the platform falls back to a single-record filter built from `activeRow`; when neither resolves, nothing is run and an info message is shown. Raw JSON objects are forwarded to the service verbatim without translation (the web `FilterGroup` dialect is not parsed on mobile), so prefer the converter pipe."
 				},
 				"notificationText": {
 					"type": "string",
-					"description": "Text of the start notification; a default is used when not set. Applies when `showNotification` is true."
+					"description": "Custom text of the success notification; a localized default is used when not set. Applies when `showNotification` is true. Supports `#ResourceString(...)#` macros."
 				},
 				"parameterMappings": {
 					"type": "Record",
 					"keyType": "string",
 					"valueType": "string",
-					"description": "Single-entry map { \"<ParameterCODE>\": \"<sourceColumn>\" }: the first key is the code of the process input parameter that receives each matched record (`ForTheSelectedRecords` run type); extra entries and the column values are ignored by the client handler."
+					"description": "Single-entry map { \"<ParameterCODE>\": \"<sourceColumn>\" }: the first key is the code of the process input parameter that receives each matched record (`ForTheSelectedRecords` run type); extra entries and the column values are ignored by the mobile client."
 				},
 				"processName": {
 					"type": "string",
@@ -96,13 +115,13 @@
 						"kind": "environment",
 						"tool": "get-process-signature"
 					},
-					"description": "Code (schema name) of the business process to run, not its display caption."
+					"description": "Code (schema name) of the business process to run, not its display caption. The mobile client posts it without validation; a wrong or empty code fails on the server and surfaces the error message."
 				},
 				"processParameters": {
 					"type": "Record",
 					"keyType": "string",
 					"valueType": "unknown",
-					"description": "Input parameters passed to the process, keyed by process parameter code (not caption); values may be static constants or `$Attribute` view-model bindings. A key that does not match a real parameter code is silently dropped by the core."
+					"description": "Input parameters passed to the process, keyed by process parameter code (not caption); values may be static constants or `$Attribute` view-model bindings and are posted as raw JSON. Not applied to the `ForTheSelectedRecords` run type. A key that does not match a real parameter code is silently dropped by the server."
 				},
 				"processRunType": {
 					"type": "string",
@@ -112,30 +131,30 @@
 						"ForTheSelectedPage",
 						"ForTheSelectedRecords"
 					],
-					"description": "How the process is run: `RegardlessOfThePage` (no record context), `ForTheSelectedPage` (the current record), or `ForTheSelectedRecords` (records selected in a list). Determines which of the other parameters apply."
+					"description": "How the process is run: `ForTheSelectedRecords` (records selected in a list) switches to the matching-records flow with its own set of parameters; `ForTheSelectedPage` (the current record) and `RegardlessOfThePage` (no record context) result in the same call on mobile - passing the current record's Id is controlled solely by `recordIdProcessParameterName`."
 				},
 				"recordIdProcessParameterName": {
 					"type": "string",
-					"description": "Code of the process parameter that receives the current record's Id; typically used with the `ForTheSelectedPage` run type."
+					"description": "Code of the process parameter that receives the current record's Id, resolved from the page's primary data source. Applied under any run type except `ForTheSelectedRecords`, where process input parameters are not sent; skipped silently when the Id cannot be resolved."
 				},
 				"resultParameterNames": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
-					"description": "Codes of the process output parameters to read back after the run (applies to non-`ForTheSelectedRecords` run types)."
+					"description": "Codes of the process output parameters to read back after the run (non-`ForTheSelectedRecords` run types). The values are returned to the dispatching code only; nothing is shown to the user or stored on the page."
 				},
 				"saveAtProcessStart": {
 					"type": "boolean",
-					"description": "Whether to save the current record before the process starts."
+					"description": "Whether to save the current record before the process starts; the page stays open after the save. When the save fails, the process is not started."
 				},
 				"selectionStateAttributeName": {
 					"type": "string",
-					"description": "View-model attribute holding the list's selection state; reset after the process starts (`ForTheSelectedRecords` run type)."
+					"description": "View-model attribute holding the list's selection state; reset after the run request completes (`ForTheSelectedRecords` run type)."
 				},
 				"showNotification": {
 					"type": "boolean",
-					"description": "Whether to show a notification when the process starts."
+					"description": "Whether to show a notification after the run request succeeds. There is no start notification on mobile, and failure messages are always shown regardless of this flag."
 				},
 				"sorting": {
 					"type": "array",
@@ -145,10 +164,30 @@
 					"description": "Sort order for the matching records (`ForTheSelectedRecords` run type); each entry is `{ columnName, direction }`."
 				}
 			},
-			"description": "Runs a business process - with no record context, for the current record, or for the records selected in a list - optionally saving the record first and notifying when it starts. Bound to buttons and menu items.",
+			"description": "Runs a business process with no record context, for the current record, or for the records selected in a list. Optionally saves the record first and notifies when the run request succeeds. Bound to buttons.",
 			"references": {
 				"docs": [
 					"mobile-request-docs/mobile-run-business-process.request.md"
+				]
+			}
+		},
+		{
+			"requestType": "crt.UpdateRecordRequest",
+			"parameters": {
+				"entityName": {
+					"type": "string",
+					"description": "Schema name of the entity whose record edit page is opened (e.g. \"Account\"). When omitted, a page preprocessor fills it with the page's primary data source entity, so you only need to set it for a record that belongs to a different entity - a detail, nested collection, or map/list of another object. If it is still missing after preprocessing the request does nothing (an error is logged). Note there is no `itemsAttributeName` resolution on mobile: name the entity explicitly for non-primary collections."
+				},
+				"recordId": {
+					"type": "string",
+					"required": true,
+					"description": "Primary-key value (Id) of the record to open; required - the request does nothing (an error is logged) when it is null or empty. Usually an `$Attribute` binding to the row's Id (e.g. \"$NearbyDS_Id\", \"$Participant.Id\"); a literal Id is also accepted. A bound value is resolved to the record's primary key before navigation."
+				}
+			},
+			"description": "Opens an existing record's edit page so the user can view or change it. Bound to list/detail row taps and link cells, and to buttons. The new page is pushed onto the navigation stack; opening a record does not prompt to discard unsaved changes on the current page.",
+			"references": {
+				"docs": [
+					"mobile-request-docs/mobile-update-record.request.md"
 				]
 			}
 		}
@@ -159,261 +198,63 @@
 				"type": "ViewModelContext",
 				"description": "The view-model context in which the request was triggered. Injected by the platform at dispatch time, never set via the binding's `params`."
 			},
-			"$initialEvent": {
-				"type": "unknown",
-				"description": "The original UI event that triggered the request.",
-				"deprecated": true,
-				"deprecationReason": "use event binding expression instead."
-			},
 			"scopes": {
 				"type": "array",
 				"items": {
 					"type": "string"
 				},
-				"description": "The scope chain of the request. Populated by the platform from the emitting view element, never set via the binding's `params`."
+				"description": "The scope chain of the request, resolved by the platform from the emitting execution context (the page schema's template tag chain). Do not set it via the binding's `params`."
 			},
 			"type": {
 				"type": "string",
-				"description": "Request type discriminator, e.g. \"crt.ClosePageRequest\". Set implicitly by the `request` field of the request binding, never set via the binding's `params`."
+				"description": "Request type discriminator, e.g. \"crt.ClosePageRequest\". Set implicitly by the `request` field of the request binding. Do not set it via the binding's `params` - on mobile a `params.type` key would override the request type."
 			}
 		},
 		"typeDefinitions": {
-			"BooleanComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"EQUAL"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "boolean",
-						"required": true
-					}
-				}
-			},
-			"DateComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"EQUAL",
-							"NOT_EQUAL",
-							"LESS",
-							"LESS_OR_EQUAL",
-							"GREATER",
-							"GREATER_OR_EQUAL"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "string",
-						"required": true
-					}
-				}
-			},
-			"FilterGroup": {
-				"fields": {
-					"backwardReferenceFilters": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"shape": {
-								"aggregationType": {
-									"type": "string",
-									"values": [
-										"COUNT",
-										"SUM",
-										"MIN",
-										"MAX",
-										"AVG",
-										"EXISTS",
-										"NOT_EXISTS"
-									],
-									"required": true
-								},
-								"aggregationValue": {
-									"type": "string",
-									"required": true,
-									"description": "it's string, because string | number is not supported in OpenApi"
-								},
-								"columnPath": {
-									"type": "string",
-									"required": true
-								},
-								"comparisonType": {
-									"type": "string",
-									"values": [
-										"EQUAL",
-										"NOT_EQUAL",
-										"LESS",
-										"LESS_OR_EQUAL",
-										"GREATER",
-										"GREATER_OR_EQUAL"
-									],
-									"required": true
-								},
-								"subFilters": {
-									"type": "FilterGroup",
-									"required": true
-								}
-							}
-						},
-						"required": true
-					},
-					"filters": {
-						"type": "(BooleanComparisonFilter | MathComparisonFilter | StringComparisonFilter | DateComparisonFilter | RelativeDateComparisonFilter | LookupComparisonFilter | IsNullComparisonFilter | IsNotNullComparisonFilter | FilterGroup)[]",
-						"required": true
-					},
-					"logicalOperation": {
-						"type": "string",
-						"values": [
-							"AND",
-							"OR"
-						],
-						"required": true
-					}
-				}
-			},
-			"IsNotNullComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"IS_NOT_NULL"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "unknown",
-						"required": true
-					}
-				}
-			},
-			"IsNullComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"IS_NULL"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "unknown",
-						"required": true
-					}
-				}
-			},
 			"JsonObject": {
 				"type": "object",
 				"description": "Arbitrary JSON object."
 			},
-			"LocalizableStringArray": {
-				"type": "array",
-				"items": {
-					"type": "LocalizableStringModel"
-				}
-			},
-			"LocalizableStringModel": {
+			"ModelDefaultValue": {
 				"fields": {
-					"cultureName": {
+					"attributeName": {
 						"type": "string",
-						"required": true
+						"required": true,
+						"description": "Name of the model attribute to seed."
 					},
 					"value": {
-						"type": "string",
-						"required": true
+						"type": "unknown",
+						"required": true,
+						"description": "Value to seed the attribute with."
 					}
 				}
 			},
-			"LookupComparisonFilter": {
+			"ModelInitConfig": {
 				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
+					"action": {
 						"type": "string",
 						"values": [
-							"EQUAL",
-							"NOT_EQUAL",
-							"EXISTS",
-							"NOT_EXISTS"
+							"edit",
+							"add",
+							"copy"
 						],
-						"required": true
+						"required": true,
+						"description": "Mode the target model is initialized in."
 					},
-					"value": {
+					"defaultValues": {
 						"type": "array",
 						"items": {
-							"type": "string"
+							"type": "ModelDefaultValue"
 						},
-						"required": true
-					}
-				}
-			},
-			"MathComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
+						"description": "Attribute values to pre-fill on the model."
 					},
-					"comparisonType": {
+					"name": {
 						"type": "string",
-						"values": [
-							"EQUAL",
-							"NOT_EQUAL",
-							"LESS",
-							"LESS_OR_EQUAL",
-							"GREATER",
-							"GREATER_OR_EQUAL"
-						],
-						"required": true
+						"description": "Name of the model (from the target page's modelConfig) to initialize."
 					},
-					"value": {
-						"type": "number",
-						"required": true
-					}
-				}
-			},
-			"RelativeDateComparisonFilter": {
-				"fields": {
-					"columnPath": {
+					"recordId": {
 						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"EQUAL",
-							"NOT_EQUAL",
-							"LESS",
-							"LESS_OR_EQUAL",
-							"GREATER",
-							"GREATER_OR_EQUAL"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "string",
-						"required": true
+						"description": "Primary-key value of the record to load into the model."
 					}
 				}
 			},
@@ -422,23 +263,16 @@
 					"params": {
 						"type": "Record",
 						"keyType": "string",
-						"valueType": "string | boolean | number | null | undefined | RequestParamsBindingConfig | RequestParamBindingConfigValue[] | LocalizableStringArray",
-						"required": true
+						"valueType": "string | boolean | number | null | RequestParamsBindingConfig | RequestParamBindingConfigValue[]"
 					},
 					"request": {
 						"type": "string",
 						"required": true
-					},
-					"skipOnError": {
-						"type": "boolean"
-					},
-					"useRelativeContext": {
-						"type": "boolean"
 					}
 				}
 			},
 			"RequestParamBindingConfigValue": {
-				"type": "string | boolean | number | null | undefined | RequestParamsBindingConfig | RequestParamBindingConfigValue[] | LocalizableStringArray"
+				"type": "string | boolean | number | null | RequestParamsBindingConfig | RequestParamBindingConfigValue[]"
 			},
 			"RequestParamsBindingConfig": {
 				"type": "Record",
@@ -461,38 +295,6 @@
 							"none"
 						],
 						"description": "Sort direction."
-					},
-					"visible": {
-						"type": "boolean",
-						"description": "Indicates whether the column is included in the result set."
-					}
-				}
-			},
-			"StringComparisonFilter": {
-				"fields": {
-					"columnPath": {
-						"type": "string",
-						"required": true
-					},
-					"comparisonType": {
-						"type": "string",
-						"values": [
-							"EQUAL",
-							"NOT_EQUAL",
-							"START_WITH",
-							"NOT_START_WITH",
-							"CONTAIN",
-							"NOT_CONTAIN",
-							"END_WITH",
-							"NOT_END_WITH",
-							"EXISTS",
-							"NOT_EXISTS"
-						],
-						"required": true
-					},
-					"value": {
-						"type": "string",
-						"required": true
 					}
 				}
 			}

--- a/clio.tests/Command/McpServer/Fixtures/RequestRegistry.live-snapshot.json
+++ b/clio.tests/Command/McpServer/Fixtures/RequestRegistry.live-snapshot.json
@@ -41,6 +41,73 @@
 			}
 		},
 		{
+			"requestType": "crt.CreateRecordRequest",
+			"parameters": {
+				"defaultValues": {
+					"type": "array",
+					"items": {
+						"type": "DefaultAttributeValue"
+					},
+					"description": "Column values pre-filled on the new record page; each entry is `{ attributeName, value }` where `value` may be a constant, a lookup record Id or a `{ value, displayValue }` pair, or an `$Attribute` binding; entries with a falsy value are dropped. Optional - omit it to open the page with the entity's own defaults."
+				},
+				"entityName": {
+					"type": "string",
+					"description": "Schema name of the entity to create a new record of (e.g. \"Contact\"). Provide it for a button that always adds the same entity. On a list \"New\" action you may omit it and set `itemsAttributeName` instead - the handler then resolves the entity from that collection's bound data source. At least one of `entityName`, `itemsAttributeName`, or `entityPageName` must be present, otherwise the handler shows a settings error and opens nothing."
+				},
+				"entityPageName": {
+					"type": "string",
+					"description": "Schema name of a specific add page to open for the new record (for example a typed card page). Usually stamped by the platform's quick-add menu items (the in-page typed-page \"New <type>\" menu stamps the record-type default value instead, not this field); author it directly only to force a particular add page. When set it satisfies the settings check on its own - the entity is derived from the page - so `entityName` may be omitted."
+				},
+				"itemsAttributeName": {
+					"type": "string",
+					"description": "Name of the list collection attribute (the grid's items attribute, e.g. \"DataGrid_6m6ky7l\") whose bound data source supplies `entityName` when `entityName` is not given. Author it without a leading `$`; ignored when `entityName` is set."
+				}
+			},
+			"description": "Opens a blank add page to create a new record of an entity, optionally pre-filling column values. Bound to \"New\" buttons wired to the \"Open new record\" action of the Designer's event panel, and to the quick-add and typed-page menu items the platform generates from them.",
+			"references": {
+				"docs": [
+					"request-docs/create-record.request.md"
+				]
+			}
+		},
+		{
+			"requestType": "crt.OpenPageRequest",
+			"parameters": {
+				"modelInitConfigs": {
+					"type": "array",
+					"items": {
+						"type": "ModelInitConfig"
+					},
+					"description": "Initial model configuration forwarded to the opened page: for each entry, which model to seed (`name`), the record to load (`recordId`), the mode (`action`: `edit` / `add` / `copy`), and `defaultValues` to pre-fill. Use it to open a page already scoped to a specific record, or to a new record with defaults."
+				},
+				"parameters": {
+					"type": "Record",
+					"keyType": "string",
+					"valueType": "JsonData",
+					"description": "Page-parameter values passed to the opened page, keyed by page-parameter name; values may be static constants or `$Attribute` view-model bindings. The target page reads them through its `crt.PageParametersDataSource`."
+				},
+				"schemaName": {
+					"type": "string",
+					"required": true,
+					"valueSource": {
+						"kind": "environment",
+						"tool": "list-pages"
+					},
+					"description": "Schema name (code) of the page to open, not its display caption (e.g. \"OrderProductCatalogPage\"). Required: the handler shows a settings-error dialog and opens nothing when it is empty. Authored via the \"Open specific page\" action's page picker, or supplied as a literal / `$Attribute` binding from custom code."
+				},
+				"skipUnsavedData": {
+					"type": "boolean",
+					"description": "Only affects card pages. When `false`, a card with unsaved changes is saved before the target page opens and the page opens only if the save succeeds; when `true` or omitted, the page opens without saving. Rarely authored; most page surfaces leave it unset."
+				}
+			},
+			"description": "Opens a Freedom UI page by its schema name, optionally passing page-parameter values and model init configs. Bound to buttons and menu items wired to the \"Open specific page\" action of the Designer's event panel. On a card page the current record's unsaved changes can be saved first before the target page opens.",
+			"references": {
+				"docs": [
+					"request-docs/open-page.request.md"
+				]
+			}
+		},
+		{
 			"requestType": "crt.PrintablesRequest",
 			"parameters": {
 				"convertInPDF": {
@@ -186,6 +253,30 @@
 					"request-docs/save-data.request.md"
 				]
 			}
+		},
+		{
+			"requestType": "crt.UpdateRecordRequest",
+			"parameters": {
+				"entityName": {
+					"type": "string",
+					"description": "Schema name of the entity whose record edit page is opened (e.g. \"Contact\"). Provide it for a button that opens a specific record. On a list or detail row action you may omit it and set `itemsAttributeName` instead - the handler then resolves the entity from that collection's bound data source (falling back to the page's primary data source when the attribute is not bound). At least one of `entityName` or `itemsAttributeName` must be present, otherwise the handler shows a settings error and opens nothing."
+				},
+				"itemsAttributeName": {
+					"type": "string",
+					"description": "Name of the list/detail collection attribute the record belongs to (the grid's items attribute, e.g. \"DataGrid_6m6ky7l\" or \"GridDetail_h7omalt\"), used to resolve `entityName` from that data source when `entityName` is not given. Author it (without a leading `$`) on a grid row's primary-column link or row menu action so the row opens its own entity; ignored when `entityName` is set."
+				},
+				"recordId": {
+					"type": "string | number",
+					"required": true,
+					"description": "Primary-key value (Id) of the record to open; required - the handler shows a settings error and opens nothing when it is null or an empty string (`0` is a valid Id). Usually an `$Attribute` binding to the row's Id (e.g. \"$Items.PDS_Id\" or \"$GridDetail_h7omalt.<DS>_Id\"), an `@event` value, or a literal Id."
+				}
+			},
+			"description": "Opens the edit page of an existing record so the user can view or change it. Bound to record links (a list row's primary-column link), row \"Open\" menu actions, and buttons wired to the \"Open existing record\" action of the Designer's event panel. Prompts to discard unsaved changes on the current page before navigating.",
+			"references": {
+				"docs": [
+					"request-docs/update-record.request.md"
+				]
+			}
 		}
 	],
 	"references": {
@@ -253,6 +344,20 @@
 					"value": {
 						"type": "string",
 						"required": true
+					}
+				}
+			},
+			"DefaultAttributeValue": {
+				"fields": {
+					"attributeName": {
+						"type": "string",
+						"required": true,
+						"description": "Name of the entity column to pre-fill on the new record."
+					},
+					"value": {
+						"type": "unknown",
+						"required": true,
+						"description": "Value to set on that column: a constant, a lookup record Id or a `{ value, displayValue }` pair (the pair carries the display value, so the platform does not resolve it again), or an `$Attribute` view-model binding. Entries with a falsy value (null, empty string, 0, false) are dropped by the add flow - a default cannot clear a column."
 					}
 				}
 			},
@@ -357,6 +462,10 @@
 					}
 				}
 			},
+			"JsonData": {
+				"type": "string | number | boolean | null | JsonObject | JsonData[]",
+				"description": "Any JSON-serializable value: a primitive, a JsonObject, or an array of JsonData."
+			},
 			"JsonObject": {
 				"type": "object",
 				"description": "Arbitrary JSON object."
@@ -425,6 +534,49 @@
 					"value": {
 						"type": "number",
 						"required": true
+					}
+				}
+			},
+			"ModelDefaultValue": {
+				"fields": {
+					"attributeName": {
+						"type": "string",
+						"required": true,
+						"description": "Name of the model attribute to seed."
+					},
+					"value": {
+						"type": "unknown",
+						"required": true,
+						"description": "Value to seed the attribute with. For a lookup attribute, either the record Id or a `{ value, displayValue }` pair - the pair carries the display value, so the platform does not resolve it again."
+					}
+				}
+			},
+			"ModelInitConfig": {
+				"fields": {
+					"action": {
+						"type": "string",
+						"values": [
+							"edit",
+							"add",
+							"copy"
+						],
+						"required": true,
+						"description": "Mode the target model is initialized in."
+					},
+					"defaultValues": {
+						"type": "array",
+						"items": {
+							"type": "ModelDefaultValue"
+						},
+						"description": "Attribute values to pre-fill on the model."
+					},
+					"name": {
+						"type": "string",
+						"description": "Name of the model (from the target page's modelConfig) to initialize."
+					},
+					"recordId": {
+						"type": "string",
+						"description": "Primary-key value of the record to load into the model."
 					}
 				}
 			},

--- a/clio.tests/Command/McpServer/RequestRegistrySnapshotTests.cs
+++ b/clio.tests/Command/McpServer/RequestRegistrySnapshotTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Clio.Command.McpServer.Tools;
 using FluentAssertions;
 using NUnit.Framework;
@@ -129,6 +131,136 @@ public sealed class RequestRegistrySnapshotTests {
 			because: "templateId must be resolved from the list-printables probe - pinned at the data layer, not as a guide-text substring");
 	}
 
+	[Test]
+	[Description("A detail response against the pinned payload must inline type definitions referenced ONLY through `keyType`/`valueType` strings — crt.OpenPageRequest's parameters map (valueType: JsonData, transitively JsonObject) and the RequestBindingConfig.params wiring hop (valueType: ...RequestParamBindingConfigValue...) — otherwise the response names types it never defines and stops being self-contained.")]
+	public void Pinned_Snapshot_Detail_Should_Inline_ValueType_Referenced_TypeDefinitions() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, SnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.OpenPageRequest", out RequestRegistryEntry? openPage).Should().BeTrue(
+			because: "crt.OpenPageRequest is the pinned entry whose parameters map declares valueType: JsonData");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			openPage!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — the parameter-level valueType reference resolves...
+		detail.References.Should().NotBeNull(
+			because: "crt.OpenPageRequest references named types, so the detail must carry a typeDefinitions block");
+		detail.References!.TypeDefinitions.Should().ContainKey("JsonData",
+			because: "parameters.valueType names JsonData, and a named type must ship its definition");
+		// ...transitively through the resolved type's own union string...
+		detail.References.TypeDefinitions.Should().ContainKey("JsonObject",
+			because: "JsonData's union references JsonObject, so the closure must pull it through");
+		// ...and the wiring chain broken at the same valueType hop heals for every request.
+		detail.References.TypeDefinitions.Should().ContainKey("RequestParamBindingConfigValue",
+			because: "RequestBindingConfig.params references its value type only through a valueType string");
+		// Following two more property names must not degrade the closure into "merge the whole global bag":
+		// over-inclusion on real fixture data is the risk the widened tokenizer introduces.
+		detail.References.TypeDefinitions.Should().NotContainKey("FilterGroup",
+			because: "FilterGroup is reachable only from crt.RunBusinessProcessRequest.filters - crt.OpenPageRequest must not pull it in");
+		detail.References.TypeDefinitions.Should().NotContainKey("SortColumnOptions",
+			because: "sorting types belong to other requests; the closure must stay scoped to what this entry references");
+		detail.References.TypeDefinitions.Should().NotContainKey("DefaultAttributeValue",
+			because: "DefaultAttributeValue is crt.CreateRecordRequest's defaultValues item type, unreachable from crt.OpenPageRequest");
+	}
+
+	[Test]
+	[Description("Content-level pin for the crt.CreateRecordRequest entry this fixture refresh added: defaultValues must surface as an array of DefaultAttributeValue with the item type's schema inlined through the closure, defaultValues itself must stay optional, and none of the three record-target parameters may carry a required flag — the producer models 'at least one of entityName / itemsAttributeName / entityPageName' in prose because a per-parameter flag cannot express a disjunctive contract.")]
+	public void Pinned_Snapshot_Detail_Should_Pin_CreateRecordRequest_DefaultValues_Content() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, SnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.CreateRecordRequest", out RequestRegistryEntry? createRecord).Should().BeTrue(
+			because: "crt.CreateRecordRequest is one of the record-page entries this fixture refresh added");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			createRecord!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — the authorable surface carries exactly the four authored parameters.
+		detail.Parameters.Should().NotBeNull(
+			because: "crt.CreateRecordRequest declares authorable parameters");
+		detail.Parameters!.Keys.Should().BeEquivalentTo(
+			["defaultValues", "entityName", "entityPageName", "itemsAttributeName"],
+			because: "the pinned entry authors exactly these parameters — a lost or extra key means the fixture and the producer diverged");
+		// Assert — defaultValues content: an optional array whose items are DefaultAttributeValue entries.
+		JsonElement defaultValues = detail.Parameters["defaultValues"];
+		defaultValues.GetProperty("type").GetString().Should().Be("array",
+			because: "defaultValues is a list of column pre-fills, not a single value");
+		defaultValues.GetProperty("items").GetProperty("type").GetString().Should().Be("DefaultAttributeValue",
+			because: "each entry follows the `{ attributeName, value }` contract named by the item type");
+		defaultValues.TryGetProperty("required", out _).Should().BeFalse(
+			because: "defaultValues is optional — omitting it opens the page with the entity's own defaults");
+		// Assert — the disjunctive target contract stays prose, never per-parameter required flags.
+		foreach (string targetParameter in new[] { "entityName", "entityPageName", "itemsAttributeName" }) {
+			detail.Parameters[targetParameter].TryGetProperty("required", out _).Should().BeFalse(
+				because: $"'{targetParameter}' alone is not required — the contract is 'at least one of the three', "
+					+ "and a per-parameter required flag would misstate it");
+		}
+		// Assert — the item type named by defaultValues is inlined, so the response stays self-contained...
+		detail.References.Should().NotBeNull(
+			because: "the entry references named types, so the detail must carry a typeDefinitions block");
+		detail.References!.TypeDefinitions.Should().ContainKey("DefaultAttributeValue",
+			because: "a named item type must ship its definition on the same response");
+		JsonElement attributeName = detail.References.TypeDefinitions!["DefaultAttributeValue"]
+			.GetProperty("fields").GetProperty("attributeName");
+		attributeName.GetProperty("required").GetBoolean().Should().BeTrue(
+			because: "each defaultValues entry must name the column it pre-fills");
+		// ...and the closure stays scoped: the mobile seeding twin must not ride along.
+		detail.References.TypeDefinitions.Should().NotContainKey("ModelDefaultValue",
+			because: "ModelDefaultValue is the model-seeding type reached from crt.OpenPageRequest's modelInitConfigs, "
+				+ "unreachable from crt.CreateRecordRequest on the web flavor");
+	}
+
+	[Test]
+	[Description("Content-level pin for the crt.UpdateRecordRequest entry this fixture refresh added: recordId must carry required:true and the 'string | number' union (0 is a valid Id, so number must not be dropped from the union), while entityName stays flag-free because it is disjunctively required with itemsAttributeName.")]
+	public void Pinned_Snapshot_Detail_Should_Pin_UpdateRecordRequest_RecordId_Content() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, SnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.UpdateRecordRequest", out RequestRegistryEntry? updateRecord).Should().BeTrue(
+			because: "crt.UpdateRecordRequest is one of the record-page entries this fixture refresh added");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			updateRecord!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — the authorable surface carries exactly the three authored parameters.
+		detail.Parameters.Should().NotBeNull(
+			because: "crt.UpdateRecordRequest declares authorable parameters");
+		detail.Parameters!.Keys.Should().BeEquivalentTo(
+			["entityName", "itemsAttributeName", "recordId"],
+			because: "the pinned entry authors exactly these parameters — a lost or extra key means the fixture and the producer diverged");
+		// Assert — recordId content: the one genuinely required parameter, with the full Id union.
+		JsonElement recordId = detail.Parameters["recordId"];
+		recordId.GetProperty("required").GetBoolean().Should().BeTrue(
+			because: "the handler shows a settings error and opens nothing without a recordId");
+		recordId.GetProperty("type").GetString().Should().Be("string | number",
+			because: "0 is a valid Id, so the number alternative must survive on the wire");
+		// Assert — the disjunctive target contract stays prose, never per-parameter required flags.
+		foreach (string targetParameter in new[] { "entityName", "itemsAttributeName" }) {
+			detail.Parameters[targetParameter].TryGetProperty("required", out _).Should().BeFalse(
+				because: $"'{targetParameter}' alone is not required — the contract is 'at least one of the two', "
+					+ "and a per-parameter required flag would misstate it");
+		}
+	}
+
 	private const string MobileSnapshotRelativePath = "Command/McpServer/Fixtures/MobileRequestRegistry.live-snapshot.json";
 
 	[Test]
@@ -196,6 +328,209 @@ public sealed class RequestRegistrySnapshotTests {
 		detail.References!.TypeDefinitions.Should().ContainKey("RequestBindingConfig",
 			because: "every request is wired through RequestBindingConfig, so the mobile detail inlines its schema");
 	}
+
+	[Test]
+	[Description("The MOBILE counterpart of the valueType closure pin, on the flavor whose parameter surface differs: mobile crt.OpenPageRequest declares parameters as Record<string, unknown> (the web flavor uses Record<string, JsonData>), so the closure must inline what the entry really reaches - the items type behind modelInitConfigs and the wiring chain behind RequestBindingConfig.params' valueType - while a lowercase `unknown` value type contributes nothing and unrelated globals stay out.")]
+	public void Pinned_Mobile_Snapshot_Detail_Should_Resolve_TypeDefinitions_For_The_Mobile_Parameter_Shape() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MobileSnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.OpenPageRequest", out RequestRegistryEntry? openPage).Should().BeTrue(
+			because: "crt.OpenPageRequest ships in the pinned mobile payload");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			openPage!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — everything the mobile entry genuinely reaches is inlined.
+		detail.References.Should().NotBeNull(
+			because: "the mobile entry references named types, so the detail must carry a typeDefinitions block");
+		detail.References!.TypeDefinitions.Should().ContainKey("ModelInitConfig",
+			because: "modelInitConfigs names its element type through items.type");
+		detail.References.TypeDefinitions.Should().ContainKey("ModelDefaultValue",
+			because: "ModelInitConfig.defaultValues reaches ModelDefaultValue transitively");
+		detail.References.TypeDefinitions.Should().ContainKey("RequestParamBindingConfigValue",
+			because: "the mobile RequestBindingConfig.params also names its value type only through a valueType string");
+		detail.References.TypeDefinitions.Should().ContainKey("RequestParamsBindingConfig",
+			because: "the same valueType union names the nested params config");
+
+		// Assert — the mobile-specific parameter shape stays honest: `unknown` is a built-in, and
+		// JsonData (the web value type for the same parameter) is not published on mobile at all.
+		detail.References.TypeDefinitions.Should().NotContainKey("JsonData",
+			because: "mobile declares parameters as Record<string, unknown>; JsonData is a web-only type definition");
+		detail.References.TypeDefinitions.Should().NotContainKey("SortColumnOptions",
+			because: "sorting types are reachable only from crt.RunBusinessProcessRequest on mobile");
+	}
+
+	[Test]
+	[Description("Content-level pin for the MOBILE crt.CreateRecordRequest entry this fixture refresh added, on the exact points where it diverges from the web twin: defaultValues items are ModelDefaultValue (not the web-only DefaultAttributeValue), the mobile-only preventCardClose boolean is present, and the web-only entityPageName / itemsAttributeName parameters are absent because mobile resolves the entity through a page preprocessor instead.")]
+	public void Pinned_Mobile_Snapshot_Detail_Should_Pin_CreateRecordRequest_Mobile_Divergence() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MobileSnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.CreateRecordRequest", out RequestRegistryEntry? createRecord).Should().BeTrue(
+			because: "crt.CreateRecordRequest is one of the record-page entries the mobile fixture refresh added");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			createRecord!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — the mobile authorable surface: no entityPageName / itemsAttributeName, plus the mobile-only flag.
+		detail.Parameters.Should().NotBeNull(
+			because: "the mobile crt.CreateRecordRequest declares authorable parameters");
+		detail.Parameters!.Keys.Should().BeEquivalentTo(
+			["defaultValues", "entityName", "preventCardClose"],
+			because: "mobile resolves the entity through a page preprocessor, so the web-only target parameters "
+				+ "must not appear, while preventCardClose exists only on mobile");
+		// Assert — defaultValues content: same array shape as web, but the mobile item type.
+		JsonElement defaultValues = detail.Parameters["defaultValues"];
+		defaultValues.GetProperty("type").GetString().Should().Be("array",
+			because: "defaultValues is a list of attribute pre-fills on mobile too");
+		defaultValues.GetProperty("items").GetProperty("type").GetString().Should().Be("ModelDefaultValue",
+			because: "the mobile flavor seeds through ModelDefaultValue, not the web-only DefaultAttributeValue");
+		detail.Parameters["preventCardClose"].GetProperty("type").GetString().Should().Be("boolean",
+			because: "preventCardClose toggles the add-then-edit reopen behavior");
+		// Assert — the item type is inlined and the web twin's item type stays out.
+		detail.References.Should().NotBeNull(
+			because: "the mobile entry references named types, so the detail must carry a typeDefinitions block");
+		detail.References!.TypeDefinitions.Should().ContainKey("ModelDefaultValue",
+			because: "a named item type must ship its definition on the same response");
+		detail.References.TypeDefinitions.Should().NotContainKey("ModelInitConfig",
+			because: "ModelInitConfig belongs to crt.OpenPageRequest's modelInitConfigs; crt.CreateRecordRequest must not pull it in");
+	}
+
+	[Test]
+	[Description("Content-level pin for the MOBILE crt.UpdateRecordRequest entry this fixture refresh added, on the exact points where it diverges from the web twin: recordId is required but typed plain 'string' (no `| number` union on mobile), and the web-only itemsAttributeName parameter is absent because mobile resolves the entity through a page preprocessor instead.")]
+	public void Pinned_Mobile_Snapshot_Detail_Should_Pin_UpdateRecordRequest_Mobile_Divergence() {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, MobileSnapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		state.Lookup.TryGetValue("crt.UpdateRecordRequest", out RequestRegistryEntry? updateRecord).Should().BeTrue(
+			because: "crt.UpdateRecordRequest is one of the record-page entries the mobile fixture refresh added");
+
+		// Act
+		RequestInfoResponse detail = RequestInfoTool.CreateDetailResponse(
+			updateRecord!,
+			resolvedTargetVersion: state.ResolvedVersion,
+			resolvedFrom: "latest-fallback",
+			documentation: null,
+			globalReferences: state.GlobalReferences);
+
+		// Assert — the mobile authorable surface: no itemsAttributeName resolution on mobile.
+		detail.Parameters.Should().NotBeNull(
+			because: "the mobile crt.UpdateRecordRequest declares authorable parameters");
+		detail.Parameters!.Keys.Should().BeEquivalentTo(
+			["entityName", "recordId"],
+			because: "mobile resolves the entity through a page preprocessor, so the web-only itemsAttributeName must not appear");
+		// Assert — recordId content: required on both flavors, but mobile narrows the type to string.
+		JsonElement recordId = detail.Parameters["recordId"];
+		recordId.GetProperty("required").GetBoolean().Should().BeTrue(
+			because: "the request does nothing without a recordId on mobile too");
+		recordId.GetProperty("type").GetString().Should().Be("string",
+			because: "the mobile flavor resolves bound values to the primary key string; the web 'string | number' union does not apply");
+	}
+
+	[TestCase(SnapshotRelativePath)]
+	[TestCase(MobileSnapshotRelativePath)]
+	[Description("Completeness guard against dangling type references, on BOTH request-registry flavors: every PascalCase identifier tokenised from a `type`/`keyType`/`valueType` string anywhere in the pinned payload (entry parameters, per-request typedefs, global typedefs, baseParameters) must resolve to a type definition the same payload publishes, or sit on the explicit built-in/platform allowlist. A named-but-undefined type is silently dropped from detail responses — the silent-data-loss mode the keyType/valueType closure fix removed — and this invariant catches EVERY typedef removed or renamed by a future fixture refresh, unlike the denylist of specific removed names it replaces. Prose mentions stay unchecked by design: `description` text may discuss types freely, and the closure never tokenises payload properties.")]
+	public void Pinned_Snapshot_Every_Type_Reference_Should_Resolve_To_A_Published_TypeDefinition(string snapshotRelativePath) {
+		// Arrange
+		string snapshotPath = Path.Combine(TestContext.CurrentContext.TestDirectory, snapshotRelativePath);
+		using FileStream stream = File.OpenRead(snapshotPath);
+		RequestCatalogState state = RequestInfoCatalog.LoadFromStream(stream);
+		List<string> typeReferences = state.Entries
+			.SelectMany(entry => (entry.Parameters?.Values ?? Enumerable.Empty<JsonElement>())
+				.Concat(entry.References?.TypeDefinitions?.Values ?? Enumerable.Empty<JsonElement>()))
+			.Concat(state.GlobalReferences?.TypeDefinitions?.Values ?? Enumerable.Empty<JsonElement>())
+			.Concat(state.GlobalReferences?.BaseParameters?.Values ?? Enumerable.Empty<JsonElement>())
+			.SelectMany(TypeReferenceStrings)
+			.ToList();
+		HashSet<string> publishedTypeNames = new(
+			(state.GlobalReferences?.TypeDefinitions?.Keys ?? Enumerable.Empty<string>())
+				.Concat(state.Entries.SelectMany(entry =>
+					entry.References?.TypeDefinitions?.Keys ?? Enumerable.Empty<string>())),
+			System.StringComparer.Ordinal);
+		// `Record` is the TypeScript built-in generic the closure silently drops. `ViewModelContext`
+		// is named only by the platform-injected baseParameters.$context — never authorable, never a
+		// closure seed — so the producer deliberately publishes no schema for it on either flavor.
+		HashSet<string> knownUnpublishedTypeNames = new(System.StringComparer.Ordinal) { "Record", "ViewModelContext" };
+
+		// Act
+		List<string> danglingTypeNames = typeReferences
+			.SelectMany(PascalCaseIdentifiers)
+			.Where(identifier => !publishedTypeNames.Contains(identifier))
+			.Where(identifier => !knownUnpublishedTypeNames.Contains(identifier))
+			.Distinct(System.StringComparer.Ordinal)
+			.ToList();
+
+		// Assert — the payload carries type references at all, so the sweep below is not vacuous...
+		typeReferences.Should().NotBeEmpty(
+			because: "request entries and type definitions declare types through `type` / `keyType` / `valueType` strings");
+		// ...and every producer-defined-looking name resolves to a definition the payload actually ships.
+		danglingTypeNames.Should().BeEmpty(
+			because: "a type named by any `type`/`keyType`/`valueType` string but defined nowhere in the same payload "
+				+ "would be silently dropped from detail responses — a typedef removal must take every reference "
+				+ "with it, which a hand-maintained list of removed names cannot guarantee");
+	}
+
+	/// <summary>
+	/// Collects every type-reference string (<c>type</c> / <c>keyType</c> / <c>valueType</c>) reachable in a
+	/// payload element, skipping the producer's payload properties exactly as the production closure does.
+	/// Deliberately duplicated here rather than reused: this test pins WHICH properties carry type references,
+	/// so sharing the production set would make the guard agree with a regression in it.
+	/// </summary>
+	private static IEnumerable<string> TypeReferenceStrings(JsonElement element) {
+		switch (element.ValueKind) {
+			case JsonValueKind.Object:
+				foreach (JsonProperty property in element.EnumerateObject()) {
+					if (property.Name is "description" or "default" or "values" or "valueSource") {
+						continue;
+					}
+					if ((property.Name is "type" or "keyType" or "valueType")
+						&& property.Value.ValueKind == JsonValueKind.String) {
+						string? value = property.Value.GetString();
+						if (!string.IsNullOrEmpty(value)) {
+							yield return value!;
+						}
+						continue;
+					}
+					foreach (string nested in TypeReferenceStrings(property.Value)) {
+						yield return nested;
+					}
+				}
+				break;
+			case JsonValueKind.Array:
+				foreach (JsonElement item in element.EnumerateArray()) {
+					foreach (string nested in TypeReferenceStrings(item)) {
+						yield return nested;
+					}
+				}
+				break;
+		}
+	}
+
+	/// <summary>
+	/// Tokenises a type-reference string into candidate producer-defined type names using the same
+	/// PascalCase heuristic as the production closure (identifiers starting with an uppercase letter;
+	/// lowercase tokens are TypeScript built-ins like <c>string</c> or <c>unknown</c>). Deliberately
+	/// duplicated for the same reason as <see cref="TypeReferenceStrings"/>: the completeness guard
+	/// must not inherit a regression in the production tokenizer.
+	/// </summary>
+	private static IEnumerable<string> PascalCaseIdentifiers(string typeReference) =>
+		Regex.Matches(typeReference, "[A-Za-z_][A-Za-z0-9_]*")
+			.Select(match => match.Value)
+			.Where(token => char.IsUpper(token[0]));
 
 	private static IEnumerable<string> UnmappedKeys(IDictionary<string, JsonElement>? bucket) =>
 		bucket is null ? System.Array.Empty<string>() : bucket.Keys;

--- a/clio.tests/Command/McpServer/TypeReferenceClosureTests.cs
+++ b/clio.tests/Command/McpServer/TypeReferenceClosureTests.cs
@@ -126,6 +126,89 @@ public sealed class TypeReferenceClosureTests {
 	}
 
 	[Test]
+	[Description("Record-shaped schemas reference their key/value types through `keyType`/`valueType` strings, not `type` — the closure must follow them, else a Record-valued input names types it never defines.")]
+	public void Resolve_Follows_KeyType_And_ValueType_References() {
+		IReadOnlyDictionary<string, JsonElement> inputs = ParseDict("""
+		{
+		  "parameters": { "type": "Record", "keyType": "BrandedKey", "valueType": "string | Payload | PayloadItem[]" }
+		}
+		""");
+		IReadOnlyDictionary<string, JsonElement> global = ParseDict("""
+		{
+		  "BrandedKey":  { "type": "string" },
+		  "Payload":     { "fields": { "inner": { "type": "Nested" } } },
+		  "PayloadItem": { "type": "string" },
+		  "Nested":      { "type": "string" },
+		  "Unrelated":   { "type": "string" }
+		}
+		""");
+
+		IReadOnlyDictionary<string, JsonElement>? resolved = TypeReferenceClosure.Resolve(
+			inputs: inputs, outputs: null,
+			perComponentTypeDefinitions: null, globalTypeDefinitions: global);
+
+		resolved.Should().NotBeNull();
+		resolved!.Should().ContainKey("BrandedKey", because: "a `keyType` string is a type reference, not payload");
+		resolved.Should().ContainKey("Payload", because: "every PascalCase member of a `valueType` union is a type reference");
+		resolved.Should().ContainKey("PayloadItem", because: "an array-suffixed `valueType` member must tokenise to its element type");
+		resolved.Should().ContainKey("Nested", because: "types reached via `valueType` contribute their own inner references transitively");
+		resolved.Should().NotContainKey("Unrelated",
+			because: "following keyType/valueType must not weaken the closure filter");
+	}
+
+	[Test]
+	[Description("A typedef whose field references another type only through `valueType` (the RequestBindingConfig.params shape) must still pull that type in — the wiring chain is broken at exactly this hop otherwise.")]
+	public void Resolve_Follows_ValueType_References_Inside_Typedefs() {
+		IReadOnlyDictionary<string, JsonElement> inputs = ParseDict("""
+		{ "binding": { "type": "Wiring" } }
+		""");
+		IReadOnlyDictionary<string, JsonElement> global = ParseDict("""
+		{
+		  "Wiring":      { "fields": { "params": { "type": "Record", "keyType": "string", "valueType": "WiringValue" } } },
+		  "WiringValue": { "type": "string" },
+		  "Unrelated":   { "type": "string" }
+		}
+		""");
+
+		IReadOnlyDictionary<string, JsonElement>? resolved = TypeReferenceClosure.Resolve(
+			inputs: inputs, outputs: null,
+			perComponentTypeDefinitions: null, globalTypeDefinitions: global);
+
+		resolved.Should().NotBeNull();
+		resolved!.Should().ContainKey("Wiring");
+		resolved.Should().ContainKey("WiringValue",
+			because: "the only reference to WiringValue lives in a `valueType` string inside the Wiring typedef");
+		resolved.Should().NotContainKey("Unrelated");
+	}
+
+	[Test]
+	[Description("Pins the deliberate scope of the keyType/valueType hop: those property names are followed ANYWHERE in the walked tree, not only next to a Record-shaped `type`, while the payload skip-list still wins over them. Leniency is the intended trade — a redundant definition costs a few bytes of response, whereas skipping a real reference leaves a named type undefined, which is the defect the hop was added to fix.")]
+	public void Resolve_Follows_TypeReferenceProperties_Everywhere_Except_Payload_Properties() {
+		IReadOnlyDictionary<string, JsonElement> inputs = ParseDict("""
+		{
+		  "plain":  { "type": "string", "example": { "valueType": "ReachedThroughExample" } },
+		  "listed": { "type": "string", "values": [{ "valueType": "SkippedInsideValues" }] }
+		}
+		""");
+		IReadOnlyDictionary<string, JsonElement> global = ParseDict("""
+		{
+		  "ReachedThroughExample": { "type": "string" },
+		  "SkippedInsideValues":   { "type": "string" }
+		}
+		""");
+
+		IReadOnlyDictionary<string, JsonElement>? resolved = TypeReferenceClosure.Resolve(
+			inputs: inputs, outputs: null,
+			perComponentTypeDefinitions: null, globalTypeDefinitions: global);
+
+		resolved.Should().NotBeNull();
+		resolved!.Should().ContainKey("ReachedThroughExample",
+			because: "a valueType string is treated as a type reference wherever it appears, not only inside a Record schema");
+		resolved.Should().NotContainKey("SkippedInsideValues",
+			because: "the payload skip-list (`description`, `default`, `values`, `valueSource`) is checked first, so allowed-value payloads are never tokenised - even when they contain a keyType/valueType key");
+	}
+
+	[Test]
 	[Description("`values` payload arrays must not be misread as type names — 'close-icon' is a literal allowed value, not a type identifier.")]
 	public void Resolve_Does_Not_Tokenise_Values_Payload() {
 		IReadOnlyDictionary<string, JsonElement> inputs = ParseDict("""

--- a/clio/Command/McpServer/Tools/TypeReferenceClosure.cs
+++ b/clio/Command/McpServer/Tools/TypeReferenceClosure.cs
@@ -19,8 +19,8 @@ namespace Clio.Command.McpServer.Tools;
 ///
 /// This helper walks the transitive closure starting from:
 /// <list type="bullet">
-/// <item>type identifiers tokenised from every <c>"type": "..."</c> string in
-/// <c>entry.inputs</c> and <c>entry.outputs</c>;</item>
+/// <item>type identifiers tokenised from every <c>"type"</c> / <c>"keyType"</c> /
+/// <c>"valueType"</c> string in <c>entry.inputs</c> and <c>entry.outputs</c>;</item>
 /// <item>the type identifiers tokenised from inside the per-component typedefs
 /// themselves (a per-component schema can reference a global type — e.g. a
 /// <c>filter</c> field whose type is <c>BaseFilter</c>).</item>
@@ -49,6 +49,20 @@ internal static class TypeReferenceClosure {
 		"default",
 		"values",
 		"valueSource",
+	};
+
+	/// <summary>
+	/// Property names whose string value carries type references to tokenise.
+	/// <c>type</c> is the primary carrier; Record-shaped schemas reference their key and
+	/// value types through <c>keyType</c> / <c>valueType</c> instead (e.g. a request's
+	/// <c>parameters</c> map or <c>RequestBindingConfig.params</c>), so those strings
+	/// must feed the closure too - otherwise the detail response names types it never
+	/// defines.
+	/// </summary>
+	private static readonly HashSet<string> TypeReferencePropertyNames = new(System.StringComparer.Ordinal) {
+		"type",
+		"keyType",
+		"valueType",
 	};
 
 	/// <summary>
@@ -148,7 +162,8 @@ internal static class TypeReferenceClosure {
 
 	/// <summary>
 	/// Walks a <see cref="JsonElement"/> and pushes every PascalCase-ish identifier
-	/// found under a <c>"type"</c> string into the queue. Recurses through nested
+	/// found under a <see cref="TypeReferencePropertyNames"/> string (<c>type</c>,
+	/// <c>keyType</c>, <c>valueType</c>) into the queue. Recurses through nested
 	/// objects and arrays; skips properties listed in <see cref="PayloadPropertyNames"/>
 	/// because their string values are user-facing data (allowed values, defaults,
 	/// descriptions), not type references.
@@ -157,10 +172,13 @@ internal static class TypeReferenceClosure {
 		switch (element.ValueKind) {
 			case JsonValueKind.Object:
 				foreach (JsonProperty property in element.EnumerateObject()) {
-					if (PayloadPropertyNames.Contains(property.Name)) {
+					// JsonProperty.Name transcodes UTF-8 to a new string on every access,
+					// so read it once per property — this walk runs on every detail call.
+					string propertyName = property.Name;
+					if (PayloadPropertyNames.Contains(propertyName)) {
 						continue;
 					}
-					if (property.NameEquals("type") && property.Value.ValueKind == JsonValueKind.String) {
+					if (TypeReferencePropertyNames.Contains(propertyName) && property.Value.ValueKind == JsonValueKind.String) {
 						TokenizeTypeString(property.Value.GetString(), queue);
 						continue;
 					}


### PR DESCRIPTION
Refreshes the pinned request-registry fixtures that RequestRegistrySnapshotTests
guards, so the snapshot check exercises the three navigation requests newly
added to the static-files-mcp catalogs (crt.CreateRecordRequest,
crt.UpdateRecordRequest, crt.OpenPageRequest).

- RequestRegistry.live-snapshot.json: adds the three web entries plus the new
  DefaultAttributeValue / JsonData / ModelInitConfig / ModelDefaultValue
  typedefs; brings the fixture in line with latest/RequestRegistry.json
- MobileRequestRegistry.live-snapshot.json: adds the three mobile entries and
  drops the stale crt.PrintablesRequest entry that no longer ships in the
  mobile catalog

Fixtures are copied verbatim from static-files-mcp/latest (the source the CDN
serves), per the refresh note in RequestRegistrySnapshotTests. No production
code change; the snapshot guard now also covers the new entries'
valueSource / required shape. All 5 snapshot tests pass.


**Update:** 
TypeReferenceClosure only tokenised strings under `type` properties, so a
type referenced solely through a Record schema's `keyType`/`valueType`
(crt.OpenPageRequest parameters -> JsonData, RequestBindingConfig.params ->
RequestParamBindingConfigValue and friends) was named in the detail
response but never inlined into references.typeDefinitions, leaving
get-request-info / get-component-info responses non-self-contained.

Follow `keyType` and `valueType` strings the same way as `type`. Covered
by two hermetic TypeReferenceClosureTests and a data-layer pin in
RequestRegistrySnapshotTests: the OpenPageRequest detail now inlines
JsonData, JsonObject and the wiring chain's RequestParamBindingConfigValue.


---

ClioRing compatibility: no Ring-consumed MCP contract changed - no tool name,
args, response schema or stage-event change. The only difference is additive
content inside the existing references.typeDefinitions map: definitions that
were previously named but omitted are now inlined. Nothing is removed or
renamed.