### PR TITLE
ENG-94482 Refresh registry fixtures for crt.SaveRecordRequest

### DIFF
--- a/clio.tests/Command/McpServer/Fixtures/MobileRequestRegistry.live-snapshot.json
+++ b/clio.tests/Command/McpServer/Fixtures/MobileRequestRegistry.live-snapshot.json
@@ -172,6 +172,21 @@
 			}
 		},
 		{
+			"requestType": "crt.SaveRecordRequest",
+			"parameters": {
+				"preventCardClose": {
+					"type": "boolean",
+					"description": "Keeps the page open after a successful save. When `false` or omitted, a record opened in add or copy mode has its page closed after the save; a record opened in edit mode stays open either way. In both stay-open cases the page switches to the edit state. Distinct from the `preventCardClose` of crt.CreateRecordRequest, which controls whether the saved record is reopened."
+				}
+			},
+			"description": "Saves all data of the current record page - every root data source with pending changes, then the changed items of nested collections - after validating the primary data source. Failed saves are shown in a modal message; there is no success notification on mobile. Bound to the Save button in the Scaffold actions slot on form-page templates. The web-only parameters (showSuccessMessage, messageTextAfterCompletion, reloadSavedRecord) are ignored on mobile.",
+			"references": {
+				"docs": [
+					"mobile-request-docs/mobile-save-record.request.md"
+				]
+			}
+		},
+		{
 			"requestType": "crt.UpdateRecordRequest",
 			"parameters": {
 				"entityName": {
@@ -181,7 +196,7 @@
 				"recordId": {
 					"type": "string",
 					"required": true,
-					"description": "Primary-key value (Id) of the record to open; required - the request does nothing (an error is logged) when it is null or empty. Usually an `$Attribute` binding to the row's Id (e.g. \"$NearbyDS_Id\", \"$Participant.Id\"); a literal Id is also accepted. A bound value is resolved to the record's primary key before navigation."
+					"description": "Primary-key value (Id) of the record to open; required - the request does nothing (an error is logged) when it is null or empty. Usually an `$Attribute` binding to the row's Id (e.g. \"$NearbyDS_Id\", \"$Participant.Id\"); a literal Id is also accepted. A bound value is resolved and then reduced to a primary key: a lookup value is unwrapped to its `value`, a data row to its primary value, a plain string is passed through, anything else becomes null. Because of that unwrapping a lookup column of the current page is bound as-is, without extracting `.value` (e.g. \"$PDS_CreatedBy_vmpu5u4\"), same as web; for that case set `entityName` to the schema the lookup REFERENCES, not the entity of the page the button lives on. Unlike web, a `$` expression here is read as a plain attribute name, so the redundant `\"$Attr.value\"` spelling that web tolerates is looked up as an attribute literally named `Attr.value` and does not resolve."
 				}
 			},
 			"description": "Opens an existing record's edit page so the user can view or change it. Bound to list/detail row taps and link cells, and to buttons. The new page is pushed onto the navigation stack; opening a record does not prompt to discard unsaved changes on the current page.",

--- a/clio.tests/Command/McpServer/Fixtures/RequestRegistry.live-snapshot.json
+++ b/clio.tests/Command/McpServer/Fixtures/RequestRegistry.live-snapshot.json
@@ -255,6 +255,33 @@
 			}
 		},
 		{
+			"requestType": "crt.SaveRecordRequest",
+			"parameters": {
+				"messageTextAfterCompletion": {
+					"type": "string",
+					"description": "Text of the completion message; the localized default (\"Data saved successfully\") is used when not set. Authored via the Designer's \"Message text\" input, usually as a `#ResourceString(<key>)#` reference to a page resource. Only shown as a notification together with `showSuccessMessage: true`; otherwise it is announced to screen readers only."
+				},
+				"preventCardClose": {
+					"type": "boolean",
+					"description": "Keeps the page open after a successful save. When `false` or omitted, a record page opened in add or copy mode navigates back after the save (an edit-mode page always stays open), and a mini page is closed after any successful save. Authored via the Designer's \"Stay on page after record is created\" checkbox."
+				},
+				"reloadSavedRecord": {
+					"type": "boolean",
+					"description": "Only applies together with `preventCardClose`: after a new (add or copy mode) record is saved and its page stays open, `true` reloads the record from the server so server-side changes (for example legacy autonumbering) appear instantly. Authored via the Designer's \"Reload saved record\" checkbox, shown once \"Stay on page after record is created\" is checked."
+				},
+				"showSuccessMessage": {
+					"type": "boolean",
+					"description": "Whether to show a success message after the record is saved: when `true`, the completion message is displayed as a notification; when `false` or omitted, it is only announced to screen readers. The OOTB page templates set it to `true` on the standard Save button."
+				}
+			},
+			"description": "Saves the current record page: persists every page data source with pending changes, then handles the page-level concerns - the completion notification, the card state, and closing a new record's card (the targeted single-data-source tool underneath it is crt.SaveDataRequest). Bound to Save buttons on record pages and mini pages via the \"Save data\" action of the Designer's event panel.",
+			"references": {
+				"docs": [
+					"request-docs/save-record.request.md"
+				]
+			}
+		},
+		{
 			"requestType": "crt.UpdateRecordRequest",
 			"parameters": {
 				"entityName": {
@@ -268,7 +295,7 @@
 				"recordId": {
 					"type": "string | number",
 					"required": true,
-					"description": "Primary-key value (Id) of the record to open; required - the handler shows a settings error and opens nothing when it is null or an empty string (`0` is a valid Id). Usually an `$Attribute` binding to the row's Id (e.g. \"$Items.PDS_Id\" or \"$GridDetail_h7omalt.<DS>_Id\"), an `@event` value, or a literal Id."
+					"description": "Primary-key value (Id) of the record to open; required - the handler shows a settings error and opens nothing when it is null or an empty string (`0` is a valid Id). Usually an `$Attribute` binding to the row's Id (e.g. \"$Items.PDS_Id\" or \"$GridDetail_h7omalt.<DS>_Id\"), an `@event` value, or a literal Id. Three shapes are accepted and all are reduced to the Id by the navigation layer: a Guid string, a numeric primary key, or a whole `LookupValue` (`{ value, displayValue }`). So a lookup column of the current page is bound as-is, without extracting `.value` (e.g. \"$PDS_CreatedBy_vmpu5u4\"), which is also what the Designer's \"Open existing record\" action emits; for that case set `entityName` to the schema the lookup REFERENCES, not the entity of the page the button lives on."
 				}
 			},
 			"description": "Opens the edit page of an existing record so the user can view or change it. Bound to record links (a list row's primary-column link), row \"Open\" menu actions, and buttons wired to the \"Open existing record\" action of the Designer's event panel. Prompts to discard unsaved changes on the current page before navigating.",


### PR DESCRIPTION
- Verbatim re-copy of both live-snapshot fixtures from static-files-mcp latest after adding the crt.SaveRecordRequest entries
- No production code changes
- RequestRegistrySnapshotTests green on net8.0 (13/13)