### PR TITLE
Keep request base parameters producer-driven

### DIFF
--- a/.codex/workspace-diary.md
+++ b/.codex/workspace-diary.md
@@ -9124,3 +9124,17 @@ Decision: Bind optional JSON values to locals before asserting them, pin the com
 Discovery: FluentAssertions cannot execute after a null-conditional chain short-circuits; a local null value is required so `Should().Be(...)` actually fails.
 Files: clio.tests/Package/UiProjectCreatorIntegrationTests.cs, clio/tpl/ui-project/README.md, clio/tpl/ui-project-Empty/README.md
 Impact: removing the builder-to-config link or adding another project setup entry now fails the regression, and fresh-scaffold behavior is explicit to users.
+
+## 2026-08-21 01:20 – GH #1139 validate custom output payload binding
+Context: Issue #1139 asked how a Freedom UI remote-module `@CrtOutput` payload reaches a request handler and reported possible duplicate invocation.
+Decision: Publish the supported `@event.detail` request-parameter binding in clio-knowledge and make Clio's request catalog describe BaseRequest fields as producer-defined metadata rather than a fixed list.
+Discovery: Creatio UI source at `e8c0882bea89923e493c8476f1ecc177c7c22bd1` resolves nested `@event` expressions, passes Angular Elements output payloads through `event.detail`, and marks `$initialEvent` deprecated in favor of event binding expressions. One configured output creates one request binding, so duplicate invocation remains unconfirmed without a reproducible page/component/version.
+Files: clio/Command/McpServer/Tools/RequestInfoTool.cs, clio/Command/McpServer/Tools/RequestInfoCatalog.cs, clio/Command/McpServer/Tools/ToolContractGetTool.cs, clio.tests/Command/McpServer/RequestInfoToolTests.cs, clio.mcp.e2e/RequestInfoToolE2ETests.cs, clio.tests/Command/McpServer/Fixtures/curated-knowledge-names.json
+Impact: Agents receive the current producer-owned BaseRequest surface including deprecation metadata, while the canonical guidance teaches payload binding without relying on deprecated `$initialEvent` access.
+
+## 2026-08-21 01:31 – GH #1139 close review coverage gaps
+Context: The comprehensive pre-PR review found that tests covered the curated tool contract but not the native `tools/list` description, and the first guidance draft retained an explicitly excluded generic payload guard.
+Decision: Pin the exact producer-driven wording on both MCP discovery surfaces, assert `$initialEvent` metadata from the checked-in producer snapshot, add Allure steps to the changed E2E paths, and remove the unproven guard from clio-knowledge.
+Discovery: Synthetic request-registry fixtures alone cannot protect the live producer evidence boundary; the pinned snapshot must assert the deprecation flag and reason directly.
+Files: clio.tests/Command/McpServer/RequestRegistrySnapshotTests.cs, clio.tests/Command/McpServer/RequestInfoToolTests.cs, clio.mcp.e2e/RequestInfoToolE2ETests.cs, clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+Impact: A stale fixed BaseRequest list now fails unit and wire-level discovery tests, and the published guidance contains only behavior established by Creatio source.

--- a/clio.mcp.e2e/RequestInfoToolE2ETests.cs
+++ b/clio.mcp.e2e/RequestInfoToolE2ETests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -6,6 +7,7 @@ using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
+using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 
 namespace Clio.Mcp.E2E;
@@ -54,7 +56,8 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 	  ],
 	  "references": {
 	    "baseParameters": {
-	      "$context": { "type": "ViewModelContext", "description": "Platform-injected view-model context." }
+	      "$context": { "type": "ViewModelContext", "description": "Platform-injected view-model context." },
+	      "$initialEvent": { "type": "unknown", "description": "The original UI event.", "deprecated": true, "deprecationReason": "use event binding expression instead." }
 	    },
 	    "typeDefinitions": {
 	      "RequestBindingConfig": {
@@ -145,21 +148,36 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 	}
 
 	[Test]
-	[Description("get-request-info is registered as a resident core tool and reachable on the MCP surface of a default install.")]
+	[Description("tools/list publishes get-request-info as a resident core tool with producer-driven BaseRequest and deprecation guidance.")]
 	[AllureTag(ToolName)]
-	[AllureName("get-request-info is reachable on the default MCP surface")]
-	[AllureDescription("Starts the real clio MCP server and verifies get-request-info is reachable.")]
-	public async Task RequestInfoTool_Should_Be_Reachable() {
+	[AllureName("get-request-info is resident with producer-driven discovery guidance")]
+	[AllureDescription("Starts the real clio MCP server and verifies tools/list publishes get-request-info plus producer-driven BaseRequest and deprecation metadata guidance without the stale fixed field list.")]
+	public async Task RequestInfoTool_Should_Be_Reachable_With_Producer_Driven_Description_When_Tools_Are_Listed() {
 		// Arrange
-		await using var context = Arrange();
+		await using var context = AllureApi.Step("Arrange a real MCP server session", () => Arrange());
 
 		// Act
-		IReadOnlyCollection<string> toolNames =
-			await context.Session.ListReachableToolNamesAsync(context.CancellationTokenSource.Token);
+		IList<McpClientTool> tools = await AllureApi.Step(
+			"Act by listing native MCP tools",
+			async () => await context.Session.ListToolsAsync(context.CancellationTokenSource.Token));
 
 		// Assert
-		toolNames.Should().Contain(ToolName,
-			because: "the request catalog is a resident core tool and must always register on the MCP surface");
+		AllureApi.Step("Assert get-request-info is resident", () =>
+			tools.Select(item => item.Name).Should().Contain(ToolName,
+				because: "the request catalog is a resident core tool and must always register on the MCP surface"));
+		McpClientTool tool = AllureApi.Step(
+			"Select the native get-request-info definition",
+			() => tools.Single(item => item.Name == ToolName));
+		AllureApi.Step("Assert native discovery describes producer-driven base parameters", () =>
+			tool.Description.Should().Contain(
+				"'baseParameters' publishes the current BaseRequest fields and their producer metadata",
+				because: "the live MCP description must follow the producer catalog instead of a fixed field list"));
+		AllureApi.Step("Assert native discovery explains producer deprecation metadata", () =>
+			tool.Description.Should().Contain("deprecated/deprecationReason",
+				because: "agents must know how to recognize and honor deprecation metadata on published base parameters"));
+		AllureApi.Step("Assert native discovery omits the stale BaseRequest field list", () =>
+			tool.Description.Should().NotContain("($context, scopes, type)",
+				because: "the actual tools/list surface must not reintroduce the stale fixed enumeration"));
 	}
 
 	[Test]
@@ -284,41 +302,65 @@ public sealed class RequestInfoToolE2ETests : McpContractFixtureBase {
 	}
 
 	[Test]
-	[Description("Detail mode over the wire surfaces the authorable parameters map (explicitly empty for the parameterless pilot request) and keeps the platform-injected baseParameters separate, with the RequestBindingConfig wiring contract inlined.")]
+	[Description("Detail mode over the wire surfaces the explicitly empty authorable parameters map, keeps producer-defined baseParameters separate, preserves their deprecation metadata, and inlines the RequestBindingConfig wiring contract.")]
 	[AllureTag(ToolName)]
 	[AllureName("get-request-info returns a detail with separate baseParameters over the wire")]
-	[AllureDescription("Requests crt.ClosePageRequest detail against the local registry fixture and verifies the empty parameters map, the separate baseParameters block, and the inlined wiring type definition.")]
+	[AllureDescription("Requests crt.ClosePageRequest detail against the local registry fixture and verifies the empty parameters map, separate producer-defined baseParameters with deprecation metadata, and the inlined wiring type definition.")]
 	public async Task RequestInfoTool_Should_Return_Detail_With_Separate_BaseParameters_When_Type_Is_Known() {
 		// Arrange
-		await using var context = Arrange();
+		await using var context = AllureApi.Step("Arrange a request-registry MCP session", () => Arrange());
 
 		// Act
-		RequestInfoResponse response = await CallRequestInfoAsync(
-			context.Session,
-			context.CancellationTokenSource.Token,
-			new Dictionary<string, object?> { ["request-type"] = "crt.ClosePageRequest" });
+		RequestInfoResponse response = await AllureApi.Step(
+			"Act by requesting crt.ClosePageRequest detail",
+			async () => await CallRequestInfoAsync(
+				context.Session,
+				context.CancellationTokenSource.Token,
+				new Dictionary<string, object?> { ["request-type"] = "crt.ClosePageRequest" }));
 
 		// Assert
-		response.Success.Should().BeTrue(
-			because: "crt.ClosePageRequest exists in the fixture registry");
-		response.Mode.Should().Be("detail",
-			because: "a known request type selects detail mode");
-		response.RequestType.Should().Be("crt.ClosePageRequest",
-			because: "the detail response echoes the requested type");
-		response.Parameters.Should().NotBeNull(
-			because: "the explicitly empty parameters map must survive the wire — it means 'accepts no parameters'");
-		response.Parameters.Should().BeEmpty(
-			because: "crt.ClosePageRequest accepts no authorable parameters");
-		response.BaseParameters.Should().NotBeNull(
-			because: "the registry publishes root references.baseParameters");
-		response.BaseParameters!.Should().ContainKey("$context",
-			because: "the platform-injected context field is part of the published base surface");
-		response.Parameters.Should().NotContainKey("$context",
-			because: "baseParameters must never merge into the authorable parameters map");
-		response.References.Should().NotBeNull(
-			because: "the wiring contract is reachable from the closure seed");
-		response.References!.TypeDefinitions.Should().ContainKey("RequestBindingConfig",
-			because: "every request is wired through RequestBindingConfig, so the detail inlines its schema");
+		AllureApi.Step("Assert the request detail succeeded", () =>
+			response.Success.Should().BeTrue(
+				because: "crt.ClosePageRequest exists in the fixture registry"));
+		AllureApi.Step("Assert the response is detail mode", () =>
+			response.Mode.Should().Be("detail", because: "a known request type selects detail mode"));
+		AllureApi.Step("Assert the requested type is echoed", () =>
+			response.RequestType.Should().Be("crt.ClosePageRequest",
+				because: "the detail response echoes the requested type"));
+		AllureApi.Step("Assert the authorable parameters map is present", () =>
+			response.Parameters.Should().NotBeNull(
+				because: "the explicitly empty parameters map must survive the wire — it means 'accepts no parameters'"));
+		AllureApi.Step("Assert the request has no authorable parameters", () =>
+			response.Parameters.Should().BeEmpty(
+				because: "crt.ClosePageRequest accepts no authorable parameters"));
+		AllureApi.Step("Assert producer base parameters are separate", () =>
+			response.BaseParameters.Should().NotBeNull(
+				because: "the registry publishes root references.baseParameters"));
+		AllureApi.Step("Assert the context base parameter is published", () =>
+			response.BaseParameters!.Should().ContainKey("$context",
+				because: "the platform-injected context field is part of the published base surface"));
+		AllureApi.Step("Assert the initial-event base parameter is published", () =>
+			response.BaseParameters!.Should().ContainKey("$initialEvent",
+				because: "the MCP response must carry newly published BaseRequest fields without a Clio code change"));
+		AllureApi.Step("Assert initial-event deprecation metadata survives the wire", () =>
+			response.BaseParameters!["$initialEvent"].GetProperty("deprecated").GetBoolean().Should().BeTrue(
+				because: "producer deprecation metadata must survive the MCP wire format"));
+		AllureApi.Step("Assert the producer's initial-event replacement guidance survives the wire", () =>
+			response.BaseParameters!["$initialEvent"].GetProperty("deprecationReason").GetString().Should()
+				.Be("use event binding expression instead.",
+					because: "the MCP response must retain the producer's replacement guidance"));
+		AllureApi.Step("Assert context does not become authorable", () =>
+			response.Parameters.Should().NotContainKey("$context",
+				because: "baseParameters must never merge into the authorable parameters map"));
+		AllureApi.Step("Assert deprecated initial event does not become authorable", () =>
+			response.Parameters.Should().NotContainKey("$initialEvent",
+				because: "deprecated BaseRequest fields are still platform-injected rather than authorable params"));
+		AllureApi.Step("Assert wiring references are included", () =>
+			response.References.Should().NotBeNull(
+				because: "the wiring contract is reachable from the closure seed"));
+		AllureApi.Step("Assert RequestBindingConfig is inlined", () =>
+			response.References!.TypeDefinitions.Should().ContainKey("RequestBindingConfig",
+				because: "every request is wired through RequestBindingConfig, so the detail inlines its schema"));
 	}
 
 	[Test]

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -1,4 +1,5 @@
 using System;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
@@ -1075,6 +1076,58 @@ public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 			precondition => precondition.Contains("postpone", StringComparison.Ordinal)
 				&& precondition.Contains("standing consent", StringComparison.Ordinal),
 			because: "the real MCP server must advertise the ENG-93157 proceed/postpone confirmation invariant, including that a repeated request is not standing consent");
+	}
+
+	[Test]
+	[Description("The live get-request-info contract describes baseParameters as producer-defined metadata without hard-coding a BaseRequest field list.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract keeps request base parameters producer-driven")]
+	[AllureDescription("Requests the get-request-info contract from the live MCP server and verifies its baseParameters description follows the producer catalog rather than naming a fixed BaseRequest field set.")]
+	public async Task ToolContractGet_Should_Keep_Request_BaseParameters_Producer_Driven_When_Contract_Is_Requested() {
+		// Arrange
+		await using var context = AllureApi.Step(
+			"Arrange a real MCP server session",
+			() => Arrange(TimeSpan.FromMinutes(3)));
+
+		// Act
+		ToolContractGetResponse response = await AllureApi.Step(
+			"Act by requesting the get-request-info contract",
+			async () => await CallAsync(
+				context.Session,
+				context.CancellationTokenSource.Token,
+				new Dictionary<string, object?> {
+					["tool-names"] = new[] { RequestInfoTool.ToolName }
+				}));
+
+		// Assert
+		AllureApi.Step("Assert the contract request succeeded", () =>
+			response.Success.Should().BeTrue(
+				because: "the live MCP server should expose the curated get-request-info contract"));
+		ToolContractDefinition contract = AllureApi.Step(
+			"Assert the requested contract is returned",
+			() => {
+				response.Tools.Should().ContainSingle(
+					because: "only get-request-info was requested");
+				return response.Tools!.Single();
+			});
+		ToolContractField baseParameters = AllureApi.Step(
+			"Assert the baseParameters output field is present",
+			() => contract.OutputContract.Fields.Single(field => field.Name == "baseParameters"));
+		AllureApi.Step("Assert the baseParameters description is producer-driven", () =>
+			baseParameters.Description.Should().Contain("Current BaseRequest fields and producer metadata",
+				because: "the live contract must describe a producer-driven field surface instead of a fixed list"));
+		AllureApi.Step("Assert the baseParameters description explains deprecation metadata", () =>
+			baseParameters.Description.Should().Contain("deprecated/deprecationReason",
+				because: "the live contract must tell agents to honor producer deprecation metadata"));
+		AllureApi.Step("Assert the baseParameters description requires honoring deprecations", () =>
+			baseParameters.Description.Should().Contain("honor that guidance",
+				because: "the live contract must turn producer deprecation metadata into an agent action"));
+		AllureApi.Step("Assert the baseParameters description forbids authoring platform fields", () =>
+			baseParameters.Description.Should().Contain("must NEVER be passed via params",
+				because: "producer-owned BaseRequest fields are not authorable request parameters"));
+		AllureApi.Step("Assert the baseParameters description omits known producer field names", () =>
+			baseParameters.Description.Should().NotContainAny(["$context", "scopes", "$initialEvent"],
+				because: "the served contract must not restore a fixed list of producer fields"));
 	}
 
 	private static async Task<ToolContractGetResponse> CallAsync(

--- a/clio.tests/Command/McpServer/Fixtures/curated-knowledge-names.json
+++ b/clio.tests/Command/McpServer/Fixtures/curated-knowledge-names.json
@@ -1,7 +1,7 @@
 {
   "library": "com.creatio.clio",
-  "libraryVersion": "1.13.34",
-  "sequence": 1013034000,
+  "libraryVersion": "1.13.36",
+  "sequence": 1013036000,
   "availableNames": [
     "agent-execution",
     "app-modeling",

--- a/clio.tests/Command/McpServer/RequestInfoToolTests.cs
+++ b/clio.tests/Command/McpServer/RequestInfoToolTests.cs
@@ -47,7 +47,8 @@ public sealed class RequestInfoToolTests {
 	    "baseParameters": {
 	      "$context": { "type": "ViewModelContext", "description": "Platform-injected view-model context." },
 	      "scopes": { "type": "array", "items": { "type": "string" }, "description": "Platform-populated scope chain." },
-	      "type": { "type": "string", "description": "Request type discriminator." }
+	      "type": { "type": "string", "description": "Request type discriminator." },
+	      "$initialEvent": { "type": "unknown", "description": "The original UI event.", "deprecated": true, "deprecationReason": "use event binding expression instead." }
 	    },
 	    "typeDefinitions": {
 	      "RequestBindingConfig": {
@@ -101,6 +102,28 @@ public sealed class RequestInfoToolTests {
 	  }
 	}
 	""";
+
+	[Test]
+	[Description("The native get-request-info MCP description keeps BaseRequest fields producer-driven instead of publishing a stale fixed list.")]
+	public void GetRequestInfo_Description_ShouldKeepBaseParametersProducerDriven_WhenToolIsDiscovered() {
+		// Arrange
+		System.Reflection.MethodInfo method = typeof(RequestInfoTool).GetMethod(nameof(RequestInfoTool.GetRequestInfo))!;
+
+		// Act
+		string description = method.GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false)
+			.Cast<System.ComponentModel.DescriptionAttribute>()
+			.Single()
+			.Description;
+
+		// Assert
+		description.Should().Contain(
+			"'baseParameters' publishes the current BaseRequest fields and their producer metadata",
+			because: "native MCP discovery must tell agents that the field surface follows the producer catalog");
+		description.Should().Contain("deprecated/deprecationReason",
+			because: "native discovery must tell agents how to recognize and honor producer deprecation metadata");
+		description.Should().NotContain("($context, scopes, type)",
+			because: "a fixed BaseRequest field list drifts when the producer adds or deprecates fields");
+	}
 
 	[Test]
 	[Description("Omitting request-type returns list mode with every cataloged request, ordered alphabetically, and honest latest-fallback version markers on a bare call.")]
@@ -185,7 +208,7 @@ public sealed class RequestInfoToolTests {
 	}
 
 	[Test]
-	[Description("baseParameters are surfaced as a SEPARATE field and never merged into parameters — $context/scopes/type are platform-injected, and merging would teach an AI consumer to author them via the binding's params block. This is a deliberate divergence from the component catalog's baseInputs merge.")]
+	[Description("Producer-defined baseParameters and their metadata are surfaced as a SEPARATE field and never merged into parameters, because merging would teach an AI consumer to author platform-injected values through the binding's params block.")]
 	public async Task GetRequestInfo_ShouldSurfaceBaseParametersSeparately_WhenGlobalReferencesArePublished() {
 		// Arrange
 		RequestInfoTool tool = CreateTool();
@@ -198,10 +221,19 @@ public sealed class RequestInfoToolTests {
 			because: "the registry publishes root references.baseParameters");
 		response.BaseParameters!.Should().ContainKey("$context",
 			because: "the platform-injected context field must be visible for handler-authoring context");
+		response.BaseParameters.Should().ContainKey("$initialEvent",
+			because: "the response must follow the producer's current BaseRequest surface instead of a hard-coded field list");
+		response.BaseParameters["$initialEvent"].GetProperty("deprecated").GetBoolean().Should().BeTrue(
+			because: "the producer marks $initialEvent as deprecated and consumers need that metadata");
+		response.BaseParameters["$initialEvent"].GetProperty("deprecationReason").GetString().Should()
+			.Be("use event binding expression instead.",
+				because: "the response must preserve the producer's replacement guidance verbatim");
 		response.Parameters.Should().NotContainKey("$context",
 			because: "baseParameters must NOT merge into parameters — the request accepts no authorable params");
 		response.Parameters.Should().NotContainKey("scopes",
 			because: "platform-populated fields never belong to the authorable parameters surface");
+		response.Parameters.Should().NotContainKey("$initialEvent",
+			because: "even deprecated BaseRequest fields remain platform-injected rather than authorable params");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/RequestRegistrySnapshotTests.cs
+++ b/clio.tests/Command/McpServer/RequestRegistrySnapshotTests.cs
@@ -89,8 +89,17 @@ public sealed class RequestRegistrySnapshotTests {
 			because: "root.references.baseParameters must surface as its own field");
 		detail.BaseParameters!.Should().ContainKey("$context",
 			because: "the platform-injected context is part of the published base surface");
+		detail.BaseParameters.Should().ContainKey("$initialEvent",
+			because: "the pinned producer snapshot publishes the deprecated initial event on BaseRequest");
+		detail.BaseParameters["$initialEvent"].GetProperty("deprecated").GetBoolean().Should().BeTrue(
+			because: "the detail response must preserve the producer's deprecation metadata");
+		detail.BaseParameters["$initialEvent"].GetProperty("deprecationReason").GetString().Should()
+			.Be("use event binding expression instead.",
+				because: "the pinned producer snapshot directs consumers to event binding expressions");
 		detail.Parameters.Should().NotContainKey("$context",
 			because: "platform-injected fields must never leak into the authorable parameters map");
+		detail.Parameters.Should().NotContainKey("$initialEvent",
+			because: "deprecated BaseRequest fields remain platform-injected rather than authorable parameters");
 
 		// Assert — wiring contract inlined via the closure seed.
 		detail.References.Should().NotBeNull(

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -2618,6 +2618,17 @@ public sealed class ToolContractGetToolTests {
 		contract.OutputContract.Fields.Should().Contain(field => field.Name == "parameters"
 				&& field.Description.Contains("valueSource", StringComparison.Ordinal),
 			because: "the parameters field must explain the valueSource probe annotation so an agent fills environment-dependent values from the named probe, never from memory");
+		ToolContractField baseParameters = contract.OutputContract.Fields.Single(field => field.Name == "baseParameters");
+		baseParameters.Description.Should().Contain("Current BaseRequest fields and producer metadata",
+			because: "the contract must describe a producer-driven field surface instead of a fixed BaseRequest list");
+		baseParameters.Description.Should().Contain("deprecated/deprecationReason",
+			because: "the contract must tell agents to honor producer deprecation metadata");
+		baseParameters.Description.Should().Contain("honor that guidance",
+			because: "publishing deprecation keys is insufficient unless the contract tells agents to act on them");
+		baseParameters.Description.Should().Contain("must NEVER be passed via params",
+			because: "producer-owned BaseRequest fields are not part of the authorable request surface");
+		baseParameters.Description.Should().NotContainAny(["$context", "scopes", "$initialEvent"],
+			because: "the contract prose must not restore a fixed list of known producer fields");
 		contract.AntiPatterns.Should().NotBeNullOrEmpty(
 			because: "the contract must carry anti-patterns steering agents away from inventing request names and values");
 		contract.AntiPatterns!.Should().Contain(pattern =>

--- a/clio.tests/Command/McpServer/WorkspaceTemplateGuidanceDriftTests.cs
+++ b/clio.tests/Command/McpServer/WorkspaceTemplateGuidanceDriftTests.cs
@@ -247,8 +247,8 @@ public sealed class WorkspaceTemplateGuidanceDriftTests {
 	/// resolves a bare name against that role alone, so reference articles are reachable by URI only.
 	/// Guidance content lives in clio-knowledge, so this fixture — not a compiled catalog — is what a
 	/// unit test can check shipped templates against without network access. Regenerate it from that
-	/// repository's <c>bundle-source.json</c> (currently tracking library version 1.13.34,
-	/// sequence 1013034000)
+	/// repository's <c>bundle-source.json</c> (currently tracking library version 1.13.36,
+	/// sequence 1013036000)
 	/// whenever the curated library publishes a new generation. A generation that only edits article
 	/// bodies leaves the name arrays untouched; refresh the recorded version and sequence anyway, so
 	/// the fixture states which generation it was checked against.

--- a/clio/Command/McpServer/AGENTS.md
+++ b/clio/Command/McpServer/AGENTS.md
@@ -363,10 +363,11 @@ Consumer rules that differ from the component catalog — do not "unify" them aw
 
 - **`baseParameters` are NOT merged into `parameters`.** The component catalog
   merges `baseInputs` into `inputs` because base inputs are authorable. The request
-  catalog's base fields (`$context`, `scopes`, `type`) are platform-injected at
-  dispatch time; merging them would teach an AI consumer to pass them through the
-  binding's `params` block. `RequestInfoTool.CreateDetailResponse` surfaces them as
-  a SEPARATE `baseParameters` response field instead.
+  catalog producer publishes the current BaseRequest field names and metadata; those
+  fields are platform-injected at dispatch time, so merging them would teach an AI
+  consumer to pass them through the binding's `params` block.
+  `RequestInfoTool.CreateDetailResponse` surfaces them as a SEPARATE
+  `baseParameters` response field instead.
 - **An empty `parameters` map is meaningful and stays on the wire.** It says "this
   request accepts NO parameters" (e.g. `crt.ClosePageRequest`); absence of the field
   would read as "unknown".

--- a/clio/Command/McpServer/Tools/RequestInfoCatalog.cs
+++ b/clio/Command/McpServer/Tools/RequestInfoCatalog.cs
@@ -305,9 +305,9 @@ public sealed class RequestReferences {
 /// </summary>
 public sealed class RequestGlobalReferences {
 	/// <summary>
-	/// Gets or sets the fields every request inherits from <c>BaseRequest</c>
-	/// (<c>type</c>, <c>$context</c>, <c>scopes</c>, …). These are platform-injected at
-	/// dispatch time — a page schema never sets them through the binding's <c>params</c>
+	/// Gets or sets the producer-defined fields and metadata every request inherits from
+	/// <c>BaseRequest</c>. These are platform-injected at dispatch time — a page schema
+	/// never sets them through the binding's <c>params</c>
 	/// block, so unlike the component registry's <c>baseInputs</c> they are surfaced as a
 	/// SEPARATE <c>baseParameters</c> field on the detail response instead of being
 	/// merged into <c>parameters</c>. Merging would teach an AI consumer to author

--- a/clio/Command/McpServer/Tools/RequestInfoTool.cs
+++ b/clio/Command/McpServer/Tools/RequestInfoTool.cs
@@ -89,7 +89,7 @@ public sealed class RequestInfoTool(
 		"PROACTIVELY list the catalog (omit request-type, or pass 'list') before wiring a button/menu action to a platform request, " +
 		"so the request name and its params come from the catalog instead of memory. " +
 		"Detail responses carry 'parameters' — the ONLY keys a page schema may pass via the binding's params block; an EMPTY parameters map means the request accepts NO parameters, do not invent any. " +
-		"'baseParameters' are fields every request inherits from BaseRequest ($context, scopes, type) — they are platform-injected at dispatch time and must NEVER be passed via params. " +
+		"'baseParameters' publishes the current BaseRequest fields and their producer metadata, including deprecated/deprecationReason when applicable — honor that guidance; these fields are platform-injected at dispatch time and must NEVER be passed via params. " +
 		"'documentation' carries the authoring recipe (canonical wiring, pitfalls, checklist) when the producer published one. " +
 		"IMPORTANT: pass environment-name to scope the catalog to the target environment's actual platform version — " +
 		"otherwise results come from the 'latest' catalog, a SUPERSET of every GA version, and may list requests that do NOT exist in that environment. " +
@@ -217,8 +217,8 @@ public sealed class RequestInfoTool(
 	/// <summary>
 	/// Builds the detail response for a catalog hit. Unlike the component catalog's
 	/// <c>baseInputs</c> — which are authorable and therefore merged flat into
-	/// <c>inputs</c> — the request catalog's <c>baseParameters</c> are platform-injected
-	/// (<c>$context</c>, <c>scopes</c>, <c>type</c>) and are surfaced as a SEPARATE field,
+	/// <c>inputs</c> — the request catalog's producer-defined <c>baseParameters</c> are
+	/// platform-injected and surfaced with their metadata as a SEPARATE field,
 	/// so an AI consumer never learns to author them through the binding's <c>params</c>.
 	/// </summary>
 	internal static RequestInfoResponse CreateDetailResponse(
@@ -515,9 +515,9 @@ public sealed class RequestInfoResponse {
 	public IReadOnlyDictionary<string, JsonElement>? Parameters { get; init; }
 
 	/// <summary>
-	/// Gets or sets the fields every request inherits from <c>BaseRequest</c>
-	/// (<c>type</c>, <c>$context</c>, <c>scopes</c>, …). Platform-injected at dispatch
-	/// time — NEVER authored through the binding's <c>params</c>, which is why they are
+	/// Gets or sets the producer-defined fields and metadata every request inherits from
+	/// <c>BaseRequest</c>. Platform-injected at dispatch time — NEVER authored through the
+	/// binding's <c>params</c>, which is why they are
 	/// NOT merged into <see cref="Parameters"/> (the component catalog merges its
 	/// authorable <c>baseInputs</c>; this catalog deliberately does not).
 	/// </summary>

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -4645,7 +4645,7 @@ internal static class ToolContractCatalog {
 				Field("items", ArrayType, "Flat list-mode request summaries, each with requestType and an optional description."),
 				Field("requestType", StringType, "Request type echoed back in detail mode."),
 				Field("parameters", ObjectType, "The ONLY keys a page schema may pass via the binding's params block. An EMPTY map means the request accepts NO parameters — do not invent any. A parameter may carry a valueSource annotation ({kind:'environment', tool:'<probe>'}): fill that value ONLY from the named probe tool's result (e.g. templateId -> list-printables, processName -> get-process-signature)."),
-				Field("baseParameters", ObjectType, "Fields every request inherits from BaseRequest ($context, scopes, type) — platform-injected at dispatch time; NEVER pass them via params."),
+				Field("baseParameters", ObjectType, "Current BaseRequest fields and producer metadata, including deprecated/deprecationReason when applicable — honor that guidance; these fields are platform-injected at dispatch time and must NEVER be passed via params."),
 				Field("documentation", StringType, "Per-request authoring recipe (canonical wiring, pitfalls, checklist) when the producer published one."),
 				Field("resolvedTargetVersion", StringType, "Catalog version the response was filtered against."),
 				Field("resolvedFrom", StringType, "Resolver tier that produced the version: 'environment' (known, exact), 'environment-superset' (known version, approximate catalog — soft caveat), or 'latest-fallback' (version unknown — hard stop)."),


### PR DESCRIPTION
Closes #1139

## Summary
- keep `get-request-info` BaseRequest fields producer-driven instead of publishing a stale fixed list
- tell agents to honor producer `deprecated` / `deprecationReason` metadata while keeping base fields out of authored `params`
- pin the verified clio-knowledge `1.13.36` / sequence `1013036000` generation
- cover the producer snapshot, native `tools/list`, `get-tool-contract`, and request-detail MCP wire surfaces

## Creatio source validation
Validated against `C:\bare\Forest\creatio-ui\master` at `e8c0882bea89923e493c8476f1ecc177c7c22bd1`:
- request parameter binding resolves `@event` and nested paths such as `@event.detail`
- Angular Elements output payloads arrive through `CustomEvent.detail`
- `BaseRequest.$initialEvent` is deprecated in favor of event binding expressions
- one configured component output creates one request binding; duplicate invocation remains unsupported/unconfirmed without a reproducible component, page, and platform version

Canonical guidance was delivered in clio-knowledge PR #81 and verified in release `1.13.36`:
https://github.com/Advance-Technologies-Foundation/clio-knowledge/releases/tag/1.13.36

## Validation
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" --no-build` — 3,659 passed
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~RequestInfoToolE2ETests|FullyQualifiedName~ToolContractGetToolE2ETests"` — 35 passed
- `dotnet test automation/Clio.Knowledge.Bundle.Tests/Clio.Knowledge.Bundle.Tests.csproj -c Release` — 98 passed
- released `clio-knowledge-bundle.zip` SHA-256: `8654a2af4df0c86a8a58d6483d1b3f023a6384118aca21ca7aa00dc2cdc0f9b5`

## Reviews
- comprehensive agentic review: quality, security, performance, testing, and bug/correctness lenses; all findings resolved
- Claude final-diff review: accepted deprecation-metadata signaling and producer-snapshot coverage findings; both resolved
- docs reviewed, no CLI command documentation update required (`get-request-info` has no CLI command twin)
- MCP reviewed and updated: native description, curated contract, unit tests, and no-environment E2E coverage
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`

## KISS check
The intent is to teach the supported output-payload path. The flow remains one output binding, one named request parameter, and one handler field; no duplicate-dispatch workaround or new runtime abstraction was introduced.