### PR TITLE
Fix scenario environment refresh after deploy

### DIFF
--- a/clio.tests/Command/Program.Tests.cs
+++ b/clio.tests/Command/Program.Tests.cs
@@ -102,6 +102,23 @@ public class ProgramTestCase : BaseClioModuleTests
 
 	[Test]
 	[Category("Unit")]
+	[Description("Builds the scenario runner without requiring an active environment before provisioning begins.")]
+	public void Resolve_Should_Not_Throw_For_ScenarioRunner_When_Active_Environment_Key_Is_Invalid() {
+		// Arrange
+		Program.Container = null;
+		AddWrongActiveEnvironmentFixture();
+		ScenarioRunnerOptions options = new() { FileName = "phase1.yaml" };
+
+		// Act
+		Action act = () => Program.Resolve<ScenarioRunnerCommand>(options, false);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "a scenario may deploy and register its first environment before later steps consume it");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Builds the bootstrap container for mcp-server without requiring a valid active environment in appsettings.json.")]
 	public void Resolve_Should_Not_Throw_For_McpServerCommand_When_Active_Environment_Key_Is_Invalid() {
 		// Arrange

--- a/clio.tests/Command/ScenarioRunnerCommandTests.cs
+++ b/clio.tests/Command/ScenarioRunnerCommandTests.cs
@@ -31,6 +31,7 @@ public class ScenarioRunnerCommandTests
 		IScenario script = new Scenario(_deserializer);
 		ILogger logger = Substitute.For<ILogger>();
 		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
 		settingsRepository.FindEnvironment(Arg.Any<string>()).Returns(new EnvironmentSettings {
 			Uri = "http://localhost",
 			Login = "Supervisor",

--- a/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
+++ b/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
@@ -209,6 +209,38 @@ public class ScenarioRunnerEnvironmentRefreshTests : BaseCommandTests<ScenarioRu
 	}
 
 	[Test]
+	[Description("Fails a Safe environment step cleanly and still completes scenario accounting.")]
+	public void Execute_ShouldFailSafeEnvironmentStepWithoutEscapingScenarioLoop() {
+		// Arrange
+		EnvironmentSettings safeEnvironment = new() {
+			Uri = "https://production.example.com",
+			Login = "Supervisor",
+			Password = "Supervisor",
+			Safe = true
+		};
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment(null).Returns(safeEnvironment);
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions { FileName = "YAML/Script/single_restart.yaml" });
+
+		// Assert
+		result.Should().Be(1,
+			because: "non-interactive scenarios must fail closed when a Safe environment needs confirmation");
+		receivedOptions.Should().BeEmpty(
+			because: "the protected command must not run without explicit Safe-environment confirmation");
+		_logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Safe environment confirmation required", StringComparison.Ordinal)));
+		// The runner must reach its terminal log instead of letting the confirmation exception escape.
+		_logger.Received(1).WriteInfo(Arg.Is<string>(message => message.EndsWith("Scenario finished")));
+	}
+
+	[Test]
 	[Description("Uses explicit direct URI credentials without requiring a registered environment refresh.")]
 	public void Execute_ShouldUseDirectUriWithoutReload() {
 		// Arrange

--- a/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
+++ b/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
@@ -1,0 +1,399 @@
+namespace Clio.Tests.Command;
+
+using System;
+using System.Collections.Generic;
+using Clio.Command;
+using Clio.Command.CreatioInstallCommand;
+using Clio.Common;
+using Clio.UserEnvironment;
+using Clio.YAML;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+using YamlDotNet.Serialization;
+
+[TestFixture]
+[NonParallelizable]
+[Property("Module", "Command")]
+public class ScenarioRunnerEnvironmentRefreshTests : BaseCommandTests<ScenarioRunnerOptions> {
+	private const string ScenarioFileName = "YAML/Script/deploy_then_install_gate.yaml";
+	private Func<object, int> _originalExecuteCommandWithOption;
+	private IServiceProvider _originalContainer;
+	private ILogger _logger;
+	private ISettingsRepository _settingsRepository;
+	private ScenarioRunnerCommand _sut;
+
+	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
+		base.AdditionalRegistrations(containerBuilder);
+		containerBuilder.AddSingleton(_logger);
+		containerBuilder.AddSingleton(_settingsRepository);
+		containerBuilder.AddSingleton<IScenario>(new Scenario(new DeserializerBuilder().Build()));
+	}
+
+	public override void Setup() {
+		_logger = Substitute.For<ILogger>();
+		_settingsRepository = Substitute.For<ISettingsRepository>();
+		_originalExecuteCommandWithOption = Program.ExecuteCommandWithOption;
+		_originalContainer = Program.Container;
+		base.Setup();
+		_sut = Container.GetRequiredService<ScenarioRunnerCommand>();
+	}
+
+	public override void TearDown() {
+		Program.ExecuteCommandWithOption = _originalExecuteCommandWithOption;
+		Program.Container = _originalContainer;
+		base.TearDown();
+	}
+
+	[Test]
+	[Description("Reloads settings after deployment and gives the next scenario step the newly registered environment.")]
+	public void Execute_ShouldReloadEnvironmentCreatedByEarlierStep() {
+		// Arrange
+		EnvironmentSettings freshEnvironment = new() {
+			Uri = "https://localhost:40001",
+			Login = "Supervisor",
+			Password = "Supervisor",
+			IsNetCore = true,
+			EnvironmentPath = "C:/Creatio/fresh-environment"
+		};
+		bool settingsReloaded = false;
+		_settingsRepository.Reload().Returns(_ => {
+			settingsReloaded = true;
+			return new SettingsReloadResult(true, null, null);
+		});
+		_settingsRepository.FindEnvironment("fresh-environment")
+			.Returns(_ => settingsReloaded ? freshEnvironment : null);
+		List<object> receivedOptions = [];
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			if (option is InstallGateOptions) {
+				receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			}
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions { FileName = ScenarioFileName });
+
+		// Assert
+		result.Should().Be(0, because: "both scenario steps should execute successfully");
+		receivedOptions.Should().HaveCount(2, because: "deploy-creatio and install-gate should both be dispatched");
+		receivedOptions[0].Should().BeOfType<PfInstallerOptions>(because: "the first step deploys Creatio");
+		receivedOptions[1].Should().BeOfType<InstallGateOptions>(because: "the second step installs cliogate");
+		receivedSettings.Should().BeEquivalentTo(freshEnvironment,
+			because: "the environment-scoped container must use the settings persisted by deployment");
+		_settingsRepository.Received(1).Reload();
+	}
+
+	[Test]
+	[Description("Lets reg-web-app provision a new environment without resolving that environment first.")]
+	public void Execute_ShouldDispatchEnvironmentProvisionerWithoutReload() {
+		// Arrange
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/register_new_environment.yaml"
+		});
+
+		// Assert
+		result.Should().Be(0, because: "reg-web-app must be allowed to create a previously unknown environment");
+		receivedOptions.Should().ContainSingle().Which.Should().BeOfType<RegAppOptions>(
+			because: "the provisioning step must be dispatched without pre-resolution");
+		_settingsRepository.DidNotReceive().Reload();
+		_settingsRepository.DidNotReceive().FindEnvironment(Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Refreshes an explicitly targeted optional environment command after deployment.")]
+	public void Execute_ShouldRefreshOptionalEnvironmentConsumer() {
+		// Arrange
+		EnvironmentSettings freshEnvironment = new() {
+			Uri = "https://localhost:40001",
+			Login = "Supervisor",
+			Password = "Supervisor",
+			IsNetCore = true,
+			EnvironmentPath = "C:/Creatio/fresh-environment"
+		};
+		bool settingsReloaded = false;
+		_settingsRepository.Reload().Returns(_ => {
+			settingsReloaded = true;
+			return new SettingsReloadResult(true, null, null);
+		});
+		_settingsRepository.FindEnvironment("fresh-environment")
+			.Returns(_ => settingsReloaded ? freshEnvironment : null);
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = option => {
+			if (option is Link4RepoOptions) {
+				receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			}
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/deploy_then_link_repository.yaml"
+		});
+
+		// Assert
+		result.Should().Be(0, because: "the explicitly targeted optional command should resolve after deployment");
+		receivedSettings.Should().BeEquivalentTo(freshEnvironment,
+			because: "l4r services must be scoped to the newly deployed environment");
+		_settingsRepository.Received(1).Reload();
+	}
+
+	[Test]
+	[Description("Applies the scenario-level environment to a step that omits its own target.")]
+	public void Execute_ShouldInheritScenarioEnvironment() {
+		// Arrange
+		EnvironmentSettings inheritedEnvironment = new() {
+			Uri = "https://localhost:40003",
+			Login = "Supervisor",
+			Password = "Supervisor"
+		};
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment("inherited-environment").Returns(inheritedEnvironment);
+		EnvironmentOptions receivedOptions = null;
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions = (EnvironmentOptions)option;
+			receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/single_restart.yaml",
+			Environment = "inherited-environment"
+		});
+
+		// Assert
+		result.Should().Be(0, because: "the scenario default names a registered environment");
+		receivedOptions.Environment.Should().Be("inherited-environment",
+			because: "the step should inherit the scenario-level environment name");
+		receivedSettings.Uri.Should().Be(inheritedEnvironment.Uri,
+			because: "the step container must use the inherited environment");
+	}
+
+	[Test]
+	[Description("Refreshes and resolves the active environment when neither the step nor scenario names one.")]
+	public void Execute_ShouldResolveActiveEnvironment() {
+		// Arrange
+		EnvironmentSettings activeEnvironment = new() {
+			Uri = "https://localhost:40004",
+			Login = "Supervisor",
+			Password = "Supervisor"
+		};
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment(null).Returns(activeEnvironment);
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = _ => {
+			receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions { FileName = "YAML/Script/single_restart.yaml" });
+
+		// Assert
+		result.Should().Be(0, because: "a configured active environment satisfies the required step");
+		receivedSettings.Uri.Should().Be(activeEnvironment.Uri,
+			because: "the step container must use the refreshed active environment");
+		_settingsRepository.Received(1).FindEnvironment(null);
+	}
+
+	[Test]
+	[Description("Uses explicit direct URI credentials without requiring a registered environment refresh.")]
+	public void Execute_ShouldUseDirectUriWithoutReload() {
+		// Arrange
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = _ => {
+			receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/direct_uri_restart.yaml",
+			Environment = "scenario-default"
+		});
+
+		// Assert
+		result.Should().Be(0, because: "a direct URI supplies a complete target without registration");
+		receivedSettings.Uri.Should().Be("https://localhost:40002",
+			because: "the direct URI should be preserved in the step container");
+		receivedSettings.Login.Should().Be("Supervisor",
+			because: "the direct credentials should be preserved in the step container");
+		_settingsRepository.DidNotReceive().Reload();
+	}
+
+	[Test]
+	[Description("Rejects a step that combines a named environment with a direct URI.")]
+	public void Execute_ShouldRejectNamedEnvironmentWithDirectUri() {
+		// Arrange
+		EnvironmentSettings storedEnvironment = new() {
+			Uri = "https://localhost:40005",
+			Login = "Supervisor",
+			Password = "stored-password"
+		};
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment("stored-environment").Returns(storedEnvironment);
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/named_environment_with_uri.yaml"
+		});
+
+		// Assert
+		result.Should().Be(1, because: "the step has two conflicting target identities");
+		receivedOptions.Should().BeEmpty(
+			because: "an ambiguous target must not reach command dispatch with stored credentials");
+		_logger.Received(1).WriteError(
+			"A scenario step cannot combine a named environment with a direct application or authentication URI.");
+		_settingsRepository.DidNotReceive().Reload();
+	}
+
+	[Test]
+	[Description("Rejects an authentication endpoint override for a named OAuth environment.")]
+	public void Execute_ShouldRejectNamedEnvironmentWithAuthenticationUri() {
+		// Arrange
+		EnvironmentSettings storedEnvironment = new() {
+			Uri = "https://localhost:40005",
+			ClientId = "stored-client",
+			ClientSecret = "stored-secret",
+			AuthAppUri = "https://localhost:40006/connect/token"
+		};
+		_settingsRepository.FindEnvironment("stored-environment").Returns(storedEnvironment);
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/named_environment_with_auth_uri.yaml"
+		});
+
+		// Assert
+		result.Should().Be(1, because: "the authentication endpoint conflicts with the named target identity");
+		receivedOptions.Should().BeEmpty(
+			because: "stored OAuth credentials must not be dispatched toward an overridden token endpoint");
+		_logger.Received(1).WriteError(
+			"A scenario step cannot combine a named environment with a direct application or authentication URI.");
+		_settingsRepository.DidNotReceive().Reload();
+	}
+
+	[Test]
+	[Description("Rejects a direct authentication endpoint that omits its direct application endpoint.")]
+	public void Execute_ShouldRejectIncompleteDirectOAuthTarget() {
+		// Arrange
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/auth_uri_without_application_uri.yaml"
+		});
+
+		// Assert
+		result.Should().Be(1, because: "a token endpoint alone does not identify the Creatio application");
+		receivedOptions.Should().BeEmpty(because: "an incomplete direct target must not reach command dispatch");
+		_logger.Received(1).WriteError(
+			"A direct authentication URI requires a direct application URI in the same scenario step.");
+		_settingsRepository.DidNotReceive().Reload();
+	}
+
+	[Test]
+	[Description("Applies non-URI overrides to a named environment without changing its endpoint.")]
+	public void Execute_ShouldApplyNamedEnvironmentOverrides() {
+		// Arrange
+		EnvironmentSettings storedEnvironment = new() {
+			Uri = "https://localhost:40005",
+			Login = "Supervisor",
+			Password = "stored-password"
+		};
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment("stored-environment").Returns(storedEnvironment);
+		EnvironmentSettings receivedSettings = null;
+		Program.ExecuteCommandWithOption = _ => {
+			receivedSettings = Program.Container.GetRequiredService<EnvironmentSettings>();
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/named_environment_with_overrides.yaml"
+		});
+
+		// Assert
+		result.Should().Be(0, because: "the named environment and its overrides form one unambiguous target");
+		receivedSettings.Uri.Should().Be(storedEnvironment.Uri,
+			because: "credential overrides must not change the registered endpoint");
+		receivedSettings.Login.Should().Be("ScenarioUser",
+			because: "named environment steps support explicit login overrides");
+		receivedSettings.Password.Should().Be("scenario-password",
+			because: "named environment steps support explicit password overrides");
+	}
+
+	[Test]
+	[Description("Does not dispatch an environment-dependent scenario step when its named environment is absent after refresh.")]
+	public void Execute_ShouldFailNamedStepWhenEnvironmentIsMissingAfterReload() {
+		// Arrange
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment("fresh-environment").Returns((EnvironmentSettings)null);
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions { FileName = ScenarioFileName });
+
+		// Assert
+		result.Should().Be(1, because: "a missing named environment must fail the scenario");
+		receivedOptions.Should().ContainSingle().Which.Should().BeOfType<PfInstallerOptions>(
+			because: "install-gate must not be dispatched with a fabricated localhost environment");
+		_logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("Environment with key 'fresh-environment' not found.", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Description("Does not dispatch an environment-dependent scenario step when settings cannot be refreshed safely.")]
+	public void Execute_ShouldFailNamedStepWhenSettingsReloadFails() {
+		// Arrange
+		const string warning = "Settings file could not be read.";
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(false, null, warning));
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions { FileName = ScenarioFileName });
+
+		// Assert
+		result.Should().Be(1, because: "an unsafe settings refresh must fail the environment-dependent step");
+		receivedOptions.Should().ContainSingle().Which.Should().BeOfType<PfInstallerOptions>(
+			because: "install-gate must not run against stale or bootstrap settings");
+		_logger.Received(1).WriteWarning(warning);
+		_logger.Received(1).WriteError("Scenario cannot refresh clio settings before an environment-dependent step.");
+		_settingsRepository.DidNotReceive().FindEnvironment(Arg.Any<string>());
+	}
+}

--- a/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
+++ b/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
@@ -47,6 +47,20 @@ public class ScenarioRunnerEnvironmentRefreshTests : BaseCommandTests<ScenarioRu
 	}
 
 	[Test]
+	[Description("Allows a provisioning scenario to start without a registered active environment.")]
+	public void Options_ShouldNotRequireEnvironmentAtTopLevel() {
+		// Arrange
+		ScenarioRunnerOptions options = new();
+
+		// Act
+		bool requiredEnvironment = options.RequiredEnvironment;
+
+		// Assert
+		requiredEnvironment.Should().BeFalse(
+			because: "the scenario itself may deploy and register its first environment");
+	}
+
+	[Test]
 	[Description("Reloads settings after deployment and gives the next scenario step the newly registered environment.")]
 	public void Execute_ShouldReloadEnvironmentCreatedByEarlierStep() {
 		// Arrange

--- a/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
+++ b/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
@@ -149,6 +149,32 @@ public class ScenarioRunnerEnvironmentRefreshTests : BaseCommandTests<ScenarioRu
 	}
 
 	[Test]
+	[Description("Uses the CLI bootstrap fallback when an optional consumer names an environment that is not registered yet.")]
+	public void Execute_ShouldDispatchOptionalConsumerWhenNamedEnvironmentIsMissing() {
+		// Arrange
+		_settingsRepository.Reload().Returns(new SettingsReloadResult(true, null, null));
+		_settingsRepository.FindEnvironment("fresh-environment").Returns((EnvironmentSettings)null);
+		List<object> receivedOptions = [];
+		Program.ExecuteCommandWithOption = option => {
+			receivedOptions.Add(option);
+			return 0;
+		};
+
+		// Act
+		int result = _sut.Execute(new ScenarioRunnerOptions {
+			FileName = "YAML/Script/deploy_then_link_repository.yaml"
+		});
+
+		// Assert
+		result.Should().Be(0,
+			because: "optional environment consumers should retain the same offline fallback as direct CLI dispatch");
+		receivedOptions.Should().Contain(option => option is Link4RepoOptions,
+			because: "l4r can run in its local mode before the named environment is registered");
+		Program.Container.GetRequiredService<EnvironmentSettings>().Login.Should().Be("default",
+			because: "the established CLI fallback uses bootstrap settings for optional commands");
+	}
+
+	[Test]
 	[Description("Applies the scenario-level environment to a step that omits its own target.")]
 	public void Execute_ShouldInheritScenarioEnvironment() {
 		// Arrange

--- a/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
+++ b/clio.tests/Command/ScenarioRunnerEnvironmentRefreshTests.cs
@@ -47,20 +47,6 @@ public class ScenarioRunnerEnvironmentRefreshTests : BaseCommandTests<ScenarioRu
 	}
 
 	[Test]
-	[Description("Allows a provisioning scenario to start without a registered active environment.")]
-	public void Options_ShouldNotRequireEnvironmentAtTopLevel() {
-		// Arrange
-		ScenarioRunnerOptions options = new();
-
-		// Act
-		bool requiredEnvironment = options.RequiredEnvironment;
-
-		// Assert
-		requiredEnvironment.Should().BeFalse(
-			because: "the scenario itself may deploy and register its first environment");
-	}
-
-	[Test]
 	[Description("Reloads settings after deployment and gives the next scenario step the newly registered environment.")]
 	public void Execute_ShouldReloadEnvironmentCreatedByEarlierStep() {
 		// Arrange

--- a/clio.tests/YAML/Script/auth_uri_without_application_uri.yaml
+++ b/clio.tests/YAML/Script/auth_uri_without_application_uri.yaml
@@ -1,0 +1,7 @@
+steps:
+- action: restart
+  description: restart with an incomplete direct OAuth target
+  options:
+    auth-app-uri: "https://untrusted.invalid/connect/token"
+    client-id: explicit-client
+    client-secret: explicit-secret

--- a/clio.tests/YAML/Script/deploy_then_install_gate.yaml
+++ b/clio.tests/YAML/Script/deploy_then_install_gate.yaml
@@ -1,0 +1,11 @@
+steps:
+- action: deploy-creatio
+  description: deploy a fresh environment
+  options:
+    site-name: fresh-environment
+    silent: true
+
+- action: install-gate
+  description: install cliogate into the fresh environment
+  options:
+    Environment: fresh-environment

--- a/clio.tests/YAML/Script/deploy_then_link_repository.yaml
+++ b/clio.tests/YAML/Script/deploy_then_link_repository.yaml
@@ -1,0 +1,13 @@
+steps:
+- action: deploy-creatio
+  description: deploy a fresh environment
+  options:
+    site-name: fresh-environment
+    silent: true
+
+- action: link-from-repository
+  description: link packages to the fresh environment
+  options:
+    repoPath: "."
+    packages: "*"
+    Environment: fresh-environment

--- a/clio.tests/YAML/Script/direct_uri_restart.yaml
+++ b/clio.tests/YAML/Script/direct_uri_restart.yaml
@@ -1,0 +1,7 @@
+steps:
+- action: restart
+  description: restart a direct URI
+  options:
+    uri: "https://localhost:40002"
+    login: Supervisor
+    password: Supervisor

--- a/clio.tests/YAML/Script/named_environment_with_auth_uri.yaml
+++ b/clio.tests/YAML/Script/named_environment_with_auth_uri.yaml
@@ -1,0 +1,6 @@
+steps:
+- action: restart
+  description: restart a named OAuth environment
+  options:
+    Environment: stored-environment
+    auth-app-uri: "https://untrusted.invalid/connect/token"

--- a/clio.tests/YAML/Script/named_environment_with_overrides.yaml
+++ b/clio.tests/YAML/Script/named_environment_with_overrides.yaml
@@ -1,0 +1,7 @@
+steps:
+- action: restart
+  description: restart a named environment with explicit credentials
+  options:
+    Environment: stored-environment
+    login: ScenarioUser
+    password: scenario-password

--- a/clio.tests/YAML/Script/named_environment_with_uri.yaml
+++ b/clio.tests/YAML/Script/named_environment_with_uri.yaml
@@ -1,0 +1,8 @@
+steps:
+- action: restart
+  description: restart a named environment
+  options:
+    Environment: stored-environment
+    uri: "https://untrusted.invalid"
+    login: attacker
+    password: attacker

--- a/clio.tests/YAML/Script/register_new_environment.yaml
+++ b/clio.tests/YAML/Script/register_new_environment.yaml
@@ -1,0 +1,8 @@
+steps:
+- action: reg-web-app
+  description: register a new environment
+  options:
+    e: new-environment
+    u: "https://localhost:40001"
+    p: Supervisor
+    l: Supervisor

--- a/clio.tests/YAML/Script/single_restart.yaml
+++ b/clio.tests/YAML/Script/single_restart.yaml
@@ -1,0 +1,4 @@
+steps:
+- action: restart
+  description: restart the selected environment
+  options: {}

--- a/clio/Command/ScenarioRunnerCommand.cs
+++ b/clio/Command/ScenarioRunnerCommand.cs
@@ -137,7 +137,7 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 		if (baseSettings is not null) {
 			return true;
 		}
-		if (!stepOptions.RequiredEnvironment && !hasNamedEnvironment) {
+		if (!stepOptions.RequiredEnvironment) {
 			baseSettings = new EnvironmentSettings { Login = "default" };
 			return true;
 		}

--- a/clio/Command/ScenarioRunnerCommand.cs
+++ b/clio/Command/ScenarioRunnerCommand.cs
@@ -10,6 +10,8 @@ namespace Clio.Command;
 /// <summary>Options for executing a YAML scenario.</summary>
 [Verb("run", Aliases = ["scenario", "run-scenario"], HelpText = "Run scenario")]
 public class ScenarioRunnerOptions : EnvironmentOptions {
+	internal override bool RequiredEnvironment => false;
+
 	/// <summary>Gets or sets the scenario file path.</summary>
 	[Option("file-name", Required = true, HelpText = "Scenario file name")]
 	public string FileName { get; set; }
@@ -65,43 +67,14 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 	}
 
 	private bool TryConfigureEnvironmentStep(EnvironmentOptions stepOptions, ScenarioRunnerOptions scenarioOptions) {
-		if (string.IsNullOrWhiteSpace(stepOptions.Environment)
-			&& string.IsNullOrWhiteSpace(stepOptions.Uri)
-			&& string.IsNullOrWhiteSpace(stepOptions.AuthAppUri)
-			&& !string.IsNullOrWhiteSpace(scenarioOptions.Environment)) {
-			stepOptions.Environment = scenarioOptions.Environment;
-		}
-
+		ApplyScenarioEnvironmentDefault(stepOptions, scenarioOptions);
 		bool hasNamedEnvironment = !string.IsNullOrWhiteSpace(stepOptions.Environment);
 		bool hasDirectUri = !string.IsNullOrWhiteSpace(stepOptions.Uri);
 		bool hasDirectAuthAppUri = !string.IsNullOrWhiteSpace(stepOptions.AuthAppUri);
-		if (hasNamedEnvironment && (hasDirectUri || hasDirectAuthAppUri)) {
-			_logger.WriteError(AmbiguousEnvironmentTargetMessage);
+		if (!ValidateTargetIdentity(hasNamedEnvironment, hasDirectUri, hasDirectAuthAppUri)
+			|| !TryResolveBaseSettings(stepOptions, hasNamedEnvironment, hasDirectUri,
+				out EnvironmentSettings baseSettings)) {
 			return false;
-		}
-		if (!hasDirectUri && hasDirectAuthAppUri) {
-			_logger.WriteError(IncompleteDirectTargetMessage);
-			return false;
-		}
-		EnvironmentSettings baseSettings;
-		if (!hasNamedEnvironment && hasDirectUri) {
-			baseSettings = new EnvironmentSettings();
-		}
-		else {
-			if (!TryReloadSettings()) {
-				return false;
-			}
-
-			baseSettings = _settingsRepository.FindEnvironment(stepOptions.Environment);
-			if (baseSettings is null) {
-				if (!stepOptions.RequiredEnvironment && !hasNamedEnvironment) {
-					baseSettings = new EnvironmentSettings { Login = "default" };
-				}
-				else {
-					_logger.WriteError(EnvironmentNotFoundError.Build(stepOptions.Environment, _settingsRepository));
-					return false;
-				}
-			}
 		}
 
 		EnvironmentSettings resolvedSettings = baseSettings.Fill(stepOptions, NonInteractiveConsole.Shared);
@@ -113,6 +86,53 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 			NonInteractiveConsole.ForceInContainer);
 		Program.Container = container;
 		return true;
+	}
+
+	private static void ApplyScenarioEnvironmentDefault(EnvironmentOptions stepOptions,
+		ScenarioRunnerOptions scenarioOptions) {
+		if (string.IsNullOrWhiteSpace(stepOptions.Environment)
+			&& string.IsNullOrWhiteSpace(stepOptions.Uri)
+			&& string.IsNullOrWhiteSpace(stepOptions.AuthAppUri)
+			&& !string.IsNullOrWhiteSpace(scenarioOptions.Environment)) {
+			stepOptions.Environment = scenarioOptions.Environment;
+		}
+	}
+
+	private bool ValidateTargetIdentity(bool hasNamedEnvironment, bool hasDirectUri,
+		bool hasDirectAuthAppUri) {
+		if (hasNamedEnvironment && (hasDirectUri || hasDirectAuthAppUri)) {
+			_logger.WriteError(AmbiguousEnvironmentTargetMessage);
+			return false;
+		}
+		if (!hasDirectUri && hasDirectAuthAppUri) {
+			_logger.WriteError(IncompleteDirectTargetMessage);
+			return false;
+		}
+		return true;
+	}
+
+	private bool TryResolveBaseSettings(EnvironmentOptions stepOptions, bool hasNamedEnvironment,
+		bool hasDirectUri, out EnvironmentSettings baseSettings) {
+		if (!hasNamedEnvironment && hasDirectUri) {
+			baseSettings = new EnvironmentSettings();
+			return true;
+		}
+		if (!TryReloadSettings()) {
+			baseSettings = null;
+			return false;
+		}
+
+		baseSettings = _settingsRepository.FindEnvironment(stepOptions.Environment);
+		if (baseSettings is not null) {
+			return true;
+		}
+		if (!stepOptions.RequiredEnvironment && !hasNamedEnvironment) {
+			baseSettings = new EnvironmentSettings { Login = "default" };
+			return true;
+		}
+
+		_logger.WriteError(EnvironmentNotFoundError.Build(stepOptions.Environment, _settingsRepository));
+		return false;
 	}
 
 	private bool TryReloadSettings() {

--- a/clio/Command/ScenarioRunnerCommand.cs
+++ b/clio/Command/ScenarioRunnerCommand.cs
@@ -1,79 +1,130 @@
 using System;
-using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
+using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.UserEnvironment;
 using Clio.YAML;
 using CommandLine;
 
-
 namespace Clio.Command;
 
-[Verb("run", Aliases = ["scenario","run-scenario"], HelpText = "Run scenario")]
-public class ScenarioRunnerOptions : EnvironmentOptions{
-    [Option("file-name", Required = true, HelpText = "Scenario file name")]
-    public string FileName { get; set; }
+/// <summary>Options for executing a YAML scenario.</summary>
+[Verb("run", Aliases = ["scenario", "run-scenario"], HelpText = "Run scenario")]
+public class ScenarioRunnerOptions : EnvironmentOptions {
+	/// <summary>Gets or sets the scenario file path.</summary>
+	[Option("file-name", Required = true, HelpText = "Scenario file name")]
+	public string FileName { get; set; }
 }
 
-public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions>{
-    private readonly ILogger _logger;
-    private readonly IScenario _scenario;
-    private readonly ISettingsRepository _settingsRepository;
+/// <summary>Executes the commands declared in a YAML scenario.</summary>
+public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
+	private const string SettingsReloadFailedMessage =
+		"Scenario cannot refresh clio settings before an environment-dependent step.";
+	private const string AmbiguousEnvironmentTargetMessage =
+		"A scenario step cannot combine a named environment with a direct application or authentication URI.";
+	private const string IncompleteDirectTargetMessage =
+		"A direct authentication URI requires a direct application URI in the same scenario step.";
 
-    public ScenarioRunnerCommand(IScenario scenario, ILogger logger, ISettingsRepository settingsRepository) {
-        _scenario = scenario;
-        _logger = logger;
-        _settingsRepository = settingsRepository;
-    }
+	private readonly ILogger _logger;
+	private readonly IScenario _scenario;
+	private readonly ISettingsRepository _settingsRepository;
 
-    public override int Execute(ScenarioRunnerOptions options) {
-        int result = 0;
-        _logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Scenario started");
+	/// <summary>Initializes a new instance of the <see cref="ScenarioRunnerCommand"/> class.</summary>
+	/// <param name="scenario">Scenario parser and step provider.</param>
+	/// <param name="logger">Command logger.</param>
+	/// <param name="settingsRepository">Repository used to resolve current environments.</param>
+	public ScenarioRunnerCommand(IScenario scenario, ILogger logger, ISettingsRepository settingsRepository) {
+		_scenario = scenario;
+		_logger = logger;
+		_settingsRepository = settingsRepository;
+	}
 
-        _scenario
-            .InitScript(options.FileName)
-            .GetSteps(GetType().Assembly.GetTypes())
-            .ToList()
-            .ForEach(step => {
-                _logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Starting step: {step.StepDescription}");
-                if (step.CommandOption is EnvironmentOptions stepOptions and not RegAppOptions) {
-                    if (!string.IsNullOrWhiteSpace(stepOptions.Environment)) {
-                        EnvironmentSettings settings = _settingsRepository.FindEnvironment(stepOptions.Environment);
-                        // Scenario steps are automation, never a human at the console: force a
-                        // non-interactive console into the step container so a compile step
-                        // (compile-configuration / compile-package) fails OPEN instead of blocking on the
-                        // heavy-operation prompt's Console.ReadKey on an attached TTY (ENG-93157, RC-15).
-                        IServiceProvider container = new BindingsModule().Register(settings, NonInteractiveConsole.ForceInContainer);
-                        Program.Container = container;
-                    }
-                    else if (!string.IsNullOrWhiteSpace(options.Environment)) {
-                        stepOptions.Environment = options.Environment;
-                        EnvironmentSettings settings = _settingsRepository.FindEnvironment(options.Environment);
-                        // Scenario steps are automation, never a human at the console: force a
-                        // non-interactive console into the step container so a compile step
-                        // (compile-configuration / compile-package) fails OPEN instead of blocking on the
-                        // heavy-operation prompt's Console.ReadKey on an attached TTY (ENG-93157, RC-15).
-                        IServiceProvider container = new BindingsModule().Register(settings, NonInteractiveConsole.ForceInContainer);
-                        Program.Container = container;
-                    }
-                    else {
-                        EnvironmentSettings settings = _settingsRepository.FindEnvironment(options.Environment);
-                        // Scenario steps are automation, never a human at the console: force a
-                        // non-interactive console into the step container so a compile step
-                        // (compile-configuration / compile-package) fails OPEN instead of blocking on the
-                        // heavy-operation prompt's Console.ReadKey on an attached TTY (ENG-93157, RC-15).
-                        IServiceProvider container = new BindingsModule().Register(settings, NonInteractiveConsole.ForceInContainer);
-                        Program.Container = container;
-                    }
-                }
+	/// <inheritdoc />
+	public override int Execute(ScenarioRunnerOptions options) {
+		int result = 0;
+		_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Scenario started");
 
-                result += Program.ExecuteCommandWithOption(step.CommandOption);
-                _logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Finished step: {step.StepDescription}");
-                _logger.WriteLine();
-            });
-        _logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Scenario finished");
-        return result >= 1 ? 1 : 0;
-    }
+		foreach ((object commandOption, string stepDescription) in _scenario
+			.InitScript(options.FileName)
+			.GetSteps(GetType().Assembly.GetTypes())) {
+			_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Starting step: {stepDescription}");
+			if (commandOption is EnvironmentOptions stepOptions
+				&& stepOptions is not RegAppOptions and not PfInstallerOptions
+				&& !TryConfigureEnvironmentStep(stepOptions, options)) {
+				result += 1;
+				_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Finished step: {stepDescription}");
+				_logger.WriteLine();
+				continue;
+			}
+
+			result += Program.ExecuteCommandWithOption(commandOption);
+			_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Finished step: {stepDescription}");
+			_logger.WriteLine();
+		}
+		_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Scenario finished");
+		return result >= 1 ? 1 : 0;
+	}
+
+	private bool TryConfigureEnvironmentStep(EnvironmentOptions stepOptions, ScenarioRunnerOptions scenarioOptions) {
+		if (string.IsNullOrWhiteSpace(stepOptions.Environment)
+			&& string.IsNullOrWhiteSpace(stepOptions.Uri)
+			&& string.IsNullOrWhiteSpace(stepOptions.AuthAppUri)
+			&& !string.IsNullOrWhiteSpace(scenarioOptions.Environment)) {
+			stepOptions.Environment = scenarioOptions.Environment;
+		}
+
+		bool hasNamedEnvironment = !string.IsNullOrWhiteSpace(stepOptions.Environment);
+		bool hasDirectUri = !string.IsNullOrWhiteSpace(stepOptions.Uri);
+		bool hasDirectAuthAppUri = !string.IsNullOrWhiteSpace(stepOptions.AuthAppUri);
+		if (hasNamedEnvironment && (hasDirectUri || hasDirectAuthAppUri)) {
+			_logger.WriteError(AmbiguousEnvironmentTargetMessage);
+			return false;
+		}
+		if (!hasDirectUri && hasDirectAuthAppUri) {
+			_logger.WriteError(IncompleteDirectTargetMessage);
+			return false;
+		}
+		EnvironmentSettings baseSettings;
+		if (!hasNamedEnvironment && hasDirectUri) {
+			baseSettings = new EnvironmentSettings();
+		}
+		else {
+			if (!TryReloadSettings()) {
+				return false;
+			}
+
+			baseSettings = _settingsRepository.FindEnvironment(stepOptions.Environment);
+			if (baseSettings is null) {
+				if (!stepOptions.RequiredEnvironment && !hasNamedEnvironment) {
+					baseSettings = new EnvironmentSettings { Login = "default" };
+				}
+				else {
+					_logger.WriteError(EnvironmentNotFoundError.Build(stepOptions.Environment, _settingsRepository));
+					return false;
+				}
+			}
+		}
+
+		EnvironmentSettings resolvedSettings = baseSettings.Fill(stepOptions, NonInteractiveConsole.Shared);
+		resolvedSettings.EnvironmentPath = string.IsNullOrWhiteSpace(stepOptions.EnvironmentPath)
+			? baseSettings.EnvironmentPath
+			: stepOptions.EnvironmentPath;
+		IServiceProvider container = new BindingsModule().Register(
+			resolvedSettings,
+			NonInteractiveConsole.ForceInContainer);
+		Program.Container = container;
+		return true;
+	}
+
+	private bool TryReloadSettings() {
+		SettingsReloadResult reloadResult = _settingsRepository.Reload();
+		if (!string.IsNullOrWhiteSpace(reloadResult.Warning)) {
+			_logger.WriteWarning(reloadResult.Warning);
+		}
+		if (reloadResult.Reloaded || reloadResult.Report?.CanExecuteEnvTools == true) {
+			return true;
+		}
+
+		_logger.WriteError(SettingsReloadFailedMessage);
+		return false;
+	}
 }
-
-

--- a/clio/Command/ScenarioRunnerCommand.cs
+++ b/clio/Command/ScenarioRunnerCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.UserEnvironment;
@@ -8,7 +9,8 @@ using CommandLine;
 namespace Clio.Command;
 
 /// <summary>Options for executing a YAML scenario.</summary>
-[Verb("run", Aliases = ["scenario", "run-scenario"], HelpText = "Run scenario")]
+[Verb("run", Aliases = ["scenario", "run-scenario"],
+	HelpText = "Run a YAML scenario and refresh environments between dependent steps")]
 public class ScenarioRunnerOptions : EnvironmentOptions {
 	internal override bool RequiredEnvironment => false;
 
@@ -45,9 +47,11 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 		int result = 0;
 		_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Scenario started");
 
-		foreach ((object commandOption, string stepDescription) in _scenario
+		var steps = _scenario
 			.InitScript(options.FileName)
-			.GetSteps(GetType().Assembly.GetTypes())) {
+			.GetSteps(GetType().Assembly.GetTypes())
+			.ToList();
+		foreach ((object commandOption, string stepDescription) in steps) {
 			_logger.WriteInfo($"[{DateTime.Now:hh:mm:ss}] Starting step: {stepDescription}");
 			if (commandOption is EnvironmentOptions stepOptions
 				&& stepOptions is not RegAppOptions and not PfInstallerOptions
@@ -77,7 +81,14 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 			return false;
 		}
 
-		EnvironmentSettings resolvedSettings = baseSettings.Fill(stepOptions, NonInteractiveConsole.Shared);
+		EnvironmentSettings resolvedSettings;
+		try {
+			resolvedSettings = baseSettings.Fill(stepOptions, NonInteractiveConsole.Shared);
+		}
+		catch (SafeEnvironmentConfirmationRequiredException exception) {
+			_logger.WriteError(exception.Message);
+			return false;
+		}
 		resolvedSettings.EnvironmentPath = string.IsNullOrWhiteSpace(stepOptions.EnvironmentPath)
 			? baseSettings.EnvironmentPath
 			: stepOptions.EnvironmentPath;
@@ -140,7 +151,7 @@ public class ScenarioRunnerCommand : Command<ScenarioRunnerOptions> {
 		if (!string.IsNullOrWhiteSpace(reloadResult.Warning)) {
 			_logger.WriteWarning(reloadResult.Warning);
 		}
-		if (reloadResult.Reloaded || reloadResult.Report?.CanExecuteEnvTools == true) {
+		if (reloadResult.Reloaded) {
 			return true;
 		}
 

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -465,7 +465,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="run"></a>
 <a id="run-scenario"></a>
 <a id="scenario"></a>
-- [`run`](docs/commands/run.md) - Run scenario, `run-scenario`, `scenario`
+- [`run`](docs/commands/run.md) - Run a YAML scenario and refresh environments between dependent steps, `run-scenario`, `scenario`
 <a id="save-state"></a>
 <a id="save-manifest"></a>
 <a id="state"></a>

--- a/clio/docs/commands/run.md
+++ b/clio/docs/commands/run.md
@@ -1,34 +1,28 @@
 # run
 
-Run all commands declared in a YAML scenario in one clio process.
+## Name
 
-Before every environment-dependent step, `run` refreshes `appsettings.json` and resolves the requested
-environment again. This allows a scenario to deploy and register a Creatio environment in one step and use
-that environment in the next step. If the environment is still missing, the step fails instead of falling
-back to `http://localhost`. A step must identify its target with either a named environment or direct
-application/authentication URIs, not both.
+run - Run a YAML scenario and refresh environments between dependent steps
 
-
-## Usage
+## Synopsis
 
 ```bash
-clio run [options]
+clio run --file-name <scenario.yaml> [OPTIONS]
 ```
-
-## Description
-
-Run scenario.
 
 ## Aliases
 
-`run-scenario`, `scenario`
+scenario, run-scenario
 
-## Examples
+## Description
 
-```bash
-clio run --file-name ./Phase1.yaml
-clio run --file-name ./Phase1.yaml -e dev
-```
+Runs all commands declared in a YAML scenario. Environment-dependent steps
+refresh appsettings.json before resolving their target, so a deployment step
+can register an environment for following steps in the same process.
+
+A missing environment fails the step instead of falling back to localhost.
+A step cannot combine a named environment with direct application or
+authentication URIs.
 
 ## Options
 
@@ -41,7 +35,7 @@ Scenario file name. Required.
 
 ```bash
 -u, --uri <VALUE>
-Application uri
+Application URI
 -p, --Password <VALUE>
 User password
 -l, --Login <VALUE>
@@ -49,7 +43,7 @@ User login (administrator permission required)
 -i, --IsNetCore
 Use NetCore application
 -e, --Environment <VALUE>
-Environment name
+Default environment name for steps that omit a target
 -m, --Maintainer <VALUE>
 Maintainer name
 -c, --dev <VALUE>
@@ -59,7 +53,7 @@ Workspace path
 -s, --Safe <VALUE>
 Safe action in this environment
 --clientId <VALUE>
-OAuth client id
+OAuth client ID
 --clientSecret <VALUE>
 OAuth client secret
 --authAppUri <VALUE>
@@ -67,9 +61,9 @@ OAuth app URI
 --silent
 Use default behavior without user interaction
 --restart-environment
-Restart environment after execute command
+Restart environment after command execution
 --db-server-uri <VALUE>
-Db server uri
+Database server URI
 --db-user <VALUE>
 Database user
 --db-password <VALUE>
@@ -77,7 +71,7 @@ Database password
 --backup-file <VALUE>
 Full path to backup file
 --db-working-folder <VALUE>
-Folder visible to db server
+Folder visible to the database server
 --db-name <VALUE>
 Desired database name
 --force
@@ -87,5 +81,25 @@ Callback process name
 --ep <VALUE>
 Path to the application root folder
 ```
+
+## Examples
+
+```bash
+Run a provisioning scenario that creates its first environment:
+clio run --file-name ./Phase1.yaml
+
+Supply a default environment for steps that omit a target:
+clio run --file-name ./Phase1.yaml -e dev
+```
+
+## Notes
+
+Scenarios run non-interactively. A step targeting an environment marked Safe
+fails closed because the runner cannot request production confirmation.
+
+## See Also
+
+create-workspace - Create a clio workspace
+list-environments - List registered environments
 
 - [Clio Command Reference](../../Commands.md#run)

--- a/clio/docs/commands/run.md
+++ b/clio/docs/commands/run.md
@@ -35,7 +35,7 @@ Scenario file name. Required.
 ## Environment Options
 
 ```bash
--e, --Environment <VALUE>
+-e, --environment <VALUE>
 Default environment name for steps that omit a target
 ```
 
@@ -53,6 +53,9 @@ clio run --file-name ./Phase1.yaml -e dev
 
 Only --environment is inherited as a scenario-level step default. Put direct
 URIs, credentials, and other environment options on the individual step.
+
+A command that supports running without an environment keeps its offline
+bootstrap mode when its named environment has not been registered yet.
 
 Scenarios run non-interactively. A step targeting an environment marked Safe
 fails closed because the runner cannot request production confirmation.

--- a/clio/docs/commands/run.md
+++ b/clio/docs/commands/run.md
@@ -20,7 +20,8 @@ Runs all commands declared in a YAML scenario. Environment-dependent steps
 refresh appsettings.json before resolving their target, so a deployment step
 can register an environment for following steps in the same process.
 
-A missing environment fails the step instead of falling back to localhost.
+A required environment that is missing fails the step instead of falling
+back to localhost.
 A step cannot combine a named environment with direct application or
 authentication URIs.
 
@@ -34,52 +35,8 @@ Scenario file name. Required.
 ## Environment Options
 
 ```bash
--u, --uri <VALUE>
-Application URI
--p, --Password <VALUE>
-User password
--l, --Login <VALUE>
-User login (administrator permission required)
--i, --IsNetCore
-Use NetCore application
 -e, --Environment <VALUE>
 Default environment name for steps that omit a target
--m, --Maintainer <VALUE>
-Maintainer name
--c, --dev <VALUE>
-Developer mode state for environment
---WorkspacePathes <VALUE>
-Workspace path
--s, --Safe <VALUE>
-Safe action in this environment
---clientId <VALUE>
-OAuth client ID
---clientSecret <VALUE>
-OAuth client secret
---authAppUri <VALUE>
-OAuth app URI
---silent
-Use default behavior without user interaction
---restart-environment
-Restart environment after command execution
---db-server-uri <VALUE>
-Database server URI
---db-user <VALUE>
-Database user
---db-password <VALUE>
-Database password
---backup-file <VALUE>
-Full path to backup file
---db-working-folder <VALUE>
-Folder visible to the database server
---db-name <VALUE>
-Desired database name
---force
-Force restore
---callback-process <VALUE>
-Callback process name
---ep <VALUE>
-Path to the application root folder
 ```
 
 ## Examples
@@ -93,6 +50,9 @@ clio run --file-name ./Phase1.yaml -e dev
 ```
 
 ## Notes
+
+Only --environment is inherited as a scenario-level step default. Put direct
+URIs, credentials, and other environment options on the individual step.
 
 Scenarios run non-interactively. A step targeting an environment marked Safe
 fails closed because the runner cannot request production confirmation.

--- a/clio/docs/commands/run.md
+++ b/clio/docs/commands/run.md
@@ -1,6 +1,12 @@
 # run
 
-Run scenario.
+Run all commands declared in a YAML scenario in one clio process.
+
+Before every environment-dependent step, `run` refreshes `appsettings.json` and resolves the requested
+environment again. This allows a scenario to deploy and register a Creatio environment in one step and use
+that environment in the next step. If the environment is still missing, the step fails instead of falling
+back to `http://localhost`. A step must identify its target with either a named environment or direct
+application/authentication URIs, not both.
 
 
 ## Usage
@@ -20,7 +26,8 @@ Run scenario.
 ## Examples
 
 ```bash
-clio run -e dev
+clio run --file-name ./Phase1.yaml
+clio run --file-name ./Phase1.yaml -e dev
 ```
 
 ## Options

--- a/clio/help/en/run.txt
+++ b/clio/help/en/run.txt
@@ -22,7 +22,7 @@ OPTIONS
         Scenario file name. Required.
 
 ENVIRONMENT OPTIONS
-    -e, --Environment <VALUE>
+    -e, --environment <VALUE>
         Default environment name for steps that omit a target
 
 EXAMPLES
@@ -35,6 +35,9 @@ EXAMPLES
 NOTES
     Only --environment is inherited as a scenario-level step default. Put direct
     URIs, credentials, and other environment options on the individual step.
+
+    A command that supports running without an environment keeps its offline
+    bootstrap mode when its named environment has not been registered yet.
 
     Scenarios run non-interactively. A step targeting an environment marked Safe
     fails closed because the runner cannot request production confirmation.

--- a/clio/help/en/run.txt
+++ b/clio/help/en/run.txt
@@ -1,20 +1,35 @@
-Run all commands declared in a YAML scenario.
+NAME
+    run - Run a YAML scenario and refresh environments between dependent steps
 
-Usage:
-  clio run --file-name <scenario.yaml> [options]
+SYNOPSIS
+    clio run --file-name <scenario.yaml> [OPTIONS]
 
-Aliases:
-  run-scenario, scenario
+DESCRIPTION
+    Runs all commands declared in a YAML scenario. Environment-dependent steps
+    refresh appsettings.json before resolving their target, so a deployment step
+    can register an environment for following steps in the same process.
 
-Options:
-  --file-name <VALUE>  Scenario file name. Required.
-  -e, --environment    Default environment name for steps that omit one.
+    A missing environment fails the step instead of falling back to localhost.
+    A step cannot combine a named environment with direct application or
+    authentication URIs.
 
-Environment-dependent steps refresh appsettings.json before resolving their target. This lets a deployment
-step register an environment for the following steps in the same scenario process. A missing environment
-fails the step instead of falling back to localhost. A step cannot combine a named environment with direct
-application or authentication URIs.
+OPTIONS
+    --file-name <VALUE>
+        Scenario file name. Required.
 
-Examples:
-  clio run --file-name ./Phase1.yaml
-  clio run --file-name ./Phase1.yaml -e dev
+    -e, --environment <ENVIRONMENT_NAME>
+        Default environment name for steps that omit a target.
+
+    Environment connection options can be supplied to the command and inherited
+    by steps according to the normal clio environment option rules.
+
+EXAMPLES
+    Run a provisioning scenario that creates its first environment:
+        clio run --file-name ./Phase1.yaml
+
+    Supply a default environment for steps that omit a target:
+        clio run --file-name ./Phase1.yaml -e dev
+
+SEE ALSO
+    create-workspace - Create a clio workspace
+    list-environments - List registered environments

--- a/clio/help/en/run.txt
+++ b/clio/help/en/run.txt
@@ -12,7 +12,8 @@ DESCRIPTION
     refresh appsettings.json before resolving their target, so a deployment step
     can register an environment for following steps in the same process.
 
-    A missing environment fails the step instead of falling back to localhost.
+    A required environment that is missing fails the step instead of falling
+    back to localhost.
     A step cannot combine a named environment with direct application or
     authentication URIs.
 
@@ -21,52 +22,8 @@ OPTIONS
         Scenario file name. Required.
 
 ENVIRONMENT OPTIONS
-    -u, --uri <VALUE>
-        Application URI
-    -p, --Password <VALUE>
-        User password
-    -l, --Login <VALUE>
-        User login (administrator permission required)
-    -i, --IsNetCore
-        Use NetCore application
     -e, --Environment <VALUE>
         Default environment name for steps that omit a target
-    -m, --Maintainer <VALUE>
-        Maintainer name
-    -c, --dev <VALUE>
-        Developer mode state for environment
-    --WorkspacePathes <VALUE>
-        Workspace path
-    -s, --Safe <VALUE>
-        Safe action in this environment
-    --clientId <VALUE>
-        OAuth client ID
-    --clientSecret <VALUE>
-        OAuth client secret
-    --authAppUri <VALUE>
-        OAuth app URI
-    --silent
-        Use default behavior without user interaction
-    --restart-environment
-        Restart environment after command execution
-    --db-server-uri <VALUE>
-        Database server URI
-    --db-user <VALUE>
-        Database user
-    --db-password <VALUE>
-        Database password
-    --backup-file <VALUE>
-        Full path to backup file
-    --db-working-folder <VALUE>
-        Folder visible to the database server
-    --db-name <VALUE>
-        Desired database name
-    --force
-        Force restore
-    --callback-process <VALUE>
-        Callback process name
-    --ep <VALUE>
-        Path to the application root folder
 
 EXAMPLES
     Run a provisioning scenario that creates its first environment:
@@ -76,6 +33,9 @@ EXAMPLES
         clio run --file-name ./Phase1.yaml -e dev
 
 NOTES
+    Only --environment is inherited as a scenario-level step default. Put direct
+    URIs, credentials, and other environment options on the individual step.
+
     Scenarios run non-interactively. A step targeting an environment marked Safe
     fails closed because the runner cannot request production confirmation.
 

--- a/clio/help/en/run.txt
+++ b/clio/help/en/run.txt
@@ -4,6 +4,9 @@ NAME
 SYNOPSIS
     clio run --file-name <scenario.yaml> [OPTIONS]
 
+ALIASES
+    scenario, run-scenario
+
 DESCRIPTION
     Runs all commands declared in a YAML scenario. Environment-dependent steps
     refresh appsettings.json before resolving their target, so a deployment step
@@ -17,11 +20,53 @@ OPTIONS
     --file-name <VALUE>
         Scenario file name. Required.
 
-    -e, --environment <ENVIRONMENT_NAME>
-        Default environment name for steps that omit a target.
-
-    Environment connection options can be supplied to the command and inherited
-    by steps according to the normal clio environment option rules.
+ENVIRONMENT OPTIONS
+    -u, --uri <VALUE>
+        Application URI
+    -p, --Password <VALUE>
+        User password
+    -l, --Login <VALUE>
+        User login (administrator permission required)
+    -i, --IsNetCore
+        Use NetCore application
+    -e, --Environment <VALUE>
+        Default environment name for steps that omit a target
+    -m, --Maintainer <VALUE>
+        Maintainer name
+    -c, --dev <VALUE>
+        Developer mode state for environment
+    --WorkspacePathes <VALUE>
+        Workspace path
+    -s, --Safe <VALUE>
+        Safe action in this environment
+    --clientId <VALUE>
+        OAuth client ID
+    --clientSecret <VALUE>
+        OAuth client secret
+    --authAppUri <VALUE>
+        OAuth app URI
+    --silent
+        Use default behavior without user interaction
+    --restart-environment
+        Restart environment after command execution
+    --db-server-uri <VALUE>
+        Database server URI
+    --db-user <VALUE>
+        Database user
+    --db-password <VALUE>
+        Database password
+    --backup-file <VALUE>
+        Full path to backup file
+    --db-working-folder <VALUE>
+        Folder visible to the database server
+    --db-name <VALUE>
+        Desired database name
+    --force
+        Force restore
+    --callback-process <VALUE>
+        Callback process name
+    --ep <VALUE>
+        Path to the application root folder
 
 EXAMPLES
     Run a provisioning scenario that creates its first environment:
@@ -29,6 +74,10 @@ EXAMPLES
 
     Supply a default environment for steps that omit a target:
         clio run --file-name ./Phase1.yaml -e dev
+
+NOTES
+    Scenarios run non-interactively. A step targeting an environment marked Safe
+    fails closed because the runner cannot request production confirmation.
 
 SEE ALSO
     create-workspace - Create a clio workspace

--- a/clio/help/en/run.txt
+++ b/clio/help/en/run.txt
@@ -1,0 +1,20 @@
+Run all commands declared in a YAML scenario.
+
+Usage:
+  clio run --file-name <scenario.yaml> [options]
+
+Aliases:
+  run-scenario, scenario
+
+Options:
+  --file-name <VALUE>  Scenario file name. Required.
+  -e, --environment    Default environment name for steps that omit one.
+
+Environment-dependent steps refresh appsettings.json before resolving their target. This lets a deployment
+step register an environment for the following steps in the same scenario process. A missing environment
+fails the step instead of falling back to localhost. A step cannot combine a named environment with direct
+application or authentication URIs.
+
+Examples:
+  clio run --file-name ./Phase1.yaml
+  clio run --file-name ./Phase1.yaml -e dev

--- a/docs/knowledge/Environment/only-the-startup-settings-singleton-holds-a-stale-snapshot.md
+++ b/docs/knowledge/Environment/only-the-startup-settings-singleton-holds-a-stale-snapshot.md
@@ -4,9 +4,10 @@ applies-to:
   - clio/BindingsModule.cs
   - clio/Environment/ConfigurationOptions.cs
   - clio/Environment/ISettingsRepository.cs
+  - clio/Command/ScenarioRunnerCommand.cs
   - clio/Command/McpServer/Tools/ToolCommandResolver.cs
 ticket: ENG-94529
-date: 2026-08-19
+date: 2026-08-21
 ---
 
 **What is true** — `SettingsRepository` serves reads from a snapshot taken in its constructor, and
@@ -15,7 +16,9 @@ staleness is: `BindingsModule.RegisterInto` constructs a **new** `SettingsReposi
 `Register(...)` call, so each per-environment child container `ToolCommandResolver` builds reads
 `appsettings.json` at container-build time. Only the process-start root singleton — used by
 `ToolCommandResolver` itself and by the startup-injected commands behind the non-generic
-`BaseTool.InternalExecute(options)` — is frozen.
+`BaseTool.InternalExecute(options)` — stays frozen unless its owner explicitly calls `Reload()`.
+`ScenarioRunnerCommand` must do that before each environment-consuming step because an earlier
+provisioning step can add the target environment within the same process.
 
 **Why it is this way** — the child container is the unit of per-environment isolation, and it is
 cheaper to build a fresh repository than to share and invalidate one. The consequence was never
@@ -25,6 +28,7 @@ intentional; it is a side effect of the composition root being re-entered.
 serving pre-edit settings, and either add `Reload()` calls inside command code where they buy nothing
 but a file lock and a full deserialize, or chase a phantom cache in the child containers. The reverse
 mistake is as bad: because most tools go through a child container, an external edit is picked up
-*most* of the time, which makes the remaining root-singleton path read as intermittent flakiness
+*most* of the time, which makes an unrefreshed root-singleton path read as intermittent flakiness
 rather than a fixed boundary. The honest claim is the one the "not found" message already makes — the
-list is re-read at call time, tools bound at server start are not.
+list is re-read at call time only where the owner constructs a child container or explicitly reloads
+the root repository.


### PR DESCRIPTION
Closes #1153

## Summary
- reload appsettings before each environment-aware scenario step
- resolve the newly registered environment instead of fabricating localhost
- allow provisioning scenarios to start without any registered active environment
- preserve reg-web-app and deploy-creatio as provisioning steps
- scope optional environment consumers such as l4r and dconf correctly
- preserve the CLI bootstrap fallback for optional commands naming a missing environment
- fail Safe-environment steps cleanly without aborting scenario accounting
- reject ambiguous named/direct application or authentication targets

## Validation
- dotnet test clio.tests/clio.tests.csproj --filter "FullyQualifiedName~ScenarioRunner|FullyQualifiedName~ProgramTestCase|FullyQualifiedName~HelpArtifactConsistencyTests|FullyQualifiedName~CommandHelpRendererTests" --no-restore
  - 48 passed
- dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Command" --no-build --no-restore
  - 3663 passed, 15 skipped
- help artifact and renderer subset after final documentation regeneration
  - 15 passed
- python scripts/check-knowledge-applies-to.py
  - all 115 records resolve and match the schema
- clio run -H rendered structured manual sections from the canonical run.txt source
- updated from origin/master at 0d903e3a5; focused upstream linter coverage and Command/McpServer modules passed after the merge
- real F:\Projects\Issue-Workspaces\issue-1150\Phase1.yaml with the Release binary from 82888afc9
  - exit 0 in 00:00:53.0177046
  - all post-deploy steps targeted https://k-krylov-nb.tscrm.com:40001 in the same process; no localhost fallback
  - Creatio 10.1.585.0, .NET 8.0.30, PostgreSQL, ClioGate 2.0.0.45
  - IIS site and app pool started
  - fileDesignMode=true, UseStaticFileContent=false, 93 filesystem packages
  - immediate post-run pkg-to-file-system verification exited 0
  - turn-fsm and the following 2fs emitted a transient disabled-file-design-mode message during app-pool warm-up; compilation and final handoff succeeded, and the post-run 2fs probe confirmed readiness

## Reviews
- comprehensive final agentic review: code quality, security, performance, testing, and bug/edge-case lenses; all Blocker/High findings resolved
- final bootstrap, Safe-environment, lazy-enumeration, optional fallback, and manual-help findings resolved and re-reviewed
- documentation-only follow-up review skipped under policy after targeted help validation
- credential target-mixing protection retained as a deliberate scenario safety boundary
- docs reviewed, canonical help and generated run.md updated
- MCP reviewed, no ScenarioRunnerCommand MCP artifact exists and no update is required
- ClioRing compatibility reviewed, no Ring-consumed run/scenario command contract changed