### PR TITLE
Security: run install/Dockerfile and docker-templates images as non-root

### DIFF
--- a/clio/tpl/docker-templates/base/Dockerfile
+++ b/clio/tpl/docker-templates/base/Dockerfile
@@ -14,3 +14,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     sed -i 's/openssl_conf/#openssl_conf/g' /etc/ssl/openssl.cnf && \
     mkdir -p /var/log/supervisor
+
+# GH #1161: this stage intentionally does not switch to a non-root USER. It has no
+# ENTRYPOINT/CMD of its own - it exists only as the shared FROM ${BASE_IMAGE} layer
+# for the dev and prod leaf templates (see BuildDockerImageService), which are out
+# of scope for #1161 and legitimately need root for their own RUN steps (apt-get,
+# sshd/user setup) and to run supervisord/sshd at container start. A USER switch
+# here would silently break those builds since neither leaf re-elevates. A future
+# non-root-capable leaf image built from this base is free to add its own USER.

--- a/clio/tpl/docker-templates/base/Dockerfile
+++ b/clio/tpl/docker-templates/base/Dockerfile
@@ -18,7 +18,12 @@ RUN apt-get update && \
 # GH #1161: this stage intentionally does not switch to a non-root USER. It has no
 # ENTRYPOINT/CMD of its own - it exists only as the shared FROM ${BASE_IMAGE} layer
 # for the dev and prod leaf templates (see BuildDockerImageService), which are out
-# of scope for #1161 and legitimately need root for their own RUN steps (apt-get,
-# sshd/user setup) and to run supervisord/sshd at container start. A USER switch
-# here would silently break those builds since neither leaf re-elevates. A future
-# non-root-capable leaf image built from this base is free to add its own USER.
+# of scope for #1161. dev/Dockerfile legitimately needs root for its own RUN steps
+# (apt-get, sshd/user setup) and to run supervisord/sshd at container start.
+# prod/Dockerfile has no such steps - it only runs supervisord/creatio-webhost, an
+# unprivileged process - and is swept into this same restriction only because it
+# shares this base file, not because it independently needs root; a prod-only
+# hardening pass (its own USER plus the chown that entails) is a separate, deferred
+# follow-up. A USER switch here would silently break the dev build today since it
+# does not re-elevate. A future non-root-capable leaf image built from this base is
+# free to add its own USER.

--- a/clio/tpl/docker-templates/db/Dockerfile
+++ b/clio/tpl/docker-templates/db/Dockerfile
@@ -4,3 +4,10 @@ LABEL org.creatio.capability.db="true"
 
 WORKDIR /db
 COPY db/ ./
+
+# GH #1161: this is a data-only image (no ENTRYPOINT/running process, used only as a
+# labeled source to copy files from), so it can run as a non-root, unprivileged UID.
+# A numeric USER works without a /etc/passwd entry, which keeps this independent of
+# busybox's applet set (e.g. adduser).
+RUN chown -R 10001:10001 /db
+USER 10001:10001

--- a/docs/knowledge/Command/docker-base-template-cannot-switch-to-non-root-user.md
+++ b/docs/knowledge/Command/docker-base-template-cannot-switch-to-non-root-user.md
@@ -13,13 +13,18 @@ shared `FROM ${BASE_IMAGE}` layer that `dev/Dockerfile` and `prod/Dockerfile` bu
 (`BuildDockerImageService`). Neither leaf template re-elevates with `USER root` before its own
 `RUN` steps.
 
-**Why it is this way** — `dev`/`prod` need root for their own build-time `RUN` steps (`apt-get
-install`, `chpasswd`, writing under `/root`) and to run `supervisord`/`sshd` at container start;
-they are deliberately out of scope for the GH #1161 root-hardening pass pending separate analysis.
+**Why it is this way** — `dev/Dockerfile` needs root for its own build-time `RUN` steps (`apt-get
+install`, `chpasswd`, writing under `/root`) and to run `supervisord`/`sshd` at container start.
+`prod/Dockerfile` has no such steps — it only runs `supervisord`/`creatio-webhost`, an
+unprivileged process — and stays root only because it shares this same base file with `dev`, not
+because it independently needs root. Both are deliberately out of scope for the GH #1161
+root-hardening pass; a `prod`-only hardening pass (its own `USER` plus the `chown` that entails)
+is a separate, deferred follow-up.
 
 **What breaks if you ignore it** — adding a `USER <non-root>` instruction to `base/Dockerfile`
 (the obvious fix for its own missing-`USER` Sonar hotspot) is inherited by every stage `FROM
-${BASE_IMAGE}`. `dev`/`prod`'s subsequent `RUN apt-get ...` etc. would then execute as that
-non-root user and fail with permission errors, breaking their Docker builds — a regression in
-files this fix is explicitly not allowed to touch. Do not add `USER` to `base/Dockerfile` without
-also auditing/updating `dev` and `prod` to re-elevate first.
+${BASE_IMAGE}`. `dev`'s subsequent `RUN apt-get ...` etc. would then execute as that non-root user
+and fail with permission errors, breaking its Docker build — a regression in a file this fix is
+explicitly not allowed to touch. Do not add `USER` to `base/Dockerfile` without also
+auditing/updating `dev` (required) and `prod` (as its own deferred follow-up) to handle
+non-root correctly.

--- a/docs/knowledge/Command/docker-base-template-cannot-switch-to-non-root-user.md
+++ b/docs/knowledge/Command/docker-base-template-cannot-switch-to-non-root-user.md
@@ -1,0 +1,25 @@
+---
+description: adding USER to docker-templates/base/Dockerfile breaks dev/prod builds
+applies-to:
+  - clio/tpl/docker-templates/base/Dockerfile
+  - clio/tpl/docker-templates/dev/Dockerfile
+  - clio/tpl/docker-templates/prod/Dockerfile
+ticket: GH-1161
+date: 2026-08-21
+---
+
+**What is true** — `base/Dockerfile` has no `ENTRYPOINT`/`CMD` of its own; it only exists as the
+shared `FROM ${BASE_IMAGE}` layer that `dev/Dockerfile` and `prod/Dockerfile` build on
+(`BuildDockerImageService`). Neither leaf template re-elevates with `USER root` before its own
+`RUN` steps.
+
+**Why it is this way** — `dev`/`prod` need root for their own build-time `RUN` steps (`apt-get
+install`, `chpasswd`, writing under `/root`) and to run `supervisord`/`sshd` at container start;
+they are deliberately out of scope for the GH #1161 root-hardening pass pending separate analysis.
+
+**What breaks if you ignore it** — adding a `USER <non-root>` instruction to `base/Dockerfile`
+(the obvious fix for its own missing-`USER` Sonar hotspot) is inherited by every stage `FROM
+${BASE_IMAGE}`. `dev`/`prod`'s subsequent `RUN apt-get ...` etc. would then execute as that
+non-root user and fail with permission errors, breaking their Docker builds — a regression in
+files this fix is explicitly not allowed to touch. Do not add `USER` to `base/Dockerfile` without
+also auditing/updating `dev` and `prod` to re-elevate first.

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -23,6 +23,21 @@ RUN rm -rf /app/clio
 # Copy the published files from the build stage to the final image
 COPY --from=build /app/published /app/
 
+# Create a dedicated non-root user to run the app as (GH #1161: image ran as root).
+# --no-log-init avoids a known useradd issue with sparse/large log files for high
+# UIDs on some Debian-based images (this image is Debian-based).
+# --no-create-home is fine because ENV HOME=/app below points HOME at a directory
+# we already chown to this user.
+RUN useradd --uid 10001 --no-log-init --no-create-home --shell /usr/sbin/nologin clioapp \
+    && chown -R clioapp:clioapp /app
+
+# clio resolves its settings/config home via Environment.SpecialFolder.UserProfile,
+# which reads $HOME on Linux. Without this, a --no-create-home non-root user has no
+# $HOME and any clio command that writes settings would fail.
+ENV HOME=/app
+
+USER clioapp
+
 # Add a label to the image
 LABEL service=clio
 

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -24,11 +24,15 @@ RUN rm -rf /app/clio
 COPY --from=build /app/published /app/
 
 # Create a dedicated non-root user to run the app as (GH #1161: image ran as root).
+# The group is created explicitly with a pinned gid instead of relying on useradd's
+# default same-named-group behavior (Debian's USERGROUPS_ENAB=yes), so the build does
+# not depend on that default staying enabled in a future base-image swap.
 # --no-log-init avoids a known useradd issue with sparse/large log files for high
 # UIDs on some Debian-based images (this image is Debian-based).
 # --no-create-home is fine because ENV HOME=/app below points HOME at a directory
 # we already chown to this user.
-RUN useradd --uid 10001 --no-log-init --no-create-home --shell /usr/sbin/nologin clioapp \
+RUN groupadd -g 10001 clioapp \
+    && useradd --uid 10001 --gid 10001 --no-log-init --no-create-home --shell /usr/sbin/nologin clioapp \
     && chown -R clioapp:clioapp /app
 
 # clio resolves its settings/config home via Environment.SpecialFolder.UserProfile,


### PR DESCRIPTION
Fixes #1161

## Summary

`install/Dockerfile` and `clio/tpl/docker-templates/db/Dockerfile` now run as a fixed non-root user (UID 10001) instead of root. `clio/tpl/docker-templates/base/Dockerfile` is deliberately left as root — see below. `dev`/`prod` Dockerfiles are explicitly out of scope (they share `base/Dockerfile` and `dev` genuinely needs root for `sshd`/user setup).

## Review process

Ran a dedicated deep review (CIS Docker Benchmark) before requesting review. Found:

- **High (unresolved — needs a docker daemon)**: the issue itself required verifying no UID collision (`getent passwd 10001` against the base image) and an actual settings-writing command running successfully as the non-root user, not just `--version`/`--help`. **Neither could be executed in this sandboxed environment (no docker daemon available)** — this remains reasoned-but-unverified. Please run before merging:
  ```
  docker run --rm mcr.microsoft.com/dotnet/sdk:10.0 getent passwd 10001   # expect no match
  docker build -f install/Dockerfile -t clio-nonroot-test .
  docker run --rm clio-nonroot-test reg-web-app -help   # or another real settings-touching command
  ```
- **Medium (fixed)**: `useradd` didn't pin `--gid`, relying on Debian's `USERGROUPS_ENAB=yes` default to auto-create a same-named group — fragile against a future base-image swap. Now uses explicit `groupadd -g 10001` + `useradd --gid 10001`.
- **Medium (fixed)**: the `base/Dockerfile`/knowledge-doc justification for staying root cited both `dev` and `prod` needing apt-get/sshd setup — independently verified against `prod/Dockerfile`/`prod/entrypoint.sh`/`prod/supervisord.conf` that **only `dev` actually needs root** (`prod` runs a single unprivileged webhost process with no setup steps); `prod` is only swept in because it shares `base/Dockerfile`. Reworded both to attribute this correctly and flagged a `prod`-only hardening pass as a deferred follow-up.
- **Low (noted, not fixed)**: `db/Dockerfile`'s separate `RUN chown` layer could be collapsed into `COPY --chown=`; `install/Dockerfile`'s final stage ships the full SDK rather than a slim runtime image (pre-existing, unrelated to this PR).

The decision to leave `base/Dockerfile` as root was independently re-verified by the reviewer (read `dev`/`prod` Dockerfiles directly) and confirmed sound — `dev` has no `USER root` re-elevation and needs root for its own build/runtime steps, so `base/Dockerfile` can't switch without breaking it.

Consumer sweep (independently re-run by the reviewer): no CI workflow, docker-compose file, or script assumes root for any of the three touched images — only `README.md`'s two documented `docker run` examples (both read-only/`-help`, no volume mounts) reference `install/Dockerfile`.
