### PR TITLE
Strip UTF-8 BOM from the shipped build-netcore-sdk.sh workspace template

### DIFF
--- a/clio.tests/Examples/workspaces/iframe-sample/tasks/build-netcore-sdk.sh
+++ b/clio.tests/Examples/workspaces/iframe-sample/tasks/build-netcore-sdk.sh
@@ -1,2 +1,2 @@
-﻿source "./../.solution/set-netcore-environment.sh"
+source "./../.solution/set-netcore-environment.sh"
 dotnet build "./../.solution/CreatioPackages.slnx"

--- a/clio/tpl/workspace/tasks/build-netcore-sdk.sh
+++ b/clio/tpl/workspace/tasks/build-netcore-sdk.sh
@@ -1,2 +1,2 @@
-﻿source "./../.solution/set-netcore-environment.sh"
+source "./../.solution/set-netcore-environment.sh"
 dotnet build "./../.solution/CreatioPackages.slnx"


### PR DESCRIPTION
## Summary
Found while investigating SonarCloud's "problems with file encoding in the source code" analysis warning (Overview page). Root cause of that generic warning is broader (Automatic Analysis mode with no explicit `sonar.sourceEncoding`, combined with widespread inconsistent BOM usage across ~700+ tracked text files of many types) and is intentionally out of scope here — this PR fixes only the one instance with an actual functional consequence.

## The bug
`clio/tpl/workspace/tasks/build-netcore-sdk.sh` (and its identical mirror `clio.tests/Examples/workspaces/iframe-sample/tasks/build-netcore-sdk.sh`) started with a UTF-8 BOM directly followed by `source "./../.solution/set-netcore-environment.sh"` — no shebang line, since the file is meant to be `source`d by a caller, not executed directly.

This template is copied byte-for-byte into every workspace scaffolded by `clio create-workspace` (`WorkspaceCreator.cs` → `TemplateProvider.CopyTemplateFolder` → raw `CopyDirectory`, confirmed via review). A leading BOM before a bare shell command attaches to the first token, so `sh`/`bash` looks for a command literally named `\xEF\xBB\xBFsource`, which doesn't exist — sourcing this file in a scaffolded workspace on macOS/Linux would fail.

## Fix
Stripped the 3-byte BOM from both files. They remain byte-identical to each other. No shebang/content/line-ending change otherwise.

## Review
Per repo policy, ran the full 3-lens pre-PR review even though the diff is trivial:
- **Security**: all clear — no checksum/hash pins reference this file (that machinery is scoped to the bundled `cliogate`/`CrtProcessBuilder` packages only), and nothing in the repo relies on BOM as an encoding-based boundary.
- **Code quality**: approved. Flagged a sibling file (`build-netcore.sh`, also shebang-less) as worth double-checking for the same issue — verified directly: no BOM, and a full scan of `clio/tpl/` and `clio.tests/Examples/` found no other `.sh` file with a leading BOM. This fix is complete.
- **Correctness**: safe to merge — traced the full `create-workspace` → `CopyTemplateFolder` → `CopyDirectory` consumer chain, confirmed no test/hash/glob depends on this file's exact byte content, and confirmed the fix restores correct `source`-ability.

## Testing
```
bash -n clio/tpl/workspace/tasks/build-netcore-sdk.sh   # syntax OK
diff clio/tpl/workspace/tasks/build-netcore-sdk.sh clio.tests/Examples/workspaces/iframe-sample/tasks/build-netcore-sdk.sh   # still identical
dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Workspace" --no-build
```
Workspace module: 34/34 passed.

## Note
Left `tmp/workspace-gitignore-test/SampleWs/tasks/build-netcore-sdk.sh` untouched — it's a pre-existing, deliberately committed fixture (unrelated prior commit) verifying byte-for-byte `.gitignore` preservation during packaging, not part of this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)