### PR TITLE
#ENG-93666 Un-mute uninstall warning e2e (drop McpE2E.Manual)

### DIFF
--- a/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
+++ b/clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs
@@ -19,7 +19,6 @@ namespace Clio.Mcp.E2E;
 // explicit Allure metadata; fixture-level AOP can block async continuations in this suite.
 [TestFixture]
 [Category("McpE2E.Sandbox")]
-[Category("McpE2E.Manual")]
 [AllureFeature("uninstall-creatio")]
 [NonParallelizable]
 public sealed class UninstallCreatioWarningE2ETests {


### PR DESCRIPTION
## What
Removes `[Category("McpE2E.Manual")]` from `UninstallCreatioWarningE2ETests` ([clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs](clio.mcp.e2e/UninstallCreatioWarningE2ETests.cs)) so the fixture is discovered again by the `Team_Atf_ClioMcpE2eTests` run step, whose filter is `TestCategory!=McpE2E.ProcessDesigner&TestCategory!=McpE2E.Manual`.

Jira: ENG-93666

## Why
The category was added in `082aa19d` to stop 46 never-in-CI `Assert.Ignore` suites from polluting the plan's `ignored` count. This fixture was swept in with them.

The **root cause described in ENG-93666** (`ResolveEnvironmentPath` asserting on an empty `EnvironmentPath`) was **already fixed** in `54c6c510`, which rerouted the test to resolve the sandbox via **IIS URI** instead of `EnvironmentPath`. So re-enabling discovery does **not** reintroduce that failure.

## Scope / safety
- Retains `McpE2E.Sandbox` and `[NonParallelizable]` — the `McpFixturePolicyTests` guard (Sandbox fixtures must be non-parallelizable) still holds.
- The TeamCity run-step filter is **not** touched (it still excludes the other ~45 manual suites); the filter lives in TeamCity, not the repo.
- ⚠️ **Deterministic green in CI still requires provisioning** a disposable destructive sandbox on the agent (exclusive IIS app pool + `AllowDestructiveMcpTests=true` + `Sandbox:EnvironmentName`). Without it, the runtime `Assert.Ignore` guards skip the scenario gracefully rather than failing. Also: the separate TeamCity mute #36531 on this test must be removed for the un-mute to be complete.

## Validation
`dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~McpFixturePolicyTests"` → 2/2 passed on net8.0 and net10.0.

## Review notes
- Code review gate: **review skipped** — test-only change, single-line category-attribute removal (test-selection metadata), no product/command/logic path touched.
- **MCP reviewed, no update required** — no command/options/tool/prompt/resource change.
- **Docs reviewed, no update required** — no command behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)