### PR TITLE
Security: gate plaintext HTTP registry fallback behind --allow-insecure-registry

### DIFF
--- a/clio.tests/Common/ContainerRegistryPreflightServiceTests.cs
+++ b/clio.tests/Common/ContainerRegistryPreflightServiceTests.cs
@@ -85,13 +85,38 @@ public class ContainerRegistryPreflightServiceTests {
 
 		// Act
 		ContainerRegistryPreflightResult result =
-			service.ValidatePushTarget("registry.krylov.cloud", "registry.krylov.cloud/creatio-prod:1.0.0");
+			service.ValidatePushTarget(
+				"registry.krylov.cloud", "registry.krylov.cloud/creatio-prod:1.0.0", allowInsecureRegistry: true);
 
 		// Assert
 		result.Success.Should().BeTrue(
-			"because the command should still be able to preflight plain HTTP registries on trusted local networks");
+			"because the command should still be able to preflight plain HTTP registries on trusted local networks when the caller opted in with --allow-insecure-registry");
 		result.Endpoint.Should().Be("http://registry.krylov.cloud/",
 			"because the fallback HTTP endpoint is the one that actually accepted the upload probe");
+	}
+
+	[Test]
+	[Description("ValidatePushTarget should not fall back to HTTP for a bare-authority registry prefix when allowInsecureRegistry is left at its default of false, and should mention the opt-in flag in the failure message.")]
+	public void ValidatePushTarget_ShouldNotFallbackToHttpAndShouldMentionFlag_WhenAllowInsecureRegistryIsDefault() {
+		// Arrange
+		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
+		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
+		using HttpClient httpClient = new(new StubHttpMessageHandler([
+			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/", new HttpRequestException("Connection refused"))
+		]));
+		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
+
+		// Act
+		ContainerRegistryPreflightResult result =
+			service.ValidatePushTarget("registry.krylov.cloud", "registry.krylov.cloud/creatio-prod:1.0.0");
+
+		// Assert
+		result.Success.Should().BeFalse(
+			"because HTTPS was unreachable and the default (secure) mode must not silently fall back to plaintext HTTP");
+		result.Message.Should().NotContain("http://registry.krylov.cloud",
+			"because no plaintext HTTP endpoint should have been probed without an explicit opt-in");
+		result.Message.Should().Contain("--allow-insecure-registry",
+			"because the failure message should tell the operator how to opt in if the registry is intentionally HTTP-only");
 	}
 
 	[Test]
@@ -115,6 +140,32 @@ public class ContainerRegistryPreflightServiceTests {
 		// Assert
 		result.Success.Should().BeTrue(
 			"because the preflight should reuse locally configured registry credentials when the CLI already knows how to authenticate");
+	}
+
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("ValidatePushTarget should probe only the endpoint implied by an already-absolute registry prefix's explicit scheme, regardless of the allowInsecureRegistry flag.")]
+	public void ValidatePushTarget_ShouldUseExplicitSchemeEndpointOnly_RegardlessOfAllowInsecureRegistry(
+		bool allowInsecureRegistry) {
+		// Arrange
+		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
+		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
+		using HttpClient httpClient = new(new StubHttpMessageHandler([
+			new StubResponse(HttpMethod.Get, "http://myregistry:5000/v2/", new HttpResponseMessage(HttpStatusCode.OK)),
+			new StubResponse(HttpMethod.Post, "http://myregistry:5000/v2/repo/blobs/uploads/",
+				new HttpResponseMessage(HttpStatusCode.Accepted))
+		]));
+		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
+
+		// Act
+		ContainerRegistryPreflightResult result =
+			service.ValidatePushTarget("http://myregistry:5000", "myregistry:5000/repo:1.0.0", allowInsecureRegistry);
+
+		// Assert
+		result.Success.Should().BeTrue(
+			"because an explicit http scheme in the registry prefix is honored as-is, independent of the allowInsecureRegistry opt-in");
+		result.Endpoint.Should().Be("http://myregistry:5000/",
+			"because the early-return absolute-prefix branch probes exactly the scheme and authority the caller specified, with no https-first attempt and no additional candidate");
 	}
 
 	private sealed record StubResponse(HttpMethod Method, string Uri, object Result);

--- a/clio.tests/Common/ContainerRegistryPreflightServiceTests.cs
+++ b/clio.tests/Common/ContainerRegistryPreflightServiceTests.cs
@@ -76,7 +76,8 @@ public class ContainerRegistryPreflightServiceTests {
 		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
 		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
 		using HttpClient httpClient = new(new StubHttpMessageHandler([
-			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/", new HttpRequestException("Connection refused")),
+			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/",
+				new HttpRequestException(HttpRequestError.ConnectionError, "Connection refused")),
 			new StubResponse(HttpMethod.Get, "http://registry.krylov.cloud/v2/", new HttpResponseMessage(HttpStatusCode.OK)),
 			new StubResponse(HttpMethod.Post, "http://registry.krylov.cloud/v2/creatio-prod/blobs/uploads/",
 				new HttpResponseMessage(HttpStatusCode.Accepted)),
@@ -102,7 +103,8 @@ public class ContainerRegistryPreflightServiceTests {
 		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
 		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
 		using HttpClient httpClient = new(new StubHttpMessageHandler([
-			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/", new HttpRequestException("Connection refused"))
+			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/",
+				new HttpRequestException(HttpRequestError.ConnectionError, "Connection refused"))
 		]));
 		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
 
@@ -142,11 +144,29 @@ public class ContainerRegistryPreflightServiceTests {
 			"because the preflight should reuse locally configured registry credentials when the CLI already knows how to authenticate");
 	}
 
-	[TestCase(false)]
-	[TestCase(true)]
-	[Description("ValidatePushTarget should probe only the endpoint implied by an already-absolute registry prefix's explicit scheme, regardless of the allowInsecureRegistry flag.")]
-	public void ValidatePushTarget_ShouldUseExplicitSchemeEndpointOnly_RegardlessOfAllowInsecureRegistry(
-		bool allowInsecureRegistry) {
+	[Test]
+	[Description("ValidatePushTarget should reject an explicit http:// registry prefix when allowInsecureRegistry is left at its default of false, with a message mentioning the opt-in flag.")]
+	public void ValidatePushTarget_ShouldRejectExplicitHttpScheme_WhenAllowInsecureRegistryIsDefault() {
+		// Arrange
+		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
+		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
+		using HttpClient httpClient = new(new StubHttpMessageHandler([]));
+		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
+
+		// Act
+		ContainerRegistryPreflightResult result =
+			service.ValidatePushTarget("http://myregistry:5000", "myregistry:5000/repo:1.0.0");
+
+		// Assert
+		result.Success.Should().BeFalse(
+			"because an explicit http:// scheme must not be probed without the --allow-insecure-registry opt-in, for consistency with the bare-authority fallback case");
+		result.Message.Should().Contain("--allow-insecure-registry",
+			"because the failure message should tell the operator how to opt in if the registry is intentionally HTTP-only");
+	}
+
+	[Test]
+	[Description("ValidatePushTarget should probe an explicit http:// registry prefix when allowInsecureRegistry is set to true.")]
+	public void ValidatePushTarget_ShouldProbeExplicitHttpScheme_WhenAllowInsecureRegistryIsTrue() {
 		// Arrange
 		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
 		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
@@ -159,13 +179,61 @@ public class ContainerRegistryPreflightServiceTests {
 
 		// Act
 		ContainerRegistryPreflightResult result =
-			service.ValidatePushTarget("http://myregistry:5000", "myregistry:5000/repo:1.0.0", allowInsecureRegistry);
+			service.ValidatePushTarget("http://myregistry:5000", "myregistry:5000/repo:1.0.0", allowInsecureRegistry: true);
 
 		// Assert
 		result.Success.Should().BeTrue(
-			"because an explicit http scheme in the registry prefix is honored as-is, independent of the allowInsecureRegistry opt-in");
+			"because an explicit http scheme is probed once the caller opts in with --allow-insecure-registry");
 		result.Endpoint.Should().Be("http://myregistry:5000/",
 			"because the early-return absolute-prefix branch probes exactly the scheme and authority the caller specified, with no https-first attempt and no additional candidate");
+	}
+
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("ValidatePushTarget should always honor an explicit https:// registry prefix, independent of the allowInsecureRegistry flag, because that scheme is already secure.")]
+	public void ValidatePushTarget_ShouldProbeExplicitHttpsScheme_RegardlessOfAllowInsecureRegistry(
+		bool allowInsecureRegistry) {
+		// Arrange
+		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
+		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
+		using HttpClient httpClient = new(new StubHttpMessageHandler([
+			new StubResponse(HttpMethod.Get, "https://myregistry:5000/v2/", new HttpResponseMessage(HttpStatusCode.OK)),
+			new StubResponse(HttpMethod.Post, "https://myregistry:5000/v2/repo/blobs/uploads/",
+				new HttpResponseMessage(HttpStatusCode.Accepted))
+		]));
+		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
+
+		// Act
+		ContainerRegistryPreflightResult result =
+			service.ValidatePushTarget("https://myregistry:5000", "myregistry:5000/repo:1.0.0", allowInsecureRegistry);
+
+		// Assert
+		result.Success.Should().BeTrue(
+			"because an explicit https scheme in the registry prefix is already secure and is honored as-is, independent of the allowInsecureRegistry opt-in");
+		result.Endpoint.Should().Be("https://myregistry:5000/",
+			"because the early-return absolute-prefix branch probes exactly the scheme and authority the caller specified, with no additional candidate");
+	}
+
+	[Test]
+	[Description("ValidatePushTarget should not mention --allow-insecure-registry for a bare-authority registry prefix when the probe failure is an unrelated HTTP error response rather than evidence of a missing HTTPS listener.")]
+	public void ValidatePushTarget_ShouldNotMentionFlag_WhenBareAuthorityProbeFailsWithUnrelatedHttpError() {
+		// Arrange
+		IContainerRegistryCredentialProvider credentialProvider = Substitute.For<IContainerRegistryCredentialProvider>();
+		credentialProvider.TryResolveCredentials(Arg.Any<string>(), Arg.Any<Uri>()).Returns((ContainerRegistryCredentials)null);
+		using HttpClient httpClient = new(new StubHttpMessageHandler([
+			new StubResponse(HttpMethod.Get, "https://registry.krylov.cloud/v2/", new HttpResponseMessage(HttpStatusCode.NotFound))
+		]));
+		ContainerRegistryPreflightService service = new(httpClient, credentialProvider);
+
+		// Act
+		ContainerRegistryPreflightResult result =
+			service.ValidatePushTarget("registry.krylov.cloud", "registry.krylov.cloud/creatio-prod:1.0.0");
+
+		// Assert
+		result.Success.Should().BeFalse(
+			"because a 404 response from GET /v2/ does not confirm registry API availability");
+		result.Message.Should().NotContain("--allow-insecure-registry",
+			"because a generic HTTP error response is not evidence of a missing HTTPS listener, so suggesting the insecure opt-in would be misleading");
 	}
 
 	private sealed record StubResponse(HttpMethod Method, string Uri, object Result);

--- a/clio/Command/BuildDockerImageCommand.cs
+++ b/clio/Command/BuildDockerImageCommand.cs
@@ -64,7 +64,7 @@ public class BuildDockerImageOptions {
 	/// Gets or sets a value indicating whether the registry push preflight may fall back to plaintext HTTP.
 	/// </summary>
 	[Option("allow-insecure-registry", Required = false, Default = false,
-		HelpText = "Allow falling back to a plaintext HTTP connection when probing a container registry that has no explicit scheme and does not respond over HTTPS. Off by default.")]
+		HelpText = "Required opt-in for any plaintext HTTP registry probing: allows falling back to HTTP when the registry prefix has no explicit scheme and does not respond over HTTPS, and allows probing an explicitly specified http:// prefix. Off by default.")]
 	public bool AllowInsecureRegistry { get; set; }
 }
 

--- a/clio/Command/BuildDockerImageCommand.cs
+++ b/clio/Command/BuildDockerImageCommand.cs
@@ -59,6 +59,13 @@ public class BuildDockerImageOptions {
 	/// </summary>
 	[Option("use-nerdctl", Required = false, HelpText = "Use the nerdctl CLI for this invocation, bypassing runtime CLI auto-detection")]
 	public bool UseNerdctl { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the registry push preflight may fall back to plaintext HTTP.
+	/// </summary>
+	[Option("allow-insecure-registry", Required = false, Default = false,
+		HelpText = "Allow falling back to a plaintext HTTP connection when probing a container registry that has no explicit scheme and does not respond over HTTPS. Off by default.")]
+	public bool AllowInsecureRegistry { get; set; }
 }
 
 /// <summary>

--- a/clio/Command/BuildDockerImageService.cs
+++ b/clio/Command/BuildDockerImageService.cs
@@ -178,7 +178,8 @@ public sealed class BuildDockerImageService(
 		}
 
 		if (!sharedRegistryPreflightCompleted) {
-			int registryPreflightResult = ValidateRegistryPushTarget(containerImageCli, registryImageReference);
+			int registryPreflightResult =
+				ValidateRegistryPushTarget(containerImageCli, registryImageReference, options.AllowInsecureRegistry);
 			if (registryPreflightResult != 0) {
 				failedSteps.Add("registry-preflight");
 				return new BuildDockerImageTemplateResult(templateRequest.DisplayName, localImageReference, false, failedSteps);
@@ -386,7 +387,8 @@ public sealed class BuildDockerImageService(
 
 		foreach (string registryTarget in registryTargets) {
 			_logger.WriteInfo($"Running shared registry push preflight for batch against: {registryTarget}");
-			int registryPreflightResult = ValidateRegistryPushTarget(containerImageCli, registryTarget);
+			int registryPreflightResult =
+				ValidateRegistryPushTarget(containerImageCli, registryTarget, options.AllowInsecureRegistry);
 			if (registryPreflightResult != 0) {
 				return registryPreflightResult;
 			}
@@ -1127,7 +1129,8 @@ public sealed class BuildDockerImageService(
 
 	private int ValidateRegistryPushTarget(
 		ContainerImageCliKind containerImageCli,
-		string registryImageReference) {
+		string registryImageReference,
+		bool allowInsecureRegistry) {
 		if (string.IsNullOrWhiteSpace(registryImageReference)) {
 			return 0;
 		}
@@ -1139,7 +1142,7 @@ public sealed class BuildDockerImageService(
 
 		_logger.WriteInfo($"Running registry push preflight for: {registryImageReference}");
 		ContainerRegistryPreflightResult preflightResult =
-			_containerRegistryPreflightService.ValidatePushTarget(registryPrefix, registryImageReference);
+			_containerRegistryPreflightService.ValidatePushTarget(registryPrefix, registryImageReference, allowInsecureRegistry);
 		if (preflightResult.Success) {
 			_logger.WriteInfo(
 				$"Registry push preflight succeeded via '{preflightResult.Endpoint}' for '{registryImageReference}'.");

--- a/clio/Common/ContainerRegistryPreflightService.cs
+++ b/clio/Common/ContainerRegistryPreflightService.cs
@@ -17,9 +17,12 @@ public interface IContainerRegistryPreflightService {
 	/// <param name="registryPrefix">Registry or repository prefix supplied by the user.</param>
 	/// <param name="registryImageReference">Fully qualified image reference that would be pushed.</param>
 	/// <param name="allowInsecureRegistry">
-	/// When <c>true</c> and <paramref name="registryPrefix"/> has no explicit scheme, probing falls back to a
-	/// plaintext HTTP endpoint if HTTPS is unreachable. Defaults to <c>false</c> so credentials and probe traffic
-	/// never leave the process over plaintext HTTP without an explicit opt-in.
+	/// Required opt-in for any plaintext HTTP probing. When <paramref name="registryPrefix"/> has no explicit
+	/// scheme, setting this to <c>true</c> allows probing to fall back to a plaintext HTTP endpoint if HTTPS is
+	/// unreachable. When <paramref name="registryPrefix"/> explicitly specifies <c>http://</c>, that endpoint is
+	/// only probed if this is also <c>true</c> - otherwise validation fails immediately with a message pointing at
+	/// this flag. An explicit <c>https://</c> scheme is unaffected and always honored. Defaults to <c>false</c> so
+	/// credentials and probe traffic never leave the process over plaintext HTTP without an explicit opt-in.
 	/// </param>
 	/// <returns>Preflight result describing whether the push target appears usable.</returns>
 	ContainerRegistryPreflightResult ValidatePushTarget(
@@ -62,8 +65,21 @@ public sealed class ContainerRegistryPreflightService(
 		}
 
 		string repositoryName = ExtractRepositoryName(registryImageReference);
-		bool isBareAuthorityPrefix = !Uri.TryCreate(registryPrefix.Trim().TrimEnd('/'), UriKind.Absolute, out _);
+		bool hasExplicitScheme =
+			Uri.TryCreate(registryPrefix.Trim().TrimEnd('/'), UriKind.Absolute, out Uri absolutePrefix);
+		bool isBareAuthorityPrefix = !hasExplicitScheme;
+		if (hasExplicitScheme
+			&& string.Equals(absolutePrefix.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+			&& !allowInsecureRegistry) {
+			return new ContainerRegistryPreflightResult(
+				false,
+				string.Empty,
+				$"Registry prefix '{registryPrefix}' explicitly specifies http:// but --allow-insecure-registry "
+				+ "was not set. Retry with --allow-insecure-registry if this registry is intentionally HTTP-only.");
+		}
+
 		List<string> probeErrors = [];
+		bool anyProbeSuggestsMissingHttpsListener = false;
 		foreach (Uri endpoint in BuildCandidateEndpoints(registryPrefix, allowInsecureRegistry)) {
 			try {
 				ContainerRegistryCredentials credentials = _credentialProvider.TryResolveCredentials(registryPrefix, endpoint);
@@ -126,17 +142,31 @@ public sealed class ContainerRegistryPreflightService(
 			}
 			catch (Exception exception) {
 				probeErrors.Add($"{endpoint} probe failed: {exception.Message}");
+				if (LooksLikeMissingHttpsListener(exception)) {
+					anyProbeSuggestsMissingHttpsListener = true;
+				}
 			}
 		}
 
 		string combinedMessage = probeErrors.Count == 0
 			? $"No reachable registry endpoint was found for '{registryPrefix}'."
 			: string.Join(Environment.NewLine, probeErrors);
-		if (!allowInsecureRegistry && isBareAuthorityPrefix && probeErrors.Count > 0) {
+		if (!allowInsecureRegistry && isBareAuthorityPrefix && anyProbeSuggestsMissingHttpsListener) {
 			combinedMessage += " If this registry is intentionally HTTP-only, retry with --allow-insecure-registry.";
 		}
 
 		return new ContainerRegistryPreflightResult(false, string.Empty, combinedMessage);
+	}
+
+	/// <summary>
+	/// Determines whether a probe failure looks like there is no HTTPS listener at all (connection refused or a
+	/// failed TLS handshake), as opposed to an unrelated HTTP error response, DNS failure, or timeout. Used to
+	/// decide whether suggesting <c>--allow-insecure-registry</c> is actually relevant to the failure at hand.
+	/// </summary>
+	private static bool LooksLikeMissingHttpsListener(Exception exception) {
+		return exception is HttpRequestException httpRequestException
+			&& httpRequestException.HttpRequestError
+				is HttpRequestError.ConnectionError or HttpRequestError.SecureConnectionError;
 	}
 
 	private IEnumerable<Uri> BuildCandidateEndpoints(string registryPrefix, bool allowInsecureRegistry) {

--- a/clio/Common/ContainerRegistryPreflightService.cs
+++ b/clio/Common/ContainerRegistryPreflightService.cs
@@ -16,8 +16,14 @@ public interface IContainerRegistryPreflightService {
 	/// </summary>
 	/// <param name="registryPrefix">Registry or repository prefix supplied by the user.</param>
 	/// <param name="registryImageReference">Fully qualified image reference that would be pushed.</param>
+	/// <param name="allowInsecureRegistry">
+	/// When <c>true</c> and <paramref name="registryPrefix"/> has no explicit scheme, probing falls back to a
+	/// plaintext HTTP endpoint if HTTPS is unreachable. Defaults to <c>false</c> so credentials and probe traffic
+	/// never leave the process over plaintext HTTP without an explicit opt-in.
+	/// </param>
 	/// <returns>Preflight result describing whether the push target appears usable.</returns>
-	ContainerRegistryPreflightResult ValidatePushTarget(string registryPrefix, string registryImageReference);
+	ContainerRegistryPreflightResult ValidatePushTarget(
+		string registryPrefix, string registryImageReference, bool allowInsecureRegistry = false);
 }
 
 /// <summary>
@@ -45,7 +51,8 @@ public sealed class ContainerRegistryPreflightService(
 		credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
 
 	/// <inheritdoc />
-	public ContainerRegistryPreflightResult ValidatePushTarget(string registryPrefix, string registryImageReference) {
+	public ContainerRegistryPreflightResult ValidatePushTarget(
+		string registryPrefix, string registryImageReference, bool allowInsecureRegistry = false) {
 		if (string.IsNullOrWhiteSpace(registryPrefix)) {
 			throw new ArgumentException("Registry prefix is required.", nameof(registryPrefix));
 		}
@@ -55,8 +62,9 @@ public sealed class ContainerRegistryPreflightService(
 		}
 
 		string repositoryName = ExtractRepositoryName(registryImageReference);
+		bool isBareAuthorityPrefix = !Uri.TryCreate(registryPrefix.Trim().TrimEnd('/'), UriKind.Absolute, out _);
 		List<string> probeErrors = [];
-		foreach (Uri endpoint in BuildCandidateEndpoints(registryPrefix)) {
+		foreach (Uri endpoint in BuildCandidateEndpoints(registryPrefix, allowInsecureRegistry)) {
 			try {
 				ContainerRegistryCredentials credentials = _credentialProvider.TryResolveCredentials(registryPrefix, endpoint);
 				using HttpResponseMessage anonymousPingResponse =
@@ -124,10 +132,14 @@ public sealed class ContainerRegistryPreflightService(
 		string combinedMessage = probeErrors.Count == 0
 			? $"No reachable registry endpoint was found for '{registryPrefix}'."
 			: string.Join(Environment.NewLine, probeErrors);
+		if (!allowInsecureRegistry && isBareAuthorityPrefix && probeErrors.Count > 0) {
+			combinedMessage += " If this registry is intentionally HTTP-only, retry with --allow-insecure-registry.";
+		}
+
 		return new ContainerRegistryPreflightResult(false, string.Empty, combinedMessage);
 	}
 
-	private IEnumerable<Uri> BuildCandidateEndpoints(string registryPrefix) {
+	private IEnumerable<Uri> BuildCandidateEndpoints(string registryPrefix, bool allowInsecureRegistry) {
 		string trimmedPrefix = registryPrefix.Trim().TrimEnd('/');
 		if (Uri.TryCreate(trimmedPrefix, UriKind.Absolute, out Uri absolutePrefix)) {
 			yield return new Uri($"{absolutePrefix.Scheme}://{absolutePrefix.Authority}/");
@@ -136,7 +148,9 @@ public sealed class ContainerRegistryPreflightService(
 
 		string authority = trimmedPrefix.Split('/', 2, StringSplitOptions.RemoveEmptyEntries)[0];
 		yield return new Uri($"https://{authority}/");
-		yield return new Uri($"http://{authority}/");
+		if (allowInsecureRegistry) {
+			yield return new Uri($"http://{authority}/");
+		}
 	}
 
 	private string ExtractRepositoryName(string registryImageReference) {

--- a/clio/docs/commands/build-docker-image.md
+++ b/clio/docs/commands/build-docker-image.md
@@ -94,6 +94,17 @@ prepending `PREFIX`.
 Before the image build starts, clio runs a registry preflight probe against
 the final push target and fails fast if the registry is unreachable or
 upload initiation is rejected.
+When PREFIX has no explicit scheme, the preflight probes HTTPS only unless
+`--allow-insecure-registry` is set; see that option for the plaintext HTTP
+fallback behavior.
+
+--allow-insecure-registry
+Optional. Default: off. When PREFIX has no explicit scheme and the registry
+does not respond over HTTPS, allow the preflight probe to fall back to a
+plaintext HTTP connection. Off by default so credentials and probe traffic
+never leave the process over plaintext HTTP without an explicit opt-in.
+Has no effect when PREFIX already has an explicit scheme (for example
+`http://registry.internal:5000`); that scheme is always honored as-is.
 
 --use-docker
 Optional. Force docker for this invocation and bypass runtime CLI auto-detection.
@@ -209,6 +220,9 @@ without registry access
 8. If `--registry` is set, run registry push preflight before the expensive image build
 - probe `GET /v2/` to confirm registry availability
 - probe `POST /v2/<repository>/blobs/uploads/` to confirm upload initiation
+- when the registry prefix has no explicit scheme, probe HTTPS only, unless
+`--allow-insecure-registry` is set, in which case fall back to plaintext
+HTTP if HTTPS is unreachable
 - fail early when the registry is unreachable, rejects anonymous upload,
 or requires authentication
 - multi-template builds run this preflight once per invocation, then rely on
@@ -295,6 +309,13 @@ Use a custom template directory:
 clio build-docker-image \
 --from "/opt/builds/creatio-net8" \
 --template "/workspace/docker-templates/custom-prod"
+
+Push to an intentionally HTTP-only registry:
+clio build-docker-image \
+--from "/opt/builds/creatio-net8" \
+--template prod \
+--registry "registry.internal:5000" \
+--allow-insecure-registry
 ```
 
 ## Output
@@ -331,6 +352,12 @@ clio build-docker-image \
     "looks like a .NET Framework Creatio distribution"
         Use a Creatio .NET 8+ distribution. .NET Framework builds are not supported
         for Docker image creation.
+
+    "If this registry is intentionally HTTP-only, retry with --allow-insecure-registry."
+        The registry prefix has no explicit scheme and did not respond over HTTPS.
+        By default clio does not fall back to plaintext HTTP. If the registry is
+        genuinely HTTP-only and you accept sending credentials/probe traffic over
+        plaintext HTTP, retry the command with `--allow-insecure-registry`.
 
 ## Reporting Bugs
 

--- a/clio/docs/commands/build-docker-image.md
+++ b/clio/docs/commands/build-docker-image.md
@@ -94,17 +94,21 @@ prepending `PREFIX`.
 Before the image build starts, clio runs a registry preflight probe against
 the final push target and fails fast if the registry is unreachable or
 upload initiation is rejected.
-When PREFIX has no explicit scheme, the preflight probes HTTPS only unless
-`--allow-insecure-registry` is set; see that option for the plaintext HTTP
-fallback behavior.
+The preflight never uses plaintext HTTP without `--allow-insecure-registry`,
+whether PREFIX has no explicit scheme (HTTPS-only, no HTTP fallback) or
+PREFIX explicitly specifies `http://` (rejected immediately with a message
+pointing at the flag); see that option for details.
 
 --allow-insecure-registry
-Optional. Default: off. When PREFIX has no explicit scheme and the registry
-does not respond over HTTPS, allow the preflight probe to fall back to a
-plaintext HTTP connection. Off by default so credentials and probe traffic
-never leave the process over plaintext HTTP without an explicit opt-in.
-Has no effect when PREFIX already has an explicit scheme (for example
-`http://registry.internal:5000`); that scheme is always honored as-is.
+Optional. Default: off. Required opt-in for any plaintext HTTP probing.
+When PREFIX has no explicit scheme and the registry does not respond over
+HTTPS, this allows the preflight probe to fall back to a plaintext HTTP
+connection. When PREFIX explicitly specifies `http://` (for example
+`http://registry.internal:5000`), that endpoint is only probed if this flag
+is also set; otherwise the command fails immediately without probing.
+Off by default so credentials and probe traffic never leave the process
+over plaintext HTTP without an explicit opt-in. An explicit `https://`
+PREFIX is unaffected either way.
 
 --use-docker
 Optional. Force docker for this invocation and bypass runtime CLI auto-detection.
@@ -223,6 +227,9 @@ without registry access
 - when the registry prefix has no explicit scheme, probe HTTPS only, unless
 `--allow-insecure-registry` is set, in which case fall back to plaintext
 HTTP if HTTPS is unreachable
+- when the registry prefix explicitly specifies `http://`, probe it only if
+`--allow-insecure-registry` is set; otherwise fail immediately without
+probing (an explicit `https://` prefix is always honored)
 - fail early when the registry is unreachable, rejects anonymous upload,
 or requires authentication
 - multi-template builds run this preflight once per invocation, then rely on
@@ -354,10 +361,19 @@ clio build-docker-image \
         for Docker image creation.
 
     "If this registry is intentionally HTTP-only, retry with --allow-insecure-registry."
-        The registry prefix has no explicit scheme and did not respond over HTTPS.
-        By default clio does not fall back to plaintext HTTP. If the registry is
-        genuinely HTTP-only and you accept sending credentials/probe traffic over
-        plaintext HTTP, retry the command with `--allow-insecure-registry`.
+        The registry prefix has no explicit scheme and HTTPS probing failed with a
+        connection-refused or TLS-handshake error, suggesting no HTTPS listener is
+        present. By default clio does not fall back to plaintext HTTP. If the
+        registry is genuinely HTTP-only and you accept sending credentials/probe
+        traffic over plaintext HTTP, retry the command with
+        `--allow-insecure-registry`. This hint is not shown for unrelated failures
+        (for example a 404/500 response, DNS failure, or timeout), since those are
+        not evidence of a missing HTTPS listener.
+
+    "Registry prefix 'X' explicitly specifies http:// but --allow-insecure-registry was not set."
+        PREFIX explicitly used `http://`. clio never probes an explicit plaintext
+        HTTP endpoint without the opt-in. Retry with `--allow-insecure-registry` if
+        the registry is intentionally HTTP-only.
 
 ## Reporting Bugs
 

--- a/clio/help/en/build-docker-image.txt
+++ b/clio/help/en/build-docker-image.txt
@@ -83,17 +83,21 @@ OPTIONS
         Before the image build starts, clio runs a registry preflight probe against
         the final push target and fails fast if the registry is unreachable or
         upload initiation is rejected.
-        When PREFIX has no explicit scheme, the preflight probes HTTPS only unless
-        `--allow-insecure-registry` is set; see that option for the plaintext HTTP
-        fallback behavior.
+        The preflight never uses plaintext HTTP without `--allow-insecure-registry`,
+        whether PREFIX has no explicit scheme (HTTPS-only, no HTTP fallback) or
+        PREFIX explicitly specifies `http://` (rejected immediately with a message
+        pointing at the flag); see that option for details.
 
     --allow-insecure-registry
-        Optional. Default: off. When PREFIX has no explicit scheme and the registry
-        does not respond over HTTPS, allow the preflight probe to fall back to a
-        plaintext HTTP connection. Off by default so credentials and probe traffic
-        never leave the process over plaintext HTTP without an explicit opt-in.
-        Has no effect when PREFIX already has an explicit scheme (for example
-        `http://registry.internal:5000`); that scheme is always honored as-is.
+        Optional. Default: off. Required opt-in for any plaintext HTTP probing.
+        When PREFIX has no explicit scheme and the registry does not respond over
+        HTTPS, this allows the preflight probe to fall back to a plaintext HTTP
+        connection. When PREFIX explicitly specifies `http://` (for example
+        `http://registry.internal:5000`), that endpoint is only probed if this flag
+        is also set; otherwise the command fails immediately without probing.
+        Off by default so credentials and probe traffic never leave the process
+        over plaintext HTTP without an explicit opt-in. An explicit `https://`
+        PREFIX is unaffected either way.
 
     --use-docker
         Optional. Force docker for this invocation and bypass runtime CLI auto-detection.
@@ -207,6 +211,9 @@ BEHAVIOR
        - when the registry prefix has no explicit scheme, probe HTTPS only, unless
          `--allow-insecure-registry` is set, in which case fall back to plaintext
          HTTP if HTTPS is unreachable
+       - when the registry prefix explicitly specifies `http://`, probe it only if
+         `--allow-insecure-registry` is set; otherwise fail immediately without
+         probing (an explicit `https://` prefix is always honored)
        - fail early when the registry is unreachable, rejects anonymous upload,
          or requires authentication
         - multi-template builds run this preflight once per invocation, then rely on
@@ -332,10 +339,19 @@ TROUBLESHOOTING
         for Docker image creation.
 
     "If this registry is intentionally HTTP-only, retry with --allow-insecure-registry."
-        The registry prefix has no explicit scheme and did not respond over HTTPS.
-        By default clio does not fall back to plaintext HTTP. If the registry is
-        genuinely HTTP-only and you accept sending credentials/probe traffic over
-        plaintext HTTP, retry the command with `--allow-insecure-registry`.
+        The registry prefix has no explicit scheme and HTTPS probing failed with a
+        connection-refused or TLS-handshake error, suggesting no HTTPS listener is
+        present. By default clio does not fall back to plaintext HTTP. If the
+        registry is genuinely HTTP-only and you accept sending credentials/probe
+        traffic over plaintext HTTP, retry the command with
+        `--allow-insecure-registry`. This hint is not shown for unrelated failures
+        (for example a 404/500 response, DNS failure, or timeout), since those are
+        not evidence of a missing HTTPS listener.
+
+    "Registry prefix 'X' explicitly specifies http:// but --allow-insecure-registry was not set."
+        PREFIX explicitly used `http://`. clio never probes an explicit plaintext
+        HTTP endpoint without the opt-in. Retry with `--allow-insecure-registry` if
+        the registry is intentionally HTTP-only.
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio

--- a/clio/help/en/build-docker-image.txt
+++ b/clio/help/en/build-docker-image.txt
@@ -83,6 +83,17 @@ OPTIONS
         Before the image build starts, clio runs a registry preflight probe against
         the final push target and fails fast if the registry is unreachable or
         upload initiation is rejected.
+        When PREFIX has no explicit scheme, the preflight probes HTTPS only unless
+        `--allow-insecure-registry` is set; see that option for the plaintext HTTP
+        fallback behavior.
+
+    --allow-insecure-registry
+        Optional. Default: off. When PREFIX has no explicit scheme and the registry
+        does not respond over HTTPS, allow the preflight probe to fall back to a
+        plaintext HTTP connection. Off by default so credentials and probe traffic
+        never leave the process over plaintext HTTP without an explicit opt-in.
+        Has no effect when PREFIX already has an explicit scheme (for example
+        `http://registry.internal:5000`); that scheme is always honored as-is.
 
     --use-docker
         Optional. Force docker for this invocation and bypass runtime CLI auto-detection.
@@ -193,6 +204,9 @@ BEHAVIOR
     8. If `--registry` is set, run registry push preflight before the expensive image build
        - probe `GET /v2/` to confirm registry availability
        - probe `POST /v2/<repository>/blobs/uploads/` to confirm upload initiation
+       - when the registry prefix has no explicit scheme, probe HTTPS only, unless
+         `--allow-insecure-registry` is set, in which case fall back to plaintext
+         HTTP if HTTPS is unreachable
        - fail early when the registry is unreachable, rejects anonymous upload,
          or requires authentication
         - multi-template builds run this preflight once per invocation, then rely on
@@ -277,6 +291,13 @@ EXAMPLES
           --from "/opt/builds/creatio-net8" \
           --template "/workspace/docker-templates/custom-prod"
 
+    Push to an intentionally HTTP-only registry:
+        clio build-docker-image \
+          --from "/opt/builds/creatio-net8" \
+          --template prod \
+          --registry "registry.internal:5000" \
+          --allow-insecure-registry
+
 OUTPUT
     On success, the command logs:
     - Resolved source path
@@ -309,6 +330,12 @@ TROUBLESHOOTING
     "looks like a .NET Framework Creatio distribution"
         Use a Creatio .NET 8+ distribution. .NET Framework builds are not supported
         for Docker image creation.
+
+    "If this registry is intentionally HTTP-only, retry with --allow-insecure-registry."
+        The registry prefix has no explicit scheme and did not respond over HTTPS.
+        By default clio does not fall back to plaintext HTTP. If the registry is
+        genuinely HTTP-only and you accept sending credentials/probe traffic over
+        plaintext HTTP, retry the command with `--allow-insecure-registry`.
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio


### PR DESCRIPTION
Fixes #1164

## Summary

`ContainerRegistryPreflightService` no longer falls back to plaintext HTTP when probing a container registry unless the operator explicitly passes the new `--allow-insecure-registry` flag on `build-docker-image`. Previously this fallback was silent and unconditional for a bare-authority registry prefix.

## Review process

Ran a dedicated deep review (secure-by-default API design, precedents from `npm`/`docker`/`git`'s own insecure-transport opt-ins) before requesting review. Found and fixed a real self-contradiction between the code's stated guarantee and its actual behavior:

- **High (fixed)**: the XML doc and user-facing docs claimed plaintext HTTP is "never used without explicit opt-in" — but an *already-absolute* `http://`-scheme registry prefix was honored unconditionally regardless of the flag, contradicting that claim in the same paragraph of the docs. Rather than just weakening the docs to match the looser behavior, tightened the behavior itself for consistency with this PR's whole premise: an explicit `http://` prefix now also requires `--allow-insecure-registry`, with a clear rejection message when it's missing. An explicit `https://` prefix is unaffected either way.
- **Medium (fixed)**: the "retry with `--allow-insecure-registry`" hint in the failure message previously fired for *any* probe failure on a bare-authority prefix (including unrelated 404s, DNS failures, timeouts) — nudging users toward disabling transport security for problems it wouldn't fix. Scoped the hint to only fire when the failure looks like a genuinely missing HTTPS listener (`HttpRequestError.ConnectionError`/`SecureConnectionError`).
- **Low (noted, pre-existing, out of scope)**: `BuildDockerImageService.ExtractRegistryPrefix` currently can't actually route an explicit-scheme `--registry "http://host:5000"` value through to the now-stricter absolute-URI branch correctly (it truncates at the first `/`, landing on `"http:"`) — the absolute-URI branch is only reachable today via direct calls to the interface, as in the unit tests. Not a live risk right now, but a follow-up ticket is warranted so the tightened behavior above is actually reachable from the CLI.

## Tests

10/10 tests passing on `ContainerRegistryPreflightServiceTests` (added: reject-explicit-http-when-flag-false, scoped-hint-absent-on-unrelated-404; updated: explicit-https-unaffected). `clio.csproj` builds clean on net8.0/net10.0. Targeted `Module=Common` suite: 20 pre-existing unrelated failures (confirmed unrelated to this diff), 0 new failures. Docs (`clio/docs/commands/build-docker-image.md`, `clio/help/en/build-docker-image.txt`) updated to remove the contradiction and describe the tightened behavior.
