### PR TITLE
fix: let Jest builder initialize Angular tests

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9097,3 +9097,10 @@ Decision: Keep the Angular 19 Jest builder and the project-specific setup hook, 
 Discovery: `@angular-builders/jest` 19.0.1 concatenates custom `setupFilesAfterEnv` with its own setup. A token-substituted shipped template with locked dependencies passed a real `TestBed` component test after the duplicate initializer was removed. A zero-spec scaffold still reports Jest's normal `No tests found`; `passWithNoTests` is deliberately not enabled.
 Files: clio/tpl/ui-project/setup-jest.ts, clio/tpl/ui-project-Empty/setup-jest.ts, clio.tests/Package/UiProjectCreatorIntegrationTests.cs
 Impact: both default and empty scaffolds retain their Jest extension point while real specs can execute; structural tests prevent either template from reintroducing a second initializer.
+
+## 2026-08-21 00:37 – GH #1136 Claude review: make runner ownership explicit
+Context: Claude agreed with the Jest-builder ownership fix but found that direct `jest` invocation would bypass the builder-owned Angular test environment and that the regression did not pin `configPath`.
+Decision: Document `npm test` / `ng test` as the supported runner path in both setup files and READMEs, assert the complete setup contract, and pin the Angular builder's `configPath` and `tsConfig`.
+Discovery: The generated `jest.config.ts` is an extension consumed by `@angular-builders/jest`, not a supported standalone test entry point.
+Files: clio/tpl/ui-project/setup-jest.ts, clio/tpl/ui-project-Empty/setup-jest.ts, clio/tpl/ui-project/README.md, clio/tpl/ui-project-Empty/README.md, clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+Impact: maintainers and generated-project users can see the single-owner contract, while regression coverage protects the configuration link that makes it work.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9090,3 +9090,10 @@ Decision: Use the registered `vbg` environment for a disposable empty workspace,
 Discovery: The built CLI returned success with the new warning and preserved `packages/placeholder.txt` against `vbg`. The shared E2E harness has stale sandbox URL/readiness configuration, so it fails before invoking the branch; the direct CLI boundary proved the empty path while the E2E now covers partial-restore preservation in CI.
 Files: clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs, clio.tests/Package/PackageDownloaderTests.cs, clio.tests/Workspace/WorkspaceRestorerTests.cs
 Impact: Both empty and partial restore regressions are pinned, and the final module gate passes 3,806 tests.
+
+## 2026-08-21 00:11 – GH #1136 Angular Jest setup ownership
+Context: Fresh `new-ui-project` scaffolds failed every real Angular spec because the template and `@angular-builders/jest` both initialized TestBed.
+Decision: Keep the Angular 19 Jest builder and the project-specific setup hook, but reduce both shipped `setup-jest.ts` files to the JIT compiler import so the builder is the single test-environment owner.
+Discovery: `@angular-builders/jest` 19.0.1 concatenates custom `setupFilesAfterEnv` with its own setup. A token-substituted shipped template with locked dependencies passed a real `TestBed` component test after the duplicate initializer was removed. A zero-spec scaffold still reports Jest's normal `No tests found`; `passWithNoTests` is deliberately not enabled.
+Files: clio/tpl/ui-project/setup-jest.ts, clio/tpl/ui-project-Empty/setup-jest.ts, clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+Impact: both default and empty scaffolds retain their Jest extension point while real specs can execute; structural tests prevent either template from reintroducing a second initializer.

--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9104,3 +9104,10 @@ Decision: Document `npm test` / `ng test` as the supported runner path in both s
 Discovery: The generated `jest.config.ts` is an extension consumed by `@angular-builders/jest`, not a supported standalone test entry point.
 Files: clio/tpl/ui-project/setup-jest.ts, clio/tpl/ui-project-Empty/setup-jest.ts, clio/tpl/ui-project/README.md, clio/tpl/ui-project-Empty/README.md, clio.tests/Package/UiProjectCreatorIntegrationTests.cs
 Impact: maintainers and generated-project users can see the single-owner contract, while regression coverage protects the configuration link that makes it work.
+
+## 2026-08-21 00:48 – GH #1136 Claude rereview: make config assertions effective
+Context: Claude found that null-conditional chaining could skip the new `configPath` and `tsConfig` assertions when a node was missing, and that the generated README omitted the intentional zero-spec exit behavior.
+Decision: Bind optional JSON values to locals before asserting them, pin the complete project Jest configuration, and disclose the initial `No tests found` non-zero result in both READMEs.
+Discovery: FluentAssertions cannot execute after a null-conditional chain short-circuits; a local null value is required so `Should().Be(...)` actually fails.
+Files: clio.tests/Package/UiProjectCreatorIntegrationTests.cs, clio/tpl/ui-project/README.md, clio/tpl/ui-project-Empty/README.md
+Impact: removing the builder-to-config link or adding another project setup entry now fails the regression, and fresh-scaffold behavior is explicit to users.

--- a/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+++ b/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
@@ -188,20 +188,24 @@ public class UiProjectCreatorIntegrationTests {
 
 		// Assert
 		string setupContent = File.ReadAllText(Path.Combine(projectPath, "setup-jest.ts"));
-		setupContent.Should().Contain("import '@angular/compiler';",
-			because: "the generated Jest setup should retain the Angular JIT compiler import")
-			.And.NotContain("setupZoneTestEnv",
-				because: "@angular-builders/jest already initializes the Angular test environment");
+		setupContent.ReplaceLineEndings("\n").Trim().Should().Be(
+			"// The @angular-builders/jest runner initializes Angular's test environment. Use npm test or ng test.\n" +
+			"import '@angular/compiler';",
+			because: "the generated setup should retain only project-specific compiler setup and document its runner-owned test environment");
 
 		string jestConfig = File.ReadAllText(Path.Combine(projectPath, "jest.config.ts"));
-		jestConfig.Should().Contain("setupFilesAfterEnv: ['<rootDir>/setup-jest.ts']",
+		jestConfig.Should().MatchRegex("setupFilesAfterEnv\\s*:\\s*\\[\\s*['\"]<rootDir>/setup-jest\\.ts['\"]\\s*\\]",
 			because: "the generated project should retain its extension point for project-specific Jest setup");
 
 		JsonObject angularJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectPath, "angular.json"))).AsObject();
-		string testBuilder = angularJson["projects"]?[ProjectName]?["architect"]?["test"]?["builder"]?
-			.GetValue<string>();
+		JsonNode testTarget = angularJson["projects"]?[ProjectName]?["architect"]?["test"];
+		string testBuilder = testTarget?["builder"]?.GetValue<string>();
 		testBuilder.Should().Be("@angular-builders/jest:run",
 			because: "the builder must remain the single owner of Angular test-environment initialization");
+		testTarget?["options"]?["configPath"]?.GetValue<string>().Should().Be("jest.config.ts",
+			because: "the builder must load the project-specific setup extension point");
+		testTarget?["options"]?["tsConfig"]?.GetValue<string>().Should().Be("tsconfig.spec.json",
+			because: "the builder must compile specs with the generated test TypeScript configuration");
 	}
 
 	#endregion

--- a/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+++ b/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
@@ -175,6 +175,35 @@ public class UiProjectCreatorIntegrationTests {
 		cleanScript.Should().Contain("packages/UsrRssReader/Files/src/js/rss_reader");
 	}
 
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Delegates Angular test-environment initialization to the configured Jest builder for every shipped UI template.")]
+	public void Create_ShouldDelegateAngularTestEnvironmentSetupToJestBuilder_WhenTemplateIsScaffolded(
+		bool isEmpty) {
+		// Arrange
+		string projectPath = Path.Combine(_tempDir, "projects", ProjectName);
+
+		// Act
+		_creator.Create(ProjectName, PackageName, VendorPrefix, isEmpty, string.Empty, _ => false);
+
+		// Assert
+		string setupContent = File.ReadAllText(Path.Combine(projectPath, "setup-jest.ts"));
+		setupContent.Should().Contain("import '@angular/compiler';",
+			because: "the generated Jest setup should retain the Angular JIT compiler import")
+			.And.NotContain("setupZoneTestEnv",
+				because: "@angular-builders/jest already initializes the Angular test environment");
+
+		string jestConfig = File.ReadAllText(Path.Combine(projectPath, "jest.config.ts"));
+		jestConfig.Should().Contain("setupFilesAfterEnv: ['<rootDir>/setup-jest.ts']",
+			because: "the generated project should retain its extension point for project-specific Jest setup");
+
+		JsonObject angularJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectPath, "angular.json"))).AsObject();
+		string testBuilder = angularJson["projects"]?[ProjectName]?["architect"]?["test"]?["builder"]?
+			.GetValue<string>();
+		testBuilder.Should().Be("@angular-builders/jest:run",
+			because: "the builder must remain the single owner of Angular test-environment initialization");
+	}
+
 	#endregion
 
 	#region Methods: Private

--- a/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
+++ b/clio.tests/Package/UiProjectCreatorIntegrationTests.cs
@@ -194,17 +194,29 @@ public class UiProjectCreatorIntegrationTests {
 			because: "the generated setup should retain only project-specific compiler setup and document its runner-owned test environment");
 
 		string jestConfig = File.ReadAllText(Path.Combine(projectPath, "jest.config.ts"));
-		jestConfig.Should().MatchRegex("setupFilesAfterEnv\\s*:\\s*\\[\\s*['\"]<rootDir>/setup-jest\\.ts['\"]\\s*\\]",
-			because: "the generated project should retain its extension point for project-specific Jest setup");
+		jestConfig.ReplaceLineEndings("\n").Trim().Should().Be(
+			"import type { Config } from 'jest';\n\n" +
+			"export default {\n" +
+			"  preset: 'jest-preset-angular',\n" +
+			"  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],\n" +
+			"} satisfies Config;",
+			because: "the generated project should retain exactly one project-specific Jest setup extension point");
+
+		JsonObject packageJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectPath, "package.json"))).AsObject();
+		string testScript = packageJson["scripts"]?["test"]?.GetValue<string>();
+		testScript.Should().Be("ng test",
+			because: "the documented zero-spec exit behavior requires the package script to preserve Jest's default result");
 
 		JsonObject angularJson = JsonNode.Parse(File.ReadAllText(Path.Combine(projectPath, "angular.json"))).AsObject();
 		JsonNode testTarget = angularJson["projects"]?[ProjectName]?["architect"]?["test"];
 		string testBuilder = testTarget?["builder"]?.GetValue<string>();
+		string configPath = testTarget?["options"]?["configPath"]?.GetValue<string>();
+		string testTsConfig = testTarget?["options"]?["tsConfig"]?.GetValue<string>();
 		testBuilder.Should().Be("@angular-builders/jest:run",
 			because: "the builder must remain the single owner of Angular test-environment initialization");
-		testTarget?["options"]?["configPath"]?.GetValue<string>().Should().Be("jest.config.ts",
+		configPath.Should().Be("jest.config.ts",
 			because: "the builder must load the project-specific setup extension point");
-		testTarget?["options"]?["tsConfig"]?.GetValue<string>().Should().Be("tsconfig.spec.json",
+		testTsConfig.Should().Be("tsconfig.spec.json",
 			because: "the builder must compile specs with the generated test TypeScript configuration");
 	}
 

--- a/clio/tpl/ui-project-Empty/README.md
+++ b/clio/tpl/ui-project-Empty/README.md
@@ -9,6 +9,7 @@ and copy *.js files to 8.x package file content.
 ## Test
 Execute command
 `npm run test`. This runs `ng test` through `@angular-builders/jest`, which owns Angular test-environment initialization. Do not invoke `jest` directly.
+A new project contains no specs, so this command exits non-zero with `No tests found` until you add a `*.spec.ts` file.
 
 ## How to develop and consume remote module
 You can find different examples by following https://academy.creatio.com link.

--- a/clio/tpl/ui-project-Empty/README.md
+++ b/clio/tpl/ui-project-Empty/README.md
@@ -8,7 +8,7 @@ and copy *.js files to 8.x package file content.
 
 ## Test
 Execute command
-`npm run test`
+`npm run test`. This runs `ng test` through `@angular-builders/jest`, which owns Angular test-environment initialization. Do not invoke `jest` directly.
 
 ## How to develop and consume remote module
 You can find different examples by following https://academy.creatio.com link.

--- a/clio/tpl/ui-project-Empty/setup-jest.ts
+++ b/clio/tpl/ui-project-Empty/setup-jest.ts
@@ -1,4 +1,1 @@
 import '@angular/compiler';
-import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-
-setupZoneTestEnv();

--- a/clio/tpl/ui-project-Empty/setup-jest.ts
+++ b/clio/tpl/ui-project-Empty/setup-jest.ts
@@ -1,1 +1,2 @@
+// The @angular-builders/jest runner initializes Angular's test environment. Use npm test or ng test.
 import '@angular/compiler';

--- a/clio/tpl/ui-project/README.md
+++ b/clio/tpl/ui-project/README.md
@@ -9,6 +9,7 @@ and copy *.js files to 8.x package file content.
 ## Test
 Execute command
 `npm run test`. This runs `ng test` through `@angular-builders/jest`, which owns Angular test-environment initialization. Do not invoke `jest` directly.
+A new project contains no specs, so this command exits non-zero with `No tests found` until you add a `*.spec.ts` file.
 
 ## How to develop and consume remote module
 You can find different examples by following https://academy.creatio.com link.

--- a/clio/tpl/ui-project/README.md
+++ b/clio/tpl/ui-project/README.md
@@ -8,7 +8,7 @@ and copy *.js files to 8.x package file content.
 
 ## Test
 Execute command
-`npm run test`
+`npm run test`. This runs `ng test` through `@angular-builders/jest`, which owns Angular test-environment initialization. Do not invoke `jest` directly.
 
 ## How to develop and consume remote module
 You can find different examples by following https://academy.creatio.com link.

--- a/clio/tpl/ui-project/setup-jest.ts
+++ b/clio/tpl/ui-project/setup-jest.ts
@@ -1,4 +1,1 @@
 import '@angular/compiler';
-import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-
-setupZoneTestEnv();

--- a/clio/tpl/ui-project/setup-jest.ts
+++ b/clio/tpl/ui-project/setup-jest.ts
@@ -1,1 +1,2 @@
+// The @angular-builders/jest runner initializes Angular's test environment. Use npm test or ng test.
 import '@angular/compiler';


### PR DESCRIPTION
Fixes #1136.

The matching guidance correction is merged in Advance-Technologies-Foundation/clio-knowledge#79 and published in immutable release 1.13.35.

## Root cause and fix
`@angular-builders/jest` already initializes the Angular Zone test environment. Both Angular 19 templates initialized it a second time in `setup-jest.ts`, so every real Angular TestBed spec failed before execution.

The templates now retain `import '@angular/compiler'` and delegate test-environment initialization to the Jest builder. Generated READMEs and setup comments define `npm test` / `ng test` as the supported path and disclose the intentional zero-spec non-zero result. The regression covers both template variants and pins the complete setup, Jest config, package script, builder, `configPath`, and `tsConfig` contract.

## Validation
- `dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~UiProjectCreatorIntegrationTests"` (4 passed)
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Package" --no-build` (144 passed)
- Runtime scaffold probe: `npm ci`, token substitution, and a real Angular TestBed spec compiling a standalone component plus `RuntimeFeatureModule`; 1/1 passed.
- Comprehensive five-lens agentic review against `origin/master`: no findings. Post-PR incremental reviews: all findings fixed and re-reviewed.
- Claude design review: agreed with builder-owned initialization while retaining `@angular/compiler`.
- Claude complete-diff review `rev_ff7e4ae80ac14648`: one P2 test weakness found and fixed.
- Claude focused rereview `rev_ebed5cce3d7a483a`: no P1/P2 findings; final P3 fixed and independently verified.
- docs reviewed, generated template README updated; command docs otherwise accurate
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed