### PR TITLE
Fix empty workspace restore behavior

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9083,3 +9083,10 @@ Decision: Materialize the eligible package list, warn and skip package download 
 Discovery: The shared-root clear also removed ignored and external package content during partial restores; package-scoped overwrite preserves those directories without weakening refresh semantics. The local MCP sandbox E2E target is configured but not registered on this machine, so the new real-server test compiles but requires the configured TeamCity sandbox to execute.
 Files: clio/Workspace/WorkspaceRestorer.cs, clio/Package/PackageDownloader.cs, clio/Command/McpServer/Tools/WorkspaceSyncTool.cs, clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
 Impact: Empty restores are explicit, preserve workspace placeholders, and no longer let a successful exit imply that environment packages were downloaded.
+
+## 2026-08-20 23:08 – Verify workspace restore repair against vbg
+Context: Issue #1137 required real-environment proof and a comprehensive pre-PR review after the repair.
+Decision: Use the registered `vbg` environment for a disposable empty workspace, and strengthen the existing MCP sandbox E2E with unrelated package content during a non-empty restore.
+Discovery: The built CLI returned success with the new warning and preserved `packages/placeholder.txt` against `vbg`. The shared E2E harness has stale sandbox URL/readiness configuration, so it fails before invoking the branch; the direct CLI boundary proved the empty path while the E2E now covers partial-restore preservation in CI.
+Files: clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs, clio.tests/Package/PackageDownloaderTests.cs, clio.tests/Workspace/WorkspaceRestorerTests.cs
+Impact: Both empty and partial restore regressions are pinned, and the final module gate passes 3,806 tests.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9076,3 +9076,10 @@ Decision: move the four canonical skill bodies to `.ai/skills` and keep identica
 Discovery: Claude's independent review confirmed the shared-pointer structure and identified the Codex-specific consultation and worktree wording that had to become model-neutral. A focused contract test now extracts each wrapper's declared redirect and proves it resolves to the canonical body.
 Files: .ai/skills/clio-issue-workflow/SKILL.md, .ai/skills/claim-clio-issue/SKILL.md, .ai/skills/investigate-clio-issue/SKILL.md, .ai/skills/repair-clio-issue/SKILL.md, .codex/skills/, .claude/skills/, .codex/agents/reviewer.toml, clio.tests/Command/McpServer/SharedIssueWorkflowSkillTests.cs, AGENTS.md, CONTRIBUTING.md
 Impact: both supported agents discover the same workflow and cannot silently drift; the shared body remains model-neutral and the repository's default reviewer model can evolve without a hardcoded pin.
+
+## 2026-08-20 22:21 – Preserve workspace content on empty restore (issue #1137)
+Context: `restore-workspace` reported `Done` and deleted `packages/placeholder.txt` when `.clio/workspaceSettings.json` contained no packages.
+Decision: Materialize the eligible package list, warn and skip package download when it is empty, and remove the redundant packages-root clear because the archiver already overwrites each requested package directory.
+Discovery: The shared-root clear also removed ignored and external package content during partial restores; package-scoped overwrite preserves those directories without weakening refresh semantics. The local MCP sandbox E2E target is configured but not registered on this machine, so the new real-server test compiles but requires the configured TeamCity sandbox to execute.
+Files: clio/Workspace/WorkspaceRestorer.cs, clio/Package/PackageDownloader.cs, clio/Command/McpServer/Tools/WorkspaceSyncTool.cs, clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+Impact: Empty restores are explicit, preserve workspace placeholders, and no longer let a successful exit imply that environment packages were downloaded.

--- a/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
@@ -96,6 +96,35 @@ public sealed class WorkspaceSyncToolE2ETests {
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
+	[Description("Creates a fresh empty workspace, restores it through the real MCP server, and verifies the warning plus preservation of the packages placeholder.")]
+	[AllureTag(RestoreToolName)]
+	[AllureName("Restore workspace warns and preserves packages placeholder when package list is empty")]
+	[AllureDescription("Uses the real create-workspace command to produce Packages: [] and packages/placeholder.txt, invokes restore-workspace through MCP against the sandbox, and verifies success-with-warning without deleting the placeholder.")]
+	public async Task RestoreWorkspace_Should_Warn_And_Preserve_Placeholder_When_Package_List_Is_Empty() {
+		// Arrange
+		await using WorkspaceSyncArrangeContext arrangeContext = await ArrangeSandboxWorkspaceAsync(includePackage: false);
+		string placeholderPath = Path.Combine(arrangeContext.WorkspacePath, "packages", "placeholder.txt");
+		AssertFileExists(placeholderPath,
+			"create-workspace should provide the placeholder that makes the no-op restore side effect observable");
+
+		// Act
+		WorkspaceCommandActResult restoreResult =
+			await ActWorkspaceCommandAsync(arrangeContext, RestoreToolName, arrangeContext.WorkspacePath);
+
+		// Assert
+		AssertToolCallSucceeded(restoreResult);
+		AssertCommandExitCode(restoreResult, 0,
+			"an empty eligible package list is a successful no-op with an actionable warning");
+		AssertIncludesInfoMessage(restoreResult,
+			"successful restore-workspace execution should still include its completion message");
+		AssertIncludesWarningMessage(restoreResult, "workspaceSettings.json",
+			"the MCP result should plainly identify why no packages were downloaded");
+		AssertFileExists(placeholderPath,
+			"an empty restore must not clear the packages root or delete its placeholder");
+	}
+
+	[Category("McpE2E.Sandbox")]
+	[Test]
 	[Description("Drives restore-workspace (a [RequiresPackage(\"cliogate\")] command) through the real clio MCP server against a sandbox where cliogate IS installed, and verifies the environment-scoped package-requirement gate does NOT false-positive: the tool runs to completion instead of refusing. "
 		+ "Residual gap: the 'package absent' refusal branch is NOT covered here because the sandbox arrange step (ArrangeSandboxWorkspaceAsync -> EnsureCliogateInstalledAsync) guarantees cliogate is present, and the invalid-environment tests fail during command resolution BEFORE the gate runs. Asserting a refusal would require a live environment that lacks cliogate, which the current harness cannot provision. The refusal branch is covered at the unit level in clio.tests/Command/McpServer/BaseToolTests.cs.")]
 	[AllureTag(RestoreToolName)]
@@ -147,7 +176,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 		});
 	}
 
-	private static async Task<WorkspaceSyncArrangeContext> ArrangeSandboxWorkspaceAsync() {
+	private static async Task<WorkspaceSyncArrangeContext> ArrangeSandboxWorkspaceAsync(bool includePackage = true) {
 		return await AllureApi.Step("Arrange workspace-sync sandbox lifecycle", async () => {
 			McpE2ESettings settings = TestConfiguration.Load();
 			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
@@ -163,7 +192,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 			string workspacePath = Path.Combine(rootDirectory, workspaceName);
 			string restoreWorkspaceName = $"restore-{Guid.NewGuid():N}";
 			string restoreWorkspacePath = Path.Combine(rootDirectory, restoreWorkspaceName);
-			string packageName = $"Pkg{Guid.NewGuid():N}".Substring(0, 18);
+			string packageName = includePackage ? $"Pkg{Guid.NewGuid():N}".Substring(0, 18) : string.Empty;
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 
 			await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
@@ -171,8 +200,11 @@ public sealed class WorkspaceSyncToolE2ETests {
 				settings.Sandbox.EnvironmentName!,
 				cancellationTokenSource.Token);
 			await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationTokenSource.Token);
-			await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
-			PackageMetadata packageMetadata = ReadPackageMetadata(workspacePath, packageName);
+			PackageMetadata? packageMetadata = null;
+			if (includePackage) {
+				await AddPackageAsync(settings, workspacePath, packageName, cancellationTokenSource.Token);
+				packageMetadata = ReadPackageMetadata(workspacePath, packageName);
+			}
 
 			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 			return new WorkspaceSyncArrangeContext(
@@ -343,6 +375,25 @@ public sealed class WorkspaceSyncToolE2ETests {
 			because: "successful command execution should emit human-readable diagnostics");
 		actResult.Execution.Output!.Should().Contain(message => message.MessageType == LogDecoratorType.Info,
 			because: because);
+	}
+
+	[AllureStep("Assert execution includes Warning message")]
+	private static void AssertIncludesWarningMessage(
+		WorkspaceCommandActResult actResult,
+		string expectedText,
+		string because) {
+		actResult.Execution.Output.Should().NotBeNullOrEmpty(
+			because: "a successful no-op restore should emit human-readable diagnostics");
+		actResult.Execution.Output!.Should().Contain(message =>
+			message.MessageType == LogDecoratorType.Warning &&
+			message.Value != null &&
+			message.Value.ToString()!.Contains(expectedText, StringComparison.Ordinal),
+			because: because);
+	}
+
+	[AllureStep("Assert file exists")]
+	private static void AssertFileExists(string path, string because) {
+		File.Exists(path).Should().BeTrue(because: because);
 	}
 
 	[AllureStep("Assert invalid environment diagnostics mention the missing environment name")]

--- a/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
@@ -69,17 +69,20 @@ public sealed class WorkspaceSyncToolE2ETests {
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
-	[Description("Creates a workspace and package with the real clio CLI, pushes it through MCP, deletes the local package files, restores into the same workspace, and verifies the package metadata is recreated from the environment.")]
+	[Description("Creates a workspace and package with the real clio CLI, restores the configured package through MCP, and verifies its metadata while unrelated package content is preserved.")]
 	[AllureTag(PushToolName)]
 	[AllureTag(RestoreToolName)]
-	[AllureName("Restore workspace recreates the pushed package in the same workspace")]
-	[AllureDescription("Uses the real clio CLI to create a workspace and package locally, pushes it through MCP, removes the local package folder, restores through MCP into the same workspace, and verifies the restored package descriptor matches the pushed package.")]
-	public async Task RestoreWorkspace_Should_Recreate_Pushed_Package_In_Same_Workspace() {
+	[AllureName("Restore workspace recreates the pushed package and preserves unrelated package content")]
+	[AllureDescription("Uses the real clio CLI to create a workspace and package locally, pushes it through MCP, removes the local package folder, restores through MCP into the same workspace, verifies the restored package descriptor, and confirms unrelated package content remains unchanged.")]
+	public async Task RestoreWorkspace_ShouldRecreatePackageAndPreserveUnrelatedContent_WhenPackageIsConfigured() {
 		// Arrange - the package is already pushed once for the fixture (ENG-92459); push assertions are
 		// covered by PushWorkspace_Should_Publish_Arranged_Package_And_GetPkgList_Should_Return_It.
 		await using WorkspaceSyncArrangeContext arrangeContext = await ArrangeSharedRestoreWorkspaceAsync();
 		string descriptorPath = FindPackageDescriptorPath(arrangeContext.WorkspacePath, arrangeContext.PackageName);
 		string packageDirectoryPath = Directory.GetParent(descriptorPath)!.FullName;
+		string sentinelPath = Path.Combine(arrangeContext.WorkspacePath, "packages", "preserved-content", "sentinel.txt");
+		Directory.CreateDirectory(Path.GetDirectoryName(sentinelPath)!);
+		await File.WriteAllTextAsync(sentinelPath, "preserve me");
 
 		// Act
 		DeletePackageDirectory(packageDirectoryPath);
@@ -92,6 +95,8 @@ public sealed class WorkspaceSyncToolE2ETests {
 		AssertCommandExitCode(restoreResult, 0, "restore-workspace should succeed for a valid sandbox environment and existing workspace settings");
 		AssertIncludesInfoMessage(restoreResult, "successful restore-workspace execution should emit progress output");
 		AssertRestoredPackageMatchesSourceMetadata(arrangeContext.WorkspacePath, arrangeContext.PackageName, arrangeContext.PackageMetadata);
+		AssertFileContent(sentinelPath, "preserve me",
+			"restoring one configured package must not clear unrelated content from the shared packages root");
 	}
 
 	[Category("McpE2E.Sandbox")]
@@ -100,7 +105,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 	[AllureTag(RestoreToolName)]
 	[AllureName("Restore workspace warns and preserves packages placeholder when package list is empty")]
 	[AllureDescription("Uses the real create-workspace command to produce Packages: [] and packages/placeholder.txt, invokes restore-workspace through MCP against the sandbox, and verifies success-with-warning without deleting the placeholder.")]
-	public async Task RestoreWorkspace_Should_Warn_And_Preserve_Placeholder_When_Package_List_Is_Empty() {
+	public async Task RestoreWorkspace_ShouldWarnAndPreservePlaceholder_WhenPackageListIsEmpty() {
 		// Arrange
 		await using WorkspaceSyncArrangeContext arrangeContext = await ArrangeSandboxWorkspaceAsync(includePackage: false);
 		string placeholderPath = Path.Combine(arrangeContext.WorkspacePath, "packages", "placeholder.txt");
@@ -394,6 +399,11 @@ public sealed class WorkspaceSyncToolE2ETests {
 	[AllureStep("Assert file exists")]
 	private static void AssertFileExists(string path, string because) {
 		File.Exists(path).Should().BeTrue(because: because);
+	}
+
+	[AllureStep("Assert unrelated package content is preserved")]
+	private static void AssertFileContent(string path, string expectedContent, string because) {
+		File.ReadAllText(path).Should().Be(expectedContent, because: because);
 	}
 
 	[AllureStep("Assert invalid environment diagnostics mention the missing environment name")]

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -2177,8 +2177,8 @@ public sealed class ToolContractGetToolTests {
 			because: "the contract should not imply that restore-workspace downloads every package in the environment");
 		restore.Preconditions.Should().Contain(precondition =>
 			precondition.Contains("none are eligible", StringComparison.Ordinal) &&
-			precondition.Contains("unchanged", StringComparison.Ordinal),
-			because: "callers should understand the successful warning and preservation behavior before invoking restore-workspace");
+			precondition.Contains("does not clear or delete", StringComparison.Ordinal),
+			because: "callers should understand the successful warning and directory-preservation behavior before invoking restore-workspace");
 
 		ToolContractDefinition assert = result.Tools!.Single(contract =>
 			contract.Name == AssertInfrastructureTool.AssertInfrastructureToolName);

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -2173,6 +2173,12 @@ public sealed class ToolContractGetToolTests {
 			precondition.Contains("cliogate", StringComparison.Ordinal) &&
 			precondition.Contains("install-gate", StringComparison.Ordinal),
 			because: "restore-workspace should tell callers how to satisfy the cliogate prerequisite");
+		restore.Description.Should().Contain("workspaceSettings.json",
+			because: "the contract should not imply that restore-workspace downloads every package in the environment");
+		restore.Preconditions.Should().Contain(precondition =>
+			precondition.Contains("none are eligible", StringComparison.Ordinal) &&
+			precondition.Contains("unchanged", StringComparison.Ordinal),
+			because: "callers should understand the successful warning and preservation behavior before invoking restore-workspace");
 
 		ToolContractDefinition assert = result.Tools!.Single(contract =>
 			contract.Name == AssertInfrastructureTool.AssertInfrastructureToolName);

--- a/clio.tests/Command/McpServer/WorkspaceSyncToolTests.cs
+++ b/clio.tests/Command/McpServer/WorkspaceSyncToolTests.cs
@@ -369,6 +369,10 @@ public sealed class WorkspaceSyncToolTests {
 			because: "the restore-workspace prompt should tell agents how to target the correct local workspace");
 		restorePrompt.Should().Contain(RestoreWorkspaceTool.RestoreWorkspaceToolName,
 			because: "the restore-workspace prompt should reference the exact MCP tool name");
+		restorePrompt.Should().Contain("workspaceSettings.json",
+			because: "the restore prompt should identify the package list that controls what is downloaded");
+		restorePrompt.Should().Contain("do not report that environment packages were restored",
+			because: "an MCP caller must not translate an empty-list warning into a misleading restore claim");
 	}
 
 	private sealed class FakePushWorkspaceCommand : PushWorkspaceCommand {

--- a/clio.tests/Package/PackageDownloaderTests.cs
+++ b/clio.tests/Package/PackageDownloaderTests.cs
@@ -2,12 +2,12 @@ using System;
 using System.Linq;
 using Clio.Common;
 using Clio.Package;
+using Clio.Tests.Command;
 using Clio.WebApplication;
 using Clio.Workspaces;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using IAbstractionsFileSystem = System.IO.Abstractions.IFileSystem;
 using IClioFileSystem = Clio.Common.IFileSystem;
 
 namespace Clio.Tests.Package;
@@ -18,59 +18,65 @@ namespace Clio.Tests.Package;
 [TestFixture]
 [Category("Unit")]
 [Property("Module", "Package")]
-public sealed class PackageDownloaderTests {
+public sealed class PackageDownloaderTests : BaseClioModuleTests {
 
-	[Test]
-	[Description("Downloads and overwrites the requested package directory without clearing unrelated content from the shared destination root.")]
-	public void DownloadPackages_Should_Not_Clear_Shared_Destination_Root() {
-		// Arrange
-		const string destinationPath = @"C:\workspace\packages";
-		const string tempPath = @"C:\temp";
-		const string packageName = "PkgOne";
-		const string packageZipPath = @"C:\temp\PkgOne.zip";
-		EnvironmentSettings environmentSettings = new();
+	private IClioFileSystem _clioFileSystem;
+	private IPackageArchiver _packageArchiver;
+	private IPackageDownloader _packageDownloader;
+
+	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
 		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
 		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
-		applicationClientFactory.CreateClient(environmentSettings).Returns(applicationClient);
-		IPackageArchiver packageArchiver = Substitute.For<IPackageArchiver>();
+		applicationClientFactory.CreateClient(EnvironmentSettings).Returns(applicationClient);
+		_packageArchiver = Substitute.For<IPackageArchiver>();
 		IApplicationDownloader applicationDownloader = Substitute.For<IApplicationDownloader>();
 		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
-		serviceUrlBuilder.Build(Arg.Any<ServiceUrlBuilder.KnownRoute>(), environmentSettings)
+		serviceUrlBuilder.Build(Arg.Any<ServiceUrlBuilder.KnownRoute>(), EnvironmentSettings)
 			.Returns("https://example.invalid/package");
 		IWorkingDirectoriesProvider workingDirectoriesProvider = Substitute.For<IWorkingDirectoriesProvider>();
 		workingDirectoriesProvider
 			.When(provider => provider.CreateTempDirectory(Arg.Any<Action<string>>()))
-			.Do(call => call.Arg<Action<string>>()(tempPath));
+			.Do(call => call.Arg<Action<string>>()(FileSystem.Path.Combine("temp")));
 		IApplicationPing applicationPing = Substitute.For<IApplicationPing>();
-		applicationPing.Ping(environmentSettings).Returns(true);
-		IClioFileSystem fileSystem = Substitute.For<IClioFileSystem>();
-		fileSystem.GetCurrentDirectoryIfEmpty(destinationPath).Returns(destinationPath);
-		IAbstractionsFileSystem abstractionsFileSystem = Substitute.For<IAbstractionsFileSystem>();
-		abstractionsFileSystem.Path.Combine(tempPath, $"{packageName}.zip").Returns(packageZipPath);
-		PackageDownloader downloader = new(
-			environmentSettings,
-			applicationClientFactory,
-			packageArchiver,
-			applicationDownloader,
-			serviceUrlBuilder,
-			workingDirectoriesProvider,
-			applicationPing,
-			fileSystem,
-			abstractionsFileSystem,
-			Substitute.For<ILogger>());
+		applicationPing.Ping(EnvironmentSettings).Returns(true);
+		_clioFileSystem = Substitute.For<IClioFileSystem>();
+
+		containerBuilder.AddSingleton(applicationClientFactory);
+		containerBuilder.AddSingleton(_packageArchiver);
+		containerBuilder.AddSingleton(applicationDownloader);
+		containerBuilder.AddSingleton(serviceUrlBuilder);
+		containerBuilder.AddSingleton(workingDirectoriesProvider);
+		containerBuilder.AddSingleton(applicationPing);
+		containerBuilder.AddSingleton(_clioFileSystem);
+		containerBuilder.AddTransient<IPackageDownloader, PackageDownloader>();
+	}
+
+	public override void Setup() {
+		base.Setup();
+		_packageDownloader = Container.GetRequiredService<IPackageDownloader>();
+	}
+
+	[Test]
+	[Description("Downloads and overwrites the requested package directory without clearing unrelated content from the shared destination root.")]
+	public void DownloadPackages_ShouldPreserveSharedDestinationRoot_WhenPackageIsRequested() {
+		// Arrange
+		const string packageName = "PkgOne";
+		string destinationPath = FileSystem.Path.Combine("workspace", "packages");
+		string packageZipPath = FileSystem.Path.Combine("temp", $"{packageName}.zip");
+		_clioFileSystem.GetCurrentDirectoryIfEmpty(destinationPath).Returns(destinationPath);
 
 		// Act
-		downloader.DownloadPackages([packageName], environmentSettings, destinationPath);
+		_packageDownloader.DownloadPackages([packageName], EnvironmentSettings, destinationPath);
 
 		// Assert
-		fileSystem.ReceivedCalls()
+		_clioFileSystem.ReceivedCalls()
 			.Where(call => call.GetMethodInfo().Name == nameof(IClioFileSystem.CreateOrOverwriteExistsDirectoryIfNeeded))
 			.Should().BeEmpty(
 				because: "restore must preserve ignored, external, and placeholder content in the shared packages root");
-		packageArchiver.ReceivedCalls().Should().ContainSingle(call =>
+		_packageArchiver.ReceivedCalls().Should().ContainSingle(call =>
 			call.GetMethodInfo().Name == nameof(IPackageArchiver.UnZipPackages) &&
-			Equals(call.GetArguments()[0], packageZipPath) &&
-			Equals(call.GetArguments()[5], destinationPath),
-			because: "the requested package should still be overwritten through the package-scoped archiver path");
+			call.GetArguments().SequenceEqual(new object[] {
+				packageZipPath, true, true, true, false, destinationPath
+			}), because: "the requested package must still be overwritten through the package-scoped archiver path");
 	}
 }

--- a/clio.tests/Package/PackageDownloaderTests.cs
+++ b/clio.tests/Package/PackageDownloaderTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using Clio.Common;
+using Clio.Package;
+using Clio.WebApplication;
+using Clio.Workspaces;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using IAbstractionsFileSystem = System.IO.Abstractions.IFileSystem;
+using IClioFileSystem = Clio.Common.IFileSystem;
+
+namespace Clio.Tests.Package;
+
+/// <summary>
+/// Covers package-root preservation while packages are downloaded and overwritten individually.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Package")]
+public sealed class PackageDownloaderTests {
+
+	[Test]
+	[Description("Downloads and overwrites the requested package directory without clearing unrelated content from the shared destination root.")]
+	public void DownloadPackages_Should_Not_Clear_Shared_Destination_Root() {
+		// Arrange
+		const string destinationPath = @"C:\workspace\packages";
+		const string tempPath = @"C:\temp";
+		const string packageName = "PkgOne";
+		const string packageZipPath = @"C:\temp\PkgOne.zip";
+		EnvironmentSettings environmentSettings = new();
+		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		applicationClientFactory.CreateClient(environmentSettings).Returns(applicationClient);
+		IPackageArchiver packageArchiver = Substitute.For<IPackageArchiver>();
+		IApplicationDownloader applicationDownloader = Substitute.For<IApplicationDownloader>();
+		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		serviceUrlBuilder.Build(Arg.Any<ServiceUrlBuilder.KnownRoute>(), environmentSettings)
+			.Returns("https://example.invalid/package");
+		IWorkingDirectoriesProvider workingDirectoriesProvider = Substitute.For<IWorkingDirectoriesProvider>();
+		workingDirectoriesProvider
+			.When(provider => provider.CreateTempDirectory(Arg.Any<Action<string>>()))
+			.Do(call => call.Arg<Action<string>>()(tempPath));
+		IApplicationPing applicationPing = Substitute.For<IApplicationPing>();
+		applicationPing.Ping(environmentSettings).Returns(true);
+		IClioFileSystem fileSystem = Substitute.For<IClioFileSystem>();
+		fileSystem.GetCurrentDirectoryIfEmpty(destinationPath).Returns(destinationPath);
+		IAbstractionsFileSystem abstractionsFileSystem = Substitute.For<IAbstractionsFileSystem>();
+		abstractionsFileSystem.Path.Combine(tempPath, $"{packageName}.zip").Returns(packageZipPath);
+		PackageDownloader downloader = new(
+			environmentSettings,
+			applicationClientFactory,
+			packageArchiver,
+			applicationDownloader,
+			serviceUrlBuilder,
+			workingDirectoriesProvider,
+			applicationPing,
+			fileSystem,
+			abstractionsFileSystem,
+			Substitute.For<ILogger>());
+
+		// Act
+		downloader.DownloadPackages([packageName], environmentSettings, destinationPath);
+
+		// Assert
+		fileSystem.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(IClioFileSystem.CreateOrOverwriteExistsDirectoryIfNeeded))
+			.Should().BeEmpty(
+				because: "restore must preserve ignored, external, and placeholder content in the shared packages root");
+		packageArchiver.ReceivedCalls().Should().ContainSingle(call =>
+			call.GetMethodInfo().Name == nameof(IPackageArchiver.UnZipPackages) &&
+			Equals(call.GetArguments()[0], packageZipPath) &&
+			Equals(call.GetArguments()[5], destinationPath),
+			because: "the requested package should still be overwritten through the package-scoped archiver path");
+	}
+}

--- a/clio.tests/Workspace/WorkspaceRestorerTests.cs
+++ b/clio.tests/Workspace/WorkspaceRestorerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Clio.Command;
 using Clio.Common;
 using Clio.Package;
@@ -24,7 +26,9 @@ public class WorkspaceRestorerTests {
 	#region Fields: Private
 
 	private ICreatioSdk _creatioSdk;
+	private ILogger _logger;
 	private IPackageDownloader _packageDownloader;
+	private IWorkspacePackageFilter _workspacePackageFilter;
 	private WorkspaceRestorer _workspaceRestorer;
 
 	#endregion
@@ -34,18 +38,25 @@ public class WorkspaceRestorerTests {
 	[SetUp]
 	public void SetUp() {
 		_creatioSdk = Substitute.For<ICreatioSdk>();
+		_logger = Substitute.For<ILogger>();
 		_packageDownloader = Substitute.For<IPackageDownloader>();
+		_workspacePackageFilter = Substitute.For<IWorkspacePackageFilter>();
+		_workspacePackageFilter
+			.FilterPackages(Arg.Any<IEnumerable<string>>(), Arg.Any<WorkspaceSettings>())
+			.Returns(call => call.ArgAt<IEnumerable<string>>(0));
 		_workspaceRestorer = new WorkspaceRestorer(Substitute.For<INuGetManager>(),
 			Substitute.For<IWorkspacePathBuilder>(), Substitute.For<IEnvironmentScriptCreator>(),
 			Substitute.For<IWorkspaceSolutionCreator>(), _packageDownloader, _creatioSdk,
-			Substitute.For<IAbstractionsFileSystem>(), Substitute.For<ILogger>(),
-			Substitute.For<ITemplateProvider>(), Substitute.For<IWorkspacePackageFilter>());
+			Substitute.For<IAbstractionsFileSystem>(), _logger,
+			Substitute.For<ITemplateProvider>(), _workspacePackageFilter);
 	}
 
 	[TearDown]
 	public void TearDown() {
 		_creatioSdk.ClearReceivedCalls();
+		_logger.ClearReceivedCalls();
 		_packageDownloader.ClearReceivedCalls();
+		_workspacePackageFilter.ClearReceivedCalls();
 	}
 
 	[Test]
@@ -81,6 +92,31 @@ public class WorkspaceRestorerTests {
 			because: "the restore cannot complete without the SDK, so it must say so rather than proceed");
 		_packageDownloader.ReceivedCalls().Should().BeEmpty(
 			because: "failing after packages are on disk would leave a half-restored workspace behind");
+	}
+
+	[Test]
+	[Description("Warns and skips package download when workspace settings contain no eligible packages, preventing a no-op restore from clearing local package content.")]
+	public void Restore_Should_Warn_And_Skip_Package_Download_When_No_Packages_Are_Eligible() {
+		// Arrange
+		WorkspaceSettings workspaceSettings = new();
+		WorkspaceOptions options = new() {
+			IsNugetRestore = false, IsCreateSolution = false, AddBuildProps = false
+		};
+
+		// Act
+		_workspaceRestorer.Restore(workspaceSettings, new EnvironmentSettings(), options);
+
+		// Assert
+		_packageDownloader.ReceivedCalls().Should().BeEmpty(
+			because: "an empty restore must not enter the downloader that can replace local package content");
+		_logger.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(ILogger.WriteWarning))
+			.Select(call => call.GetArguments().SingleOrDefault()?.ToString())
+			.Should().ContainSingle(message =>
+				message != null &&
+				message.Contains("workspaceSettings.json", StringComparison.Ordinal) &&
+				message.Contains("package download was skipped", StringComparison.Ordinal),
+				because: "the successful no-op must plainly explain why no packages were restored");
 	}
 
 	#endregion

--- a/clio.tests/Workspace/WorkspaceRestorerTests.cs
+++ b/clio.tests/Workspace/WorkspaceRestorerTests.cs
@@ -96,7 +96,7 @@ public class WorkspaceRestorerTests {
 
 	[Test]
 	[Description("Warns and skips package download when workspace settings contain no eligible packages, preventing a no-op restore from clearing local package content.")]
-	public void Restore_Should_Warn_And_Skip_Package_Download_When_No_Packages_Are_Eligible() {
+	public void Restore_ShouldWarnAndSkipPackageDownload_WhenNoPackagesAreEligible() {
 		// Arrange
 		WorkspaceSettings workspaceSettings = new();
 		WorkspaceOptions options = new() {

--- a/clio/Command/McpServer/Prompts/WorkspaceSyncPrompt.cs
+++ b/clio/Command/McpServer/Prompts/WorkspaceSyncPrompt.cs
@@ -41,8 +41,9 @@ public static class WorkspaceSyncPrompt {
 		[Description("Absolute path to the local workspace")]
 		string workspacePath) =>
 		$"""
-		 Use clio mcp server `{RestoreWorkspaceTool.RestoreWorkspaceToolName}` tool to restore the workspace at
-		 `{workspacePath}` from Creatio environment `{environmentName}`.
+		 Use clio mcp server `{RestoreWorkspaceTool.RestoreWorkspaceToolName}` tool to restore the packages listed
+		 in `.clio/workspaceSettings.json` at `{workspacePath}` from Creatio environment `{environmentName}`.
 		 Pass `workspace-path` exactly as provided and use `environment-name` `{environmentName}`.
+		 If the tool warns that no packages are eligible, do not report that environment packages were restored.
 		 """;
 }

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5575,7 +5575,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildRestoreWorkspace() {
 		return new ToolContractDefinition(
 			RestoreWorkspaceTool.RestoreWorkspaceToolName,
-			"Restores the local workspace at workspace-path from the specified Creatio environment. Requires the cliogate package on the target environment; when it is missing, install it with install-gate and retry.",
+			"Restores packages listed in .clio/workspaceSettings.json at workspace-path from the specified Creatio environment. An empty eligible package list succeeds with a warning and preserves existing packages content. Requires the cliogate package on the target environment; when it is missing, install it with install-gate and retry.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName, WorkspacePathFieldName],
 				[
@@ -5597,13 +5597,14 @@ internal static class ToolContractCatalog {
 					RestoreWorkspaceTool.RestoreWorkspaceToolName,
 					PushWorkspaceTool.PushWorkspaceToolName
 				],
-				"Restore packages from the environment into the local workspace, then push local changes back with push-workspace."),
+				"Restore the packages listed in workspaceSettings.json from the environment into the local workspace, then push local changes back with push-workspace."),
 			[],
 			[],
 			Preconditions: [
 				"The environment is registered (see list-environments / reg-web-app).",
 				"cliogate is installed on the target environment; if restore fails with a missing-cliogate error, run install-gate and retry.",
-				"workspace-path is a local absolute path to an existing directory (network-share paths are not supported)."
+				"workspace-path is a local absolute path to an existing directory (network-share paths are not supported).",
+				"Only packages eligible from .clio/workspaceSettings.json are downloaded; when none are eligible, the tool warns and leaves packages content unchanged."
 			]);
 	}
 

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5575,7 +5575,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildRestoreWorkspace() {
 		return new ToolContractDefinition(
 			RestoreWorkspaceTool.RestoreWorkspaceToolName,
-			"Restores packages listed in .clio/workspaceSettings.json at workspace-path from the specified Creatio environment. An empty eligible package list succeeds with a warning and preserves existing packages content. Requires the cliogate package on the target environment; when it is missing, install it with install-gate and retry.",
+			"Restores packages listed in .clio/workspaceSettings.json at workspace-path from the specified Creatio environment. An empty eligible package list succeeds with a warning and does not clear or delete existing package directories. Requires the cliogate package on the target environment; when it is missing, install it with install-gate and retry.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName, WorkspacePathFieldName],
 				[
@@ -5604,7 +5604,7 @@ internal static class ToolContractCatalog {
 				"The environment is registered (see list-environments / reg-web-app).",
 				"cliogate is installed on the target environment; if restore fails with a missing-cliogate error, run install-gate and retry.",
 				"workspace-path is a local absolute path to an existing directory (network-share paths are not supported).",
-				"Only packages eligible from .clio/workspaceSettings.json are downloaded; when none are eligible, the tool warns and leaves packages content unchanged."
+				"Only packages eligible from .clio/workspaceSettings.json are downloaded; when none are eligible, the tool warns and does not clear or delete existing package directories."
 			]);
 	}
 

--- a/clio/Command/McpServer/Tools/WorkspaceSyncTool.cs
+++ b/clio/Command/McpServer/Tools/WorkspaceSyncTool.cs
@@ -142,11 +142,11 @@ public sealed class RestoreWorkspaceTool(
 	internal const string RestoreWorkspaceToolName = "restore-workspace";
 
 	/// <summary>
-	/// Restores the local workspace from the specified Creatio environment.
+	/// Restores the packages listed in the local workspace settings from the specified Creatio environment.
 	/// </summary>
 	[McpServerTool(Name = RestoreWorkspaceToolName, ReadOnly = false, Destructive = true, Idempotent = false,
 		OpenWorld = false)]
-	[Description("Restores the local workspace at `workspace-path` from the specified Creatio environment")]
+	[Description("Restores packages listed in `.clio/workspaceSettings.json` at `workspace-path` from the specified Creatio environment. When no packages are eligible, returns success with a warning and preserves existing `packages/` content.")]
 	public CommandExecutionResult RestoreWorkspace(
 		[Description("Restore-workspace parameters")] [Required] RestoreWorkspaceArgs args
 	) {

--- a/clio/Command/McpServer/Tools/WorkspaceSyncTool.cs
+++ b/clio/Command/McpServer/Tools/WorkspaceSyncTool.cs
@@ -146,7 +146,7 @@ public sealed class RestoreWorkspaceTool(
 	/// </summary>
 	[McpServerTool(Name = RestoreWorkspaceToolName, ReadOnly = false, Destructive = true, Idempotent = false,
 		OpenWorld = false)]
-	[Description("Restores packages listed in `.clio/workspaceSettings.json` at `workspace-path` from the specified Creatio environment. When no packages are eligible, returns success with a warning and preserves existing `packages/` content.")]
+	[Description("Restores packages listed in `.clio/workspaceSettings.json` at `workspace-path` from the specified Creatio environment. When no packages are eligible, returns success with a warning and does not clear or delete existing package directories.")]
 	public CommandExecutionResult RestoreWorkspace(
 		[Description("Restore-workspace parameters")] [Required] RestoreWorkspaceArgs args
 	) {

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -297,7 +297,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="pull-workspace"></a>
 <a id="pullw"></a>
 <a id="restorew"></a>
-- [`restore-workspace`](docs/commands/restore-workspace.md) - Restore editable packages into a workspace, `pull-workspace`, `pullw`, `restorew`
+- [`restore-workspace`](docs/commands/restore-workspace.md) - Restore packages listed in workspace settings without clearing ineligible package content, `pull-workspace`, `pullw`, `restorew`
 <a id="switch-nuget-to-dll-reference"></a>
 <a id="nuget2dll"></a>
 - [`switch-nuget-to-dll-reference`](docs/commands/switch-nuget-to-dll-reference.md) - Switches nuget references to dll references in csproj files, `nuget2dll`

--- a/clio/Package/IPackageDownloader.cs
+++ b/clio/Package/IPackageDownloader.cs
@@ -14,8 +14,12 @@ namespace Clio.Package
 			string destinationPath = null);
 		void DownloadZipPackage(string packageName, EnvironmentSettings environmentSettings = null,
 			string destinationPath = null);
+		/// <summary>
+		/// Downloads and overwrites the requested package directories without clearing unrelated content from
+		/// the shared destination root.
+		/// </summary>
 		void DownloadPackages(IEnumerable<string> packagesNames, EnvironmentSettings environmentSettings = null,
-			string destinationPath = null); 
+			string destinationPath = null);
 		void DownloadPackage(string packageName, EnvironmentSettings environmentSettings  = null,
 			string destinationPath = null);
 

--- a/clio/Package/PackageDownloader.cs
+++ b/clio/Package/PackageDownloader.cs
@@ -131,7 +131,8 @@ namespace Clio.Package
 				foreach (string packageName in packagesNames) {
 					DownloadZipPackagesInternal(packageName, environmentSettings, tempDirectory, true);
 				}
-				_fileSystem.CreateOrOverwriteExistsDirectoryIfNeeded(destinationPath, true);
+				// Each requested package directory is overwritten by PackageArchiver.Unpack. Clearing the shared
+				// destination root here would also delete ignored, external, and placeholder content.
 				foreach (string packageName in packagesNames) {
 					string packageZipPath = GetPackageZipPath(packageName, tempDirectory);
 					_packageArchiver.UnZipPackages(packageZipPath, true, true, true, 

--- a/clio/Workspace/WorkspaceRestorer.cs
+++ b/clio/Workspace/WorkspaceRestorer.cs
@@ -16,6 +16,9 @@ namespace Clio.Workspace;
 #region Class: WorkspaceSettings
 
 public class WorkspaceRestorer : IWorkspaceRestorer{
+	private const string NoPackagesEligibleMessage =
+		"No packages are eligible for restore from .clio/workspaceSettings.json; package download was skipped.";
+
 	#region Fields: Private
 
 	private readonly ICreatioSdk _creatioSdk;
@@ -144,14 +147,20 @@ public class WorkspaceRestorer : IWorkspaceRestorer{
 		Version creatioSdkVersion = restoreWorkspaceOptions.IsNugetRestore == true
 			? _creatioSdk.FindLatestSdkVersion(workspaceSettings.ApplicationVersion)
 			: null;
-		IEnumerable<string> packagesToDownload = _workspacePackageFilter
-			.FilterPackages(workspaceSettings.Packages, workspaceSettings);
+		IEnumerable<string> filteredPackages = _workspacePackageFilter
+			.FilterPackages(workspaceSettings.Packages, workspaceSettings) ?? [];
+		List<string> packagesToDownload = filteredPackages.ToList();
 		IList<string> externalPackages = workspaceSettings.ExternalPackages;
 		if (externalPackages != null && externalPackages.Any()) {
-			packagesToDownload = packagesToDownload.Where(p => !externalPackages.Contains(p));
+			packagesToDownload = packagesToDownload.Where(p => !externalPackages.Contains(p)).ToList();
 		}
-		_packageDownloader.DownloadPackages(packagesToDownload, environmentSettings,
-			_workspacePathBuilder.PackagesFolderPath);
+		if (packagesToDownload.Count == 0) {
+			_logger.WriteWarning(NoPackagesEligibleMessage);
+		}
+		else {
+			_packageDownloader.DownloadPackages(packagesToDownload, environmentSettings,
+				_workspacePathBuilder.PackagesFolderPath);
+		}
 		if (restoreWorkspaceOptions.IsNugetRestore == true) {
 			RestoreNugetCreatioSdk(creatioSdkVersion);
 			CreateEnvironmentScript(creatioSdkVersion);

--- a/clio/docs/commands/restore-workspace.md
+++ b/clio/docs/commands/restore-workspace.md
@@ -11,11 +11,14 @@ from Creatio environment
 
 ## Description
 
-restore-workspace command restores a local clio workspace by downloading
-packages from a Creatio environment and setting up the development environment.
+restore-workspace downloads the packages listed in `.clio/workspaceSettings.json`
+from a Creatio environment and sets up the local development environment.
+
+When no packages are eligible after applying ignore and external-package settings,
+the command reports a warning and leaves existing `packages/` content unchanged.
 
 The command performs the following operations:
-- Downloads package source code from Creatio environment
+- Downloads eligible package source code from the Creatio environment
 - Restores CreatioSDK NuGet package (optional, default: true)
 - Creates MainSolution.slnx file for IDE integration (optional, default: true)
 - Creates .build-props directory with build configuration (optional, default: true)
@@ -47,34 +50,34 @@ clio restore-workspace -e <ENVIRONMENT_NAME> [options]
 ## Options
 
 ```bash
---Environment           -e          Environment name (recommended method)
+--environment           -e          Environment name (recommended method)
 
---IsNugetRestore                    Restore CreatioSDK NuGet package
+--is-nuget-restore                    Restore CreatioSDK NuGet package
 Default: true
-Example: --IsNugetRestore false
+Example: --is-nuget-restore false
 
---IsCreateSolution                  Create MainSolution.slnx solution file
+--is-create-solution                  Create MainSolution.slnx solution file
 Default: true
-Example: --IsCreateSolution false
+Example: --is-create-solution false
 
---AddBuildProps                     Create .build-props directory and update
+--add-build-props                     Create .build-props directory and update
 project files with build props imports
 Default: true
-Example: --AddBuildProps false
+Example: --add-build-props false
 
---AppCode               -a          Application code for package filtering
+--app-code               -a          Application code for package filtering
 
 --uri                   -u          Server URI (alternative to -e)
 
---Login                 -l          Username for basic authentication
+--login                 -l          Username for basic authentication
 
---Password              -p          Password for basic authentication
+--password              -p          Password for basic authentication
 
---ClientId                          OAuth Client ID (OAuth authentication)
+--client-id                          OAuth Client ID (OAuth authentication)
 
---ClientSecret                      OAuth Client Secret (OAuth authentication)
+--client-secret                      OAuth Client Secret (OAuth authentication)
 
---AuthAppUri                        OAuth Authentication App URI
+--auth-app-uri                        OAuth Authentication App URI
 ```
 
 ## Output
@@ -100,25 +103,25 @@ clio restore-workspace -e dev
 clio restore-workspace -e dev
 
 Restore without creating solution file:
-clio restore-workspace -e dev --IsCreateSolution false
+clio restore-workspace -e dev --is-create-solution false
 
 Restore without NuGet SDK:
-clio restore-workspace -e dev --IsNugetRestore false
+clio restore-workspace -e dev --is-nuget-restore false
 
 Restore without build props:
-clio restore-workspace -e dev --AddBuildProps false
+clio restore-workspace -e dev --add-build-props false
 
 Restore using OAuth authentication:
 clio restore-workspace --uri https://mysite.com \
---ClientId abc123 --ClientSecret secret123 \
---AuthAppUri https://oauth.site.com
+--client-id abc123 --client-secret secret123 \
+--auth-app-uri https://oauth.site.com
 
 Restore using basic authentication:
 clio restore-workspace --uri https://mysite.com \
---Login administrator --Password mypass
+--login administrator --password mypass
 
 Restore with application code filter:
-clio restore-workspace -e dev --AppCode MyApp
+clio restore-workspace -e dev --app-code MyApp
 ```
 
 ## Authentication Methods
@@ -130,12 +133,12 @@ clio restore-workspace -e dev --AppCode MyApp
        Example: clio restore-workspace -e dev
 
     2. OAuth authentication:
-       Requires: --uri, --ClientId, --ClientSecret, --AuthAppUri
-       Example: clio restore-workspace --uri https://site.com --ClientId abc
+       Requires: --uri, --client-id, --client-secret, --auth-app-uri
+       Example: clio restore-workspace --uri https://site.com --client-id abc
 
     3. Basic authentication:
-       Requires: --uri, --Login, --Password
-       Example: clio restore-workspace --uri https://site.com --Login admin
+       Requires: --uri, --login, --password
+       Example: clio restore-workspace --uri https://site.com --login admin
 
 ## Workflow
 
@@ -185,6 +188,8 @@ configuration exists
 - MainSolution.slnx and .build-props are key updates that improve the
 development experience
 - Workspace configuration is stored in .clio/workspaceSettings.json
+- Only packages eligible from the `Packages` list are downloaded. An empty eligible
+  list produces a warning and does not clear the `packages/` directory.
 
 ## Troubleshooting
 
@@ -197,10 +202,14 @@ development experience
 
     Build errors after restore:
         Ensure build props were created:
-            clio restore-workspace -e dev --AddBuildProps true
+            clio restore-workspace -e dev --add-build-props true
 
     Missing packages:
         Check workspace settings filter in .clio/workspaceSettings.json
+
+    Warning: "No packages are eligible for restore":
+        Add the intended package names to .clio/workspaceSettings.json -> Packages,
+        or review IgnorePackages and ExternalPackages. Existing packages content is preserved.
 
 ## See Also
 

--- a/clio/docs/commands/restore-workspace.md
+++ b/clio/docs/commands/restore-workspace.md
@@ -15,7 +15,7 @@ restore-workspace downloads the packages listed in `.clio/workspaceSettings.json
 from a Creatio environment and sets up the local development environment.
 
 When no packages are eligible after applying ignore and external-package settings,
-the command reports a warning and leaves existing `packages/` content unchanged.
+the command reports a warning and does not clear or delete existing package directories.
 
 The command performs the following operations:
 - Downloads eligible package source code from the Creatio environment
@@ -209,7 +209,7 @@ development experience
 
     Warning: "No packages are eligible for restore":
         Add the intended package names to .clio/workspaceSettings.json -> Packages,
-        or review IgnorePackages and ExternalPackages. Existing packages content is preserved.
+        or review IgnorePackages and ExternalPackages. Existing package directories are not cleared or deleted.
 
 ## See Also
 

--- a/clio/help/en/restore-workspace.txt
+++ b/clio/help/en/restore-workspace.txt
@@ -11,8 +11,8 @@ DESCRIPTION
     development environment.
 
     When no packages are eligible after applying ignore and external-package
-    settings, the command reports a warning and leaves existing packages/ content
-    unchanged.
+    settings, the command reports a warning and does not clear or delete existing
+    package directories.
     
     The command performs the following operations:
     - Downloads eligible package source code from the Creatio environment
@@ -189,7 +189,8 @@ TROUBLESHOOTING
 
     Warning: "No packages are eligible for restore":
         Add the intended package names to .clio/workspaceSettings.json -> Packages,
-        or review IgnorePackages and ExternalPackages. Existing packages content is preserved.
+        or review IgnorePackages and ExternalPackages. Existing package directories
+        are not cleared or deleted.
 
 SEE ALSO
     create-workspace    - Create new workspace from scratch

--- a/clio/help/en/restore-workspace.txt
+++ b/clio/help/en/restore-workspace.txt
@@ -6,11 +6,16 @@ NAME
                        from Creatio environment
 
 DESCRIPTION
-    restore-workspace command restores a local clio workspace by downloading 
-    packages from a Creatio environment and setting up the development environment.
+    restore-workspace downloads the packages listed in
+    .clio/workspaceSettings.json from a Creatio environment and sets up the local
+    development environment.
+
+    When no packages are eligible after applying ignore and external-package
+    settings, the command reports a warning and leaves existing packages/ content
+    unchanged.
     
     The command performs the following operations:
-    - Downloads package source code from Creatio environment
+    - Downloads eligible package source code from the Creatio environment
     - Restores CreatioSDK NuGet package (optional, default: true)
     - Creates MainSolution.slnx file for IDE integration (optional, default: true)
     - Creates .build-props directory with build configuration (optional, default: true)
@@ -36,34 +41,34 @@ SYNOPSIS
     clio restorew -e <ENVIRONMENT_NAME> [options]
 
 OPTIONS
-    --Environment           -e          Environment name (recommended method)
+    --environment           -e          Environment name (recommended method)
 
-    --IsNugetRestore                    Restore CreatioSDK NuGet package
+    --is-nuget-restore                    Restore CreatioSDK NuGet package
                                         Default: true
-                                        Example: --IsNugetRestore false
+                                        Example: --is-nuget-restore false
 
-    --IsCreateSolution                  Create MainSolution.slnx solution file
+    --is-create-solution                  Create MainSolution.slnx solution file
                                         Default: true
-                                        Example: --IsCreateSolution false
+                                        Example: --is-create-solution false
 
-    --AddBuildProps                     Create .build-props directory and update
+    --add-build-props                     Create .build-props directory and update
                                         project files with build props imports
                                         Default: true
-                                        Example: --AddBuildProps false
+                                        Example: --add-build-props false
 
-    --AppCode               -a          Application code for package filtering
+    --app-code               -a          Application code for package filtering
 
     --uri                   -u          Server URI (alternative to -e)
 
-    --Login                 -l          Username for basic authentication
+    --login                 -l          Username for basic authentication
 
-    --Password              -p          Password for basic authentication
+    --password              -p          Password for basic authentication
 
-    --ClientId                          OAuth Client ID (OAuth authentication)
+    --client-id                          OAuth Client ID (OAuth authentication)
 
-    --ClientSecret                      OAuth Client Secret (OAuth authentication)
+    --client-secret                      OAuth Client Secret (OAuth authentication)
 
-    --AuthAppUri                        OAuth Authentication App URI
+    --auth-app-uri                        OAuth Authentication App URI
 
 OUTPUT
     The command creates the following in your workspace:
@@ -85,25 +90,25 @@ EXAMPLES
         clio restorew -e dev
 
     Restore without creating solution file:
-        clio restore-workspace -e dev --IsCreateSolution false
+        clio restore-workspace -e dev --is-create-solution false
 
     Restore without NuGet SDK:
-        clio restore-workspace -e dev --IsNugetRestore false
+        clio restore-workspace -e dev --is-nuget-restore false
 
     Restore without build props:
-        clio restore-workspace -e dev --AddBuildProps false
+        clio restore-workspace -e dev --add-build-props false
 
     Restore using OAuth authentication:
         clio restore-workspace --uri https://mysite.com \
-            --ClientId abc123 --ClientSecret secret123 \
-            --AuthAppUri https://oauth.site.com
+            --client-id abc123 --client-secret secret123 \
+            --auth-app-uri https://oauth.site.com
 
     Restore using basic authentication:
         clio restore-workspace --uri https://mysite.com \
-            --Login administrator --Password mypass
+            --login administrator --password mypass
 
     Restore with application code filter:
-        clio restore-workspace -e dev --AppCode MyApp
+        clio restore-workspace -e dev --app-code MyApp
 
 AUTHENTICATION METHODS
     The command supports three authentication methods:
@@ -113,12 +118,12 @@ AUTHENTICATION METHODS
        Example: clio restore-workspace -e dev
     
     2. OAuth authentication:
-       Requires: --uri, --ClientId, --ClientSecret, --AuthAppUri
-       Example: clio restore-workspace --uri https://site.com --ClientId abc
+       Requires: --uri, --client-id, --client-secret, --auth-app-uri
+       Example: clio restore-workspace --uri https://site.com --client-id abc
     
     3. Basic authentication:
-       Requires: --uri, --Login, --Password
-       Example: clio restore-workspace --uri https://site.com --Login admin
+       Requires: --uri, --login, --password
+       Example: clio restore-workspace --uri https://site.com --login admin
 
 WORKFLOW
     After running restore-workspace, typical development workflow:
@@ -164,6 +169,8 @@ NOTES
     - MainSolution.slnx and .build-props are key updates that improve the
       development experience
     - Workspace configuration is stored in .clio/workspaceSettings.json
+    - Only packages eligible from the Packages list are downloaded. An empty
+      eligible list produces a warning and does not clear the packages/ directory.
 
 TROUBLESHOOTING
     Error: "cliogate version 2.0.0.0 or higher is required"
@@ -175,10 +182,14 @@ TROUBLESHOOTING
     
     Build errors after restore:
         Ensure build props were created:
-            clio restore-workspace -e dev --AddBuildProps true
+            clio restore-workspace -e dev --add-build-props true
     
     Missing packages:
         Check workspace settings filter in .clio/workspaceSettings.json
+
+    Warning: "No packages are eligible for restore":
+        Add the intended package names to .clio/workspaceSettings.json -> Packages,
+        or review IgnorePackages and ExternalPackages. Existing packages content is preserved.
 
 SEE ALSO
     create-workspace    - Create new workspace from scratch


### PR DESCRIPTION
## Summary

- warn and skip package download when workspace settings contain no eligible packages
- preserve unrelated, ignored, external, and placeholder content by removing the redundant shared packages-root clear
- align CLI help, detailed docs, MCP tool guidance, prompt, and long-tail contract
- add unit and MCP sandbox E2E regression coverage for empty and partial restores

## Root cause

`WorkspaceRestorer` passed an empty filtered sequence to `PackageDownloader`. The downloader still initialized its download flow and cleared the shared `packages/` destination before unpacking zero packages, so the command reported success after deleting local content. The same root clear also removed unrelated content during partial restores. Requested package directories are already overwritten individually by `PackageArchiver`, so the shared-root clear was unnecessary.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release --framework net10.0 --filter "Category=Unit&(Module=Workspace|Module=Package|Module=McpServer)"` (3,806 passed)
- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Release -f net10.0` (passed)
- real `vbg` boundary: `get-info` passed against Creatio 10.0.0.858; a disposable `Packages: []` workspace restored with exit code 0, emitted the new warning, and preserved `packages/placeholder.txt`
- the shared local MCP sandbox harness is stale (`EnvironmentUrl` and cliogate readiness mismatch) and fails during setup before branch code; the new sandbox tests compile and will execute in the configured CI sandbox

## Reviews

- comprehensive pre-PR and final ready-to-merge agentic reviews: quality, security, performance/correctness, bug/edge-case, and testing lenses; all findings resolved, final gate clean
- final Claude attempts `rev_0d720a7f27f345bb` and narrowed `rev_da0a075ce7224d7e` reached Collab's 20-turn limit without a verdict; no approval was inferred
- post-open merge commit 3a8b1ea74: single combined-lens incremental review, no findings; the upstream change is disjoint from the restore repair
- Claude consultation: `rev_4f193b65610b4645`; root cause and smallest repair confirmed, speculative external-package semantics and count-heavy warning protocol rejected as out of scope

## Maintenance review

- docs updated: help, detailed command docs, and command index reviewed
- MCP updated: resident tool description, prompt, long-tail contract, unit coverage, and MCP E2E coverage
- clio-knowledge guidance reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`

## KISS check

Intent: make an empty workspace restore truthful and non-destructive. The implemented flow materializes the existing eligible-package filter once, skips only package download when it is empty, and otherwise keeps package-scoped overwrite behavior. No new state, protocol, or recovery mechanism was added.

Fixes #1137

