### PR TITLE
Allow curated knowledge Git source override

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -7810,3 +7810,8 @@ Discovery: CI on 062fc111 is the only place the Windows path behavior could be c
 Discovery: reviewing the body against the branch surfaced two stale claims that had survived several updates — the built-in curated source described as git/branch master when it is github-release against a fixed asset, and clio-knowledge#35 still called open after it merged. A PR body drifts silently because nothing tests it; re-read it against the code whenever the delivery model or a producer state changes, not only when the diff grows.
 Files: .codex/workspace-diary.md (PR body is not a repository file; edited through the GitHub API)
 Impact: #927's body now states the current head's CI numbers, both resyncs, the released 1.12.0 / sequence 14 generation, the manifest-driven per-resource regression on the real delivery path, the read-contract change, and the macOS fixture fix including the CI break it caused. Nothing in the body is now known to be stale.
+# Curated knowledge Git development override
+
+- Preserved an explicitly configured `creatio-curated` Git source for the canonical `clio-knowledge` repository, while retaining the signed GitHub Release source as the default.
+- Added a focused bootstrap test and documented the supported development configuration.
+- Git overrides synchronize on startup even when a checkout is already present, so changing the configured branch cannot leave stale cached knowledge active.

--- a/clio.tests/Command/McpServer/CuratedKnowledgeBootstrapServiceTests.cs
+++ b/clio.tests/Command/McpServer/CuratedKnowledgeBootstrapServiceTests.cs
@@ -180,6 +180,48 @@ public sealed class CuratedKnowledgeBootstrapServiceTests {
 	}
 
 	[Test]
+	[Description("Bootstrap preserves and synchronizes an explicitly configured Git checkout of the canonical curated knowledge repository for development.")]
+	public void Bootstrap_ShouldRetainCanonicalGitOverride_WhenConfiguredForDevelopment() {
+		// Arrange
+		KnowledgeSourceConfiguration overrideSource = new() {
+			LibraryId = CuratedKnowledgeSourceDefaults.LibraryId,
+			Type = KnowledgeSourceType.Git,
+			Location = CuratedKnowledgeSourceDefaults.GitRepositoryLocation,
+			Branch = "feature/unreleased-guidance",
+			Priority = CuratedKnowledgeSourceDefaults.Priority,
+			Participation = KnowledgeSourceParticipation.Authoritative
+		};
+		_settings.GetKnowledgeConfiguration().Returns(
+			Configuration((CuratedKnowledgeSourceDefaults.Alias, overrideSource)));
+		_store.IsGitRepositoryInstalled(CuratedKnowledgeSourceDefaults.Alias).Returns(true);
+		_management.Install(
+			CuratedKnowledgeSourceDefaults.Alias,
+			Arg.Any<int>(),
+			Arg.Any<System.Threading.CancellationToken>()).Returns(new KnowledgeSourceBatchResult(
+				true,
+				"updated",
+				[new KnowledgeSourceOperationResult(
+					CuratedKnowledgeSourceDefaults.Alias,
+					true,
+					"updated",
+					"Curated Git knowledge was updated.")]));
+
+		// Act
+		CuratedKnowledgeBootstrapResult result = _service.Bootstrap();
+
+		// Assert
+		result.Success.Should().BeTrue(
+			because: "a developer-selected canonical checkout is a supported replacement for the release transport");
+		result.Installed.Should().BeTrue(
+			because: "the configured branch must be synchronized before it is served");
+		_settings.DidNotReceiveWithAnyArgs().EnsureKnowledgeSource(default!, default!);
+		_management.Received(1).Install(
+			CuratedKnowledgeSourceDefaults.Alias,
+			Arg.Any<int>(),
+			Arg.Any<System.Threading.CancellationToken>());
+	}
+
+	[Test]
 	[Description("Bootstrap reports an installation failure without throwing so MCP can still start with other configured sources.")]
 	public void Bootstrap_ShouldReturnFailure_WhenCuratedInstallFails() {
 		// Arrange

--- a/clio/Command/McpServer/Knowledge/CuratedKnowledgeBootstrapService.cs
+++ b/clio/Command/McpServer/Knowledge/CuratedKnowledgeBootstrapService.cs
@@ -29,6 +29,9 @@ internal static class CuratedKnowledgeSourceDefaults {
 	/// <summary>The GitHub repository publishing the curated knowledge library.</summary>
 	internal const string RepositoryName = "clio-knowledge";
 
+	/// <summary>The canonical Git repository URI accepted for an explicit developer override.</summary>
+	internal const string GitRepositoryLocation = "https://github.com/Advance-Technologies-Foundation/clio-knowledge.git";
+
 	/// <summary>The fixed release-asset file name carrying the signed bundle.</summary>
 	internal const string AssetName = "clio-knowledge-bundle.zip";
 
@@ -233,10 +236,11 @@ internal sealed class CuratedKnowledgeBootstrapService(
 			// its own. Whether the cached content is actually usable is decided by activation, which
 			// never blocks on the source mutation lock and falls back when it is not.
 			//
-			// This branch is what keeps a warm start offline. Without an artifact-shaped probe the
-			// bundle transports would fall through to Install below and reach the network on every
-			// single MCP start, inside the five-second pre-serve budget.
-			if (IsLocallyInstalled(source.Type, CuratedKnowledgeSourceDefaults.Alias)) {
+			// This branch is what keeps a warm artifact-backed start offline. Git deliberately falls
+			// through to synchronization so an operator's branch, tag, or commit change cannot leave a
+			// stale checkout active under the newly configured reference.
+			if (source.Type != KnowledgeSourceType.Git
+					&& IsLocallyInstalled(source.Type, CuratedKnowledgeSourceDefaults.Alias)) {
 				return new CuratedKnowledgeBootstrapResult(
 					true,
 					true,
@@ -296,6 +300,9 @@ internal sealed class CuratedKnowledgeBootstrapService(
 	/// <param name="candidate">The persisted entry.</param>
 	/// <returns><see langword="true"/> when nothing has to be written.</returns>
 	private static bool IsCanonical(KnowledgeSourceConfiguration candidate) {
+		if (IsCuratedGitOverride(candidate)) {
+			return true;
+		}
 		KnowledgeSourceConfiguration expected = CuratedKnowledgeSourceDefaults.CreateConfiguration();
 		return string.Equals(candidate.LibraryId, expected.LibraryId, StringComparison.OrdinalIgnoreCase)
 			&& candidate.Type == expected.Type
@@ -309,6 +316,16 @@ internal sealed class CuratedKnowledgeBootstrapService(
 			&& candidate.Priority == expected.Priority
 			&& candidate.Participation == expected.Participation;
 	}
+
+	/// <summary>
+	/// Reports whether an operator explicitly selected the canonical curated repository for Git-based development.
+	/// </summary>
+	private static bool IsCuratedGitOverride(KnowledgeSourceConfiguration candidate) =>
+		candidate.Type == KnowledgeSourceType.Git
+		&& string.Equals(candidate.LibraryId, CuratedKnowledgeSourceDefaults.LibraryId, StringComparison.OrdinalIgnoreCase)
+		&& string.Equals(candidate.Location, CuratedKnowledgeSourceDefaults.GitRepositoryLocation, StringComparison.Ordinal)
+		&& candidate.Priority == CuratedKnowledgeSourceDefaults.Priority
+		&& candidate.Participation == KnowledgeSourceParticipation.Authoritative;
 
 	/// <summary>
 	/// Reports whether the alias already has content on disk that activation could serve.

--- a/clio/docs/commands/mcp-server.md
+++ b/clio/docs/commands/mcp-server.md
@@ -81,6 +81,13 @@ disabled state survives future Clio updates and MCP starts. A failed or timed-ou
 logged as a warning and does not prevent MCP from starting; retry with
 `install-knowledge --source creatio-curated` when connectivity returns.
 
+Every configured knowledge source may use the Git transport. For development, an explicit
+`creatio-curated` Git source is preserved instead of being reset to the release transport when it uses library ID `com.creatio.clio`, location
+`https://github.com/Advance-Technologies-Foundation/clio-knowledge.git`, priority `100`, and
+`authoritative` participation. Set its optional `branch`, `tag`, or `commit` to consume unpublished
+knowledge directly from that checkout. The configured Git source is synchronized during startup so a
+branch change takes effect; omitting this override retains the signed GitHub-release default.
+
 Signing trust is scoped per source so independent publishers can use different keys. The configured
 path references public ECDSA P-256 SubjectPublicKeyInfo PEM material; it is not a secret and must
 never reference or contain a private signing key. The key authorized to sign the built-in

--- a/clio/help/en/mcp-server.txt
+++ b/clio/help/en/mcp-server.txt
@@ -59,6 +59,13 @@ DESCRIPTION
     updates and MCP restarts. A failed or timed-out initial install is warned but does not
     prevent MCP startup; retry with install-knowledge --source creatio-curated.
 
+    Every configured knowledge source may use the Git transport. For development, an explicit
+    creatio-curated Git source is preserved instead of being reset to the release transport when it uses library-id com.creatio.clio, location
+    https://github.com/Advance-Technologies-Foundation/clio-knowledge.git, priority 100, and
+    authoritative participation. Its optional branch, tag, or commit can consume unpublished
+    knowledge directly from that checkout. The configured Git source is synchronized during startup so a
+    branch change takes effect. Without this override, the signed GitHub-release default applies.
+
     Public verification keys are not secrets. Never configure a private signing key.
     The public key authorized to sign the built-in com.creatio.clio library is pinned inside
     Clio and is consulted before any configured key material, so a settings entry naming that


### PR DESCRIPTION
## Summary
- preserve an explicitly configured Git source for the built-in curated knowledge library
- keep signed GitHub Release delivery as the default when no override is configured
- document the developer configuration and add bootstrap coverage

## Why
The bootstrap treated only the release transport as canonical and reset an intentional Git configuration on every MCP start, preventing use of unpublished clio-knowledge branches.

## Validation
- dotnet test clio.tests/clio.tests.csproj --filter FullyQualifiedName~CuratedKnowledgeBootstrapServiceTests