### PR TITLE
Fix 9 of 11 High-severity Reliability findings (S8949 cancellation tokens)

### DIFF
--- a/clio.tests/Command/McpServer/ApplicationToolTestInvocationExtensions.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTestInvocationExtensions.cs
@@ -34,6 +34,12 @@ internal static class ApplicationToolTestInvocationExtensions {
 		this ApplicationCreateTool tool, ApplicationCreateArgs args) =>
 		tool.ApplicationCreate(args, server: null, requestContext: null, cancellationToken: default);
 
+	// Overload for tests that must verify the exact caller-supplied token reaches downstream calls
+	// (e.g. Data Forge enrichment) rather than CancellationToken.None.
+	public static Task<ApplicationContextResponse> ApplicationCreate(
+		this ApplicationCreateTool tool, ApplicationCreateArgs args, CancellationToken cancellationToken) =>
+		tool.ApplicationCreate(args, server: null, requestContext: null, cancellationToken: cancellationToken);
+
 	public static Task<ApplicationSectionContextResponse> ApplicationSectionCreate(
 		this ApplicationSectionCreateTool tool,
 		ApplicationSectionCreateArgs args,

--- a/clio.tests/Command/McpServer/ApplicationToolTestInvocationExtensions.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTestInvocationExtensions.cs
@@ -81,6 +81,12 @@ internal static class ApplicationToolTestInvocationExtensions {
 		this SchemaSyncTool tool, SchemaSyncArgs args) =>
 		tool.SchemaSync(args, server: null, requestContext: null, cancellationToken: default);
 
+	// Overload for tests that must verify the exact caller-supplied token reaches downstream calls
+	// (e.g. enrichment) rather than CancellationToken.None.
+	public static Task<SchemaSyncResponse> SchemaSync(
+		this SchemaSyncTool tool, SchemaSyncArgs args, CancellationToken cancellationToken) =>
+		tool.SchemaSync(args, server: null, requestContext: null, cancellationToken: cancellationToken);
+
 	public static Task<ApplicationSectionListContextResponse> ApplicationSectionGetList(
 		this ApplicationSectionGetListTool tool,
 		ApplicationSectionGetListArgs args,

--- a/clio.tests/Command/McpServer/ApplicationToolTests.cs
+++ b/clio.tests/Command/McpServer/ApplicationToolTests.cs
@@ -1094,6 +1094,47 @@ public sealed class ApplicationToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Propagates OperationCanceledException from the shared DataForgeEnrichmentBuilder as MCP cancellation instead of converting it into a normal ApplicationContextResponse error, and confirms CreateApplication is never called once enrichment observes the caller's own cancellation (review #1143 follow-up: the same builder rethrow used by sync-schemas must also be preserved by every other consumer, including create-app).")]
+	public async Task ApplicationCreate_Should_Propagate_Cancellation_From_Enrichment_Instead_Of_Creating_Application() {
+		// Arrange
+		IApplicationCreateService applicationCreateService = Substitute.For<IApplicationCreateService>();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		EnvironmentSettings resolvedSettings = new() { Uri = "https://sandbox.example.com" };
+		commandResolver.Resolve<EnvironmentSettings>(Arg.Any<EnvironmentOptions>()).Returns(resolvedSettings);
+		using CancellationTokenSource cts = new();
+		IApplicationCreateEnrichmentService enrichmentService = Substitute.For<IApplicationCreateEnrichmentService>();
+		// Configured against the EXACT token (not Arg.Any<CancellationToken>()) so a future regression that
+		// forwards CancellationToken.None instead of the caller-supplied token stops matching and fails the
+		// assertions below, mirroring the SchemaSyncTool cancellation test this one is modeled on.
+		enrichmentService
+			.Enrich(Arg.Any<ApplicationCreateArgs>(), Arg.Any<ApplicationOptionalTemplateData?>(), cts.Token)
+			.Returns(_ => {
+				cts.Cancel();
+				throw new OperationCanceledException(cts.Token);
+			});
+		ApplicationCreateTool tool = new(
+			Substitute.For<ILogger>(), commandResolver, applicationCreateService, enrichmentService);
+
+		// Act
+		Func<Task> act = async () => await tool.ApplicationCreate(new ApplicationCreateArgs(
+			EnvironmentName: "sandbox",
+			Name: "Codex App",
+			Code: "UsrCodexApp",
+			Description: null,
+			TemplateCode: "AppFreedomUI",
+			IconId: null,
+			IconBackground: null,
+			ClientTypeId: null), cts.Token);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>(
+			because: "cancellation must propagate as MCP cancellation rather than be converted into a normal ApplicationContextResponse error");
+		applicationCreateService.DidNotReceiveWithAnyArgs().CreateApplication(
+			default(EnvironmentSettings)!, default!, default!);
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Serializes the application context response using Clio kebab-case field names.")]
 	public void ApplicationContextResponse_Should_Serialize_Using_Clio_Field_Names() {
 		// Arrange

--- a/clio.tests/Command/McpServer/DataForgeEnrichmentBuilderTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeEnrichmentBuilderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command;
 using Clio.Command.McpServer.Tools;
@@ -11,6 +12,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command.McpServer;
 
 [TestFixture]
+[Property("Module", "McpServer")]
 public sealed class DataForgeEnrichmentBuilderTests {
 	[Test]
 	[Category("Unit")]
@@ -111,5 +113,70 @@ public sealed class DataForgeEnrichmentBuilderTests {
 			because: "the degraded fallback should preserve the failure reason as a warning instead of throwing");
 		result.ContextSummary!.SimilarTables.Should().BeEmpty(
 			because: "the degraded fallback should return an empty compact summary when no Data Forge context is available");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Propagates OperationCanceledException instead of degrading it into a warning when the CALLER's own token requested the cancellation (review #1143 follow-up). Removing the builder's dedicated cancellation catch makes this test fail.")]
+	public void Build_Should_Propagate_OperationCanceledException_When_CallerTokenIsCanceled() {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		IDataForgeContextService contextService = Substitute.For<IDataForgeContextService>();
+		commandResolver.Resolve<IDataForgeContextService>(Arg.Any<EnvironmentOptions>())
+			.Returns(contextService);
+		using CancellationTokenSource callerCts = new();
+		contextService.GetContext(Arg.Any<DataForgeContextRequest>(), callerCts.Token)
+			.Returns(_ => {
+				callerCts.Cancel();
+				throw new OperationCanceledException(callerCts.Token);
+			});
+		DataForgeEnrichmentBuilder sut = new(commandResolver);
+
+		// Act
+		Action act = () => sut.Build(
+			new DataForgeEnrichmentRequest(
+				EnvironmentName: "sandbox",
+				RequirementSummary: "Track customer tasks",
+				CandidateTerms: ["Task App"],
+				LookupHints: []),
+			callerCts.Token);
+
+		// Assert
+		act.Should().Throw<OperationCanceledException>(
+			because: "the caller's own cancellation must propagate rather than be masked as a dataforge: warning");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Still degrades a TaskCanceledException into a warning when the CALLER's own token was never canceled, distinguishing an independent internal timeout from real caller cancellation (review #1143 follow-up).")]
+	public void Build_Should_Degrade_TaskCanceledException_Into_Warning_When_CallerTokenIsNotCanceled() {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		IDataForgeContextService contextService = Substitute.For<IDataForgeContextService>();
+		commandResolver.Resolve<IDataForgeContextService>(Arg.Any<EnvironmentOptions>())
+			.Returns(contextService);
+		using CancellationTokenSource callerCts = new();
+		// Never canceled: models the caller's own token staying live while Data Forge's own HTTP request
+		// independently times out — a source distinct from the caller's token.
+		using CancellationTokenSource unrelatedTimeoutCts = new();
+		unrelatedTimeoutCts.Cancel();
+		contextService.GetContext(Arg.Any<DataForgeContextRequest>(), callerCts.Token)
+			.Returns(_ => throw new TaskCanceledException("Data Forge request timed out", null, unrelatedTimeoutCts.Token));
+		DataForgeEnrichmentBuilder sut = new(commandResolver);
+
+		// Act
+		ApplicationDataForgeResult result = sut.Build(
+			new DataForgeEnrichmentRequest(
+				EnvironmentName: "sandbox",
+				RequirementSummary: "Track customer tasks",
+				CandidateTerms: ["Task App"],
+				LookupHints: []),
+			callerCts.Token);
+
+		// Assert
+		result.Used.Should().BeTrue(
+			because: "the builder should still report that it attempted the Data Forge enrichment stage");
+		result.Warnings.Should().ContainSingle(warning => warning.Contains("Data Forge request timed out", StringComparison.Ordinal),
+			because: "an independent timeout unrelated to the caller's token is an operational failure and must degrade to a warning, not propagate");
 	}
 }

--- a/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
@@ -1728,6 +1728,39 @@ public sealed class SchemaSyncToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("Propagates OperationCanceledException from enrichment instead of degrading it into a dataforge: warning and letting the batch continue, and confirms the exact caller-supplied token — not CancellationToken.None — reaches Enrich (review #1143 on PR #1143).")]
+	public async Task SchemaSync_Should_Propagate_Cancellation_From_Enrichment_Instead_Of_Continuing_Batch() {
+		// Arrange
+		var fakeCreateCommand = new FakeCreateEntitySchemaCommand();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreateEntitySchemaCommand>(Arg.Any<CreateEntitySchemaOptions>())
+			.Returns(fakeCreateCommand);
+		using CancellationTokenSource cts = new();
+		ISchemaEnrichmentService enrichmentService = Substitute.For<ISchemaEnrichmentService>();
+		// Configured against the EXACT token (not Arg.Any<CancellationToken>()) on purpose: if SchemaSync
+		// ever regresses to forwarding CancellationToken.None instead of the caller-supplied token, this
+		// setup silently stops matching, Enrich returns the NSubstitute default (null) instead of throwing,
+		// and the assertions below fail — catching exactly the wiring regression this test guards against.
+		enrichmentService
+			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), cts.Token)
+			.Throws(new OperationCanceledException(cts.Token));
+		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
+		SchemaSyncArgs args = new(
+			"dev", "UsrPkg",
+			[new SchemaSyncOperation("create-lookup", "UsrTodoStatus", TitleLocalizations: Localizations("Todo Status"))]);
+
+		// Act
+		Func<Task> act = async () => await tool.SchemaSync(args, cts.Token);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>(
+			because: "cancellation must propagate rather than be degraded into a dataforge: warning that lets the batch continue");
+		fakeCreateCommand.CapturedOptions.Should().BeNull(
+			because: "the batch must never reach the tenant lock or execute an operation once enrichment observes cancellation");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Retries a transient network failure on the first attempt and continues the batch when the retry succeeds (ENG-93374 AC1).")]
 	public async Task SchemaSync_Should_Retry_Transient_Failure_And_Continue_Batch() {
 		// Arrange

--- a/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command;
 using Clio.Command.EntitySchemaDesigner;
@@ -1643,7 +1644,7 @@ public sealed class SchemaSyncToolTests {
 			.Returns(Substitute.For<ILookupRegistrationService>());
 		ISchemaEnrichmentService enrichmentService = Substitute.For<ISchemaEnrichmentService>();
 		enrichmentService
-			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>())
+			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), Arg.Any<CancellationToken>())
 			.Throws(new InvalidOperationException("baseUri: Value cannot be null"));
 		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
 		SchemaSyncArgs args = new(
@@ -1675,7 +1676,7 @@ public sealed class SchemaSyncToolTests {
 			.Returns(Substitute.For<ILookupRegistrationService>());
 		ISchemaEnrichmentService enrichmentService = Substitute.For<ISchemaEnrichmentService>();
 		enrichmentService
-			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>())
+			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), Arg.Any<CancellationToken>())
 			.Throws(new InvalidOperationException("dataforge call to https://target.creatio.com/0/rest failed: /Users/dev/secret/appsettings.json missing"));
 		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
 		SchemaSyncArgs args = new(
@@ -1710,7 +1711,7 @@ public sealed class SchemaSyncToolTests {
 			.Returns(fakeCreateCommand);
 		ISchemaEnrichmentService enrichmentService = Substitute.For<ISchemaEnrichmentService>();
 		enrichmentService
-			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>())
+			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), Arg.Any<CancellationToken>())
 			.Throws(new NullReferenceException("object reference not set"));
 		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
 		SchemaSyncArgs args = new(

--- a/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaSyncToolTests.cs
@@ -1741,9 +1741,18 @@ public sealed class SchemaSyncToolTests {
 		// ever regresses to forwarding CancellationToken.None instead of the caller-supplied token, this
 		// setup silently stops matching, Enrich returns the NSubstitute default (null) instead of throwing,
 		// and the assertions below fail — catching exactly the wiring regression this test guards against.
+		// The mock actually cancels cts before throwing (rather than just constructing an already-"canceled"
+		// exception without ever cancelling the source) so cancellationToken.IsCancellationRequested is
+		// genuinely true when SchemaSyncTool's `when (cancellationToken.IsCancellationRequested)` filter
+		// runs — this is what distinguishes real caller cancellation from an unrelated OperationCanceledException
+		// (e.g. TaskCanceledException from an independent enrichment-side timeout), which must NOT propagate
+		// (see SchemaSync_Should_Degrade_Independent_Enrichment_Timeout_Into_Warning_When_CallerToken_Is_Not_Canceled).
 		enrichmentService
 			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), cts.Token)
-			.Throws(new OperationCanceledException(cts.Token));
+			.Returns(_ => {
+				cts.Cancel();
+				throw new OperationCanceledException(cts.Token);
+			});
 		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
 		SchemaSyncArgs args = new(
 			"dev", "UsrPkg",
@@ -1757,6 +1766,45 @@ public sealed class SchemaSyncToolTests {
 			because: "cancellation must propagate rather than be degraded into a dataforge: warning that lets the batch continue");
 		fakeCreateCommand.CapturedOptions.Should().BeNull(
 			because: "the batch must never reach the tenant lock or execute an operation once enrichment observes cancellation");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Still degrades an independent enrichment-side timeout (TaskCanceledException, which derives from OperationCanceledException) into a dataforge: warning and lets the batch continue, when the CALLER's own token was never canceled — distinguishing it from real caller cancellation (review #1143 follow-up).")]
+	public async Task SchemaSync_Should_Degrade_Independent_Enrichment_Timeout_Into_Warning_When_CallerToken_Is_Not_Canceled() {
+		// Arrange
+		var fakeCreateCommand = new FakeCreateEntitySchemaCommand();
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<CreateEntitySchemaCommand>(Arg.Any<CreateEntitySchemaOptions>())
+			.Returns(fakeCreateCommand);
+		commandResolver.Resolve<ILookupRegistrationService>(Arg.Any<EnvironmentOptions>())
+			.Returns(Substitute.For<ILookupRegistrationService>());
+		using CancellationTokenSource callerCts = new();
+		// Never canceled: models the CALLER's own token staying live while an unrelated internal
+		// enrichment-side operation independently times out (e.g. Data Forge's own 60s HTTP timeout).
+		using CancellationTokenSource unrelatedTimeoutCts = new();
+		unrelatedTimeoutCts.Cancel();
+		ISchemaEnrichmentService enrichmentService = Substitute.For<ISchemaEnrichmentService>();
+		enrichmentService
+			.Enrich(Arg.Any<string?>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<IReadOnlyList<string>?>(), callerCts.Token)
+			.Throws(new TaskCanceledException("Data Forge request timed out", null, unrelatedTimeoutCts.Token));
+		SchemaSyncTool tool = new(commandResolver, ConsoleLogger.Instance, Convergence(), enrichmentService);
+		SchemaSyncArgs args = new(
+			"dev", "UsrPkg",
+			[new SchemaSyncOperation("create-lookup", "UsrTodoStatus", TitleLocalizations: Localizations("Todo Status"))]);
+
+		// Act
+		SchemaSyncResponse response = await tool.SchemaSync(args, callerCts.Token);
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "an enrichment-side timeout unrelated to the caller's own token must not fail an otherwise-valid batch");
+		response.DataForge.Should().NotBeNull(
+			because: "the degraded enrichment result must still be attached so the timeout warning surfaces");
+		response.DataForge!.Warnings.Should().ContainSingle(warning => warning.StartsWith("dataforge:", StringComparison.Ordinal),
+			because: "an independent timeout is an operational enrichment failure and must be reported as a dataforge: warning, not propagated");
+		fakeCreateCommand.CapturedOptions.Should().NotBeNull(
+			because: "the batch must continue and execute the operation once the degraded enrichment result is attached");
 	}
 
 	[Test]

--- a/clio.tests/Common/K8/CpTests.cs
+++ b/clio.tests/Common/K8/CpTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Clio.Common.K8;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common.K8;
+
+[TestFixture]
+[Property("Module", "Common")]
+[Category("Unit")]
+public class CpTests {
+
+	private string _sourceFilePath;
+
+	[SetUp]
+	public void SetUp() {
+		_sourceFilePath = Path.GetTempFileName();
+		File.WriteAllText(_sourceFilePath, "clio K8 copy cancellation test payload");
+	}
+
+	[TearDown]
+	public void TearDown() {
+		if (File.Exists(_sourceFilePath)) {
+			File.Delete(_sourceFilePath);
+		}
+	}
+
+	[Test]
+	[Description("Propagates OperationCanceledException distinctly instead of wrapping it as IOException, so a caller can tell an interrupted upload apart from a genuine copy failure (review #1143 on PR #1143).")]
+	public async Task HandleExecStreamsAsync_ShouldPropagateOperationCanceledException_WhenTokenIsAlreadyCanceled() {
+		// Arrange
+		using MemoryStream stdIn = new();
+		using MemoryStream stdError = new();
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		// Act
+		Func<Task> act = () => Cp.HandleExecStreamsAsync(stdIn, stdError, _sourceFilePath, "destination.txt", cts.Token);
+
+		// Assert
+		await act.Should().ThrowAsync<OperationCanceledException>(
+			because: "cancellation is a caller-initiated abort, not a copy failure, and must not surface as IOException");
+	}
+
+	[Test]
+	[Description("Still wraps a genuine (non-cancellation) copy failure as IOException, so the cancellation fix above does not change behavior for real errors.")]
+	public async Task HandleExecStreamsAsync_ShouldWrapGenuineFailureAsIOException_WhenSourceFileIsMissing() {
+		// Arrange
+		using MemoryStream stdIn = new();
+		using MemoryStream stdError = new();
+		string missingSourcePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".missing");
+
+		// Act
+		Func<Task> act = () => Cp.HandleExecStreamsAsync(stdIn, stdError, missingSourcePath, "destination.txt", CancellationToken.None);
+
+		// Assert
+		(await act.Should().ThrowAsync<IOException>(
+			because: "a genuine failure to open the source file must still be reported as a copy failure"))
+			.WithMessage("Copy command failed:*", because: "the wrapped message must retain the original failure detail");
+	}
+
+	[Test]
+	[Description("Surfaces stderr text written by the remote exec session as IOException, independent of the cancellation-classification change.")]
+	public async Task HandleExecStreamsAsync_ShouldThrowIOException_WhenRemoteStdErrorIsNotEmpty() {
+		// Arrange
+		using MemoryStream stdIn = new();
+		byte[] errorBytes = System.Text.Encoding.UTF8.GetBytes("tar: destination folder missing");
+		using MemoryStream stdError = new(errorBytes);
+
+		// Act
+		Func<Task> act = () => Cp.HandleExecStreamsAsync(stdIn, stdError, _sourceFilePath, "destination.txt", CancellationToken.None);
+
+		// Assert
+		(await act.Should().ThrowAsync<IOException>(
+			because: "a non-empty remote stderr indicates the exec command reported a failure"))
+			.WithMessage("Copy command failed:*tar: destination folder missing*",
+				because: "the remote error text must be included verbatim for diagnosability");
+	}
+}

--- a/clio/Command/McpServer/McpHttpServerCommand.cs
+++ b/clio/Command/McpServer/McpHttpServerCommand.cs
@@ -468,7 +468,7 @@ public class McpHttpServerCommand : Command<McpHttpServerCommandOptions>
 			context.Response.ContentType = "application/json";
 			// No secret (key or credentials) is echoed (FR-11).
 			await context.Response.WriteAsJsonAsync(
-				new { error = "Error: platform API key missing or invalid" });
+				new { error = "Error: platform API key missing or invalid" }, context.RequestAborted);
 			return;
 		}
 
@@ -529,7 +529,7 @@ public class McpHttpServerCommand : Command<McpHttpServerCommandOptions>
 			context.Response.StatusCode = StatusCodes.Status400BadRequest;
 			context.Response.ContentType = "application/json";
 			// error is defect-only and never carries a secret value (FR-11).
-			await context.Response.WriteAsJsonAsync(new { error = $"Error: {error}" });
+			await context.Response.WriteAsJsonAsync(new { error = $"Error: {error}" }, context.RequestAborted);
 			return;
 		}
 

--- a/clio/Command/McpServer/Tools/ApplicationTool.cs
+++ b/clio/Command/McpServer/Tools/ApplicationTool.cs
@@ -204,6 +204,11 @@ public sealed class ApplicationCreateTool(
 			return ApplicationToolHelper.CreateContextResponse(
 				ApplicationToolResultMapper.Map(result),
 				dataForge);
+		} catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+			// The shared DataForgeEnrichmentBuilder rethrows only genuine caller-token cancellation (review
+			// #1143 follow-up); that must propagate as MCP cancellation instead of being converted into a
+			// normal ApplicationContextResponse error by the broad catch below.
+			throw;
 		} catch (Exception ex) {
 			return ApplicationToolHelper.CreateContextErrorResponse(SensitiveErrorTextRedactor.Redact(ex.Message));
 		}

--- a/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
+++ b/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
@@ -66,6 +66,10 @@ public sealed class DataForgeEnrichmentBuilder(IToolCommandResolver commandResol
 				Coverage: context.Coverage,
 				Warnings: context.Warnings,
 				ContextSummary: BuildSummary(context));
+		} catch (OperationCanceledException) {
+			// Cancellation is a caller-initiated abort, not an operational enrichment failure — it must
+			// propagate to the caller instead of being degraded into a "dataforge:" warning (review #1143).
+			throw;
 		} catch (Exception ex) {
 			return new ApplicationDataForgeResult(
 				Used: true,

--- a/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
+++ b/clio/Command/McpServer/Tools/DataForgeEnrichmentBuilder.cs
@@ -66,9 +66,12 @@ public sealed class DataForgeEnrichmentBuilder(IToolCommandResolver commandResol
 				Coverage: context.Coverage,
 				Warnings: context.Warnings,
 				ContextSummary: BuildSummary(context));
-		} catch (OperationCanceledException) {
-			// Cancellation is a caller-initiated abort, not an operational enrichment failure — it must
-			// propagate to the caller instead of being degraded into a "dataforge:" warning (review #1143).
+		} catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+			// Rethrow only when the CALLER's own token requested the cancellation — it must propagate
+			// instead of being degraded into a "dataforge:" warning. TaskCanceledException (which derives
+			// from OperationCanceledException) can also surface from Data Forge's own independent request
+			// timeout; that is an operational failure like any other and must still degrade to a warning
+			// rather than aborting an otherwise-valid schema operation (review #1143 follow-up).
 			throw;
 		} catch (Exception ex) {
 			return new ApplicationDataForgeResult(

--- a/clio/Command/McpServer/Tools/SchemaSyncTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaSyncTool.cs
@@ -143,9 +143,12 @@ public sealed class SchemaSyncTool(
 					CollectCandidateTerms(operations),
 					CollectLookupHints(operations),
 					cancellationToken);
-			} catch (OperationCanceledException) {
-				// Cancellation is a caller-initiated abort, not an operational enrichment failure — it must
-				// propagate rather than be degraded into a warning and let the batch continue (review #1143).
+			} catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+				// Rethrow only when the CALLER's own token requested the cancellation — it must propagate
+				// rather than be degraded into a warning and let the batch continue. TaskCanceledException
+				// (which derives from OperationCanceledException) can also surface from an alternate
+				// enrichment implementation's own independent timeout; that is an operational failure like
+				// any other and must still degrade to a warning (review #1143 follow-up).
 				throw;
 			} catch (Exception ex) when (!McpExceptionPolicy.IsUnrecoverable(ex)) {
 				// Degrade ONLY operational enrichment failures (dataforge/HTTP/data-layer) into a warning —

--- a/clio/Command/McpServer/Tools/SchemaSyncTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaSyncTool.cs
@@ -141,7 +141,8 @@ public sealed class SchemaSyncTool(
 				dataForge = enrichmentService.Enrich(
 					args.EnvironmentName,
 					CollectCandidateTerms(operations),
-					CollectLookupHints(operations));
+					CollectLookupHints(operations),
+					cancellationToken);
 			} catch (Exception ex) when (!McpExceptionPolicy.IsUnrecoverable(ex)) {
 				// Degrade ONLY operational enrichment failures (dataforge/HTTP/data-layer) into a warning —
 				// a fatal condition or programming defect (OOM/NRE/…) must propagate, not be hidden here

--- a/clio/Command/McpServer/Tools/SchemaSyncTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaSyncTool.cs
@@ -143,6 +143,10 @@ public sealed class SchemaSyncTool(
 					CollectCandidateTerms(operations),
 					CollectLookupHints(operations),
 					cancellationToken);
+			} catch (OperationCanceledException) {
+				// Cancellation is a caller-initiated abort, not an operational enrichment failure — it must
+				// propagate rather than be degraded into a warning and let the batch continue (review #1143).
+				throw;
 			} catch (Exception ex) when (!McpExceptionPolicy.IsUnrecoverable(ex)) {
 				// Degrade ONLY operational enrichment failures (dataforge/HTTP/data-layer) into a warning —
 				// a fatal condition or programming defect (OOM/NRE/…) must propagate, not be hidden here

--- a/clio/Command/PageDesignerPresence/PageDesignerPresenceNotifier.cs
+++ b/clio/Command/PageDesignerPresence/PageDesignerPresenceNotifier.cs
@@ -181,7 +181,14 @@ internal sealed class PageDesignerPresenceNotifier : IPageDesignerPresenceNotifi
 		if (string.IsNullOrWhiteSpace(sessionPath) || !_fileSystem.File.Exists(sessionPath)) {
 			return (null, BuildSkipWarning("browser-session storageState was not available."));
 		}
-		string storageStateJson = await _fileSystem.File.ReadAllTextAsync(sessionPath).ConfigureAwait(false);
+		string storageStateJson;
+		try {
+			storageStateJson = await _fileSystem.File.ReadAllTextAsync(sessionPath, cancellationToken).ConfigureAwait(false);
+		} catch (OperationCanceledException) {
+			return (null, BuildTimeoutWarning("acquiring browser-session cookies"));
+		} catch (Exception ex) {
+			return (null, LogAndBuildFailureWarning("could not obtain browser-session cookies", ex));
+		}
 		IReadOnlyList<BrowserCookie> cookies = StorageStateJson.ParseCookies(storageStateJson);
 		if (cookies.Count == 0) {
 			return (null, BuildSkipWarning("browser-session storageState did not contain usable cookies."));

--- a/clio/Common/K8/cp.cs
+++ b/clio/Common/K8/cp.cs
@@ -45,47 +45,8 @@ internal class Cp
             ValidatePathParameters(sourceFilePath, destinationFilePath);
 
             // The callback which processes the standard input, standard output and standard error of exec method
-            var handler = new ExecAsyncCallback(async (stdIn, stdOut, stdError) =>
-            {
-                var fileInfo = new FileInfo(destinationFilePath);
-                try
-                {
-                    using (var memoryStream = new MemoryStream())
-                    {
-                        using (var inputFileStream = File.OpenRead(sourceFilePath))
-                        using (var tarOutputStream = new TarOutputStream(memoryStream, Encoding.Default))
-                        {
-                            tarOutputStream.IsStreamOwner = false;
-
-                            var fileSize = inputFileStream.Length;
-                            var entry = TarEntry.CreateTarEntry(fileInfo.Name);
-
-                            entry.Size = fileSize;
-
-                            tarOutputStream.PutNextEntry(entry);
-                            await inputFileStream.CopyToAsync(tarOutputStream, cancellationToken);
-                            tarOutputStream.CloseEntry();
-                        }
-
-                        memoryStream.Position = 0;
-
-                        await memoryStream.CopyToAsync(stdIn, cancellationToken);
-                        await stdIn.FlushAsync(cancellationToken);
-                    }
-
-                }
-                catch (Exception ex)
-                {
-                    throw new IOException($"Copy command failed: {ex.Message}");
-                }
-
-                using StreamReader streamReader = new StreamReader(stdError);
-                string error = await streamReader.ReadToEndAsync(cancellationToken);
-                if (!string.IsNullOrEmpty(error))
-                {
-                    throw new IOException($"Copy command failed: {error}");
-                }
-            });
+            var handler = new ExecAsyncCallback((stdIn, stdOut, stdError) =>
+                HandleExecStreamsAsync(stdIn, stdError, sourceFilePath, destinationFilePath, cancellationToken));
 
             string destinationFolder = GetFolderName(destinationFilePath);
 
@@ -97,6 +58,77 @@ internal class Cp
                 false,
                 handler,
                 cancellationToken);
+        }
+
+        /// <summary>
+        /// Tars <paramref name="sourceFilePath"/> into <paramref name="stdIn"/> and surfaces any error text
+        /// written to <paramref name="stdError"/>. Extracted from the <see cref="ExecAsyncCallback"/> passed to
+        /// <see cref="IKubernetes.NamespacedPodExecAsync"/> so the stream-handling logic — including cancellation
+        /// classification — is directly unit-testable without a real Kubernetes exec session.
+        /// </summary>
+        internal static async Task HandleExecStreamsAsync(Stream stdIn, Stream stdError, string sourceFilePath,
+            string destinationFilePath, CancellationToken cancellationToken)
+        {
+            var fileInfo = new FileInfo(destinationFilePath);
+            try
+            {
+                using (var memoryStream = new MemoryStream())
+                {
+                    using (var inputFileStream = File.OpenRead(sourceFilePath))
+                    {
+                        // Not a `using` declaration: TarOutputStream.Dispose() validates that the declared
+                        // entry size was fully written and throws its own exception when it wasn't (e.g. a
+                        // write canceled mid-entry). Left to an implicit `using`, that secondary exception
+                        // would replace the real one during stack unwind, masking a cancellation as a
+                        // generic tar-write failure — see the catch below.
+                        var tarOutputStream = new TarOutputStream(memoryStream, Encoding.Default) { IsStreamOwner = false };
+                        try
+                        {
+                            var fileSize = inputFileStream.Length;
+                            var entry = TarEntry.CreateTarEntry(fileInfo.Name);
+
+                            entry.Size = fileSize;
+
+                            tarOutputStream.PutNextEntry(entry);
+                            await inputFileStream.CopyToAsync(tarOutputStream, cancellationToken);
+                            tarOutputStream.CloseEntry();
+                            tarOutputStream.Dispose();
+                        }
+                        catch
+                        {
+                            // Best-effort cleanup only: an entry left half-written after the exception above
+                            // (most commonly cancellation) makes Dispose() throw its own "entry closed before
+                            // N bytes written" exception. Swallow that secondary failure so the exception
+                            // being unwound here — rethrown as-is — is what callers actually observe.
+                            try { tarOutputStream.Dispose(); } catch { /* ignored: see comment above */ }
+                            throw;
+                        }
+                    }
+
+                    memoryStream.Position = 0;
+
+                    await memoryStream.CopyToAsync(stdIn, cancellationToken);
+                    await stdIn.FlushAsync(cancellationToken);
+                }
+
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is a caller-initiated abort, not a copy failure — it must propagate
+                // distinctly instead of being wrapped as IOException (review #1143).
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new IOException($"Copy command failed: {ex.Message}");
+            }
+
+            using StreamReader streamReader = new StreamReader(stdError);
+            string error = await streamReader.ReadToEndAsync(cancellationToken);
+            if (!string.IsNullOrEmpty(error))
+            {
+                throw new IOException($"Copy command failed: {error}");
+            }
         }
 
 

--- a/clio/Common/K8/cp.cs
+++ b/clio/Common/K8/cp.cs
@@ -92,15 +92,15 @@ internal class Cp
                             tarOutputStream.PutNextEntry(entry);
                             await inputFileStream.CopyToAsync(tarOutputStream, cancellationToken);
                             tarOutputStream.CloseEntry();
-                            tarOutputStream.Dispose();
+                            await tarOutputStream.DisposeAsync();
                         }
                         catch
                         {
                             // Best-effort cleanup only: an entry left half-written after the exception above
-                            // (most commonly cancellation) makes Dispose() throw its own "entry closed before
-                            // N bytes written" exception. Swallow that secondary failure so the exception
-                            // being unwound here — rethrown as-is — is what callers actually observe.
-                            try { tarOutputStream.Dispose(); } catch { /* ignored: see comment above */ }
+                            // (most commonly cancellation) makes DisposeAsync() throw its own "entry closed
+                            // before N bytes written" exception. Swallow that secondary failure so the
+                            // exception being unwound here — rethrown as-is — is what callers actually observe.
+                            try { await tarOutputStream.DisposeAsync(); } catch { /* ignored: see comment above */ }
                             throw;
                         }
                     }

--- a/clio/Common/K8/cp.cs
+++ b/clio/Common/K8/cp.cs
@@ -63,14 +63,14 @@ internal class Cp
                             entry.Size = fileSize;
 
                             tarOutputStream.PutNextEntry(entry);
-                            await inputFileStream.CopyToAsync(tarOutputStream);
+                            await inputFileStream.CopyToAsync(tarOutputStream, cancellationToken);
                             tarOutputStream.CloseEntry();
                         }
 
                         memoryStream.Position = 0;
 
-                        await memoryStream.CopyToAsync(stdIn);
-                        await stdIn.FlushAsync();
+                        await memoryStream.CopyToAsync(stdIn, cancellationToken);
+                        await stdIn.FlushAsync(cancellationToken);
                     }
 
                 }
@@ -80,7 +80,7 @@ internal class Cp
                 }
 
                 using StreamReader streamReader = new StreamReader(stdError);
-                string error = await streamReader.ReadToEndAsync();
+                string error = await streamReader.ReadToEndAsync(cancellationToken);
                 if (!string.IsNullOrEmpty(error))
                 {
                     throw new IOException($"Copy command failed: {error}");

--- a/clio/tpl/docker-templates/dev/entrypoint.sh
+++ b/clio/tpl/docker-templates/dev/entrypoint.sh
@@ -10,7 +10,7 @@ REDIS_HOST=${REDIS_HOST:-$DB_HOST}
 REDIS_PORT=${REDIS_PORT:-6379}
 REDIS_DB=${REDIS_DB:-0}
 
-if [ -f /app/ConnectionStrings.config.template ]; then
+if [[ -f /app/ConnectionStrings.config.template ]]; then
     envsubst < /app/ConnectionStrings.config.template > /app/ConnectionStrings.config
 fi
 

--- a/clio/tpl/docker-templates/prod/entrypoint.sh
+++ b/clio/tpl/docker-templates/prod/entrypoint.sh
@@ -14,7 +14,7 @@ escape_sed_replacement() {
     printf '%s' "$1" | sed -e 's/[\\/&|]/\\&/g'
 }
 
-if [ -f /app/ConnectionStrings.config.template ]; then
+if [[ -f /app/ConnectionStrings.config.template ]]; then
     db_host_escaped=$(escape_sed_replacement "$DB_HOST")
     db_port_escaped=$(escape_sed_replacement "$DB_PORT")
     db_name_escaped=$(escape_sed_replacement "$DB_NAME")


### PR DESCRIPTION
## Summary
Continuation of the Reliability-rating cleanup started in #1142 (which fixes the sole Blocker finding). This PR addresses the 11 open **High**-severity Reliability findings — 9 of them, with one explicitly deferred (see below).

## Findings fixed (csharpsquid:S8949 — "pass the cancellationToken")
- `clio/Command/McpServer/McpHttpServerCommand.cs` — thread `context.RequestAborted` into the two auth-failure `WriteAsJsonAsync` calls.
- `clio/Command/McpServer/Tools/SchemaSyncTool.cs` — pass `cancellationToken` into `enrichmentService.Enrich(...)`.
- `clio/Command/PageDesignerPresence/PageDesignerPresenceNotifier.cs` — pass `cancellationToken` into `ReadAllTextAsync`, and wrap it in the same timeout/failure `try/catch` as the sibling `GetSessionPathAsync` call (see "Review findings" below — this was NOT part of the original mechanical fix).
- `clio/Common/K8/cp.cs` — thread `cancellationToken` (captured from the enclosing `CopyFileToPodAsync` parameter) into `CopyToAsync` ×2, `FlushAsync`, and `ReadToEndAsync` inside the `ExecAsyncCallback` closure.

## Findings fixed (shelldre:S7688)
- `clio/tpl/docker-templates/dev/entrypoint.sh` and `.../prod/entrypoint.sh` — `[ -f ... ]` → `[[ -f ... ]]`.

## Finding deliberately left open
- `clio/Command/RingCommand.cs` (`HttpContent.LoadIntoBufferAsync`) — the `(long maxBufferSize, CancellationToken)` overload only exists starting in **.NET 10**. `clio.csproj` multi-targets `net8.0` and `net10.0`; confirmed via reflection against both target framework assemblies that net8.0 lacks this overload. Fixing this one would require `#if NET10_0_OR_GREATER` conditional compilation for a single line — judged not worth the added complexity/branching for this cleanup. Left as-is; can revisit once net8.0 support is dropped.

## Review
Per repo policy, ran 3 parallel pre-PR reviews (correctness, security, code-quality) since the diff spans multiple modules and touches auth middleware:
- **Security**: all clear — `context.RequestAborted` only affects two static, secret-free JSON error writes; all security-relevant state is set before the cancellable `await`, and `return` was already unconditional in both branches.
- **Code quality**: good, no blocking issues. Advisory (addressed): `SchemaSyncToolTests.cs`'s NSubstitute matcher for `Enrich(...)` only specified 3 of 4 arguments, implicitly requiring `CancellationToken == default` — tightened to `Arg.Any<CancellationToken>()` so a future token-wiring regression is actually caught.
- **Correctness**: 1 confirmed Low-severity issue — the newly-reachable `OperationCanceledException` from `PageDesignerPresenceNotifier.cs`'s `ReadAllTextAsync` bypassed the file's timeout-classification convention and would have surfaced as a generic "unexpected error" instead of a timeout warning. **Fixed** by wrapping the call in the same `try/catch` pattern already used for the sibling `GetSessionPathAsync` call.

## Testing
```
dotnet build clio/clio.csproj      # both net8.0 and net10.0 — confirms the LoadIntoBufferAsync overload gap
dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=McpServer|Module=Command|Module=Common)" --no-build
dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~SchemaSyncToolTests" --no-build
```
- Targeted filter: 20 pre-existing failures (confirmed identical on unmodified `master` via `git stash` — unrelated to this change: MCP-config-upsert, TLS-settings, and `ProcessExecutor` env-clearing tests), 8231 passed, 0 new failures.
- `SchemaSyncToolTests`: 97/97 passed.

## Impact
Merging this alongside #1142 clears every open Blocker/High Reliability finding, moving the SonarCloud Reliability rating from **E** toward **A/B**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)