### PR TITLE
Restore NET8 TeamCity MCP E2E compatibility

### DIFF
--- a/.codex/agents/code-quality-reviewer.toml
+++ b/.codex/agents/code-quality-reviewer.toml
@@ -1,3 +1,2 @@
-﻿model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 developer_instructions = "Focus on code code-quality issues. When finding code-quality issues give concrete steps on how to reproduce the issue and suggest potential improvements. Write tests to validate hypothesis before flagging an issue."

--- a/.codex/agents/performance-review.toml
+++ b/.codex/agents/performance-review.toml
@@ -1,3 +1,2 @@
-﻿model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 developer_instructions = "Focus on code performance issues, write tests to validate hypothesis before flagging an issue. When finding performance issues give concrete steps on how to reproduce the issue and suggest potential optimizations."

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,3 +1,2 @@
-﻿model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 developer_instructions = "Focus on security issues."

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -8658,3 +8658,24 @@ Decision: Make hybrid interleaving and mixed-protocol credential isolation posit
 Discovery: Signed Claude reply `394f2b52` is valid/trusted and replies to request `245ce8a5`; Claude agrees there are no remaining actionable findings. All four final local lenses also report no findings. The authoritative project context confirms MCP E2E runs in TeamCity for this path-filtered PR, though it remains advisory and may finish after auto-merge.
 Files: clio.mcp.e2e/McpHttpHybridSessionModeE2ETests.cs, clio.mcp.e2e/McpHttpMultiTenantE2ETests.cs, clio.mcp.e2e/Support/Mcp/McpHttpPassthroughStand.cs, clio-ring/ClioRing.Ipc/ClioIpcClient.cs, clio-ring/ClioRing.Tests/ClioIpcHealthProbeTests.cs
 Impact: The final exact diff passes 3,446 MCP unit tests, 156 Ring tests, focused real-process modern/legacy/CAADT E2E, NET8 compatibility build, read-only Ring IPC proof, clean vulnerability audit, and Windows x64 NativeAOT publish.
+
+## 2026-08-14 09:03 – Restore NET8 compatibility for TeamCity MCP E2E
+Context: PR #1075 made every modern test project NET10-only, but TeamCity intentionally builds and runs the live MCP E2E harness on NET8; current builds therefore failed in preparation with NETSDK1045 before any tests ran.
+Decision: Keep GitHub unit, integration, and analyzer execution on NET10 while restoring conditional NET8/NET10 targeting only to the MCP E2E project and its process fixture. Leave the production Clio targets and TeamCity configuration unchanged.
+Discovery: TeamCity steps explicitly build `clio.mcp.e2e` with `-f net8.0`, load `bin/Debug/net8.0/clio.dll`, and run tests on NET8. The restored projects build successfully on both frameworks, and the environment-free stdio MCP lifecycle test passes on both.
+Files: clio.mcp.e2e/clio.mcp.e2e.csproj, clio.process.fixture/clio.process.fixture.csproj
+Impact: TeamCity can continue its NET8 E2E contract without reintroducing duplicate NET8 unit-test execution in GitHub.
+
+## 2026-08-14 09:08 – Claude review closed E2E trigger coverage
+Context: The user required early Claude consultation through the observable `clio-test-optimization` Visualizer room before finalizing the NET8 TeamCity correction.
+Decision: Accept Claude's verified review that the two target projects are sufficient, add both E2E paths to GitHub's NET10 test-change filter, add the process fixture to TeamCity's trigger paths, and name the exact TeamCity configuration in both project comments.
+Discovery: Claude reply `4a73d280` (valid and trusted signature, reply to `9f65babc`) found that the original two-file diff would skip GitHub unit validation because neither path matched `build.yml`. It also identified the acceptable restore-time cost: `clio.tests` references `clio.mcp.e2e`, so restore sees the NET8 graph even though GitHub still builds and executes only NET10 tests.
+Files: .github/workflows/build.yml, .github/workflows/teamcity-mcp-e2e.yml, clio.mcp.e2e/clio.mcp.e2e.csproj, clio.process.fixture/clio.process.fixture.csproj
+Impact: NET8 and NET10 E2E builds pass; the environment-free stdio lifecycle test passes on both; the exact GitHub NET10 unit lane passes 8,998/23 skipped and integration passes 24/2 skipped. No NET8 tests were reintroduced in GitHub.
+
+## 2026-08-14 09:30 – Remove unavailable reviewer model pins
+Context: The repository's three Codex reviewer profiles pinned `gpt-5.3-codex`, which is unavailable for the current Codex account and prevented the specialist agents from starting.
+Decision: Remove the explicit model pins so Codex can select a supported model while preserving each profile's reasoning effort and instructions.
+Discovery: The pin existed only in the code-quality, performance, and security reviewer profiles under `.codex/agents`.
+Files: .codex/agents/code-quality-reviewer.toml, .codex/agents/performance-review.toml, .codex/agents/security-reviewer.toml
+Impact: Repository reviewer agents no longer fail immediately because of an unavailable model override.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
               - 'Directory.Packages.props'
             tests:
               - 'clio.tests/**'
+              - 'clio.mcp.e2e/**'
+              - 'clio.process.fixture/**'
             analyzers:
               - 'Clio.Analyzers/**'
               - 'Clio.Analyzers.Tests/**'

--- a/.github/workflows/teamcity-mcp-e2e.yml
+++ b/.github/workflows/teamcity-mcp-e2e.yml
@@ -81,6 +81,7 @@ on:
       - '!clio/help/**'
       - '!clio/Commands.md'
       - 'clio.mcp.e2e/**'
+      - 'clio.process.fixture/**'
       - 'cliogate/**'
       - 'Directory.Packages.props'
   # Manual retrigger for a specific clio branch (e.g. re-run e2e after a flaky

--- a/clio.mcp.e2e/clio.mcp.e2e.csproj
+++ b/clio.mcp.e2e/clio.mcp.e2e.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<!-- TeamCity Team_Atf_ClioMcpE2eTests requires net8.0; SDK 10 hosts also build and run net10.0. -->
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/clio.process.fixture/clio.process.fixture.csproj
+++ b/clio.process.fixture/clio.process.fixture.csproj
@@ -2,7 +2,9 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net10.0</TargetFramework>
+		<!-- TeamCity Team_Atf_ClioMcpE2eTests consumes this fixture on net8.0; SDK 10 hosts also build net10.0. -->
+		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '10.0'))">net10.0;net8.0</TargetFrameworks>
 		<AssemblyName>git</AssemblyName>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary

- restore NET8 targeting for `clio.mcp.e2e` and `clio.process.fixture` so TeamCity configuration `Team_Atf_ClioMcpE2eTests` can build and run its existing NET8 lane
- retain NET10 targeting when built with SDK 10 and keep GitHub unit, integration, analyzer, and E2E execution explicitly on NET10
- make changes to either E2E project trigger the relevant GitHub and TeamCity workflows
- remove unavailable `gpt-5.3-codex` model pins from all repository Codex reviewer profiles so they inherit a supported model

## Why

PR #1075 made the E2E projects NET10-only, while TeamCity still intentionally invokes `dotnet build ... -f net8.0` and consumes `bin/Debug/net8.0/clio.dll`. Builds therefore failed with NETSDK1045 before tests could start. Production Clio remains compatible with both NET8 and NET10; this change does not reintroduce NET8 unit-test execution in GitHub.

## Validation

Completed before the final reviewer-profile metadata cleanup:

- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net8.0 -p:RunAnalyzers=false`
- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net10.0 -p:RunAnalyzers=false`
- environment-free stdio MCP lifecycle test on NET8 and NET10: 1 passed on each framework
- GitHub NET10 unit lane: 8,998 passed, 23 skipped
- GitHub NET10 integration lane: 24 passed, 2 skipped
- workflow YAML parsed successfully
- comprehensive pre-PR review lenses completed for code quality, security, performance, and correctness with no findings; remaining check activity was stopped at user request

## Reviews

- Docs reviewed, no command documentation update required.
- MCP reviewed, no MCP tool contract update required.
- ClioRing compatibility reviewed, no Ring-consumed contract changed.
- Claude was consulted through the signed observable `clio-test-optimization` room; its path-filter finding is included in this diff.