### PR TITLE
Stop advertising alternative process identities as required in the MCP schema

### DIFF
--- a/clio.mcp.e2e/ProcessDesignerContractRequiredArgsE2ETests.cs
+++ b/clio.mcp.e2e/ProcessDesignerContractRequiredArgsE2ETests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Command.McpServer.Tools.ProcessDesigner;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+using NUnit.Framework;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>
+/// Stand-free end-to-end guard on what the REAL clio MCP server advertises as required for the
+/// process-designer tools. The three tools below identify their target with one of several alternative
+/// arguments, so none of those alternatives may appear in the advertised <c>required</c> list.
+/// </summary>
+/// <remarks>
+/// These tools are non-resident, so their schema never appears in <c>tools/list</c>: the list a strict client
+/// or an agent actually reads is <c>get-tool-contract</c>'s <c>input-schema.required</c>, which is derived
+/// from the registered tool's emitted schema. That derivation is what regressed once already — the record
+/// declared both identities as non-nullable positional parameters, so both were advertised as required while
+/// the tool itself refused a payload carrying both, leaving no sendable call at all.
+/// <para>
+/// Not in CI: process-designer fixtures carry <see cref="ProcessDesignerE2EGate.CategoryName"/> and CI lanes
+/// exclude that category, because the feature ships with the CrtProcessBuilder package rather than with the
+/// default stand. The in-CI guard over the same contract is
+/// <c>clio.tests/Command/McpServer/ProcessDesignerEmittedSchemaTests.cs</c>; this fixture proves the same
+/// facts survive the real server process and the real serializer.
+/// </para>
+/// </remarks>
+[TestFixture]
+[AllureNUnit]
+[AllureFeature("process-designer")]
+[Category(ProcessDesignerE2EGate.CategoryName)]
+[Parallelizable(ParallelScope.Self)]
+public sealed class ProcessDesignerContractRequiredArgsE2ETests : McpContractFixtureBase {
+
+	private static readonly string[] DescribeIdentities = ["process-name", "process-uid", "process-caption"];
+
+	[Test]
+	[Description("Verifies the real clio MCP server does not advertise either mutually exclusive process identity of modify-business-process as required, while environment-name and operations stay required.")]
+	[AllureTag(ModifyBusinessProcessTool.ModifyBusinessProcessToolName)]
+	[AllureName("modify-business-process advertises neither process identity as required")]
+	public async Task ModifyBusinessProcess_Should_NotAdvertiseEitherIdentityAsRequired() {
+		// Arrange
+		SkipIfProcessDesignerDisabled();
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		IReadOnlyList<string> required = await RequiredArgumentsAsync(
+			context, ModifyBusinessProcessTool.ModifyBusinessProcessToolName);
+
+		// Assert
+		required.Should().NotContain("process-name",
+			because: "the tool refuses a payload that carries both identities, so advertising this one as " +
+				"required leaves a caller no sendable combination at all");
+		required.Should().NotContain("process-uid",
+			because: "the same holds mirrored for the other accepted identity");
+		required.Should().Contain("environment-name",
+			because: "environment-name is genuinely mandatory - asserting it proves this required list is " +
+				"populated rather than empty, which is what would make the two negatives above vacuous");
+		required.Should().Contain("operations",
+			because: "the operations array is the edit itself, so the tool cannot run without it");
+	}
+
+	[Test]
+	[Description("Verifies the real clio MCP server advertises none of describe-business-process's three alternative identities, nor its optional culture, as required.")]
+	[AllureTag(DescribeProcessTool.ToolName)]
+	[AllureName("describe-business-process advertises no single identity as required")]
+	public async Task DescribeBusinessProcess_Should_NotAdvertiseAnyIdentityAsRequired() {
+		// Arrange
+		SkipIfProcessDesignerDisabled();
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		IReadOnlyList<string> required = await RequiredArgumentsAsync(context, DescribeProcessTool.ToolName);
+
+		// Assert
+		foreach (string identity in DescribeIdentities) {
+			required.Should().NotContain(identity,
+				because: $"'{identity}' is one of three accepted identities, so a caller sending exactly one of " +
+					"the other two must not be rejected before the call reaches clio");
+		}
+
+		required.Should().NotContain("culture",
+			because: "the tool defaults culture to en-US and its own description calls it optional");
+		required.Should().Contain("environment-name",
+			because: "environment-name stays mandatory, which keeps the negatives above non-vacuous");
+	}
+
+	[Test]
+	[Description("Verifies the real clio MCP server does not advertise create-business-process's optional package-name override as required, while environment-name and descriptor stay required.")]
+	[AllureTag(CreateBusinessProcessTool.CreateBusinessProcessToolName)]
+	[AllureName("create-business-process advertises package-name as optional")]
+	public async Task CreateBusinessProcess_Should_NotAdvertisePackageNameAsRequired() {
+		// Arrange
+		SkipIfProcessDesignerDisabled();
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		IReadOnlyList<string> required = await RequiredArgumentsAsync(
+			context, CreateBusinessProcessTool.CreateBusinessProcessToolName);
+
+		// Assert
+		required.Should().NotContain("package-name",
+			because: "package-name only overrides the descriptor's own packageName, so a descriptor that names " +
+				"its package is already a complete payload");
+		required.Should().Contain("environment-name",
+			because: "environment-name stays mandatory, which keeps the negative above non-vacuous");
+		required.Should().Contain("descriptor",
+			because: "the descriptor is the process definition, so the tool cannot run without it");
+	}
+
+	/// <summary>
+	/// Skips when <c>process-designer</c> is off in the appsettings the server process loads. The gate resolves
+	/// that file FROM <see cref="McpE2ESettings.ClioProcessPath" />, so the path has to be filled in exactly as
+	/// the shared fixture fills it - a bare <c>TestConfiguration.Load()</c> would look in the wrong place, read
+	/// no feature map, and fail closed into a permanent skip that looks like a passing suite.
+	/// </summary>
+	private static void SkipIfProcessDesignerDisabled() {
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		ProcessDesignerE2EGate.SkipIfFeatureDisabled(settings);
+	}
+
+	/// <summary>
+	/// Reads one tool's advertised <c>input-schema.required</c> list from the live server through
+	/// <c>get-tool-contract</c> - the surface a client sees for a non-resident tool.
+	/// </summary>
+	private static async Task<IReadOnlyList<string>> RequiredArgumentsAsync(
+		ArrangeContext context,
+		string toolName) {
+		IReadOnlyCollection<string> reachable =
+			await context.Session.ListReachableToolNamesAsync(context.CancellationTokenSource.Token);
+		reachable.Should().Contain(toolName,
+			because: $"the {toolName} MCP tool must be discoverable on the lazy surface before its advertised " +
+				"contract can be asserted");
+
+		CallToolResult contractResult = await context.Session.CallToolAsync(
+			ToolContractGetTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["tool-names"] = new[] { toolName }
+				}
+			},
+			context.CancellationTokenSource.Token);
+		ToolContractGetResponse contracts =
+			EntitySchemaStructuredResultParser.Extract<ToolContractGetResponse>(contractResult);
+		ToolContractDefinition contract = contracts.Tools!.Single(definition => definition.Name == toolName);
+		contract.InputSchema.Should().NotBeNull(
+			because: $"the advertised contract for {toolName} must carry an input schema");
+		return contract.InputSchema.Required ?? [];
+	}
+}

--- a/clio.tests/Command/McpServer/ProcessDesignerEmittedSchemaTests.cs
+++ b/clio.tests/Command/McpServer/ProcessDesignerEmittedSchemaTests.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Clio;
+using Clio.Command;
+using Clio.Command.McpServer;
+using Clio.Command.McpServer.Tools;
+using Clio.Command.McpServer.Tools.ProcessDesigner;
+using FluentAssertions;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+/// <summary>
+/// Guards the emitted MCP input schemas of the process-designer tools, so that an argument the contract
+/// advertises as one-of-several or as optional is not advertised to a strict client as mandatory.
+/// </summary>
+/// <remarks>
+/// Same mechanism as <see cref="ColumnIdentityEmittedSchemaTests" />: the SDK derives the emitted
+/// <c>required</c> array from the bound record's non-nullable, NON-DEFAULTED positional parameters, so the
+/// reliable lever is the parameter DEFAULT, not the <c>?</c> annotation alone (clio compiles with the nullable
+/// context off, so annotations carry no metadata the generator can rely on) and not
+/// <see cref="System.ComponentModel.DataAnnotations.RequiredAttribute" />, which does not feed the array.
+/// <para>
+/// This has regressed once already: <c>modify-business-process</c> shipped <c>process-name</c> and
+/// <c>process-uid</c> as non-nullable positional parameters while its own tool body mapped them with
+/// <c>?? string.Empty</c> and refused a payload carrying both — so a client that obeyed the contract and sent
+/// exactly one was rejected client-side, before clio ever saw the call. These assertions read the schema
+/// through the real registry on the production serializer options, so a half-landed relaxation fails here.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Property("Module", "McpServer")]
+public sealed class ProcessDesignerEmittedSchemaTests {
+
+	private static McpToolInvokerRegistry BuildProductionRegistry() {
+		IServiceProvider provider = Substitute.For<IServiceProvider>();
+		IFeatureToggleService featureToggle = Substitute.For<IFeatureToggleService>();
+		// The process-designer tools sit behind [FeatureToggle("process-designer")]; the schema contract is
+		// asserted with the toggle on, because that is the only state in which a client sees these tools.
+		featureToggle.IsEnabled(Arg.Any<Type>()).Returns(true);
+		return new McpToolInvokerRegistry(
+			provider,
+			typeof(SchemaSyncTool).Assembly,
+			featureToggle,
+			BindingsModule.CreateMcpSerializerOptions());
+	}
+
+	private static JsonDocument EmittedInputSchema(string toolName) {
+		McpToolInvokerRegistry registry = BuildProductionRegistry();
+		registry.TryGetTool(toolName, out McpServerTool tool).Should().BeTrue(
+			because: $"'{toolName}' must be a registered tool for its emitted schema to be assertable");
+		return JsonDocument.Parse(JsonSerializer.Serialize(tool.ProtocolTool.InputSchema));
+	}
+
+	/// <summary>The <c>args</c> envelope schema, which is where every tool argument is declared.</summary>
+	private static JsonElement ArgsSchema(JsonDocument schema) {
+		return schema.RootElement.GetProperty("properties").GetProperty("args");
+	}
+
+	private static List<string> RequiredNames(JsonElement objectSchema) {
+		List<string> names = [];
+		if (!objectSchema.TryGetProperty("required", out JsonElement required)
+			|| required.ValueKind != JsonValueKind.Array) {
+			return names;
+		}
+		foreach (JsonElement item in required.EnumerateArray()) {
+			names.Add(item.GetString() ?? string.Empty);
+		}
+		return names;
+	}
+
+	private static void ShouldAdvertise(JsonElement argsSchema, string wireName) {
+		argsSchema.GetProperty("properties").TryGetProperty(wireName, out _).Should().BeTrue(
+			because: $"'{wireName}' must stay advertised - a field dropped from the schema is as unusable to a " +
+				"strict client as one wrongly demanded");
+	}
+
+	/// <summary>Collects every <c>required</c> entry from a schema and every schema nested inside it.</summary>
+	private static List<string> CollectRequiredNames(JsonElement node) {
+		List<string> names = [];
+		switch (node.ValueKind) {
+			case JsonValueKind.Object:
+				foreach (JsonProperty property in node.EnumerateObject()) {
+					if (property.NameEquals("required") && property.Value.ValueKind == JsonValueKind.Array) {
+						names.AddRange(RequiredNames(node));
+						continue;
+					}
+					names.AddRange(CollectRequiredNames(property.Value));
+				}
+				break;
+			case JsonValueKind.Array:
+				foreach (JsonElement item in node.EnumerateArray()) {
+					names.AddRange(CollectRequiredNames(item));
+				}
+				break;
+		}
+		return names;
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("validate-process-graph's NESTED node and edge item schemas demand nothing, so the tool can report a graph's own missing fields as findings instead of having the payload rejected client-side.")]
+	public void ValidateProcessGraph_Should_NotRequireAnythingOnNestedGraphItems_InEmittedSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedInputSchema(ValidateProcessGraphTool.ToolName);
+		JsonElement args = ArgsSchema(schema);
+
+		// Assert - the sibling tools' arguments live on the args object, but a graph arrives as arrays of
+		// objects, so the required arrays that matter here are NESTED under nodes/items and edges/items and are
+		// invisible to an args-level check (the same blind spot ColumnIdentityEmittedSchemaTests exists for).
+		foreach (string wireName in new[] { "name", "type", "source", "target", "flow-kind" }) {
+			CollectRequiredNames(args).Should().NotContain(wireName,
+				because: $"'{wireName}' is a field of the graph UNDER VALIDATION - the tool's whole job is to " +
+					"report it missing as a finding, which it cannot do if a client refuses to send the call");
+		}
+
+		// Anti-vacuity: the args object itself must still demand the environment, which proves this recursive
+		// collection reaches real required arrays rather than silently finding none.
+		RequiredNames(args).Should().Contain("environment-name",
+			because: "validate-process-graph resolves element types server-side, so it needs an environment");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("modify-business-process must not advertise either process-name or process-uid as required: they are mutually exclusive alternatives, and the tool itself refuses a payload that carries both.")]
+	public void ModifyBusinessProcess_Should_NotRequireEitherProcessIdentity_InEmittedSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedInputSchema(ModifyBusinessProcessTool.ModifyBusinessProcessToolName);
+		JsonElement args = ArgsSchema(schema);
+		List<string> required = RequiredNames(args);
+
+		// Assert - navigate the `required` array rather than substring-matching the serialized schema, which
+		// would pass vacuously as soon as ordering or whitespace changed.
+		ShouldAdvertise(args, "process-name");
+		ShouldAdvertise(args, "process-uid");
+		required.Should().NotContain("process-name",
+			because: "the contract is 'exactly one of process-name or process-uid', so demanding this one makes " +
+				"a payload that legitimately sends only process-uid fail client-side schema validation");
+		required.Should().NotContain("process-uid",
+			because: "requiring the other identity instead would reproduce the same defect mirrored - and " +
+				"requiring both makes every contract-following payload unsendable");
+
+		// Anti-vacuity: the set must not be empty, or the negatives above would hold for a schema that
+		// advertises nothing as required and the guard would prove nothing.
+		required.Should().Contain("environment-name",
+			because: "environment-name is unconditionally mandatory, which proves the required array is " +
+				"populated and actually being read by these assertions");
+		required.Should().Contain("operations",
+			because: "operations is the payload the tool cannot run without, so it stays mandatory");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("describe-business-process must not advertise any of its three alternative identities, nor the optional culture, as required in its emitted schema.")]
+	public void DescribeBusinessProcess_Should_NotRequireAnyProcessIdentityOrCulture_InEmittedSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedInputSchema(DescribeProcessTool.ToolName);
+		JsonElement args = ArgsSchema(schema);
+		List<string> required = RequiredNames(args);
+
+		// Assert
+		foreach (string identity in new[] { "process-name", "process-uid", "process-caption" }) {
+			ShouldAdvertise(args, identity);
+			required.Should().NotContain(identity,
+				because: $"'{identity}' is one of three accepted identities, so a client sending exactly one of " +
+					"the other two must not be blocked before the call reaches clio");
+		}
+
+		ShouldAdvertise(args, "culture");
+		required.Should().NotContain("culture",
+			because: "the tool defaults culture to en-US, and its own description calls it optional");
+
+		// Anti-vacuity, as above.
+		required.Should().Contain("environment-name",
+			because: "environment-name remains unconditionally mandatory on this surface");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("create-business-process must not advertise package-name as required: its own description calls it an optional override of the descriptor's packageName.")]
+	public void CreateBusinessProcess_Should_NotRequirePackageName_InEmittedSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedInputSchema(CreateBusinessProcessTool.CreateBusinessProcessToolName);
+		JsonElement args = ArgsSchema(schema);
+		List<string> required = RequiredNames(args);
+
+		// Assert
+		ShouldAdvertise(args, "package-name");
+		required.Should().NotContain("package-name",
+			because: "package-name only OVERRIDES the descriptor's packageName, so a descriptor that already " +
+				"names its package is a complete payload without it");
+
+		// Anti-vacuity, as above.
+		required.Should().Contain("environment-name",
+			because: "environment-name remains unconditionally mandatory on this surface");
+		required.Should().Contain("descriptor",
+			because: "the descriptor is the process definition itself, so it stays mandatory");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("get-process-signature keeps process-name required, because it is that tool's single identity argument rather than one of several alternatives - relaxing it would be a different defect.")]
+	public void GetProcessSignature_Should_KeepItsSoleIdentityRequired_InEmittedSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedInputSchema(GetProcessSignatureTool.ToolName);
+		JsonElement args = ArgsSchema(schema);
+
+		// Assert
+		RequiredNames(args).Should().Contain("process-name",
+			because: "process-name is the ONLY way to identify a process on this surface, so it is genuinely " +
+				"mandatory; this pins the boundary of the relaxation applied to the sibling tools");
+	}
+}

--- a/clio/Command/McpServer/Tools/ProcessDesigner/CreateBusinessProcessTool.cs
+++ b/clio/Command/McpServer/Tools/ProcessDesigner/CreateBusinessProcessTool.cs
@@ -112,4 +112,4 @@ public sealed record CreateBusinessProcessArgs(
 
 	[property: JsonPropertyName("package-name")]
 	[property: Description("Optional package name that overrides the descriptor's packageName.")]
-	string PackageName);
+	string? PackageName = null);

--- a/clio/Command/McpServer/Tools/ProcessDesigner/DescribeProcessTool.cs
+++ b/clio/Command/McpServer/Tools/ProcessDesigner/DescribeProcessTool.cs
@@ -58,17 +58,17 @@ public sealed record DescribeProcessArgs(
 
 	[property: JsonPropertyName("process-name")]
 	[property: Description("Process code (schema Name), e.g. UsrProcess_493d4c9. Provide exactly one identity.")]
-	string ProcessName,
+	string? ProcessName = null,
 
 	[property: JsonPropertyName("process-uid")]
 	[property: Description("Process UId (GUID). Provide exactly one identity.")]
-	string ProcessUid,
+	string? ProcessUid = null,
 
 	[property: JsonPropertyName("process-caption")]
 	[property: Description("Process caption (display name). Provide exactly one identity.")]
-	string ProcessCaption,
+	string? ProcessCaption = null,
 
 	[property: JsonPropertyName("culture")]
 	[property: Description("Optional culture used to resolve localized captions (default en-US).")]
-	string Culture
+	string? Culture = null
 );

--- a/clio/Command/McpServer/Tools/ProcessDesigner/ModifyBusinessProcessTool.cs
+++ b/clio/Command/McpServer/Tools/ProcessDesigner/ModifyBusinessProcessTool.cs
@@ -171,8 +171,8 @@ public sealed record ModifyBusinessProcessArgs(
 
 	[property: JsonPropertyName("process-name")]
 	[property: Description("Process code (schema Name) to edit; provide exactly one of process-name or process-uid.")]
-	string ProcessName,
+	string? ProcessName = null,
 
 	[property: JsonPropertyName("process-uid")]
 	[property: Description("Process schema UId to edit; provide exactly one of process-name or process-uid.")]
-	string ProcessUid);
+	string? ProcessUid = null);


### PR DESCRIPTION
🔗 **Issue:** found while working [#1116](https://github.com/Advance-Technologies-Foundation/clio/issues/1116) (out of scope there, so it ships separately). No Jira issue.

## The defect

Three process-designer tools declared their one-of-several and optional arguments as **non-nullable, non-defaulted positional record parameters**, so the MCP SDK emitted every one of them into the schema's `required` array:

| Tool | Was advertised as required | Now |
|---|---|---|
| `modify-business-process` | `process-name` **and** `process-uid` | both optional |
| `describe-business-process` | `process-name`, `process-uid`, `process-caption`, `culture` | all four optional |
| `create-business-process` | `package-name` | optional |

A strict client validates against that schema, so a contract-following call was rejected **before clio ever saw it**. On `modify-business-process` it was worse than a false positive: the tool itself refuses a payload carrying both identities, so **no sendable combination existed at all**.

## Why this is a regression, not a new contract

Four other surfaces already described the intended contract:

- both tool bodies already mapped these args with `?? string.Empty`;
- the runtime guards already enforced "exactly one" (`ModifyBusinessProcessTool` lines 135-140, `DescribeProcessCommand:57-59`);
- `DescribeProcessPrompt.cs:32` says "exactly one of `process-name` / `process-uid` / `process-caption`";
- so do the tool descriptions and `docs/McpCapabilityMap.md:689-693`.

Only the record declarations were out of step. `get-process-signature` keeps `process-name` required — there it is the **sole** identity, not one of several, and this PR pins that boundary with its own test.

`ValidateProcessGraphTool`'s nested `ProcessGraphNodeArg` / `ProcessGraphEdgeArg` were checked too: every parameter already carries `= null`, so nothing was emitted as required. A test now pins that rather than leaving it on my word.

## The mechanism worth remembering

**The lever is the parameter DEFAULT, not the `?` annotation.** clio compiles with the nullable context off (no `<Nullable>` anywhere, `CS8632` in `NoWarn`), so annotations carry no metadata the schema generator can rely on — `= null` is what removes a parameter from `required`. This is recorded in the new fixture's `<remarks>`, because it has regressed once already; the rule itself is documented at `clio.tests/Command/McpServer/ColumnIdentityEmittedSchemaTests.cs:19-26`.

## Tests

- **`clio.tests/Command/McpServer/ProcessDesignerEmittedSchemaTests.cs`** (5 tests, in CI) — reads the emitted schema through the real registry on the production serializer options and **navigates the `required` array** rather than substring-matching the serialized schema, which would pass vacuously the moment ordering or whitespace changed. Includes the nested node/edge item schemas, which an args-level check cannot see.
- **`clio.mcp.e2e/ProcessDesignerContractRequiredArgsE2ETests.cs`** (3 tests, stand-free) — asserts the same facts on `get-tool-contract`'s `input-schema.required`, which is the list a client actually sees for these **non-resident** tools. Carries `McpE2E.ProcessDesigner`, so it is excluded from CI like every process-designer fixture; the unit fixture is the in-CI gate.
- **Every assertion has an anti-vacuity counterpart** — `environment-name` / `operations` / `descriptor` must *remain* required, which proves the `required` array is populated and actually being read.
- **Verified by mutation**: reverting `ProcessName` to non-nullable fails exactly its own test (1 failed / 3 passed), and nothing else.

## Deliberate non-goal

Expressing "exactly one" *positively* as `any-of`. That field is populated only by curated `Contracts` entries, and curated text overrides `[Description]` — a much larger change with its own review surface. The rule stays where it was before the regression: the description prose plus the runtime refusal.

## Validation

```
dotnet test --filter "Category=Unit&(Module=McpServer|Module=Command)"  →  7102 passed, 0 failed
```

No new `CLIO*` or analyzer warnings in the touched files.

- **Docs reviewed, no update required** — these three tools have no CLI `[Verb]`, so no `clio/docs/commands/*.md` or `clio/help/en/*.txt` exists for them; `McpCapabilityMap.md` and the prompt already state the contract correctly.
- **MCP reviewed** — tool arg records and the emitted schema updated; unit and e2e coverage added.
- **ClioRing compatibility reviewed, no Ring-consumed contract changed** — inspected `clio-ring/ClioRing.Desktop/actions.json` (nested verbs: `get-info`, `list-packages`, `restart-web-app`, `show-web-app-list`, deploy/uninstall-creatio) and `clio-ring/ClioRing.Ipc/ClioIpcClient.cs` (calls `get-tool-contract` only). No process-designer tool is consumed, and `get-tool-contract`'s output shape is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)