### PR TITLE
Security: CI/CD workflow hardening - pin action SHA, remove secret splicing, enforce HTTPS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0   # full history needed for accurate path diffing
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         id: filter
         with:
           filters: |

--- a/.github/workflows/reliase-to-nuget.yml
+++ b/.github/workflows/reliase-to-nuget.yml
@@ -200,5 +200,5 @@ jobs:
         run: |
           $version = "${{ steps.extract_version.outputs.VERSION }}"
           echo "Publishing clio package version $version to NuGet..."
-          dotnet nuget push ".\output\*.nupkg" --api-key ${{ secrets.CLIO_NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push ".\output\*.nupkg" --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
           echo "Successfully published clio $version to NuGet!"

--- a/.github/workflows/reliase-to-nuget.yml
+++ b/.github/workflows/reliase-to-nuget.yml
@@ -87,25 +87,6 @@ jobs:
             /p:CoverletOutput=".\..\TestResults\coverage.opencover.xml" `
             /p:AssemblyVersion=$version /p:FileVersion=$version /p:Version=$version;
 
-#      - name: Build and analyze
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#          SONAR_URL: ${{ secrets.SONAR_URL }}
-#        shell: powershell
-#        run: |
-#          dotnet build-server shutdown;
-#          dotnet build .\Clio.Analyzers\Clio.Analyzers.csproj
-#          $version = "${{ steps.extract_version.outputs.VERSION }}"
-#          echo "Building clio with version: $version"
-#          C:\Tools\dotnet-coverage.exe collect "dotnet test .\clio.tests\clio.tests.csproj" -f xml -o "coverage.xml";
-#          dotnet sonarscanner begin /k:"clio" /d:sonar.host.url="${{ secrets.SONAR_URL }}" `
-#          /d:sonar.login="${{ secrets.SONAR_TOKEN }}" `
-#          /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml;
-#          dotnet build .\clio\clio.csproj -c Release --no-incremental /p:AssemblyVersion=$version /p:FileVersion=$version /p:Version=$version;
-#          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}";
-#          dotnet build-server shutdown;
-
       - name: Pack clio with release version
         run: |
           $version = "${{ steps.extract_version.outputs.VERSION }}"
@@ -197,6 +178,7 @@ jobs:
       - name: Publish to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.CLIO_NUGET_API_KEY }}
+        shell: powershell
         run: |
           $version = "${{ steps.extract_version.outputs.VERSION }}"
           echo "Publishing clio package version $version to NuGet..."

--- a/create-release.sh
+++ b/create-release.sh
@@ -69,7 +69,7 @@ install_github_cli() {
             # Try different package managers
             if command -v apt >/dev/null 2>&1; then
                 echo -e "${CYAN}Using apt package manager...${NC}"
-                curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+                curl -fsSL --proto '=https' --tlsv1.2 https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
                 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
                 sudo apt update && sudo apt install gh
             elif command -v yum >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #1163

## Summary

Three independent CI/CD supply-chain hardening items: `dorny/paths-filter` pinned to a commit SHA (not a mutable tag), a secret no longer spliced directly into a `run:` block (routed through the already-declared `env:` var instead), and `create-release.sh`'s GitHub CLI keyring fetch now enforces HTTPS with `--proto '=https' --tlsv1.2`.

## Review process

Ran a dedicated deep review (GitHub's "Security hardening for GitHub Actions" guide, OpenSSF Scorecard's pinned-dependencies check) before requesting review, including independently re-verifying the pinned SHA against the live GitHub API rather than trusting the diff's claim. Found:

- **SHA pin: independently verified correct.** `gh api repos/dorny/paths-filter/git/refs/tags/v3.0.4` confirms the pinned SHA is real, current, and matches `v3.0.4` — the latest `v3.x` release (a `v4.x` line exists but was deliberately not adopted in this pass; scope was "pin, don't upgrade").
- **Medium (fixed)**: a commented-out "Build and analyze" step block in `reliase-to-nuget.yml` retained the *exact same* secret-splicing anti-pattern this PR fixes elsewhere (`${{ secrets.SONAR_URL }}`/`${{ secrets.SONAR_TOKEN }}` spliced into `run:` text) — inert today, but a landmine if ever re-enabled verbatim. Deleted the dead block.
- **Medium (fixed)**: the modified "Publish to NuGet" step was the only step in the file relying on the runner's implicit default shell instead of an explicit `shell:` key (every sibling step declares one). Added `shell: powershell` for consistency.
- **Low (noted)**: `actions/checkout@v5` (GitHub's own first-party action) deliberately left unpinned, per the issue's explicit lower-priority scoping.

## Tests

No C# build/test applies (workflow YAML + shell script only). YAML validated with `yaml.safe_load` after every change; `bash -n` on the shell script; manual diff review to confirm no indentation breakage.
