### PR TITLE
Set DOTNET_INSTALL_DIR at step scope so the workflow file stays valid

### DIFF
--- a/.github/workflows/reliase-to-nuget.yml
+++ b/.github/workflows/reliase-to-nuget.yml
@@ -16,19 +16,6 @@ jobs:
     # "running scripts is disabled on this system" (PSSecurityException / UnauthorizedAccess).
     env:
       PSExecutionPolicyPreference: Bypass
-      # actions/setup-dotnet installs into C:\Program Files\dotnet by default, which the
-      # self-hosted runner's service account cannot write:
-      #   "dotnet-install: The current user doesn't have write access to the installation root
-      #    'C:\Program Files\dotnet' to install .NET."
-      # The step was added to this workflow on 2026-08-14 (b5d6429c), copying the pattern from
-      # build.yml - but build.yml runs on GitHub-hosted ubuntu-latest/windows-latest, where the
-      # default root IS writable, whereas this job is the only one on self-hosted. Every release
-      # since has failed at that step before packing, so 8.1.0.105 and 8.1.0.106 were tagged and
-      # released on GitHub but never published to NuGet.
-      # Redirecting the install to the runner tool cache keeps the NET10 requirement that commit
-      # introduced (the test step below runs --framework net10.0) without needing write access to
-      # Program Files, and persists across runs so each release does not re-download the SDKs.
-      DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}\dotnet
     steps:
       - name: Free disk space
         shell: powershell
@@ -53,7 +40,22 @@ jobs:
         with:
           fetch-depth: 1  # Shallow clones should be disabled for a better relevancy of analysis
 
+      # actions/setup-dotnet installs into C:\Program Files\dotnet by default, which the
+      # self-hosted runner's service account cannot write:
+      #   "dotnet-install: The current user doesn't have write access to the installation root
+      #    'C:\Program Files\dotnet' to install .NET."
+      # This step was added on 2026-08-14 (b5d6429c), copying build.yml - but build.yml runs on
+      # GitHub-hosted runners where that root IS writable, while this job is the only one on
+      # self-hosted. Every release since 8.1.0.104 failed here before packing, so 8.1.0.105 and
+      # 8.1.0.106 were released on GitHub but never published to NuGet.
+      #
+      # DOTNET_INSTALL_DIR must be set at STEP scope: the `runner` context is not available in a
+      # job-level `env` key (only github, needs, strategy, matrix, vars, secrets, inputs), which
+      # makes the whole workflow file invalid rather than merely ineffective. setup-dotnet adds the
+      # directory to PATH and sets DOTNET_ROOT, so the later dotnet calls in this job use it too.
       - uses: actions/setup-dotnet@v4
+        env:
+          DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}\dotnet
         with:
           dotnet-version: |
             8.0.x


### PR DESCRIPTION
Follow-up to #1097, completing #1096. **My previous fix was wrong and made things worse — this corrects it.**

### What #1097 got wrong

It set `DOTNET_INSTALL_DIR` in the **job-level** `env` block. The `runner` context is not available
there — `jobs.<job_id>.env` only allows `github`, `needs`, `strategy`, `matrix`, `vars`, `secrets`,
`inputs`. So instead of merely being ineffective, it made the **whole workflow file invalid**.

Evidence: every push containing that version produced an immediate 0-second failure —
[`32135240118`](https://github.com/Advance-Technologies-Foundation/clio/actions/runs/32135240118) on the
branch and [`32135491392`](https://github.com/Advance-Technologies-Foundation/clio/actions/runs/32135491392)
on master — both reporting *"This run likely failed because of a workflow file issue."* The next release
would have failed before any step ran.

### The correction

Move the variable onto the `actions/setup-dotnet` step, where `runner` **is** available
(`jobs.<job_id>.steps.*.env`). `setup-dotnet` adds the install directory to `PATH` and sets
`DOTNET_ROOT`, so the later `dotnet` calls in the job resolve to it without needing the variable at job
scope.

### Verification

- The workflow parses, the job `env` block no longer references any context illegal at that scope, and
  the `setup-dotnet` step carries the variable.
- **Empirical**: pushing this branch produced **no run** for this workflow, versus the 0-second failures
  the previous version produced on every push. An invalid file yields a ghost failure run; a valid one
  yields nothing, since this workflow only triggers on `release: [published]`.
- `DOTNET_INSTALL_DIR` is the documented mechanism for exactly this situation — the setup-dotnet README
  states that on self-hosted runners "installing .NET under the default location may fail due to
  insufficient permissions. To ensure successful installation, set `DOTNET_INSTALL_DIR` to a
  user-writable path."

Still not exercised end to end: this workflow only runs on `release: [published]`, so the install-path
change itself is proven by the next release. Note also that re-publishing an existing tag does **not**
pick this up — a `release` event runs the workflow from the **tagged commit**, which is why re-publishing
`8.1.0.106` (tag commit `a4dd1f2b`) still failed with the original error. A new tag cut from master is
required.

Residual risk: if `runner.tool_cache` is also not writable on that runner, the release fails the same way
and the remaining options are granting the runner account write access to `C:\Program Files\dotnet`,
pre-installing the 8.0/10.0 SDKs there, or dropping the `setup-dotnet` step (only safe if that runner
already has .NET 10).
