### PR TITLE
#1106 Record login timing and concurrency context on a rejected Creatio login

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -8940,3 +8940,61 @@ Impact: any future "Unauthorized … for …" in CI now carries kind / client id
 in-flight-logins / in-flight-requests / timestamps, so the concurrent-login question is answerable
 from the log alone. Reusable pattern: when a diagnostic must survive to an MCP caller, the carrying
 exception must be the inner-most one.
+
+## 2026-08-19 – GH #1106 login diagnostics: review round (blast radius of the decoration)
+Context: PR #1117 review (m-dymytrova) requested changes with two Blockers sharing one root cause —
+the recorder replaced the surfaced exception type on paths that were never in scope. Every claim was
+re-verified against the merged tree before fixing; all seven findings were warranted except the
+process-wide-counter one, which is answered instead of changed.
+Decision (two steps, both required, in this order):
+(a) `LoginDiagnostics.Track` no longer catches `Exception` unconditionally — it now uses the same
+    login-rejection predicate as `TrackRequest`, so a `WebException` / `TimeoutException` /
+    `OperationCanceledException` / fatal type propagates as the SAME instance. That restores
+    `RemoteCommand.Login`'s `catch (WebException) => return 1` (a control-flow change, not a message
+    change — the premise "no CLI command calls adapter.Login() explicitly" was wrong: there are seven
+    production callers), `BaseDataContextCommand`'s 404 arm, `ExceptionReadableMessageExtension`'s
+    InnerException walk, `GetCreatioInfoCommand.IsRecoverable`'s fatal-type blocklist, and
+    `McpToolErrorFilter`'s deliberate `OperationCanceledException` rethrow (ENG-93373). It also removes
+    the `elapsed-ms=401` substring-classifier interaction the PR body had flagged as Low.
+(b) Only THEN `CreatioLoginFailedException : UnauthorizedAccessException`. Deriving before narrowing
+    would have reclassified a login timeout as "credentials refused" at `ServerReadinessWaiter`,
+    killing the warm-up tolerance its comment protects. With (a) in place everything decorated really
+    is a credential rejection, so the four classifiers that key on the type keep matching:
+    `ServerReadinessWaiter` (AuthenticationRejected → fail fast instead of burning the readiness budget
+    on further rejected logins, each of which destroys a live session), `GetCreatioInfoCommand`,
+    `SchemaNamePrefixTool` (an MCP-VISIBLE result-content change — the "MCP reviewed, no update
+    required" claim only becomes true again with this step) and `SysSettingsCommand.CategorizeError`.
+    Deriving preserves the inner-less invariant, so `GetBaseException().Message` and
+    `SurfacedExceptionMessage.Resolve` still surface the context.
+Discovery: the filter was exact-type + prefix with no chain unwrapping, while this repo documents the
+opposite arrival shape for this very client — `Creatio.Client` runs transport via `Task.Result`, so
+faults arrive wrapped in `AggregateException` (`EntitySchemaPublishHelper`,
+`TransientNetworkFailureClassifier`, `GetCreatioInfoCommand`, `ApplicationSectionCreateCommand`,
+`UserThemeApplier` all unwrap it). All 20 original tests threw BARE, so the suite could not tell
+"the filter matches in production" from "the feature never fires". New
+`TryFindLoginRejection(Exception, out UnauthorizedAccessException)` flattens and walks; the message is
+built from the FOUND rejection (an `AggregateException`'s own "One or more errors occurred." would
+have replaced the primary server signal) and the wrapper is recorded as `wrapped-in=`.
+Also: `ILoginDiagnostics` got an injection seam (an extra internal ctor where the reauth executor MAY
+be null — the only way to reach the `Reauthentication` closure the DEFAULT executor owns), the
+eight-fold `_reauthExecutor.Execute(() => _loginDiagnostics.TrackRequest(...))` composition collapsed
+into one `ExecuteRequest` helper (non-generic: the session-expired predicate inspects a response body,
+so it is string-only), a `void TrackRequest(Action)` overload removed `DownloadFile`'s `return null`
+contortion, and the `Reauthentication` XML doc now records that its `in-flight-requests` excludes the
+request that triggered the re-login (`ReauthExecutor` runs the request to completion first, so
+`0/0` means "no OTHER traffic").
+Not changed: the process-wide counters stay in the caller-facing message. Scoping them per tenant is
+not reachable without new plumbing — the adapter's private ctor holds only a `Lazy<CreatioClient>`,
+and the bearer/passthrough construction paths carry no credential identity at all — and moving them to
+`Exception.Data` only would defeat the PR's whole goal ("diagnosable from CI output alone"). Left as
+an open call.
+Files: clio/Common/LoginDiagnostics.cs, clio/Common/ILoginDiagnostics.cs,
+clio/Common/LoginAttemptKind.cs, clio/Common/CreatioLoginFailedException.cs,
+clio/Common/CreatioClientAdapter.cs, clio.tests/Common/LoginDiagnosticsTests.cs,
+clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+Impact: `~LoginDiagnostics|~CreatioClientAdapter` 46/46; the classifier-adjacent suites
+(`~ServerReadiness|~GetInfoCommand|~SchemaNamePrefix|~SysSettings|~Reauth|~McpToolError|~ApplicationClientFactory`)
+305/305; full `Category=Unit` 9103 passed with the same 20 pre-existing macOS-only failures
+(9085 → 9103). Generalisation: an exception decorator's blast radius is the set of `catch` clauses that
+key on the type it replaces — narrow the decoration to the exact shape it claims to describe, then
+derive from the type the callers already classify, so the wrapper adds information without removing any.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -8853,3 +8853,35 @@ Decision: new `handler-attribute-change-unscoped-write` Warning in PageBodyAstLi
 Discovery (from d-krestov's CHANGES_REQUESTED review, all four fixed): (1) an earlier `condition: { attributeName }` suppressor was UNSUBSTANTIATED — that key is nowhere in the page-schema-handlers guide nor anywhere in the repo, and if Freedom UI silently ignores it the linter would both stay quiet on the real defect AND advise a silently-ignored key. Dropped the `condition` suppressor, its message clause, and both condition tests; only the guide-documented in-body guard scopes. (2) `TryGetInitProperty` rejects `Method: true`, so a shorthand-method `handler(request, next) {}` was a FALSE NEGATIVE; added `TryGetEntryProperty` (accepts method-form) for the `request`/`handler` keys. Bracket-access `request["attributeName"]` was a FALSE POSITIVE; `ScanHandlerBody` now also matches a COMPUTED member access on the `"attributeName"` property literal — `MemberExpression { Computed: true, Property: Literal { Value: "attributeName" } }`. (A first pass matched a bare `Literal { Value: "attributeName" }` anywhere in the body; a second code-review round caught that this silences the warning on an incidental literal such as `$context.set("attributeName", x)` — a new false negative on the exact ENG-95557 footgun — so it was narrowed to the computed-member form. A THIRD round caught that neither existing test distinguished the narrowed form from the bare-literal one (a revert stayed green), so a dedicated regression lock was added — `Lint_ShouldWarn_WhenIncidentalAttributeNameLiteralButWriteUnscoped`, an unscoped `$context.set("attributeName", ...)` that MUST warn — and verified to go red under the reverted bare-literal match. A separate specificity test pins that a bracket read of a DIFFERENT key still warns.) (3) the doc comment no longer claims "zero false positives" — a guard hidden behind a helper call (an early return driven by a helper predicate) is an acknowledged residual FP (needs inter-procedural analysis); (4) the message now offers an exit for the intentional cross-field-recompute case (still guard against self-re-entry). A final commit reworded the rule doc comment to clear SonarCloud S125 (it read statement-like snippets as commented-out code).
 Files: clio/Command/McpServer/Tools/PageBodyAstLinter.cs, clio.tests/Command/McpServer/PageBodyAstLinterTests.cs, clio.mcp.e2e/PageValidateToolE2ETests.cs
 Impact: `~PageBodyAstLinter` 38 green (added shorthand-method-warns, bracket-access-no-warn, bracket-key-specificity-warns, incidental-literal regression lock, condition-only-warns; removed two condition tests, retargeted the mixed-array test's scoped entry to an in-body guard); `Category=Unit&Module=McpServer` 3463 passed / 1 skipped; new e2e `PageValidateTool_Should_Warn_On_Unscoped_AttributeChange_Handler_Write` 1/1 (net10). SonarCloud PR #1107: Quality Gate OK, 0 bugs / 0 vulns / 0 smells. Generalisation: a linter suppressor must scope on a signal the platform actually honors — before teaching a rule to stay quiet on a config key, prove the key exists in the shipped guidance and that the runtime respects it, or the rule advises a footgun while going blind to the exact defect it targets; and anchor a token-based suppressor to its real syntactic position (a computed member access), never a bare literal match, or an incidental occurrence silences it.
+
+## 2026-08-19 16:20 – Login-failure diagnostics for GH #1106 flaky e2e
+Context: GitHub issue #1106 items 3/4 — clio MCP e2e `create-app-section` / `update-app-section`
+intermittently fail with `Unauthorized ***** for [uri]`. Prior pass proposed no fix because the
+concurrent-login theory could not be confirmed from static analysis.
+Decision: ship instrumentation only (operator's call). Decorate a rejected login with timing +
+concurrency context so the next TeamCity reproduction proves or kills the theory. No behavioral
+change; `SectionCreateSerializationGuard` scope deliberately left alone (ADR-level).
+Discovery (three facts, all verified, two of them by decompiling creatio.client 1.0.38):
+1. `CreatioClient.Login()` throws `UnauthorizedAccessException("Unauthorized {user} for {url}")` when
+   the login response body contains `"Code":1` — so the e2e failures are a SERVER-side login
+   rejection, not a gap in `ReauthExecutor`. It also assigns `_authCookie = new CookieContainer()`
+   BEFORE the request, so a failed login destroys an existing valid session.
+2. `CreatioClient.InitAuthCookie()` logs in IMPLICITLY from inside every request method when the
+   client has no auth cookie yet. This is the dominant path in the MCP surface (every tool call
+   builds its own `IApplicationClient`), and it is invisible to adapter-level `Login()` wrapping.
+   Found only by a runtime check against a fake Creatio — static reading had missed it.
+3. `SurfacedExceptionMessage.Resolve` (MCP boundary) and `Exception.GetBaseException()` (application
+   -section commands) BOTH reduce to the inner-most exception. A wrapper that keeps the original as
+   its InnerException therefore has its message silently discarded — so `CreatioLoginFailedException`
+   is deliberately inner-less, with the original in `Exception.Data`.
+Runtime verification: local fake Creatio (returns `"Code":1` on the login URL; login-page HTML on
+data URLs) reproduced both shapes through the real `CreatioClient` and showed the decorated message
+for `kind=implicit` and `kind=reauth`.
+Files: clio/Common/LoginDiagnostics.cs, clio/Common/ILoginDiagnostics.cs,
+clio/Common/LoginAttemptKind.cs, clio/Common/CreatioLoginFailedException.cs,
+clio/Common/CreatioClientAdapter.cs, clio/BindingsModule.cs,
+clio.tests/Common/LoginDiagnosticsTests.cs
+Impact: any future "Unauthorized … for …" in CI now carries kind / client id / ordinal /
+in-flight-logins / in-flight-requests / timestamps, so the concurrent-login question is answerable
+from the log alone. Reusable pattern: when a diagnostic must survive to an MCP caller, the carrying
+exception must be the inner-most one.

--- a/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
@@ -34,6 +34,10 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		IReauthExecutor reauthExecutor = null) =>
 		new(new Lazy<CreatioClient>(() => null), reauthExecutor, diagnostics);
 
+	// Its own scoreboard, never LoginAttemptScoreboard.Shared: a test that reached the process-wide
+	// singleton would be order-dependent under parallel execution.
+	private static LoginDiagnostics CreateRecorder() => new(new LoginDiagnostics.LoginAttemptScoreboard());
+
 	private static IReauthExecutor CreatePassthroughExecutor() {
 		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
 		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
@@ -128,7 +132,7 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		// Arrange — a real recorder plus a client whose construction throws the rejection shape.
 		CreatioClientAdapter adapter = new(
 			new Lazy<CreatioClient>(() => throw new UnauthorizedAccessException(LoginRejectionMessage)),
-			Substitute.For<IReauthExecutor>(), new LoginDiagnostics());
+			Substitute.For<IReauthExecutor>(), CreateRecorder());
 
 		// Act
 		Action act = () => adapter.Login();
@@ -147,7 +151,7 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		// Arrange
 		WebException original = new("connect failed", WebExceptionStatus.ConnectFailure);
 		CreatioClientAdapter adapter = new(new Lazy<CreatioClient>(() => throw original),
-			Substitute.For<IReauthExecutor>(), new LoginDiagnostics());
+			Substitute.For<IReauthExecutor>(), CreateRecorder());
 
 		// Act
 		Action act = () => adapter.Login();

--- a/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Net;
+using Clio.Common;
+using Creatio.Client;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+/// <summary>
+/// Pins that <see cref="CreatioClientAdapter"/> actually routes through <see cref="ILoginDiagnostics"/>.
+/// Without these, the GitHub #1106 instrumentation could be dropped from any wiring point by a later
+/// refactor with no test signal, because every other auth test substitutes <see cref="IApplicationClient"/>
+/// and replaces the adapter entirely.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Common")]
+internal class CreatioClientAdapterLoginDiagnosticsTests {
+
+	#region Methods: Private
+
+	// The exact shape Creatio.Client throws when the login response carries "Code":1.
+	private const string LoginRejectionMessage = "Unauthorized svc_user for https://host";
+
+	private const string LoginPageBody =
+		"<!DOCTYPE html><html><head><title>Login</title></head>" +
+		"<body><form action=\"/0/Login/NuiLogin.aspx\"><input/></form></body></html>";
+
+	// The Lazy is intentionally never resolved: the substituted diagnostics never invokes the wrapped
+	// callback, so Client is never dereferenced inside the adapter.
+	private static CreatioClientAdapter CreateAdapter(ILoginDiagnostics diagnostics,
+		IReauthExecutor reauthExecutor = null) =>
+		new(new Lazy<CreatioClient>(() => null), reauthExecutor, diagnostics);
+
+	private static IReauthExecutor CreatePassthroughExecutor() {
+		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
+			.Returns(ci => ci.Arg<Func<string>>()());
+		return executor;
+	}
+
+	#endregion
+
+	#region Tests: Request wiring
+
+	[TestCase("ExecutePostRequest")]
+	[TestCase("CallConfigurationService")]
+	[Description("The request methods record every call through ILoginDiagnostics.TrackRequest")]
+	public void RequestMethod_ShouldRecordThroughLoginDiagnostics_WhenInvoked(string methodName) {
+		// Arrange
+		ILoginDiagnostics diagnostics = Substitute.For<ILoginDiagnostics>();
+		diagnostics.TrackRequest(Arg.Any<Func<string>>()).Returns("{}");
+		CreatioClientAdapter adapter = CreateAdapter(diagnostics, CreatePassthroughExecutor());
+
+		// Act
+		string result = methodName == "ExecutePostRequest"
+			? adapter.ExecutePostRequest("/x", "data")
+			: adapter.CallConfigurationService("Svc", "Method", "data");
+
+		// Assert
+		result.Should().Be("{}",
+			because: "the recorder is transparent on success and must not alter the response");
+		diagnostics.Received(1).TrackRequest(Arg.Any<Func<string>>());
+	}
+
+	[Test]
+	[Description("DownloadFile records through the void TrackRequest overload even though it bypasses the reauth executor")]
+	public void DownloadFile_ShouldRecordThroughLoginDiagnostics_WhenInvoked() {
+		// Arrange
+		ILoginDiagnostics diagnostics = Substitute.For<ILoginDiagnostics>();
+		CreatioClientAdapter adapter = CreateAdapter(diagnostics);
+
+		// Act
+		adapter.DownloadFile("https://host/file", "/tmp/file", "data");
+
+		// Assert
+		diagnostics.Received(1).TrackRequest(Arg.Any<Action>());
+	}
+
+	#endregion
+
+	#region Tests: Login wiring
+
+	[Test]
+	[Description("An explicit Login is recorded as LoginAttemptKind.Initial")]
+	public void Login_ShouldRecordInitialAttempt_WhenCalledExplicitly() {
+		// Arrange
+		ILoginDiagnostics diagnostics = Substitute.For<ILoginDiagnostics>();
+		CreatioClientAdapter adapter = CreateAdapter(diagnostics);
+
+		// Act
+		adapter.Login();
+
+		// Assert
+		diagnostics.Received(1).Track(Arg.Any<Action>(), LoginAttemptKind.Initial);
+	}
+
+	[Test]
+	[Description("The default reauth executor's re-login is recorded as LoginAttemptKind.Reauthentication")]
+	public void Reauth_ShouldRecordReauthenticationAttempt_WhenSessionExpiredResponseTriggersRelogin() {
+		// Arrange — no reauth executor, so the adapter builds the real one whose login closure is the
+		// only place the Reauthentication kind is produced.
+		ILoginDiagnostics diagnostics = Substitute.For<ILoginDiagnostics>();
+		diagnostics.TrackRequest(Arg.Any<Func<string>>()).Returns(LoginPageBody);
+		CreatioClientAdapter adapter = CreateAdapter(diagnostics);
+
+		// Act — the canned login page keeps tripping the session-expired predicate; whether the executor
+		// eventually gives up by returning or by throwing is not what this test pins.
+		try {
+			adapter.ExecutePostRequest("/x", "data");
+		} catch (Exception) {
+			// Intentionally ignored: only the recorded re-login matters here.
+		}
+
+		// Assert
+		diagnostics.Received().Track(Arg.Any<Action>(), LoginAttemptKind.Reauthentication);
+	}
+
+	#endregion
+
+	#region Tests: Surfaced exception type
+
+	[Test]
+	[Description("A login rejection surfaced by the adapter stays an UnauthorizedAccessException so clio's auth classifiers keep matching")]
+	public void Login_ShouldSurfaceUnauthorizedAccessException_WhenCredentialsAreRejected() {
+		// Arrange — a real recorder plus a client whose construction throws the rejection shape.
+		CreatioClientAdapter adapter = new(
+			new Lazy<CreatioClient>(() => throw new UnauthorizedAccessException(LoginRejectionMessage)),
+			Substitute.For<IReauthExecutor>(), new LoginDiagnostics());
+
+		// Act
+		Action act = () => adapter.Login();
+
+		// Assert
+		act.Should().Throw<UnauthorizedAccessException>(
+			because: "ServerReadinessWaiter, GetCreatioInfoCommand, SchemaNamePrefixTool and "
+				+ "SysSettingsCommand.CategorizeError all classify a refused credential by this type")
+			.Which.Message.Should().Contain("clio-login",
+				because: "the diagnostic context is the deliverable and must reach the caller in the message");
+	}
+
+	[Test]
+	[Description("A non-auth login failure surfaced by the adapter keeps its own type so typed callers keep working")]
+	public void Login_ShouldSurfaceOriginalType_WhenFailureIsNotACredentialRejection() {
+		// Arrange
+		WebException original = new("connect failed", WebExceptionStatus.ConnectFailure);
+		CreatioClientAdapter adapter = new(new Lazy<CreatioClient>(() => throw original),
+			Substitute.For<IReauthExecutor>(), new LoginDiagnostics());
+
+		// Act
+		Action act = () => adapter.Login();
+
+		// Assert
+		act.Should().Throw<WebException>(
+			because: "RemoteCommand.Login returns exit code 1 from catch (WebException) and "
+				+ "BaseDataContextCommand renders its 404 diagnostic there; substituting the type would turn "
+				+ "a returned exit code into an escaping exception")
+			.Which.Should().BeSameAs(original,
+				because: "an untouched failure must reach the caller as the identical instance");
+	}
+
+	#endregion
+
+}

--- a/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
@@ -80,7 +80,10 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		adapter.DownloadFile("https://host/file", "/tmp/file", "data");
 
 		// Assert
-		diagnostics.Received(1).TrackRequest(Arg.Any<Action>());
+		Action recorded = () => diagnostics.Received(1).TrackRequest(Arg.Any<Action>());
+		recorded.Should().NotThrow(
+			because: "DownloadFile bypasses the reauth executor, so its recording has to be wired separately "
+				+ "and is the easiest one for a later refactor to drop unnoticed");
 	}
 
 	#endregion
@@ -98,7 +101,9 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		adapter.Login();
 
 		// Assert
-		diagnostics.Received(1).Track(Arg.Any<Action>(), LoginAttemptKind.Initial);
+		Action recorded = () => diagnostics.Received(1).Track(Arg.Any<Action>(), LoginAttemptKind.Initial);
+		recorded.Should().NotThrow(
+			because: "an explicit login must be distinguishable in CI output from the two automatic ones");
 	}
 
 	[Test]
@@ -119,7 +124,11 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		}
 
 		// Assert
-		diagnostics.Received().Track(Arg.Any<Action>(), LoginAttemptKind.Reauthentication);
+		Action recorded = () =>
+			diagnostics.Received().Track(Arg.Any<Action>(), LoginAttemptKind.Reauthentication);
+		recorded.Should().NotThrow(
+			because: "the re-login closure lives inside the default reauth executor, so nothing else in the "
+				+ "suite can reach it");
 	}
 
 	#endregion

--- a/clio.tests/Common/LoginDiagnosticsTests.cs
+++ b/clio.tests/Common/LoginDiagnosticsTests.cs
@@ -105,21 +105,82 @@ internal class LoginDiagnosticsTests {
 	}
 
 	[Test]
-	[Description("Track decorates any failure of a clio-driven login, not only the Code:1 rejection shape")]
-	public void Track_ShouldDecorateAnyFailure_WhenClioDrivesTheLogin() {
+	[Description("Track decorates a clio-driven login that was rejected with the Code:1 shape")]
+	public void Track_ShouldDecorate_WhenClioDrivenLoginIsRejected() {
 		// Arrange
 		LoginDiagnostics sut = CreateSut(CreateScoreboard());
 
 		// Act
-		Action act = () => sut.Track(() => throw new TimeoutException("login timed out"),
+		Action act = () => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
 			LoginAttemptKind.Reauthentication);
 
 		// Assert
 		act.Should().Throw<CreatioLoginFailedException>(
-			because: "on the explicit paths every exception is unambiguously a login failure, so all of them "
-				+ "deserve the context — unlike the request path, where only the rejection shape is a login")
-			.Which.Message.Should().Contain("original-type=TimeoutException",
+			because: "a rejected clio-driven login is the failure GitHub #1106 needs the context for")
+			.Which.Message.Should().Contain("original-type=UnauthorizedAccessException",
 				because: "the original failure type must stay visible after the decoration");
+	}
+
+	[Test]
+	[Description("Track rethrows the very same instance when the login failed for a reason other than a credential rejection")]
+	public void Track_ShouldRethrowSameInstance_WhenFailureIsNotALoginRejection() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		TimeoutException original = new("login timed out");
+
+		// Act
+		Action act = () => sut.Track(() => throw original, LoginAttemptKind.Reauthentication);
+
+		// Assert
+		act.Should().Throw<TimeoutException>(
+			because: "substituting the type here would break the live typed handlers that key on it — "
+				+ "RemoteCommand.Login's catch (WebException) => return 1, BaseDataContextCommand's 404 "
+				+ "diagnostic, ExceptionReadableMessageExtension's InnerException walk, "
+				+ "GetCreatioInfoCommand.IsRecoverable's fatal-type blocklist, and McpToolErrorFilter's "
+				+ "OperationCanceledException rethrow (ENG-93373)")
+			.Which.Should().BeSameAs(original,
+				because: "an untouched failure must reach the caller as the identical instance, stack trace included");
+	}
+
+	[Test]
+	[Description("A WebException thrown by a clio-driven login still reaches a catch (WebException) caller")]
+	public void Track_ShouldRethrowWebExceptionUntouched_SoTypedCallersKeepWorking() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		WebException original = new("connect failed", WebExceptionStatus.ConnectFailure);
+		bool reachedTypedHandler = false;
+
+		// Act
+		try {
+			sut.Track(() => throw original, LoginAttemptKind.Initial);
+		} catch (WebException) {
+			reachedTypedHandler = true;
+		}
+
+		// Assert
+		reachedTypedHandler.Should().BeTrue(
+			because: "RemoteCommand.Login returns exit code 1 from exactly this arm; decorating the exception "
+				+ "would turn a returned exit code into an escaping exception for all of its callers");
+	}
+
+	[Test]
+	[Description("Track decorates a rejection that arrives wrapped in an AggregateException, the shape the NuGet client's Task.Result produces")]
+	public void Track_ShouldDecorate_WhenRejectionArrivesWrappedInAggregateException() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(
+				() => throw new AggregateException(new UnauthorizedAccessException(LoginRejectionMessage)),
+				LoginAttemptKind.Reauthentication));
+
+		// Assert
+		failure.Message.Should().StartWith(LoginRejectionMessage,
+			because: "the message must come from the rejection, not from the wrapper — an AggregateException's "
+				+ "own 'One or more errors occurred.' would replace the primary server signal");
+		FieldValue(failure.Message, "wrapped-in").Should().Be(nameof(AggregateException),
+			because: "the wrapper is diagnostic information in its own right and must not be silently dropped");
 	}
 
 	#endregion
@@ -233,6 +294,69 @@ internal class LoginDiagnosticsTests {
 			because: "a null request callback is a programming error and must fail loudly at the call site");
 	}
 
+
+	[Test]
+	[Description("TrackRequest decorates a rejection that arrives wrapped in an AggregateException")]
+	public void TrackRequest_ShouldDecorateAsImplicit_WhenRejectionArrivesWrappedInAggregateException() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.TrackRequest<string>(() => throw new AggregateException(
+				new UnauthorizedAccessException(LoginRejectionMessage))));
+
+		// Assert
+		FieldValue(failure.Message, "kind").Should().Be("implicit",
+			because: "this repository documents that Creatio.Client runs via Task.Result and its faults arrive "
+				+ "wrapped (EntitySchemaPublishHelper, TransientNetworkFailureClassifier, GetCreatioInfoCommand, "
+				+ "ApplicationSectionCreateCommand, UserThemeApplier all unwrap it), so the dominant MCP path "
+				+ "must match that shape and not only the bare exception a unit test constructs");
+	}
+
+	[Test]
+	[Description("The void TrackRequest overload records the attempt and decorates a rejected implicit login")]
+	public void TrackRequestAction_ShouldDecorateAsImplicit_WhenImplicitLoginIsRejected() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics sut = CreateSut(scoreboard);
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.TrackRequest(() => throw new UnauthorizedAccessException(LoginRejectionMessage)));
+
+		// Assert
+		FieldValue(failure.Message, "kind").Should().Be("implicit",
+			because: "the void overload exists for DownloadFile and must record exactly like the generic one");
+		scoreboard.RequestsInFlight.Should().Be(0,
+			because: "the void overload must release the gauge on the failure path too");
+	}
+
+	#endregion
+
+	#region Tests: Classifier contract
+
+	[Test]
+	[Description("The decorated exception is an UnauthorizedAccessException so clio's four auth classifiers keep matching")]
+	public void Decorated_ShouldBeAnUnauthorizedAccessException_SoAuthClassifiersKeepMatching() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Initial));
+
+		// Assert
+		failure.Should().BeAssignableTo<UnauthorizedAccessException>(
+			because: "four sites classify a rejected login by this type and silently degrade to their generic "
+				+ "arm without it: ServerReadinessWaiter (AuthenticationRejected — otherwise a refused "
+				+ "credential stops failing fast and burns the readiness budget on further rejected logins), "
+				+ "GetCreatioInfoCommand (BaseProbeFailure.Authentication), SchemaNamePrefixTool (the "
+				+ "MCP-visible 'Authentication error reading SchemaNamePrefix.' result) and "
+				+ "SysSettingsCommand.CategorizeError");
+	}
+
 	#endregion
 
 	#region Tests: Diagnostic context
@@ -279,7 +403,8 @@ internal class LoginDiagnosticsTests {
 
 		// Act
 		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
-			() => sut.Track(() => throw new InvalidOperationException("boom"), LoginAttemptKind.Initial));
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Initial));
 
 		// Assert
 		FieldValue(failure.Message, "kind").Should().Be("initial",
@@ -295,7 +420,7 @@ internal class LoginDiagnosticsTests {
 
 		// Act
 		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
-			() => sut.Track(() => throw new InvalidOperationException("login failed", webException),
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage, webException),
 				LoginAttemptKind.Initial));
 
 		// Assert
@@ -331,10 +456,10 @@ internal class LoginDiagnosticsTests {
 
 		// Act
 		CreatioLoginFailedException firstClientFailure = Assert.Throws<CreatioLoginFailedException>(
-			() => firstClient.Track(() => throw new InvalidOperationException("boom"),
+			() => firstClient.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
 				LoginAttemptKind.Reauthentication));
 		CreatioLoginFailedException secondClientFailure = Assert.Throws<CreatioLoginFailedException>(
-			() => secondClient.Track(() => throw new InvalidOperationException("boom"),
+			() => secondClient.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
 				LoginAttemptKind.Initial));
 
 		// Assert

--- a/clio.tests/Common/LoginDiagnosticsTests.cs
+++ b/clio.tests/Common/LoginDiagnosticsTests.cs
@@ -1,0 +1,472 @@
+using System;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading;
+using Clio.Common;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Common")]
+internal class LoginDiagnosticsTests {
+
+	#region Constants: Private
+
+	// The exact shape Creatio.Client throws when the login response carries "Code":1 — the failure
+	// GitHub #1106 tracks.
+	private const string LoginRejectionMessage = "Unauthorized svc_user for https://host";
+
+	#endregion
+
+	#region Methods: Private
+
+	private static LoginDiagnostics.LoginAttemptScoreboard CreateScoreboard() => new();
+
+	private static LoginDiagnostics CreateSut(LoginDiagnostics.LoginAttemptScoreboard scoreboard) =>
+		new(scoreboard);
+
+	private static string FieldValue(string message, string fieldName) {
+		Match match = Regex.Match(message, $@"\b{Regex.Escape(fieldName)}=([^\s\]]+)");
+		match.Success.Should().BeTrue(
+			because: $"the diagnostic context must carry a '{fieldName}' field. Actual message: {message}");
+		return match.Groups[1].Value;
+	}
+
+	#endregion
+
+	#region Tests: Track
+
+	[Test]
+	[Description("Track invokes the login callback exactly once and returns transparently when it succeeds")]
+	public void Track_ShouldInvokeLoginOnceAndNotThrow_WhenLoginSucceeds() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		int loginCallCount = 0;
+
+		// Act
+		Action act = () => sut.Track(() => loginCallCount++, LoginAttemptKind.Initial);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "a successful login must stay transparent — the recorder only decorates failures");
+		loginCallCount.Should().Be(1,
+			because: "the recorder must invoke the wrapped login callback exactly once, with no retry of its own");
+	}
+
+	[Test]
+	[Description("Track releases the login gauge after a successful login so the counter cannot leak")]
+	public void Track_ShouldReleaseLoginGauge_WhenLoginSucceeds() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics sut = CreateSut(scoreboard);
+
+		// Act
+		sut.Track(() => { }, LoginAttemptKind.Initial);
+
+		// Assert
+		scoreboard.LoginsInFlight.Should().Be(0,
+			because: "a finished login must leave no in-flight residue, otherwise every later failure would "
+				+ "report an inflated concurrency figure and the #1106 evidence would be worthless");
+	}
+
+	[Test]
+	[Description("Track releases the login gauge after a failed login so the counter cannot leak")]
+	public void Track_ShouldReleaseLoginGauge_WhenLoginThrows() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics sut = CreateSut(scoreboard);
+
+		// Act
+		Action act = () => sut.Track(
+			() => throw new UnauthorizedAccessException(LoginRejectionMessage), LoginAttemptKind.Initial);
+
+		// Assert
+		act.Should().Throw<CreatioLoginFailedException>(
+			because: "a failed login must surface as the decorated exception");
+		scoreboard.LoginsInFlight.Should().Be(0,
+			because: "the gauge must be released on the failure path too, not only on success");
+	}
+
+	[Test]
+	[Description("Track throws ArgumentNullException when the login callback is null")]
+	public void Track_ShouldThrowArgumentNullException_WhenLoginIsNull() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		Action act = () => sut.Track(null, LoginAttemptKind.Initial);
+
+		// Assert
+		act.Should().Throw<ArgumentNullException>(
+			because: "a null login callback is a programming error and must fail loudly at the call site");
+	}
+
+	[Test]
+	[Description("Track decorates any failure of a clio-driven login, not only the Code:1 rejection shape")]
+	public void Track_ShouldDecorateAnyFailure_WhenClioDrivesTheLogin() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		Action act = () => sut.Track(() => throw new TimeoutException("login timed out"),
+			LoginAttemptKind.Reauthentication);
+
+		// Assert
+		act.Should().Throw<CreatioLoginFailedException>(
+			because: "on the explicit paths every exception is unambiguously a login failure, so all of them "
+				+ "deserve the context — unlike the request path, where only the rejection shape is a login")
+			.Which.Message.Should().Contain("original-type=TimeoutException",
+				because: "the original failure type must stay visible after the decoration");
+	}
+
+	#endregion
+
+	#region Tests: TrackRequest
+
+	[Test]
+	[Description("TrackRequest returns the request result unchanged when the request succeeds")]
+	public void TrackRequest_ShouldReturnResultUnchanged_WhenRequestSucceeds() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics sut = CreateSut(scoreboard);
+
+		// Act
+		string result = sut.TrackRequest(() => "{\"success\":true}");
+
+		// Assert
+		result.Should().Be("{\"success\":true}",
+			because: "the wrapper must be transparent on the happy path — it observes, it does not transform");
+		scoreboard.RequestsInFlight.Should().Be(0,
+			because: "a finished request must release its gauge slot");
+	}
+
+	[Test]
+	[Description("TrackRequest decorates the implicit login rejection raised from inside a request")]
+	public void TrackRequest_ShouldDecorateAsImplicit_WhenImplicitLoginIsRejected() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.TrackRequest<string>(() => throw new UnauthorizedAccessException(LoginRejectionMessage)));
+
+		// Assert
+		failure.Message.Should().StartWith(LoginRejectionMessage,
+			because: "the original server message is the primary signal and must not be replaced");
+		FieldValue(failure.Message, "kind").Should().Be("implicit",
+			because: "this is the login the NuGet client performs inside the first request of a fresh client — "
+				+ "the dominant path in the MCP surface, where every tool call builds its own client");
+		FieldValue(failure.Message, "client-request").Should().Be("1",
+			because: "the implicit login happens on the client's first request, so a request ordinal of one "
+				+ "confirms the failure really is the implicit login rather than a later request");
+		failure.Message.Should().NotContain("client-login=",
+			because: "an implicit login is counted as a request, so labelling it a login ordinal would claim a "
+				+ "login count clio never observed");
+	}
+
+	[Test]
+	[Description("TrackRequest leaves an ordinary request failure completely untouched")]
+	public void TrackRequest_ShouldRethrowUntouched_WhenFailureIsNotALoginRejection() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		InvalidOperationException original = new("Select query failed.");
+
+		// Act
+		Action act = () => sut.TrackRequest<string>(() => throw original);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+			because: "wrapping the request path must not change how ordinary request failures surface")
+			.Which.Should().BeSameAs(original,
+				because: "the very same exception instance must propagate, with no decoration and no re-wrapping");
+	}
+
+	[Test]
+	[Description("TrackRequest leaves an unrelated UnauthorizedAccessException untouched")]
+	public void TrackRequest_ShouldRethrowUntouched_WhenUnauthorizedExceptionIsNotTheLoginShape() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		UnauthorizedAccessException original = new("Access to the path '/tmp/x' is denied.");
+
+		// Act
+		Action act = () => sut.TrackRequest<string>(() => throw original);
+
+		// Assert
+		act.Should().Throw<UnauthorizedAccessException>(
+			because: "matching on the exception type alone would capture unrelated access denials, so the "
+				+ "message prefix has to gate the decoration")
+			.Which.Should().BeSameAs(original,
+				because: "a non-login access denial must propagate as the very same exception instance");
+	}
+
+	[Test]
+	[Description("TrackRequest releases the request gauge after a failure so the counter cannot leak")]
+	public void TrackRequest_ShouldReleaseRequestGauge_WhenRequestThrows() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics sut = CreateSut(scoreboard);
+
+		// Act
+		Action act = () => sut.TrackRequest<string>(() => throw new InvalidOperationException("boom"));
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+			because: "the failure must still propagate");
+		scoreboard.RequestsInFlight.Should().Be(0,
+			because: "the request gauge must be released even when the request failed undecorated");
+	}
+
+	[Test]
+	[Description("TrackRequest throws ArgumentNullException when the request callback is null")]
+	public void TrackRequest_ShouldThrowArgumentNullException_WhenRequestIsNull() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		Action act = () => sut.TrackRequest<string>(null);
+
+		// Assert
+		act.Should().Throw<ArgumentNullException>(
+			because: "a null request callback is a programming error and must fail loudly at the call site");
+	}
+
+	#endregion
+
+	#region Tests: Diagnostic context
+
+	[Test]
+	[Description("A failed login keeps the original message and appends the full diagnostic context")]
+	public void Track_ShouldKeepOriginalMessageAndAppendContext_WhenLoginThrows() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Reauthentication));
+
+		// Assert
+		failure.Message.Should().StartWith(LoginRejectionMessage,
+			because: "the original server message is the primary signal and must not be replaced");
+		failure.Message.Should().Contain("clio-login",
+			because: "the appended block needs a stable marker so it is greppable in CI output");
+		FieldValue(failure.Message, "kind").Should().Be("reauth",
+			because: "the attempt kind tells which of the three login paths was rejected");
+		FieldValue(failure.Message, "client").Should().NotBeNullOrWhiteSpace(
+			because: "a per-client correlation token is what lets several concurrent tool calls be told apart");
+		FieldValue(failure.Message, "client-login").Should().Be("1",
+			because: "this is the first login attempt made by this client");
+		FieldValue(failure.Message, "process-login").Should().Be("1",
+			because: "this is the first login recorded on the scoreboard");
+		FieldValue(failure.Message, "started-at").Should().NotBeNullOrWhiteSpace(
+			because: "an absolute UTC start time is required to correlate attempts across concurrent calls");
+		FieldValue(failure.Message, "elapsed-ms").Should().MatchRegex("^[0-9]+$",
+			because: "the login duration must be an invariant-culture integer so CI parsing is stable");
+		FieldValue(failure.Message, "since-client-created-ms").Should().MatchRegex("^[0-9]+$",
+			because: "the age of the client separates a stale-session re-login from a fresh client's first login");
+		FieldValue(failure.Message, "original-type").Should().Be(nameof(UnauthorizedAccessException),
+			because: "the original exception type must survive even though it is not kept as an inner exception");
+	}
+
+	[Test]
+	[Description("The initial attempt kind is rendered as 'initial' in the diagnostic context")]
+	public void Track_ShouldRenderInitialKind_WhenLoginIsCallerInitiated() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new InvalidOperationException("boom"), LoginAttemptKind.Initial));
+
+		// Assert
+		FieldValue(failure.Message, "kind").Should().Be("initial",
+			because: "an explicitly requested login must be distinguishable from the two automatic ones");
+	}
+
+	[Test]
+	[Description("The transport status of a WebException is folded into the context so 401 stays distinguishable from a connect failure")]
+	public void Track_ShouldFoldTransportStatus_WhenLoginThrowsWebException() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+		WebException webException = new("connect failed", WebExceptionStatus.ConnectFailure);
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new InvalidOperationException("login failed", webException),
+				LoginAttemptKind.Initial));
+
+		// Assert
+		FieldValue(failure.Message, "transport").Should().Be(nameof(WebExceptionStatus.ConnectFailure),
+			because: "this exception carries no inner exception, so the transport signal the readable-message "
+				+ "extension would normally add from an inner WebException has to be folded in here instead");
+	}
+
+	[Test]
+	[Description("No transport field is emitted when the failure has no WebException anywhere in its chain")]
+	public void Track_ShouldOmitTransportField_WhenFailureCarriesNoWebException() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Initial));
+
+		// Assert
+		failure.Message.Should().NotContain("transport=",
+			because: "an absent transport field must mean 'no HTTP-level signal available', not 'unknown status'");
+	}
+
+	[Test]
+	[Description("Attempt counters advance per client and per scoreboard across separate client instances")]
+	public void Track_ShouldAdvanceClientAndProcessCounters_WhenSeveralClientsShareOneScoreboard() {
+		// Arrange
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics firstClient = CreateSut(scoreboard);
+		LoginDiagnostics secondClient = CreateSut(scoreboard);
+		firstClient.Track(() => { }, LoginAttemptKind.Initial);
+
+		// Act
+		CreatioLoginFailedException firstClientFailure = Assert.Throws<CreatioLoginFailedException>(
+			() => firstClient.Track(() => throw new InvalidOperationException("boom"),
+				LoginAttemptKind.Reauthentication));
+		CreatioLoginFailedException secondClientFailure = Assert.Throws<CreatioLoginFailedException>(
+			() => secondClient.Track(() => throw new InvalidOperationException("boom"),
+				LoginAttemptKind.Initial));
+
+		// Assert
+		FieldValue(firstClientFailure.Message, "client-login").Should().Be("2",
+			because: "the client-scoped counter must show this is the second login this client attempted");
+		FieldValue(firstClientFailure.Message, "process-login").Should().Be("2",
+			because: "the scoreboard-scoped counter must show two logins have been made in the process");
+		FieldValue(secondClientFailure.Message, "client-login").Should().Be("1",
+			because: "a freshly created client starts its own login count at one");
+		FieldValue(secondClientFailure.Message, "process-login").Should().Be("3",
+			because: "the scoreboard counter is shared, so a second client continues the process-wide sequence");
+		FieldValue(firstClientFailure.Message, "client").Should()
+			.NotBe(FieldValue(secondClientFailure.Message, "client"),
+				because: "two independently constructed clients must be distinguishable in the log");
+	}
+
+	#endregion
+
+	#region Tests: Concurrency evidence
+
+	[Test]
+	[Description("The login gauge reports the concurrent clio-driven logins a failing login competed with")]
+	public void Track_ShouldReportConcurrentLogins_WhenTwoClientsLoginSimultaneously() {
+		// Arrange — two independently constructed clients, exactly like two concurrent MCP tool calls.
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics failingClient = CreateSut(scoreboard);
+		LoginDiagnostics blockingClient = CreateSut(scoreboard);
+		using ManualResetEventSlim blockingStarted = new(false);
+		using ManualResetEventSlim failureObserved = new(false);
+		Thread blockingThread = new(() => blockingClient.Track(
+			() => {
+				blockingStarted.Set();
+				failureObserved.Wait(TimeSpan.FromSeconds(10));
+			},
+			LoginAttemptKind.Initial));
+
+		// Act
+		blockingThread.Start();
+		blockingStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+			because: "the blocking login must be in flight before the failing one starts, or the test proves nothing");
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => failingClient.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Reauthentication));
+		failureObserved.Set();
+		blockingThread.Join(TimeSpan.FromSeconds(10)).Should().BeTrue(
+			because: "the blocking login must finish so the test does not leak a thread");
+
+		// Assert
+		FieldValue(failure.Message, "in-flight-logins").Should().Be("2/2",
+			because: "this is the field that settles GitHub #1106 for the clio-driven paths: it proves whether a "
+				+ "rejected login overlapped other logins for the same credentials or was the only one in flight");
+		FieldValue(failure.Message, "in-flight-requests").Should().Be("0/0",
+			because: "keeping the two gauges apart means a login figure is never inflated by unrelated requests");
+	}
+
+	[Test]
+	[Description("The request gauge reports the concurrent requests a rejected implicit login competed with")]
+	public void TrackRequest_ShouldReportConcurrentRequests_WhenTwoClientsRequestSimultaneously() {
+		// Arrange — the shape of the concurrent create-app-section scenario: separate clients, one process.
+		LoginDiagnostics.LoginAttemptScoreboard scoreboard = CreateScoreboard();
+		LoginDiagnostics failingClient = CreateSut(scoreboard);
+		LoginDiagnostics blockingClient = CreateSut(scoreboard);
+		using ManualResetEventSlim blockingStarted = new(false);
+		using ManualResetEventSlim failureObserved = new(false);
+		Thread blockingThread = new(() => blockingClient.TrackRequest(() => {
+			blockingStarted.Set();
+			failureObserved.Wait(TimeSpan.FromSeconds(10));
+			return "ok";
+		}));
+
+		// Act
+		blockingThread.Start();
+		blockingStarted.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue(
+			because: "the blocking request must be in flight before the failing one starts, or the test proves nothing");
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => failingClient.TrackRequest<string>(
+				() => throw new UnauthorizedAccessException(LoginRejectionMessage)));
+		failureObserved.Set();
+		blockingThread.Join(TimeSpan.FromSeconds(10)).Should().BeTrue(
+			because: "the blocking request must finish so the test does not leak a thread");
+
+		// Assert
+		FieldValue(failure.Message, "in-flight-requests").Should().Be("2/2",
+			because: "an implicit login happens at the very start of its request, so the concurrent-request count "
+				+ "is the observable proxy for concurrent implicit logins — the #1106 question for this path");
+	}
+
+	#endregion
+
+	#region Tests: Message survival
+
+	[Test]
+	[Description("The decorated exception is inner-less so both clio message surfaces keep the diagnostic context")]
+	public void Track_ShouldProduceInnerLessException_SoBothMessageSurfacesKeepTheContext() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Reauthentication));
+
+		// Assert
+		failure.InnerException.Should().BeNull(
+			because: "keeping the original as an inner exception would make GetBaseException() and "
+				+ "SurfacedExceptionMessage.Resolve() both walk past the decorated message and discard it");
+		failure.GetBaseException().Message.Should().Be(failure.Message,
+			because: "the application-section commands report the root cause via GetBaseException().Message, so the "
+				+ "diagnostic context must survive that reduction");
+		SurfacedExceptionMessage.Resolve(failure).Should().Be(failure.Message,
+			because: "the MCP boundary surfaces the inner-most message, so the diagnostic context must survive it too");
+	}
+
+	[Test]
+	[Description("The original exception and the diagnostic context are preserved in Exception.Data")]
+	public void Track_ShouldPreserveOriginalExceptionAndContextInData_WhenLoginThrows() {
+		// Arrange
+		LoginDiagnostics sut = CreateSut(CreateScoreboard());
+
+		// Act
+		CreatioLoginFailedException failure = Assert.Throws<CreatioLoginFailedException>(
+			() => sut.Track(() => throw new UnauthorizedAccessException(LoginRejectionMessage),
+				LoginAttemptKind.Initial));
+
+		// Assert
+		failure.Data[CreatioLoginFailedException.OriginalExceptionDataKey].Should().BeOfType<string>()
+			.Which.Should().Contain(nameof(UnauthorizedAccessException),
+				because: "dropping the inner exception must not lose the original type and stack trace for debugging");
+		failure.Data[CreatioLoginFailedException.DiagnosticContextDataKey].Should().BeOfType<string>()
+			.Which.Should().StartWith("clio-login",
+				because: "the context must also be readable structurally, without parsing it back out of the message");
+	}
+
+	#endregion
+}

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -1255,6 +1255,9 @@ public class BindingsModule {
 					// ReauthExecutor requires a per-adapter Login closure; it is created by
 					// CreatioClientAdapter rather than resolved from DI.
 					|| implementedInterface == typeof(IReauthExecutor)
+					// LoginDiagnostics holds per-adapter state (client correlation token, attempt
+					// counter); it is created by CreatioClientAdapter, not resolved from DI.
+					|| implementedInterface == typeof(ILoginDiagnostics)
 					// CliogateHttpReadinessProbe takes runtime-only ctor args (an HttpClient, the
 					// attempt budget, and inter-attempt delays); it is constructed by the e2e
 					// readiness wait, not resolved from DI.

--- a/clio/Common/CreatioClientAdapter.cs
+++ b/clio/Common/CreatioClientAdapter.cs
@@ -14,6 +14,7 @@ public class CreatioClientAdapter : IApplicationClient{
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
 	private readonly JsonConverter _jsonConverter;
 	private readonly IReauthExecutor _reauthExecutor;
+	private readonly ILoginDiagnostics _loginDiagnostics;
 
 	private CreatioClient Client => _lazyClient.Value;
 
@@ -34,7 +35,11 @@ public class CreatioClientAdapter : IApplicationClient{
 		// shared across a long-lived MCP process can otherwise keep sending a stale cookie
 		// after long-running operations and start receiving the HTML login page instead of
 		// JSON for every subsequent request.
-		_reauthExecutor = reauthExecutor ?? new ReauthExecutor(() => _lazyClient.Value.Login());
+		// Like the reauth executor below, the diagnostics recorder is per-adapter state (its own client
+		// correlation token and attempt counter) rather than a DI service, so it is created here.
+		_loginDiagnostics = new LoginDiagnostics();
+		_reauthExecutor = reauthExecutor ?? new ReauthExecutor(
+			() => _loginDiagnostics.Track(() => _lazyClient.Value.Login(), LoginAttemptKind.Reauthentication));
 	}
 
 	#endregion
@@ -100,7 +105,8 @@ public class CreatioClientAdapter : IApplicationClient{
 		// reauth executor — otherwise a stale-cookie response surfaces directly as raw HTML
 		// to the caller.
 		return _reauthExecutor.Execute(
-			() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
@@ -119,27 +125,33 @@ public class CreatioClientAdapter : IApplicationClient{
 		// short-lived flows (cliogate file fetch) where session expiry mid-download is
 		// uncommon; wrapping it would require either a pre-flight probe or a post-download
 		// file-content sniff, both of which add I/O for very little practical gain.
-		Client.DownloadFile(absoluteUrl, filePath, requestData);
+		_loginDiagnostics.TrackRequest<object>(() => {
+			Client.DownloadFile(absoluteUrl, filePath, requestData);
+			return null;
+		});
 	}
 
 	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int maxAttempts = 1,
 		int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
@@ -149,7 +161,8 @@ public class CreatioClientAdapter : IApplicationClient{
 		// Re-auth detection runs against the raw body so an expired session cannot reach
 		// the JSON deserializer (which would throw on the HTML login page).
 		string response = _reauthExecutor.Execute(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
 			ReauthExecutor.IsSessionExpiredResponse);
 		// If the retry also returned the session-expired HTML page, the JSON deserializer
 		// below would surface the same opaque "Invalid response format" symptom that
@@ -166,7 +179,8 @@ public class CreatioClientAdapter : IApplicationClient{
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
 		return _reauthExecutor.Execute(
-			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			() => _loginDiagnostics.TrackRequest(
+				() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
@@ -179,24 +193,26 @@ public class CreatioClientAdapter : IApplicationClient{
 	}
 
 	public void Login() {
-		Client.Login();
+		// Recorded the same way as the automatic re-login above so a rejected login is diagnosable
+		// from CI output alone, and so the two attempt kinds are distinguishable (GitHub #1106).
+		_loginDiagnostics.Track(() => Client.Login(), LoginAttemptKind.Initial);
 	}
 
 	public string UploadAlmFile(string url, string filePath) {
 		return _reauthExecutor.Execute(
-			() => Client.UploadAlmFile(url, filePath),
+			() => _loginDiagnostics.TrackRequest(() => Client.UploadAlmFile(url, filePath)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public string UploadAlmFileByChunk(string url, string filePath) {
 		return _reauthExecutor.Execute(
-			() => Client.UploadAlmFileByChunk(url, filePath),
+			() => _loginDiagnostics.TrackRequest(() => Client.UploadAlmFileByChunk(url, filePath)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 
 	public string UploadFile(string url, string filePath) {
 		return _reauthExecutor.Execute(
-			() => Client.UploadFile(url, filePath),
+			() => _loginDiagnostics.TrackRequest(() => Client.UploadFile(url, filePath)),
 			ReauthExecutor.IsSessionExpiredResponse);
 	}
 

--- a/clio/Common/CreatioClientAdapter.cs
+++ b/clio/Common/CreatioClientAdapter.cs
@@ -27,7 +27,8 @@ public class CreatioClientAdapter : IApplicationClient{
 	// rather than resolved from DI. Tests pass a non-null executor through the internal
 	// constructor below to exercise the adapter in isolation from CreatioClient.
 	private CreatioClientAdapter(Lazy<CreatioClient> lazyClient, IServiceUrlBuilder serviceUrlBuilder,
-		JsonConverter jsonConverter, IReauthExecutor reauthExecutor) {
+		JsonConverter jsonConverter, IReauthExecutor reauthExecutor,
+		ILoginDiagnostics loginDiagnostics = null) {
 		_lazyClient = lazyClient;
 		_serviceUrlBuilder = serviceUrlBuilder;
 		_jsonConverter = jsonConverter ?? new JsonConverter();
@@ -36,8 +37,10 @@ public class CreatioClientAdapter : IApplicationClient{
 		// after long-running operations and start receiving the HTML login page instead of
 		// JSON for every subsequent request.
 		// Like the reauth executor below, the diagnostics recorder is per-adapter state (its own client
-		// correlation token and attempt counter) rather than a DI service, so it is created here.
-		_loginDiagnostics = new LoginDiagnostics();
+		// correlation token and attempt counter) rather than a DI service, so it defaults to a new
+		// instance here; the parameter exists so tests can substitute it and assert that every request
+		// method and both login paths really route through it.
+		_loginDiagnostics = loginDiagnostics ?? new LoginDiagnostics();
 		_reauthExecutor = reauthExecutor ?? new ReauthExecutor(
 			() => _loginDiagnostics.Track(() => _lazyClient.Value.Login(), LoginAttemptKind.Reauthentication));
 	}
@@ -75,6 +78,16 @@ public class CreatioClientAdapter : IApplicationClient{
 		: this(lazyClient, null, null,
 			reauthExecutor ?? throw new ArgumentNullException(nameof(reauthExecutor))) { }
 
+	// Test-only constructor for the diagnostics seam. Unlike the two constructors around it, the
+	// reauth executor MAY be null here: leaving it to the default is the only way to reach the
+	// Reauthentication login closure the default executor owns, which is precisely one of the
+	// wirings that has to be pinned. The diagnostics recorder is required so a test cannot silently
+	// assert against a private instance.
+	internal CreatioClientAdapter(Lazy<CreatioClient> lazyClient, IReauthExecutor reauthExecutor,
+		ILoginDiagnostics loginDiagnostics)
+		: this(lazyClient, null, null, reauthExecutor,
+			loginDiagnostics ?? throw new ArgumentNullException(nameof(loginDiagnostics))) { }
+
 	// Credential-passthrough constructor: lets ApplicationClientFactory.CreateEnvironmentClient
 	// wire BOTH a service-url builder (for environment-relative routes) and an explicit
 	// reauth executor (the NoReauthExecutor, because bearer material cannot re-login).
@@ -88,6 +101,19 @@ public class CreatioClientAdapter : IApplicationClient{
 	public event EventHandler<WebSocketState> ConnectionStateChanged;
 
 	public event EventHandler<WsMessage> MessageReceived;
+
+	#region Methods: Private
+
+	// One composition point for every request method: reauth on a session-expired response, with the
+	// login diagnostics recorded inside it. Keeping it in one place means a request method added later
+	// cannot silently lose either wrapper.
+	// Not generic: the session-expired predicate inspects the raw response body, so it only applies to
+	// the string-returning request methods — which is all of them that go through the reauth executor.
+	private string ExecuteRequest(Func<string> call) =>
+		_reauthExecutor.Execute(() => _loginDiagnostics.TrackRequest(call),
+			ReauthExecutor.IsSessionExpiredResponse);
+
+	#endregion
 
 	#region Methods: Public
 
@@ -104,10 +130,8 @@ public class CreatioClientAdapter : IApplicationClient{
 		// exactly the scenario that expires the session, so the call MUST route through the
 		// reauth executor — otherwise a stale-cookie response surfaces directly as raw HTML
 		// to the caller.
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(
+			() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout));
 	}
 
 	public void DownloadFile(string url, string filePath, string requestData) {
@@ -125,34 +149,24 @@ public class CreatioClientAdapter : IApplicationClient{
 		// short-lived flows (cliogate file fetch) where session expiry mid-download is
 		// uncommon; wrapping it would require either a pre-flight probe or a post-download
 		// file-content sniff, both of which add I/O for very little practical gain.
-		_loginDiagnostics.TrackRequest<object>(() => {
-			Client.DownloadFile(absoluteUrl, filePath, requestData);
-			return null;
-		});
+		_loginDiagnostics.TrackRequest(() => Client.DownloadFile(absoluteUrl, filePath, requestData));
 	}
 
 	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(
+			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
 	}
 
 	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int maxAttempts = 1,
 		int delaySec = 1) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec));
 	}
 
 	public string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
 	}
 
 	public T ExecutePostRequest<T>(string url, string requestData, int requestTimeout = Timeout.Infinite,
@@ -160,10 +174,8 @@ public class CreatioClientAdapter : IApplicationClient{
 		where T : BaseResponse, new() {
 		// Re-auth detection runs against the raw body so an expired session cannot reach
 		// the JSON deserializer (which would throw on the HTML login page).
-		string response = _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		string response = ExecuteRequest(
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
 		// If the retry also returned the session-expired HTML page, the JSON deserializer
 		// below would surface the same opaque "Invalid response format" symptom that
 		// triggered ENG-90393. Throw a clearer message so the caller (and the user) can
@@ -178,10 +190,8 @@ public class CreatioClientAdapter : IApplicationClient{
 
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(
-				() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(
+			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
 	}
 
 	public void Listen(CancellationToken cancellationToken) {
@@ -199,21 +209,15 @@ public class CreatioClientAdapter : IApplicationClient{
 	}
 
 	public string UploadAlmFile(string url, string filePath) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(() => Client.UploadAlmFile(url, filePath)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(() => Client.UploadAlmFile(url, filePath));
 	}
 
 	public string UploadAlmFileByChunk(string url, string filePath) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(() => Client.UploadAlmFileByChunk(url, filePath)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(() => Client.UploadAlmFileByChunk(url, filePath));
 	}
 
 	public string UploadFile(string url, string filePath) {
-		return _reauthExecutor.Execute(
-			() => _loginDiagnostics.TrackRequest(() => Client.UploadFile(url, filePath)),
-			ReauthExecutor.IsSessionExpiredResponse);
+		return ExecuteRequest(() => Client.UploadFile(url, filePath));
 	}
 
 	#endregion

--- a/clio/Common/CreatioLoginFailedException.cs
+++ b/clio/Common/CreatioLoginFailedException.cs
@@ -42,20 +42,20 @@ namespace Clio.Common;
 /// verbose log.
 /// </para>
 /// </remarks>
-internal sealed class CreatioLoginFailedException : UnauthorizedAccessException {
-	#region Constants: Internal
+public sealed class CreatioLoginFailedException : UnauthorizedAccessException {
+	#region Constants: Public
 
 	/// <summary>
 	/// <see cref="Exception.Data"/> key holding the original exception's
 	/// <see cref="object.ToString"/> (type, message, and stack trace).
 	/// </summary>
-	internal const string OriginalExceptionDataKey = "clio.login.originalException";
+	public const string OriginalExceptionDataKey = "clio.login.originalException";
 
 	/// <summary>
 	/// <see cref="Exception.Data"/> key holding the recorded diagnostic context, so a caller can read
 	/// the fields structurally instead of parsing them back out of the message.
 	/// </summary>
-	internal const string DiagnosticContextDataKey = "clio.login.diagnostics";
+	public const string DiagnosticContextDataKey = "clio.login.diagnostics";
 
 	#endregion
 

--- a/clio/Common/CreatioLoginFailedException.cs
+++ b/clio/Common/CreatioLoginFailedException.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Clio.Common;
+
+/// <summary>
+/// A Creatio login attempt failed. Carries the original failure message plus the diagnostic context
+/// recorded by <see cref="ILoginDiagnostics"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception deliberately has <b>no</b> <see cref="Exception.InnerException"/>. Both message
+/// surfaces clio uses walk to the inner-most exception —
+/// <see cref="SurfacedExceptionMessage.Resolve"/> at the MCP boundary and
+/// <see cref="Exception.GetBaseException"/> in the application-section commands — so a wrapper that
+/// kept the original as its inner exception would have its diagnostic message silently discarded,
+/// which is the whole point of recording it. Being the inner-most exception is therefore load-bearing:
+/// do not add an inner exception here.
+/// </para>
+/// <para>
+/// The original exception is not lost: its type name and, when it is (or wraps) a
+/// <see cref="System.Net.WebException"/>, its transport status are folded into
+/// <see cref="Exception.Message"/>, and its full <see cref="object.ToString"/> is stored in
+/// <see cref="Exception.Data"/> under <see cref="OriginalExceptionDataKey"/> for a debugger or a
+/// verbose log.
+/// </para>
+/// </remarks>
+internal sealed class CreatioLoginFailedException : Exception {
+	#region Constants: Internal
+
+	/// <summary>
+	/// <see cref="Exception.Data"/> key holding the original exception's
+	/// <see cref="object.ToString"/> (type, message, and stack trace).
+	/// </summary>
+	internal const string OriginalExceptionDataKey = "clio.login.originalException";
+
+	/// <summary>
+	/// <see cref="Exception.Data"/> key holding the recorded diagnostic context, so a caller can read
+	/// the fields structurally instead of parsing them back out of the message.
+	/// </summary>
+	internal const string DiagnosticContextDataKey = "clio.login.diagnostics";
+
+	#endregion
+
+	#region Constructors: Public
+
+	/// <summary>
+	/// Creates a new <see cref="CreatioLoginFailedException"/>.
+	/// </summary>
+	/// <param name="message">The failure message, already carrying the diagnostic context.</param>
+	public CreatioLoginFailedException(string message)
+		: base(message) { }
+
+	#endregion
+}

--- a/clio/Common/CreatioLoginFailedException.cs
+++ b/clio/Common/CreatioLoginFailedException.cs
@@ -17,6 +17,24 @@ namespace Clio.Common;
 /// do not add an inner exception here.
 /// </para>
 /// <para>
+/// It derives from <see cref="UnauthorizedAccessException"/> because that is the type clio's auth
+/// classifiers key on, and everything decorated here genuinely is a credential rejection (the recorder
+/// only decorates the client's <c>"Unauthorized &lt;user&gt; for &lt;url&gt;"</c> shape; every other
+/// login failure propagates as its original instance). Four sites depend on it and would silently fall
+/// through to their generic arm otherwise: <c>ServerReadinessWaiter</c> (maps it to
+/// <c>AuthenticationRejected</c> and fails fast instead of burning the readiness budget on further
+/// rejected logins), <c>GetCreatioInfoCommand</c> (<c>BaseProbeFailure.Authentication</c>),
+/// <c>SchemaNamePrefixTool</c> (the MCP-visible "Authentication error reading SchemaNamePrefix."
+/// result), and <c>SysSettingsCommand.CategorizeError</c>.
+/// </para>
+/// <para>
+/// <b>Rejected alternative:</b> keeping the original as <see cref="Exception.InnerException"/> behind an
+/// <c>IAuthoritativeErrorMessage</c> marker does not work. <c>ApplicationSectionCreateCommand</c> reports
+/// the root cause via <see cref="Exception.GetBaseException"/><c>.Message</c>, which walks to the
+/// inner-most exception and ignores marker interfaces — the diagnostic context would be dropped exactly
+/// where it is needed. Deriving keeps both properties at once: inner-most, and correctly classified.
+/// </para>
+/// <para>
 /// The original exception is not lost: its type name and, when it is (or wraps) a
 /// <see cref="System.Net.WebException"/>, its transport status are folded into
 /// <see cref="Exception.Message"/>, and its full <see cref="object.ToString"/> is stored in
@@ -24,7 +42,7 @@ namespace Clio.Common;
 /// verbose log.
 /// </para>
 /// </remarks>
-internal sealed class CreatioLoginFailedException : Exception {
+internal sealed class CreatioLoginFailedException : UnauthorizedAccessException {
 	#region Constants: Internal
 
 	/// <summary>

--- a/clio/Common/ILoginDiagnostics.cs
+++ b/clio/Common/ILoginDiagnostics.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Clio.Common;
+
+/// <summary>
+/// Records the timing and concurrency context of Creatio login attempts, so a rejected login is
+/// diagnosable from CI output alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Motivated by GitHub issue #1106 (clio MCP e2e flakiness): concurrent <c>create-app-section</c>
+/// calls intermittently fail with <c>Unauthorized &lt;user&gt; for &lt;url&gt;</c>, which
+/// <c>Creatio.Client.CreatioClient.Login()</c> throws when the login response body contains
+/// <c>"Code":1</c>. The message alone cannot tell whether several logins for the same credentials
+/// overlapped (every tool call builds its own <see cref="IApplicationClient"/>, so logins are not
+/// de-duplicated across calls) or whether a single isolated login was rejected. The recorded
+/// in-flight figures answer exactly that question on the next reproduction.
+/// </para>
+/// <para>
+/// Both entry points must be wired, because a login can start in two very different places:
+/// <see cref="Track"/> covers the logins clio drives itself (an explicit
+/// <see cref="IApplicationClient.Login"/> and the <see cref="IReauthExecutor"/> re-login), while
+/// <see cref="TrackRequest{T}"/> covers the login the NuGet client performs implicitly inside the
+/// first request of a client that has no auth cookie yet — the path clio never sees as a call.
+/// </para>
+/// </remarks>
+internal interface ILoginDiagnostics {
+	/// <summary>
+	/// Invokes <paramref name="login"/>. On success the call is transparent. On failure the original
+	/// message is re-thrown as <see cref="CreatioLoginFailedException"/> with the diagnostic context
+	/// appended.
+	/// </summary>
+	/// <param name="login">The login callback. Required.</param>
+	/// <param name="kind">Why this login is being attempted.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="login"/> is <c>null</c>.</exception>
+	/// <exception cref="CreatioLoginFailedException"><paramref name="login"/> threw.</exception>
+	void Track(Action login, LoginAttemptKind kind);
+
+	/// <summary>
+	/// Invokes <paramref name="request"/> and returns its result unchanged. Only a failure that carries
+	/// the NuGet client's login-rejection signature is decorated (as
+	/// <see cref="LoginAttemptKind.Implicit"/>); every other exception propagates untouched, so this
+	/// wrapper never changes how ordinary request failures surface.
+	/// </summary>
+	/// <typeparam name="T">The request result type.</typeparam>
+	/// <param name="request">The request callback. Required.</param>
+	/// <returns>Whatever <paramref name="request"/> returned.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="request"/> is <c>null</c>.</exception>
+	/// <exception cref="CreatioLoginFailedException">
+	/// <paramref name="request"/> failed because its implicit login was rejected.
+	/// </exception>
+	T TrackRequest<T>(Func<T> request);
+}

--- a/clio/Common/ILoginDiagnostics.cs
+++ b/clio/Common/ILoginDiagnostics.cs
@@ -50,4 +50,15 @@ internal interface ILoginDiagnostics {
 	/// <paramref name="request"/> failed because its implicit login was rejected.
 	/// </exception>
 	T TrackRequest<T>(Func<T> request);
+
+	/// <summary>
+	/// Invokes <paramref name="request"/> under the same recording as <see cref="TrackRequest{T}"/>, for
+	/// request methods that return nothing.
+	/// </summary>
+	/// <param name="request">The request callback. Required.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="request"/> is <c>null</c>.</exception>
+	/// <exception cref="CreatioLoginFailedException">
+	/// <paramref name="request"/> failed because its implicit login was rejected.
+	/// </exception>
+	void TrackRequest(Action request);
 }

--- a/clio/Common/LoginAttemptKind.cs
+++ b/clio/Common/LoginAttemptKind.cs
@@ -14,6 +14,12 @@ internal enum LoginAttemptKind {
 	/// An automatic re-login driven by <see cref="IReauthExecutor"/> after a request observed a
 	/// session-expired response.
 	/// </summary>
+	/// <remarks>
+	/// The recorded in-flight request count excludes the request that triggered this re-login:
+	/// <c>ReauthExecutor.Execute</c> runs the request to completion (or failure) before re-authenticating,
+	/// so that request has already left the gauge. Read <c>in-flight-requests</c> on a reauth record as
+	/// "besides the triggering request" — <c>0/0</c> means no <em>other</em> traffic, not no traffic.
+	/// </remarks>
 	Reauthentication,
 
 	/// <summary>

--- a/clio/Common/LoginAttemptKind.cs
+++ b/clio/Common/LoginAttemptKind.cs
@@ -1,0 +1,26 @@
+namespace Clio.Common;
+
+/// <summary>
+/// Classifies why a Creatio login was attempted. Recorded by <see cref="ILoginDiagnostics"/> so a
+/// failure surfaced in CI shows which of the three login paths was rejected.
+/// </summary>
+internal enum LoginAttemptKind {
+	/// <summary>
+	/// An explicit, caller-initiated login through <see cref="IApplicationClient.Login"/>.
+	/// </summary>
+	Initial,
+
+	/// <summary>
+	/// An automatic re-login driven by <see cref="IReauthExecutor"/> after a request observed a
+	/// session-expired response.
+	/// </summary>
+	Reauthentication,
+
+	/// <summary>
+	/// A login performed implicitly by the NuGet client from inside a request: its
+	/// <c>InitAuthCookie</c> authenticates on the first request of a client that has no auth cookie
+	/// yet. This is the dominant path in clio's MCP surface, where every tool call builds its own
+	/// client and therefore logs in on its first request without anyone calling <c>Login</c>.
+	/// </summary>
+	Implicit
+}

--- a/clio/Common/LoginDiagnostics.cs
+++ b/clio/Common/LoginDiagnostics.cs
@@ -61,8 +61,16 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 		AttemptRecord record = BeginAttempt(kind);
 		try {
 			login();
-		} catch (Exception exception) {
-			throw Decorate(exception, record);
+		} catch (Exception exception)
+			when (TryFindLoginRejection(exception, out UnauthorizedAccessException rejection)) {
+			// Only the login-rejection shape is decorated, exactly like the request path below. Anything
+			// else — a WebException, a TimeoutException, an OperationCanceledException, a fatal type —
+			// propagates as the same instance, so the typed handlers that key on it keep working
+			// (RemoteCommand.Login's catch (WebException) => return 1, BaseDataContextCommand's 404
+			// diagnostic, ExceptionReadableMessageExtension's InnerException walk,
+			// GetCreatioInfoCommand.IsRecoverable's fatal-type blocklist, and McpToolErrorFilter's
+			// deliberate OperationCanceledException rethrow for the ENG-93373 read-response deadline).
+			throw Decorate(exception, rejection, record);
 		} finally {
 			EndAttempt(record);
 		}
@@ -74,12 +82,58 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 		AttemptRecord record = BeginAttempt(LoginAttemptKind.Implicit);
 		try {
 			return request();
-		} catch (UnauthorizedAccessException exception)
-			when (exception.Message.StartsWith(LoginRejectionMessagePrefix, StringComparison.Ordinal)) {
-			throw Decorate(exception, record);
+		} catch (Exception exception)
+			when (TryFindLoginRejection(exception, out UnauthorizedAccessException rejection)) {
+			throw Decorate(exception, rejection, record);
 		} finally {
 			EndAttempt(record);
 		}
+	}
+
+	/// <inheritdoc />
+	public void TrackRequest(Action request) {
+		ArgumentNullException.ThrowIfNull(request);
+		TrackRequest<object>(() => {
+			request();
+			return null;
+		});
+	}
+
+	/// <summary>
+	/// Finds the Creatio login rejection inside <paramref name="exception"/>, if there is one.
+	/// </summary>
+	/// <remarks>
+	/// The chain is walked and every <see cref="AggregateException"/> is flattened because the NuGet
+	/// client runs its transport through <c>Task.Result</c>, so faults can arrive wrapped — the same
+	/// arrival shape this repository already unwraps in
+	/// <c>EntitySchemaPublishHelper</c>, <c>TransientNetworkFailureClassifier</c>,
+	/// <c>GetCreatioInfoCommand</c>, <c>ApplicationSectionCreateCommand</c> and <c>UserThemeApplier</c>.
+	/// Matching them here means the decoration fires on the production arrival shape and not only on the
+	/// bare exception a unit test constructs.
+	/// </remarks>
+	/// <param name="exception">The failure to inspect. May be <c>null</c>.</param>
+	/// <param name="rejection">The rejection found, or <c>null</c>.</param>
+	/// <returns><c>true</c> when a login rejection was found.</returns>
+	internal static bool TryFindLoginRejection(Exception exception,
+		out UnauthorizedAccessException rejection) {
+		for (Exception current = exception; current is not null; current = current.InnerException) {
+			if (current is AggregateException aggregate) {
+				foreach (Exception inner in aggregate.Flatten().InnerExceptions) {
+					if (TryFindLoginRejection(inner, out rejection)) {
+						return true;
+					}
+				}
+				// Flatten() already reached every branch; InnerException is just InnerExceptions[0].
+				break;
+			}
+			if (current is UnauthorizedAccessException unauthorized
+				&& unauthorized.Message.StartsWith(LoginRejectionMessagePrefix, StringComparison.Ordinal)) {
+				rejection = unauthorized;
+				return true;
+			}
+		}
+		rejection = null;
+		return false;
 	}
 
 	#endregion
@@ -114,18 +168,26 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 		}
 	}
 
-	private CreatioLoginFailedException Decorate(Exception exception, AttemptRecord record) {
+	/// <param name="surfaced">The exception the callback actually threw; may wrap the rejection.</param>
+	/// <param name="rejection">The login rejection found inside <paramref name="surfaced"/>.</param>
+	/// <param name="record">What was captured when the attempt started.</param>
+	private CreatioLoginFailedException Decorate(Exception surfaced, UnauthorizedAccessException rejection,
+		AttemptRecord record) {
 		// Read the gauges BEFORE the finally block releases this attempt, so the figures describe the
 		// concurrency this login actually competed with rather than what is left after it.
-		string context = BuildContext(exception, record, _scoreboard.LoginsInFlight,
+		string context = BuildContext(surfaced, rejection, record, _scoreboard.LoginsInFlight,
 			_scoreboard.RequestsInFlight);
-		CreatioLoginFailedException failure = new($"{exception.Message} [{context}]");
-		failure.Data[CreatioLoginFailedException.OriginalExceptionDataKey] = exception.ToString();
+		// The message is built from the rejection, not from the wrapper: an AggregateException's own
+		// message would replace the server's "Unauthorized <user> for <url>" — the primary signal — with
+		// "One or more errors occurred.".
+		CreatioLoginFailedException failure = new($"{rejection.Message} [{context}]");
+		failure.Data[CreatioLoginFailedException.OriginalExceptionDataKey] = surfaced.ToString();
 		failure.Data[CreatioLoginFailedException.DiagnosticContextDataKey] = context;
 		return failure;
 	}
 
-	private string BuildContext(Exception exception, AttemptRecord record, int loginsInFlightAtFailure,
+	private string BuildContext(Exception surfaced, UnauthorizedAccessException rejection,
+		AttemptRecord record, int loginsInFlightAtFailure,
 		int requestsInFlightAtFailure) {
 		long now = Stopwatch.GetTimestamp();
 		StringBuilder builder = new("clio-login");
@@ -143,11 +205,16 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 		Append(builder, "started-at", record.StartedAtUtc.ToString("O", CultureInfo.InvariantCulture));
 		Append(builder, "elapsed-ms", Milliseconds(now - record.StartedAtTimestamp));
 		Append(builder, "since-client-created-ms", Milliseconds(now - _createdAtTimestamp));
-		Append(builder, "original-type", exception.GetType().Name);
+		Append(builder, "original-type", rejection.GetType().Name);
+		if (!ReferenceEquals(surfaced, rejection)) {
+			// The rejection arrived wrapped, so record the wrapper too — otherwise the message would
+			// claim a bare exception was thrown where a Task.Result fault was.
+			Append(builder, "wrapped-in", surfaced.GetType().Name);
+		}
 		// The readable-message extension folds an inner WebException's transport status into its output.
 		// This exception is intentionally inner-less (see CreatioLoginFailedException), so fold the same
 		// signal in here — otherwise a 401-vs-connect-failure distinction would be lost on the CLI path.
-		if (TryDescribeTransport(exception, out string transport)) {
+		if (TryDescribeTransport(surfaced, out string transport)) {
 			Append(builder, "transport", transport);
 		}
 		return builder.ToString();
@@ -236,6 +303,14 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 		/// does so at its very beginning, so this is the closest observable proxy for concurrent implicit
 		/// logins.
 		/// </summary>
+		/// <remarks>
+		/// A <see cref="LoginAttemptKind.Reauthentication"/> record excludes its own triggering request:
+		/// <c>ReauthExecutor.Execute</c> calls the request first and re-authenticates only after it
+		/// returned or threw, by which point <see cref="TrackRequest{T}"/>'s <c>finally</c> has already
+		/// released that request. So a reauth failure reports one fewer request than were logically
+		/// active — typically <c>0/0</c> in an otherwise idle process. Read it as "besides the request
+		/// that triggered this re-login".
+		/// </remarks>
 		internal int RequestsInFlight => Volatile.Read(ref _requestsInFlight);
 
 		#endregion

--- a/clio/Common/LoginDiagnostics.cs
+++ b/clio/Common/LoginDiagnostics.cs
@@ -241,10 +241,9 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 			if (current is not WebException webException) {
 				continue;
 			}
-			description = webException.Status.ToString();
-			if (webException.Response is HttpWebResponse httpResponse) {
-				description += $"/{Number((int)httpResponse.StatusCode)}-{httpResponse.StatusCode}";
-			}
+			description = webException.Response is HttpWebResponse httpResponse
+				? $"{webException.Status}/{Number((int)httpResponse.StatusCode)}-{httpResponse.StatusCode}"
+				: webException.Status.ToString();
 			return true;
 		}
 		description = null;

--- a/clio/Common/LoginDiagnostics.cs
+++ b/clio/Common/LoginDiagnostics.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Threading;
+
+namespace Clio.Common;
+
+/// <inheritdoc cref="ILoginDiagnostics" />
+internal sealed class LoginDiagnostics : ILoginDiagnostics {
+	#region Constants: Internal
+
+	/// <summary>
+	/// Prefix of the message <c>Creatio.Client.CreatioClient.Login()</c> throws when the login response
+	/// body contains <c>"Code":1</c> (verified against creatio.client 1.0.38, which builds it as
+	/// <c>"Unauthorized " + userName + " for " + AppUrl</c>). Matching it is how an implicit login
+	/// rejection is told apart from an ordinary request failure — the NuGet client offers no typed
+	/// signal for it. A future client that reworded the message would simply stop the implicit-login
+	/// decoration; nothing else changes, and the explicit paths keep working.
+	/// </summary>
+	internal const string LoginRejectionMessagePrefix = "Unauthorized ";
+
+	#endregion
+
+	#region Fields: Private
+
+	private readonly LoginAttemptScoreboard _scoreboard;
+	private readonly string _clientId;
+	private readonly long _createdAtTimestamp;
+	private int _clientLoginCount;
+	private int _clientRequestCount;
+
+	#endregion
+
+	#region Constructors: Public
+
+	/// <summary>
+	/// Creates a new <see cref="LoginDiagnostics"/> for one client instance.
+	/// </summary>
+	/// <param name="scoreboard">
+	/// The process-wide counters. Defaults to <see cref="LoginAttemptScoreboard.Shared"/>, which is what
+	/// makes the recorded in-flight figures span independently constructed clients — the exact situation
+	/// issue #1106 needs measured. Tests pass their own instance for isolation.
+	/// </param>
+	public LoginDiagnostics(LoginAttemptScoreboard scoreboard = null) {
+		_scoreboard = scoreboard ?? LoginAttemptScoreboard.Shared;
+		// Short, log-friendly correlation token. Only has to be unique among the clients alive in one
+		// process, so eight hex characters are plenty and keep the failure message readable.
+		_clientId = Guid.NewGuid().ToString("N")[..8];
+		_createdAtTimestamp = Stopwatch.GetTimestamp();
+	}
+
+	#endregion
+
+	#region Methods: Public
+
+	/// <inheritdoc />
+	public void Track(Action login, LoginAttemptKind kind) {
+		ArgumentNullException.ThrowIfNull(login);
+		AttemptRecord record = BeginAttempt(kind);
+		try {
+			login();
+		} catch (Exception exception) {
+			throw Decorate(exception, record);
+		} finally {
+			EndAttempt(record);
+		}
+	}
+
+	/// <inheritdoc />
+	public T TrackRequest<T>(Func<T> request) {
+		ArgumentNullException.ThrowIfNull(request);
+		AttemptRecord record = BeginAttempt(LoginAttemptKind.Implicit);
+		try {
+			return request();
+		} catch (UnauthorizedAccessException exception)
+			when (exception.Message.StartsWith(LoginRejectionMessagePrefix, StringComparison.Ordinal)) {
+			throw Decorate(exception, record);
+		} finally {
+			EndAttempt(record);
+		}
+	}
+
+	#endregion
+
+	#region Methods: Private
+
+	private AttemptRecord BeginAttempt(LoginAttemptKind kind) {
+		// An implicit login cannot be observed as a call, only as the leading part of the request that
+		// triggers it, so it is counted and gauged as a request. Keeping the login and request counters
+		// apart means no figure has to be qualified when it is read off a failure message: a login
+		// ordinal never silently counts requests that performed no login at all.
+		int clientOrdinal;
+		int processOrdinal;
+		if (kind == LoginAttemptKind.Implicit) {
+			clientOrdinal = Interlocked.Increment(ref _clientRequestCount);
+			processOrdinal = _scoreboard.NextRequest();
+			_scoreboard.EnterRequest();
+		} else {
+			clientOrdinal = Interlocked.Increment(ref _clientLoginCount);
+			processOrdinal = _scoreboard.NextLogin();
+			_scoreboard.EnterLogin();
+		}
+		return new AttemptRecord(kind, clientOrdinal, processOrdinal, _scoreboard.LoginsInFlight,
+			_scoreboard.RequestsInFlight, DateTime.UtcNow, Stopwatch.GetTimestamp());
+	}
+
+	private void EndAttempt(AttemptRecord record) {
+		if (record.Kind == LoginAttemptKind.Implicit) {
+			_scoreboard.LeaveRequest();
+		} else {
+			_scoreboard.LeaveLogin();
+		}
+	}
+
+	private CreatioLoginFailedException Decorate(Exception exception, AttemptRecord record) {
+		// Read the gauges BEFORE the finally block releases this attempt, so the figures describe the
+		// concurrency this login actually competed with rather than what is left after it.
+		string context = BuildContext(exception, record, _scoreboard.LoginsInFlight,
+			_scoreboard.RequestsInFlight);
+		CreatioLoginFailedException failure = new($"{exception.Message} [{context}]");
+		failure.Data[CreatioLoginFailedException.OriginalExceptionDataKey] = exception.ToString();
+		failure.Data[CreatioLoginFailedException.DiagnosticContextDataKey] = context;
+		return failure;
+	}
+
+	private string BuildContext(Exception exception, AttemptRecord record, int loginsInFlightAtFailure,
+		int requestsInFlightAtFailure) {
+		long now = Stopwatch.GetTimestamp();
+		StringBuilder builder = new("clio-login");
+		Append(builder, "kind", DescribeKind(record.Kind));
+		Append(builder, "client", _clientId);
+		// Named after what the ordinal counts, so an implicit-login failure never claims to be the
+		// client's Nth *login* when it is really its Nth request.
+		string ordinalScope = record.Kind == LoginAttemptKind.Implicit ? "request" : "login";
+		Append(builder, $"client-{ordinalScope}", Number(record.ClientOrdinal));
+		Append(builder, $"process-{ordinalScope}", Number(record.ProcessOrdinal));
+		Append(builder, "in-flight-logins",
+			$"{Number(record.LoginsInFlightAtStart)}/{Number(loginsInFlightAtFailure)}");
+		Append(builder, "in-flight-requests",
+			$"{Number(record.RequestsInFlightAtStart)}/{Number(requestsInFlightAtFailure)}");
+		Append(builder, "started-at", record.StartedAtUtc.ToString("O", CultureInfo.InvariantCulture));
+		Append(builder, "elapsed-ms", Milliseconds(now - record.StartedAtTimestamp));
+		Append(builder, "since-client-created-ms", Milliseconds(now - _createdAtTimestamp));
+		Append(builder, "original-type", exception.GetType().Name);
+		// The readable-message extension folds an inner WebException's transport status into its output.
+		// This exception is intentionally inner-less (see CreatioLoginFailedException), so fold the same
+		// signal in here — otherwise a 401-vs-connect-failure distinction would be lost on the CLI path.
+		if (TryDescribeTransport(exception, out string transport)) {
+			Append(builder, "transport", transport);
+		}
+		return builder.ToString();
+	}
+
+	private static string DescribeKind(LoginAttemptKind kind) => kind switch {
+		LoginAttemptKind.Initial => "initial",
+		LoginAttemptKind.Reauthentication => "reauth",
+		_ => "implicit"
+	};
+
+	private static void Append(StringBuilder builder, string name, string value) {
+		builder.Append(' ').Append(name).Append('=').Append(value);
+	}
+
+	private static string Number(int value) => value.ToString(CultureInfo.InvariantCulture);
+
+	private static string Milliseconds(long elapsedTimestampTicks) =>
+		((double)elapsedTimestampTicks / Stopwatch.Frequency * 1000d)
+		.ToString("F0", CultureInfo.InvariantCulture);
+
+	private static bool TryDescribeTransport(Exception exception, out string description) {
+		for (Exception current = exception; current is not null; current = current.InnerException) {
+			if (current is not WebException webException) {
+				continue;
+			}
+			description = webException.Status.ToString();
+			if (webException.Response is HttpWebResponse httpResponse) {
+				description += $"/{Number((int)httpResponse.StatusCode)}-{httpResponse.StatusCode}";
+			}
+			return true;
+		}
+		description = null;
+		return false;
+	}
+
+	#endregion
+
+	#region Classes: Private
+
+	/// <summary>
+	/// Everything captured at the start of one attempt. A data-only carrier; a struct because one is
+	/// created per request and it never outlives the call.
+	/// </summary>
+	private readonly record struct AttemptRecord(
+		LoginAttemptKind Kind,
+		int ClientOrdinal,
+		int ProcessOrdinal,
+		int LoginsInFlightAtStart,
+		int RequestsInFlightAtStart,
+		DateTime StartedAtUtc,
+		long StartedAtTimestamp);
+
+	#endregion
+
+	#region Classes: Internal
+
+	/// <summary>
+	/// Process-wide login and request counters. A plain state carrier: it holds numbers and hands them
+	/// out, so it is created with <c>new</c> rather than resolved from DI.
+	/// </summary>
+	internal sealed class LoginAttemptScoreboard {
+		#region Fields: Private
+
+		private int _loginCount;
+		private int _requestCount;
+		private int _loginsInFlight;
+		private int _requestsInFlight;
+
+		#endregion
+
+		#region Properties: Internal
+
+		/// <summary>
+		/// The scoreboard shared by every production <see cref="LoginDiagnostics"/> instance.
+		/// </summary>
+		internal static LoginAttemptScoreboard Shared { get; } = new();
+
+		/// <summary>
+		/// Number of clio-driven logins (explicit or re-authentication) currently in flight process-wide.
+		/// </summary>
+		internal int LoginsInFlight => Volatile.Read(ref _loginsInFlight);
+
+		/// <summary>
+		/// Number of requests currently in flight process-wide. A request that authenticates implicitly
+		/// does so at its very beginning, so this is the closest observable proxy for concurrent implicit
+		/// logins.
+		/// </summary>
+		internal int RequestsInFlight => Volatile.Read(ref _requestsInFlight);
+
+		#endregion
+
+		#region Methods: Internal
+
+		/// <summary>Registers a clio-driven login as started.</summary>
+		internal void EnterLogin() => Interlocked.Increment(ref _loginsInFlight);
+
+		/// <summary>Registers a clio-driven login as finished, successfully or not.</summary>
+		internal void LeaveLogin() => Interlocked.Decrement(ref _loginsInFlight);
+
+		/// <summary>Registers a request as started.</summary>
+		internal void EnterRequest() => Interlocked.Increment(ref _requestsInFlight);
+
+		/// <summary>Registers a request as finished, successfully or not.</summary>
+		internal void LeaveRequest() => Interlocked.Decrement(ref _requestsInFlight);
+
+		/// <summary>Returns the process-wide ordinal of the next clio-driven login (1-based).</summary>
+		internal int NextLogin() => Interlocked.Increment(ref _loginCount);
+
+		/// <summary>Returns the process-wide ordinal of the next request (1-based).</summary>
+		internal int NextRequest() => Interlocked.Increment(ref _requestCount);
+
+		#endregion
+	}
+
+	#endregion
+}

--- a/clio/Common/LoginDiagnostics.cs
+++ b/clio/Common/LoginDiagnostics.cs
@@ -63,13 +63,13 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 			login();
 		} catch (Exception exception)
 			when (TryFindLoginRejection(exception, out UnauthorizedAccessException rejection)) {
-			// Only the login-rejection shape is decorated, exactly like the request path below. Anything
-			// else — a WebException, a TimeoutException, an OperationCanceledException, a fatal type —
-			// propagates as the same instance, so the typed handlers that key on it keep working
-			// (RemoteCommand.Login's catch (WebException) => return 1, BaseDataContextCommand's 404
-			// diagnostic, ExceptionReadableMessageExtension's InnerException walk,
-			// GetCreatioInfoCommand.IsRecoverable's fatal-type blocklist, and McpToolErrorFilter's
-			// deliberate OperationCanceledException rethrow for the ENG-93373 read-response deadline).
+			// Only the login-rejection shape is decorated, exactly like the request path below. Every
+			// other failure — a transport fault, a timeout, a cancellation, a fatal type — propagates as
+			// the same instance, so the callers that key on its type keep working: the remote command's
+			// transport-fault arm still returns its exit code, the data-context command still renders its
+			// not-found diagnostic, the readable-message extension still finds the inner transport fault,
+			// the info command's fatal-type blocklist still recognises a fatal failure, and the MCP tool
+			// error filter still lets a cancellation through for the ENG-93373 read-response deadline.
 			throw Decorate(exception, rejection, record);
 		} finally {
 			EndAttempt(record);


### PR DESCRIPTION
🔗 **Jira:** not applicable — the source GitHub issue [#1106](https://github.com/Advance-Technologies-Foundation/clio/issues/1106) links Jira ENG-95554, but that key does not exist in the tracker (a direct `getJiraIssue` lookup returns 404; same conclusion as #1101) and was not recreated. GitHub issue #1106 is the tracker for this work.

## What

Make a rejected Creatio login diagnosable from CI output alone. Every failed login now carries the timing and concurrency context that answers the question issue #1106 could not answer:

```
Unauthorized svc_user for https://host [clio-login kind=implicit client=9390d9fa
 client-request=1 process-request=1 in-flight-logins=0/0 in-flight-requests=1/1
 started-at=2026-08-19T13:13:53.9366930Z elapsed-ms=28 since-client-created-ms=63
 original-type=UnauthorizedAccessException]
```

`in-flight-logins` / `in-flight-requests` are reported as `at-start/at-failure` and are the load-bearing fields: they settle whether a rejected login overlapped other logins for the same credentials, or was the only one in flight.

## Why

Items 3 and 4 of #1106 fail with `Unauthorized <user> for <url>`. Decompiling `creatio.client` 1.0.38 shows where that comes from:

```csharp
// Creatio.Client.CreatioClient.Login()
_authCookie = new CookieContainer();        // an existing valid session is destroyed BEFORE the request
...
if (streamReader.ReadToEnd().Contains("\"Code\":1"))
    throw new UnauthorizedAccessException("Unauthorized " + _userName + " for " + AppUrl);
```

So these failures are a **server-side login rejection**, not the `ReauthExecutor` gap originally suspected — reauth did engage, called `_login()`, and the server refused valid credentials. The message alone cannot tell an overlapping-login burst apart from an isolated rejection, because every tool call constructs its own `IApplicationClient` and logins are not de-duplicated across calls. That is what this records.

## Three findings that shaped the implementation

1. **`CreatioClient.InitAuthCookie()` logs in implicitly from inside every request method** when the client has no auth cookie yet. That is the dominant path in the MCP surface (every tool call builds its own client and authenticates on its first request) and it is completely invisible to adapter-level `Login()` wrapping. Found only by a runtime check against a fake Creatio — static reading had missed it. The request methods are therefore instrumented too (`kind=implicit`), and **only** a failure carrying the client's login-rejection signature is decorated; every other request failure propagates as the very same exception instance.
2. **`SurfacedExceptionMessage.Resolve` (MCP boundary) and `Exception.GetBaseException()` (application-section commands) both reduce to the inner-most exception.** A wrapper that kept the original as its `InnerException` would have its diagnostic message silently discarded. `CreatioLoginFailedException` is therefore deliberately inner-less — the original goes into `Exception.Data`, and its type plus (when present) its `WebException` transport status are folded into the message so the CLI path keeps the 401-vs-connect-failure distinction. There is an XML-doc note and a unit test pinning this invariant.
3. **Login and request ordinals are counted separately**, so an implicit-login failure never claims to be the client's Nth *login* when it is really its Nth *request*.

## Why this is diagnostics, not a fix

No behavior change on any path that was already working. The one deliberate behavior change, added in the review round, is the intended one: a rejected login now surfaces as a `CreatioLoginFailedException` deriving from `UnauthorizedAccessException`, so every site that already classified a refused credential by that type keeps matching and additionally gets the diagnostic context in the message. Every other login failure — `WebException`, `TimeoutException`, `OperationCanceledException`, fatal types — propagates as the very same instance it did before.

`SectionCreateSerializationGuard`'s deliberately narrow scope (ENG-93089) is left alone — widening it to cover login on an unverified hypothesis would reverse an incident-driven design decision and reads as an ADR-level call. The four tests stay muted; the concurrent-login theory gets confirmed or killed by the next reproduction.

## Coverage — stated precisely

- **Item 3** (`ApplicationSectionCreate_ConcurrentCallsAgainstOneApp_…`, `Unauthorized … for …`): fully covered.
- **Item 4** (`ApplicationSectionUpdate_Should_Return_Structured_Readback_Data`): **partially** covered. Its `Error: Select query failed.` shape is built from a *successful* HTTP response with `Success=false` (`ApplicationInfoService.cs:622`) — no login is involved at all, so nothing is decorated. Its "SelectQuery returned an HTML page instead of JSON" shape is covered only when the HTML is a login page *and* the relogin is rejected; if the relogin succeeds and the retry still returns HTML, `NonJsonServiceResponseException` (which implements `IAuthoritativeErrorMessage`) owns the message and carries no login context.
- **#1106 item 3, second failure shape** (`Runtime entity schema ... was not returned.`): **not covered**, and out of scope here. It is not a login rejection, so nothing decorates it — the "fully covered" claim above applies to the `Unauthorized ... for ...` shape only.
- `kind=initial` is unit-covered end to end (recorder plus adapter). Seven production callers invoke `IApplicationClient.Login()` explicitly — `PackageDownloader.cs:90`, `WebApplication/Downloader.cs:88`, `BaseDataContextCommand.cs:48`, `RemoteCommand.cs:136`, `TurnFsmCommand.cs:110`, `ShowLocalEnvironmentsCommand.cs:168`, `RegAppCommand.cs:143` — so this path is live on ordinary CLI commands, not theoretical. (An earlier revision of this description claimed the opposite; that claim was wrong and is what made the unfiltered `catch` in `Track` look risk-free.)

## Validation

- **Runtime self-verification** against a local fake Creatio (returns `"Code":1` on the login URL, a login page on data URLs) driven through the real `CreatioClient`, reproducing both automatic paths:
  - `kind=implicit client-request=1 in-flight-requests=1/1 …`
  - `kind=reauth client-login=1 in-flight-logins=1/1 …` (after a first login succeeded, the session died, and the relogin was refused — exactly the item 3/4 shape)
- **Unit:** 20 new tests in `LoginDiagnosticsTests`, all green. Full `Category=Unit` reports **20 failures both with and without this change** (verified by stashing the diff) — the documented macOS-only DbHub / NetFrameworkHttps / profile-path cluster, invisible to CI. Passing count 9065 → 9085.
- `dotnet build clio.mcp.e2e` succeeds; no new `CLIO*` diagnostics.
- Review tier: full self-review of the diff. It caught two defects in my own code before this PR — `client-attempt` counting requests rather than logins on the implicit path (misleading field), and a per-request `AttemptRecord` heap allocation (now a `readonly record struct`).

### Known interaction (resolved in the review round)

Two heuristic classifiers, `CurrentUserCultureResolver.IsUnauthorized` and `MobilePageValidation.LooksLikeAccessDenied`, match `Contains("401")` / `Contains("403")`, so a numeric field value such as `elapsed-ms=401` could match them. Narrowing `Track` to the login-rejection shape removes this for free: the only decorated failures are ones both classifiers already treat as access-denied. Swept `clio/`, `clio.mcp.e2e/`, and `clio-ring/` for message equality / `EndsWith` coupling on error text — nothing else is affected (`IsDetailLessInsertRejection` compares `response.ErrorInfo?.Message`, not an exception message).

## Note for whoever picks up #1101

PR #1101's body attributes this flakiness to "shared-stand contention". That is contradicted by the per-build-isolated e2e stand and by the server-side `Code:1` rejection documented above. No code touched here; the rationale recorded there is worth rewording.

---

## Review round (m-dymytrova, CHANGES_REQUESTED)

All seven findings addressed; details in each thread. Summary:

- **Blocker 1 / Blocker 2** — the two-step fix as prescribed: `Track` narrowed to the login-rejection predicate first, then `CreatioLoginFailedException : UnauthorizedAccessException`. Order matters — deriving before narrowing would have reclassified a login timeout as "credentials refused" at `ServerReadinessWaiter`.
- **Major 3** — `ILoginDiagnostics` injection seam plus a new `CreatioClientAdapterLoginDiagnosticsTests` pinning the request wiring, both login kinds (including the reauth closure, via an internal ctor where the reauth executor may be null) and the surfaced exception type for a rejection and a non-auth failure.
- **Major 4** — `TryFindLoginRejection` flattens `AggregateException` and walks the chain, matching the arrival shape this repo documents for `Creatio.Client`; the message is built from the found rejection and the wrapper is recorded as `wrapped-in=`.
- **Minor 6 / 7** — one `ExecuteRequest` helper plus a `void TrackRequest(Action)` overload; the reauth XML doc records that `in-flight-requests` excludes the triggering request.
- **Minor 5** (process-wide counters) — not changed; reasoning in the thread, flagged as an open call.

MCP reviewed, no update required — no tool name, argument, default, destructive classification, or error-envelope schema changed. `SchemaNamePrefixTool`'s "Authentication error reading SchemaNamePrefix." result is preserved by the `UnauthorizedAccessException` derivation (this was correct only after the review round; the earlier revision did change it).

ClioRing compatibility reviewed, no Ring-consumed contract changed. Inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json` for coupling to auth error text — none found. `dotnet test clio-ring/ClioRing.Tests -c Release` → 155/156; the single failure (`ResolveContainedReceiptPath_ShouldRejectEscapeAndNeverResolveOutsideFolder_WhenRunKeyIsHostile`) fails identically on the stashed tree and is macOS-specific (backslash is a legal filename character there). The Windows x64 NativeAOT publish was **not run** — macOS host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

