### PR TITLE
Realign two MCP e2e tests with the contracts that replaced them

### DIFF
--- a/clio.mcp.e2e/KnowledgeManagementToolE2ETests.cs
+++ b/clio.mcp.e2e/KnowledgeManagementToolE2ETests.cs
@@ -46,9 +46,9 @@ public sealed class KnowledgeManagementToolE2ETests : McpContractFixtureBase {
 
 	[Test]
 	[AllureTag(KnowledgeManagementTools.InfoKnowledgeToolName)]
-	[AllureName("MCP startup migrates the curated source to GitHub Release delivery and preserves its kill switch")]
-	[AllureDescription("Starts the real Clio MCP server over a pre-upgrade Git-transport built-in source and verifies bootstrap rewrites it to the GitHub Release contract without contacting any remote and without re-enabling it.")]
-	[Description("Migrates the disabled curated source from Git to GitHub Release delivery through the real MCP startup path.")]
+	[AllureName("MCP startup retains the curated Git override and preserves its kill switch")]
+	[AllureDescription("Starts the real Clio MCP server over an explicitly configured canonical Git checkout of the curated repository and verifies bootstrap leaves the developer override in place without contacting any remote and without re-enabling it.")]
+	[Description("Retains the disabled curated Git override through the real MCP startup path.")]
 	public async Task McpStartup_ShouldPreserveCuratedKillSwitch_WhenSourceIsDisabled() {
 		// Arrange
 		await using ArrangeContext context = Arrange();
@@ -81,20 +81,19 @@ public sealed class KnowledgeManagementToolE2ETests : McpContractFixtureBase {
 			because: "the local-only info path must expose the operator's durable bootstrap opt-out");
 		source.GetProperty("library-id").GetString().Should().Be("com.creatio.clio",
 			because: "the built-in source is bound to the stable curated library identity");
-		source.GetProperty("type").GetString().Should().Be("github-release",
-			because: "an upgrade must migrate the pre-upgrade Git built-in source onto release delivery");
-		source.GetProperty("location").GetString().Should().Be("https://api.github.com/",
-			because: "bootstrap must persist the GitHub API origin rather than a Git clone URL");
-		source.GetProperty("repository-owner").GetString().Should().Be("Advance-Technologies-Foundation",
-			because: "the built-in source addresses a fixed repository identity instead of an arbitrary URL");
-		source.GetProperty("repository-name").GetString().Should().Be("clio-knowledge",
-			because: "the built-in source addresses a fixed repository identity instead of an arbitrary URL");
-		source.GetProperty("asset-name").GetString().Should().Be("clio-knowledge-bundle.zip",
-			because: "exactly one declared asset name may be retrieved from a release");
-		source.TryGetProperty("branch", out JsonElement branch).Should().BeFalse(
-			because: $"the migrated entry must carry no Git reference, but found '{branch}'");
+		source.GetProperty("type").GetString().Should().Be("git",
+			because: "an explicit canonical Git checkout is a supported developer override that bootstrap must not reset to release delivery");
+		source.GetProperty("location").GetString().Should().Be(
+			"https://github.com/Advance-Technologies-Foundation/clio-knowledge.git",
+			because: "the override is only honored for the canonical curated repository, so its clone URL must survive startup");
+		source.GetProperty("branch").GetString().Should().Be("master",
+			because: "the operator's Git reference selects which knowledge is served and may not be dropped by bootstrap");
+		source.GetProperty("priority").GetInt32().Should().Be(100,
+			because: "the override keeps the built-in source's resolution order");
+		source.GetProperty("participation").GetString().Should().Be("authoritative",
+			because: "the override keeps the built-in source's authoritative participation");
 		source.GetProperty("enabled").GetBoolean().Should().BeFalse(
-			because: "the kill switch must survive the transport migration; bootstrap may never silently re-enable a disabled built-in source");
+			because: "the kill switch must survive startup; bootstrap may never silently re-enable a disabled built-in source");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
@@ -66,45 +66,12 @@ public sealed class MobilePageConversionGuideToolE2ETests : McpContractFixtureBa
 			because: "get-mobile-page-conversion-guide must be advertised so MCP callers can discover the conversion-guide tool");
 	}
 
-	[Test]
-	[Description("Returns the freedom-page-web-to-mobile-conversion guidance article over the real MCP surface and verifies it carries the deterministic empty-container removal contract (already removed by the converter, arrives as a drop with reason \"empty container\", never re-create / re-parent / ask the user) plus the profile-island routing (SideAreaProfileContainer merges into AreaProfileContainer; other wrapper content fills GeneralTabContainer).")]
-	[AllureTag(GuidanceGetTool.ToolName)]
-	[AllureName("get-guidance returns the conversion article with the deterministic empty-container removal contract")]
-	[AllureDescription("Starts the real clio MCP server with mobile-page-converter enabled and verifies get-guidance resolves the feature-gated freedom-page-web-to-mobile-conversion article carrying the empty-container removal wording end to end.")]
-	public async Task GuidanceGet_Should_Return_Conversion_Guide_With_EmptyContainerRemoval_Contract() {
-		// Arrange
-		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
-
-		// Act
-		CallToolResult callResult = await context.Session.CallToolAsync(
-			GuidanceGetTool.ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["name"] = "freedom-page-web-to-mobile-conversion"
-				}
-			},
-			context.CancellationTokenSource.Token);
-
-		// Assert
-		callResult.IsError.Should().NotBeTrue(
-			because: "get-guidance should return a normal MCP tool result envelope for a registered guidance name");
-		GuidanceGetResponse response = EntitySchemaStructuredResultParser.Extract<GuidanceGetResponse>(callResult);
-		response.Success.Should().BeTrue(
-			because: "freedom-page-web-to-mobile-conversion is a registered guidance name while mobile-page-converter is enabled");
-		response.Article.Should().NotBeNull(
-			because: "successful guidance lookups should return the resolved article payload");
-		response.Article!.Uri.Should().Be("docs://mcp/guides/freedom-page-web-to-mobile-conversion",
-			because: "the canonical resource URI for the conversion guide should be stable");
-		response.Article.Text.Should().Contain("removed deterministically by the converter",
-			because: "the drop branch must state that empty converter-created containers are removed by the converter itself, not left for the user to delete");
-		response.Article.Text.Should().Contain("\"empty container\"",
-			because: "the article must name the exact drop reason the elementMap carries for a removed empty container so the caller can recognize it");
-		response.Article.Text.Should().Contain(
-			"Do NOT re-create such a container, do NOT re-parent anything into it, and do NOT ask the user",
-			because: "the article must forbid the caller from resurrecting a removed empty container or turning its removal into a question");
-		response.Article.Text.Should().Contain("SideAreaProfileContainer→AreaProfileContainer",
-			because: "only the profile island's children merge into the template's profile Area card, while the wrapper's other non-tab content fills the general tab's grid (CardContentWrapper→GeneralTabContainer)");
-	}
+	// The freedom-page-web-to-mobile-conversion article itself is no longer Clio-owned: since
+	// "Externalize guidance delivery mechanics" (#927) get-guidance serves only articles delivered by an
+	// installed, verified knowledge bundle, and the article now lives in the clio-knowledge repository.
+	// A hermetic NoEnvironment fixture installs no knowledge source, so asserting the article's wording
+	// here could only pass by contacting a real remote. The tool-surface contract stays covered by the
+	// discovery and invalid-environment tests below; the article's wording belongs to clio-knowledge.
 
 	[Test]
 	[Description("Returns a structured failure (not a protocol error) when the target environment is not registered, so the caller can read why the source page could not be read.")]

--- a/clio.tests/Command/McpServer/CuratedKnowledgeBootstrapServiceTests.cs
+++ b/clio.tests/Command/McpServer/CuratedKnowledgeBootstrapServiceTests.cs
@@ -222,6 +222,36 @@ public sealed class CuratedKnowledgeBootstrapServiceTests {
 	}
 
 	[Test]
+	[Description("Bootstrap rewrites a Git entry that is not the canonical curated repository onto the signed release transport instead of treating it as a developer override.")]
+	public void Bootstrap_ShouldRestoreReleaseTransport_WhenGitSourceIsNotTheCanonicalRepository() {
+		// Arrange
+		// The override is deliberately narrow: only the canonical clone URL is honored, so a fork or a
+		// mirror left behind by an older Clio must still be migrated onto release delivery.
+		KnowledgeSourceConfiguration foreignGitSource = new() {
+			LibraryId = CuratedKnowledgeSourceDefaults.LibraryId,
+			Type = KnowledgeSourceType.Git,
+			Location = "https://github.com/some-fork/clio-knowledge.git",
+			Branch = "master",
+			Priority = CuratedKnowledgeSourceDefaults.Priority,
+			Participation = KnowledgeSourceParticipation.Authoritative
+		};
+		_settings.GetKnowledgeConfiguration().Returns(
+			Configuration((CuratedKnowledgeSourceDefaults.Alias, foreignGitSource)));
+
+		// Act
+		_service.Prepare();
+
+		// Assert
+		_settings.Received(1).EnsureKnowledgeSource(
+			CuratedKnowledgeSourceDefaults.Alias,
+			Arg.Is<KnowledgeSourceConfiguration>(source =>
+				source.Type == KnowledgeSourceType.GitHubRelease
+				&& source.Location == CuratedKnowledgeSourceDefaults.ResolveLocation()
+				&& source.AssetName == CuratedKnowledgeSourceDefaults.AssetName
+				&& string.IsNullOrWhiteSpace(source.Branch)));
+	}
+
+	[Test]
 	[Description("Bootstrap reports an installation failure without throwing so MCP can still start with other configured sources.")]
 	public void Bootstrap_ShouldReturnFailure_WhenCuratedInstallFails() {
 		// Arrange


### PR DESCRIPTION
No Jira ticket — this clears CI baseline noise found while driving another PR green.

## What was broken

Two `clio.mcp.e2e` tests have failed on **every** run of `Team_Atf_ClioMcpE2eTests` since 2026-08-06, so every PR since then shows a red e2e check regardless of its own changes:

- `KnowledgeManagementToolE2ETests.McpStartup_ShouldPreserveCuratedKillSwitch_WhenSourceIsDisabled`
- `MobilePageConversionGuideToolE2ETests.GuidanceGet_Should_Return_Conversion_Guide_With_EmptyContainerRemoval_Contract`

Neither is a product defect. Each asserts a contract that a PR merged the same day deliberately replaced.

## Why they broke

**Knowledge test** — `d5999c7a4` "Allow curated knowledge Git source override" (#1017) added `IsCuratedGitOverride`, so a `creatio-curated` entry using the Git transport with the canonical clone URL, priority `100` and `authoritative` participation is now **preserved** rather than reset to the release transport. `mcp-server.md` in that same commit documents the override, including its optional `branch`. The e2e fixture configures exactly such an entry, while the test still asserted the pre-#1017 migration to `github-release`.

**Mobile test** — a semantic conflict between two PRs merged hours apart:

| | |
|---|---|
| `aa8760da6` (#927) `11:09Z` | Externalized guidance delivery: `get-guidance` now serves **only** articles from an installed, verified knowledge bundle; the article moved to `clio-knowledge`. Its e2e run was green — this test did not exist yet. |
| `f315fe0dd` (#994) `14:08Z` | **Added** this test, written against the pre-#927 world where the article shipped inside clio. |

First failure is build `15839166`, whose `lastChanges` is `f315fe0dd` — the first run after #994 landed.

## How it reached master

The `CLIO MCP e2e tests (ATF)` check is not a required status check, and on **both** #994 and #1017 the `Trigger TeamCity MCP e2e` job failed after 4 seconds, so no e2e build ran on either branch before merge. There is no evidence either test ever passed on its own PR branch.

Worth noting: #1026 adds `queue-teamcity-build.ps1` with multi-attempt queueing, which addresses the trigger-reliability half of this. Making the check required is a repo-settings decision, not part of this PR.

## What this PR changes

- **`KnowledgeManagementToolE2ETests`** — asserts what the override actually guarantees: the Git entry, its `branch`, its priority/participation, and the operator's kill switch all survive startup untouched.
- **`CuratedKnowledgeBootstrapServiceTests`** — new unit test so the migration path stays covered and the override stays narrow: a Git entry pointing at a *fork* rather than the canonical repository is still rewritten onto the signed release transport.
- **`MobilePageConversionGuideToolE2ETests`** — the article-wording test is removed, with a comment explaining why. A hermetic `NoEnvironment` fixture installs no knowledge source, so the assertion cannot pass without contacting a real remote. Re-embedding the wording in clio would undo #927 on purpose; the tool-surface contract stays covered by the discovery and invalid-environment tests, and the wording belongs to `clio-knowledge`.

## Verification

Run on macOS, net10.0 — the two failures reproduce locally, which is what makes this diff testable rather than speculative:

| | Result |
|---|---|
| `clio.mcp.e2e` (both fixtures) **before** the change | `Failed: 2, Passed: 6` — same two tests as CI |
| `clio.mcp.e2e` (both fixtures) **after** | `Passed: 7, Failed: 0` |
| `CuratedKnowledgeBootstrapServiceTests` | `Passed: 12, Failed: 0` |
| `dotnet build clio.mcp.e2e -c Debug -f net10.0` | `0 Error(s)` |

The TeamCity e2e job on this PR is the authoritative check.
