### PR TITLE
Security: resolve cmd.exe/dotnet by absolute path instead of PATH lookup

### DIFF
--- a/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
+++ b/clio-ring/ClioRing.Tests/ClioSettingsViewModelTests.cs
@@ -71,7 +71,8 @@ public sealed class ClioSettingsViewModelTests {
 		sut.HasValidationError.Should().BeFalse("because a real clio.dll passes validation");
 		sut.IsDevOverrideActive.Should().BeTrue("because a valid dev override is now active");
 		persisted.Should().Be(_devClioDll, "because the override round-trips through app-settings.json");
-		resolved.Command.Should().Be("dotnet", "because a .dll dev build is launched via dotnet");
+		resolved.Command.Should().Be(DotNetHostResolver.ResolveOrDefault(),
+			"because a .dll dev build is launched via the trusted, absolute dotnet host rather than a bare PATH-resolved name");
 		resolved.Args.Should().HaveCount(2, "because resolution passes the dev dll then the mcp-server verb");
 		resolved.Args[0].Should().Be(_devClioDll, "because the launch points at the dev dll");
 		resolved.Args[1].Should().Be("mcp-server", "because the dll is run as the mcp-server");

--- a/clio-ring/ClioRing.Tests/DevClioLaunchTests.cs
+++ b/clio-ring/ClioRing.Tests/DevClioLaunchTests.cs
@@ -8,24 +8,28 @@ namespace ClioRing.Tests;
 /// <summary>
 /// Unit tests for <see cref="DevClioLaunch.Build"/> (story 11): the pure resolution of a validated dev-clio
 /// build path into the <see cref="ClioIpcSettings"/> that launches the clio MCP child process. A <c>.dll</c>
-/// is driven by <c>dotnet</c> (dll then the <c>mcp-server</c> verb); a <c>.exe</c> is launched directly with
-/// only the <c>mcp-server</c> verb. These assert the exact resolved Command/Args at the source (the settings
-/// VM tests cover the same shape via the composition root; this pins the pure builder directly).
+/// is driven by the trusted, absolute <c>dotnet</c> host (dll then the <c>mcp-server</c> verb) instead of a
+/// bare <c>"dotnet"</c> name resolved via <c>PATH</c>; a <c>.exe</c> is launched directly with only the
+/// <c>mcp-server</c> verb. These assert the exact resolved Command/Args at the source (the settings VM tests
+/// cover the same shape via the composition root; this pins the pure builder directly).
 /// </summary>
 [TestFixture]
 [Category("Unit")]
 public sealed class DevClioLaunchTests {
 	[Test]
-	[Description("A .dll dev-clio path resolves to 'dotnet <dll> mcp-server' with the exact args in order.")]
+	[Description("A .dll dev-clio path resolves to '<resolved dotnet host> <dll> mcp-server' with the exact args in order.")]
 	public void Build_ShouldLaunchViaDotnetWithDllThenMcpServer_WhenPathIsDll() {
 		// Arrange — a dev clio.dll build path.
 		const string dll = @"C:\dev\clio\clio.dll";
+		string expectedHost = DotNetHostResolver.ResolveOrDefault();
 
 		// Act — build the launch settings.
 		ClioIpcSettings resolved = DevClioLaunch.Build(dll);
 
-		// Assert — a .dll is driven by dotnet, passing the dll then the mcp-server verb, in that exact order.
-		resolved.Command.Should().Be("dotnet", because: "a .dll dev build is launched via the dotnet host");
+		// Assert — a .dll is driven by the resolved absolute dotnet host, not a bare "dotnet" name, passing
+		// the dll then the mcp-server verb, in that exact order.
+		resolved.Command.Should().Be(expectedHost,
+			because: "a .dll dev build is launched via the trusted, absolute dotnet host, never a bare PATH-resolved name");
 		resolved.Args.Should().Equal(new[] { dll, "mcp-server" },
 			because: "dotnet receives the dev dll first then the mcp-server verb, in order");
 	}
@@ -46,17 +50,19 @@ public sealed class DevClioLaunchTests {
 	}
 
 	[Test]
-	[Description("The .dll detection is case-insensitive so a .DLL extension still resolves to the dotnet launch path.")]
+	[Description("The .dll detection is case-insensitive so a .DLL extension still resolves to the resolved dotnet launch path.")]
 	public void Build_ShouldTreatUppercaseDllAsDll_WhenExtensionCaseDiffers() {
 		// Arrange — a dev build path with an upper-case .DLL extension.
 		const string dll = @"C:\dev\clio\CLIO.DLL";
+		string expectedHost = DotNetHostResolver.ResolveOrDefault();
 
 		// Act — build the launch settings.
 		ClioIpcSettings resolved = DevClioLaunch.Build(dll);
 
-		// Assert — case-insensitive extension matching still routes a .DLL through the dotnet host.
-		resolved.Command.Should().Be("dotnet", because: "the .dll extension check is case-insensitive");
+		// Assert — case-insensitive extension matching still routes a .DLL through the resolved, absolute
+		// dotnet host rather than a bare "dotnet" name.
+		resolved.Command.Should().Be(expectedHost, because: "the .dll extension check is case-insensitive");
 		resolved.Args.Should().Equal(new[] { dll, "mcp-server" },
-			because: "an upper-case .DLL is still driven by dotnet with the dll then the mcp-server verb");
+			because: "an upper-case .DLL is still driven by the resolved dotnet host with the dll then the mcp-server verb");
 	}
 }

--- a/clio-ring/ClioRing.Tests/DotNetHostResolverTests.cs
+++ b/clio-ring/ClioRing.Tests/DotNetHostResolverTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using ClioRing.Services;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ClioRing.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DotNetHostResolver"/>: the trusted, absolute <c>dotnet</c> host resolution
+/// shared by <see cref="ClioToolUpdateService"/> and <see cref="DevClioLaunch"/>. Pins the security
+/// invariant that the resolved value is always an absolute path, never a bare <c>"dotnet"</c> name that
+/// would be resolved via <c>CreateProcess</c>'s search order (calling-process directory first, then
+/// <c>PATH</c>).
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+public sealed class DotNetHostResolverTests {
+	[Test]
+	[Description("ResolveOrDefault never returns the bare 'dotnet' name; it is always rooted (absolute).")]
+	public void ResolveOrDefault_ShouldReturnAbsolutePath_Always() {
+		// Arrange — no setup needed; the resolver reads only environment variables and the filesystem.
+
+		// Act — resolve the trusted dotnet host.
+		string resolved = DotNetHostResolver.ResolveOrDefault();
+
+		// Assert — the result is a rooted, absolute path and not the bare PATH-resolved name.
+		Path.IsPathRooted(resolved).Should().BeTrue(
+			because: "the resolved host must be an absolute path so it cannot be hijacked via PATH search order");
+		resolved.Should().NotBe("dotnet",
+			because: "falling back to the bare name would reintroduce the PATH-hijack defect this resolver exists to close");
+	}
+
+	[Test]
+	[Description("ResolveOrDefault is stable across repeated calls for the same environment.")]
+	public void ResolveOrDefault_ShouldReturnSameValue_WhenCalledTwice() {
+		// Arrange — no setup needed; resolution is a pure function of environment state.
+
+		// Act — resolve twice.
+		string first = DotNetHostResolver.ResolveOrDefault();
+		string second = DotNetHostResolver.ResolveOrDefault();
+
+		// Assert — resolution is deterministic for an unchanged environment.
+		second.Should().Be(first, because: "resolution must be deterministic so launch settings are reproducible");
+	}
+}

--- a/clio-ring/ClioRing/Services/ClioToolUpdateService.cs
+++ b/clio-ring/ClioRing/Services/ClioToolUpdateService.cs
@@ -318,7 +318,7 @@ public sealed class ClioToolInstallation : IClioToolInstallation {
 	public string TargetPath => Path.GetFullPath(ClioIpcSettings.Default.Command);
 
 	/// <inheritdoc />
-	public string? DotNetHostPath => ResolveDotNetHostPath();
+	public string? DotNetHostPath => DotNetHostResolver.TryResolve();
 
 	/// <inheritdoc />
 	public bool IsInstalled {
@@ -334,25 +334,6 @@ public sealed class ClioToolInstallation : IClioToolInstallation {
 		return Directory.Exists(storePath);
 		}
 	}
-
-	private static string? ResolveDotNetHostPath() {
-		string executableName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
-		var candidates = new List<string?> {
-			Environment.GetEnvironmentVariable("DOTNET_HOST_PATH"),
-			CombineRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT"), executableName),
-			CombineRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT_X64"), executableName)
-		};
-		if (OperatingSystem.IsWindows()) {
-			candidates.Add(CombineRoot(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-				"dotnet", executableName));
-		}
-		return candidates.Where(candidate => !string.IsNullOrWhiteSpace(candidate))
-			.Select(candidate => Path.GetFullPath(candidate!))
-			.FirstOrDefault(File.Exists);
-	}
-
-	private static string? CombineRoot(string? root, params string[] parts) =>
-		string.IsNullOrWhiteSpace(root) ? null : Path.Combine(new[] { root }.Concat(parts).ToArray());
 }
 
 /// <summary>Default shell-free process runner for dotnet tool update.</summary>

--- a/clio-ring/ClioRing/Services/DevClioLaunch.cs
+++ b/clio-ring/ClioRing/Services/DevClioLaunch.cs
@@ -14,8 +14,9 @@ public readonly record struct DevClioValidation(bool IsValid, string Message);
 
 /// <summary>
 /// Pure helpers for the dev-clio path override: validate a user-supplied path and turn a valid one into
-/// the <see cref="ClioIpcSettings"/> used to launch the clio MCP child. Kept free of I/O beyond the
-/// existence check so it is trivially unit-testable and shared by the settings VM and the composition root.
+/// the <see cref="ClioIpcSettings"/> used to launch the clio MCP child. Kept free of process-spawning I/O
+/// (only filesystem existence/env-var reads for path validation and trusted <c>dotnet</c> host resolution)
+/// so it is trivially unit-testable and shared by the settings VM and the composition root.
 /// </summary>
 public static class DevClioLaunch {
 	/// <summary>
@@ -44,8 +45,10 @@ public static class DevClioLaunch {
 	}
 
 	/// <summary>
-	/// Builds the launch configuration for a validated dev-clio path: a <c>.dll</c> is driven by
-	/// <c>dotnet</c>; a <c>.exe</c> is launched directly. Both append the <c>mcp-server</c> verb.
+	/// Builds the launch configuration for a validated dev-clio path: a <c>.dll</c> is driven by the
+	/// trusted <c>dotnet</c> host resolved to an absolute path (never a bare <c>"dotnet"</c> name, which
+	/// would be resolved via <c>PATH</c>); a <c>.exe</c> is launched directly. Both append the
+	/// <c>mcp-server</c> verb.
 	/// </summary>
 	/// <param name="path">A dev-clio build path that has passed <see cref="Validate"/>.</param>
 	/// <returns>The <see cref="ClioIpcSettings"/> that launches the dev clio.</returns>
@@ -57,7 +60,7 @@ public static class DevClioLaunch {
 		string trimmed = path.Trim();
 		bool isDll = trimmed.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
 		return isDll
-			? new ClioIpcSettings { Command = "dotnet", Args = new[] { trimmed, "mcp-server" } }
+			? new ClioIpcSettings { Command = DotNetHostResolver.ResolveOrDefault(), Args = new[] { trimmed, "mcp-server" } }
 			: new ClioIpcSettings { Command = trimmed, Args = new[] { "mcp-server" } };
 	}
 

--- a/clio-ring/ClioRing/Services/DotNetHostResolver.cs
+++ b/clio-ring/ClioRing/Services/DotNetHostResolver.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ClioRing.Services;
+
+/// <summary>
+/// Resolves the trusted <c>dotnet</c> host executable by absolute path from well-known locations
+/// (<c>DOTNET_HOST_PATH</c>, <c>DOTNET_ROOT</c>/<c>DOTNET_ROOT_X64</c>, Program Files on Windows) instead
+/// of trusting a bare <c>"dotnet"</c> name to whatever <c>CreateProcess</c>'s search order (calling-process
+/// directory first, then <c>PATH</c>) turns up. Shared by <see cref="ClioToolUpdateService"/> (global-tool
+/// update/inventory) and <see cref="DevClioLaunch"/> (Development runtime mode launch) so both consumers of
+/// the trusted host stay in one place.
+/// </summary>
+internal static class DotNetHostResolver {
+	/// <summary>
+	/// Resolves an existing, absolute <c>dotnet</c>/<c>dotnet.exe</c> host path from the trusted candidate
+	/// locations, or <c>null</c> when none of them exist.
+	/// </summary>
+	/// <returns>The absolute host path, or <c>null</c> when unresolved.</returns>
+	internal static string? TryResolve() {
+		string executableName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+		var candidates = new List<string?> {
+			Environment.GetEnvironmentVariable("DOTNET_HOST_PATH"),
+			CombineRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT"), executableName),
+			CombineRoot(Environment.GetEnvironmentVariable("DOTNET_ROOT_X64"), executableName)
+		};
+		if (OperatingSystem.IsWindows()) {
+			candidates.Add(CombineRoot(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+				"dotnet", executableName));
+		}
+		return candidates.Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+			.Select(candidate => Path.GetFullPath(candidate!))
+			.FirstOrDefault(File.Exists);
+	}
+
+	/// <summary>
+	/// Resolves the trusted <c>dotnet</c> host the same way as <see cref="TryResolve"/>, falling back to
+	/// the standard Program Files install location (Windows) or the standard install-script location
+	/// (non-Windows) as a best-guess absolute path when none of the trusted candidates exist yet. Never
+	/// falls back to a bare <c>"dotnet"</c> name that would be resolved via <c>PATH</c>.
+	/// </summary>
+	/// <returns>An absolute <c>dotnet</c> host path — resolved when possible, otherwise a guessed default.</returns>
+	internal static string ResolveOrDefault() {
+		return TryResolve() ?? Path.GetFullPath(OperatingSystem.IsWindows()
+			? CombineRoot(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet",
+				"dotnet.exe")!
+			: "/usr/local/share/dotnet/dotnet");
+	}
+
+	private static string? CombineRoot(string? root, params string[] parts) =>
+		string.IsNullOrWhiteSpace(root) ? null : Path.Combine(new[] { root }.Concat(parts).ToArray());
+}

--- a/clio-ring/ClioRing/Services/WorkspaceService.cs
+++ b/clio-ring/ClioRing/Services/WorkspaceService.cs
@@ -212,7 +212,7 @@ public class WorkspaceService
 				}
 				: new ProcessStartInfo
 				{
-					FileName = "cmd.exe", // NOSONAR: Windows system command host resolves from the protected system path
+					FileName = Path.Combine(Environment.SystemDirectory, "cmd.exe"), // Resolved by absolute path: CreateProcess searches the calling process's own directory before System32
 					Arguments = $"/c code \"{workspacePath}\"",
 					UseShellExecute = false,
 					CreateNoWindow = true

--- a/clio.mcp.e2e/Support/Configuration/TemporaryClioSettingsOverride.cs
+++ b/clio.mcp.e2e/Support/Configuration/TemporaryClioSettingsOverride.cs
@@ -79,13 +79,31 @@ internal sealed class TemporaryClioSettingsOverride : IDisposable {
 		return Path.Combine(userPath, companyName, productName, "appsettings.json");
 	}
 
+	/// <summary>
+	/// Resolves the trusted <c>dotnet</c> host used to launch a <c>clio.dll</c> under test by reusing the
+	/// current test process's own image instead of a bare <c>"dotnet"</c> name resolved via
+	/// <c>CreateProcess</c>'s search order (calling-process directory first, then <c>PATH</c> — the same
+	/// defect class fixed in GH-1162). The e2e suite always runs as a <c>dotnet</c>-hosted process (for
+	/// example via <c>dotnet test</c>), so <see cref="Environment.ProcessPath"/> already IS an absolute,
+	/// trusted <c>dotnet</c> muxer capable of launching the sibling clio.dll build on the same machine.
+	/// </summary>
+	private static string ResolveCurrentDotNetHostPath() {
+		string? processPath = Environment.ProcessPath;
+		if (!string.IsNullOrWhiteSpace(processPath) && File.Exists(processPath)) {
+			return processPath;
+		}
+		// Unexpected: the current process image could not be resolved. This is test-harness-only code
+		// exercised on a developer/CI machine that already controls its own PATH, not shipped product.
+		return "dotnet"; // NOSONAR: last-resort fallback only when Environment.ProcessPath is unavailable.
+	}
+
 	private static string ResolveSettingsPathFromClioProcess(
 		string clioProcessPath,
 		IReadOnlyDictionary<string, string?>? processEnvironmentVariables) {
 		ProcessStartInfo startInfo;
 		string fullPath = Path.GetFullPath(clioProcessPath);
 		if (fullPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)) {
-			startInfo = new ProcessStartInfo("dotnet") {
+			startInfo = new ProcessStartInfo(ResolveCurrentDotNetHostPath()) {
 				ArgumentList = { fullPath, "info", "--settings-file" }
 			};
 		}

--- a/clio/Utilities/FileManager.cs
+++ b/clio/Utilities/FileManager.cs
@@ -11,7 +11,7 @@ namespace Clio.Utilities
 			ConsoleLogger.Instance.WriteLine($"Open {filePath}...");
 			if (OSPlatformChecker.GetIsWindowsEnvironment()) {
 #pragma warning disable CLIO004 // Static context; file-open requires direct Process usage
-				Process.Start(new ProcessStartInfo("cmd", $"/c start {filePath}") { CreateNoWindow = true });
+				Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true });
 #pragma warning restore CLIO004
 			} else {
 				string terminalPath = "/usr/bin/open";


### PR DESCRIPTION
Fixes #1162

## Summary

`clio/Utilities/FileManager.cs` no longer launches `cmd.exe` by bare name (PATH-searched, CWE-427) — bypasses `cmd.exe` entirely via `Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true })` (the standard "open with OS-associated app" pattern), since the only caller passes a fixed, trusted path. `clio-ring/ClioRing/Services/WorkspaceService.cs` resolves `cmd.exe` via `Environment.SystemDirectory` instead of PATH, and its previous `// NOSONAR` justification (which incorrectly claimed protection that a bare name doesn't actually provide) is corrected.

## Review process

Ran a dedicated deep review (CWE-427, Windows process-launch semantics, a repo-wide sibling-defect sweep for the same pattern) before requesting review. Found and fixed **2 additional sibling defects the original sweep missed** — same class, different files:

- **High (fixed)**: `clio-ring/ClioRing/Services/DevClioLaunch.cs` launched `dotnet` by bare name for Ring's "Development" runtime mode (reachable from Settings, not developer-only code) — the same PATH-hijack shape #1162 fixes for `cmd.exe`. This codebase already had a correct trusted-path resolver for exactly this binary in `ClioToolUpdateService`; extracted it into a shared `DotNetHostResolver` used by both call sites.
- **High (fixed)**: `clio.mcp.e2e/Support/Configuration/TemporaryClioSettingsOverride.cs` had the same bare-`"dotnet"` pattern in test-harness code — fixed via `Environment.ProcessPath` (the current dotnet-hosted test process's own absolute path).
- **Low (noted, not fixed)**: `UseShellExecute=true` is a behavior change for the missing-file/no-association case — old code silently no-op'd inside a detached shell; new code can throw a `Win32Exception` synchronously. The one caller (`RegAppCommand.Execute`) already has a generic `catch (Exception e)`, so this is a visible-error-instead-of-silent-failure improvement, not a crash — flagging for manual QA awareness on Windows, not a defect.
- Positive side-effect confirmed by the reviewer: the old `cmd /c start {filePath}` code was actually broken for paths containing spaces (unquoted interpolation); the new fix incidentally closes that too.

## Tests

`dotnet-ring` mandatory compatibility gate: `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 157/158 passed (1 pre-existing, unrelated macOS-specific path-separator test failure, confirmed identical on `master`). `clio.mcp.e2e` builds clean on both target frameworks. `clio.csproj` builds clean on net8.0/net10.0.

ClioRing compatibility reviewed — no MCP tool, CLI verb, or Ring-consumed protocol surface changed; only the resolved `Command` value for one internal launch path changed from a bare name to an absolute path.
