### PR TITLE
fix(mcp): validate odata-update/-delete/-create response bodies before reporting success

### DIFF
--- a/clio.mcp.e2e/ODataWriteNonJsonResponseE2ETests.cs
+++ b/clio.mcp.e2e/ODataWriteNonJsonResponseE2ETests.cs
@@ -1,0 +1,206 @@
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>
+/// End-to-end coverage for ENG-95971: a session against an environment whose odata endpoint answers
+/// with an IIS-style HTML error page (never JSON, never one of the shapes <see cref="ODataResponseError"/>
+/// recognizes) showed odata-read correctly failing while odata-update reported success:true unconditionally
+/// — the write tools ignored the transport response entirely. odata-update, odata-delete, and odata-create
+/// must all report the same underlying failure instead of masking it as a successful write.
+/// </summary>
+[TestFixture]
+[Category("McpE2E.Sandbox")]
+[AllureNUnit]
+[AllureFeature(ODataUpdateTool.ToolName)]
+[NonParallelizable]
+public sealed class ODataWriteNonJsonResponseE2ETests {
+	private const string RegisterToolName = "reg-web-app";
+	private const string StubbedEntity = "labClientStatus";
+	private const string RecordId = "8ecab4a1-0ca3-4515-9399-efe0a19390bd";
+
+	[Test]
+	[AllureTag(ODataUpdateTool.ToolName)]
+	[AllureName("odata-update reports an HTML odata response as a structured failure")]
+	[AllureDescription("Registers an environment against a stub whose odata endpoint answers PATCH with an HTML error page, then verifies odata-update returns success:false instead of the unconditional success it used to report.")]
+	[Description("odata-update against an odata endpoint that answers with HTML (never JSON) returns success:false naming the transport-layer cause, not a masked success.")]
+	public async Task ODataUpdate_Should_Report_NonJson_Response_As_Failure() {
+		await RunAgainstNonJsonStubAsync(async (session, environmentName, cancellationToken) => {
+			// Act
+			CallToolResult callResult = await session.CallToolAsync(
+				ODataUpdateTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["entity"] = StubbedEntity,
+						["id"] = RecordId,
+						["data"] = new Dictionary<string, object?> { ["Name"] = "New" },
+						["confirm"] = true
+					}
+				},
+				cancellationToken);
+			ODataWriteResponse response = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
+
+			// Assert
+			callResult.IsError.Should().NotBeTrue(
+				because: "a bindable odata-update payload should return a structured tool response, not a protocol error");
+			response.Success.Should().BeFalse(
+				because: "an HTML odata response must never be reported as a successful update - the request never reached a real OData controller");
+			response.Error.Should().Contain("was not JSON",
+				because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+		});
+	}
+
+	[Test]
+	[AllureTag(ODataDeleteTool.ToolName)]
+	[AllureName("odata-delete reports an HTML odata response as a structured failure")]
+	[AllureDescription("Registers an environment against a stub whose odata endpoint answers DELETE with an HTML error page, then verifies odata-delete returns success:false instead of the unconditional success it used to report.")]
+	[Description("odata-delete against an odata endpoint that answers with HTML (never JSON) returns success:false naming the transport-layer cause, not a masked success.")]
+	public async Task ODataDelete_Should_Report_NonJson_Response_As_Failure() {
+		await RunAgainstNonJsonStubAsync(async (session, environmentName, cancellationToken) => {
+			// Act
+			CallToolResult callResult = await session.CallToolAsync(
+				ODataDeleteTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["entity"] = StubbedEntity,
+						["id"] = RecordId,
+						["confirm"] = true
+					}
+				},
+				cancellationToken);
+			ODataWriteResponse response = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
+
+			// Assert
+			callResult.IsError.Should().NotBeTrue(
+				because: "a bindable odata-delete payload should return a structured tool response, not a protocol error");
+			response.Success.Should().BeFalse(
+				because: "an HTML odata response must never be reported as a successful delete - the request never reached a real OData controller");
+			response.Error.Should().Contain("was not JSON",
+				because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+		});
+	}
+
+	[Test]
+	[AllureTag(ODataCreateTool.ToolName)]
+	[AllureName("odata-create reports an HTML odata response as a structured per-row failure")]
+	[AllureDescription("Registers an environment against a stub whose odata endpoint answers POST with an HTML error page, then verifies odata-create reports the row as failed with record-created unknown, instead of the unconditional success it used to report for a non-JSON body.")]
+	[Description("odata-create against an odata endpoint that answers with HTML (never JSON) reports the row as failed with record-created unknown, not a masked created-record success.")]
+	public async Task ODataCreate_Should_Report_NonJson_Response_As_Failure() {
+		await RunAgainstNonJsonStubAsync(async (session, environmentName, cancellationToken) => {
+			// Act
+			CallToolResult callResult = await session.CallToolAsync(
+				ODataCreateTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["entity"] = StubbedEntity,
+						["rows"] = new object[] { new Dictionary<string, object?> { ["Name"] = "Active" } }
+					}
+				},
+				cancellationToken);
+			ODataCreateBatchResponse response = EntitySchemaStructuredResultParser.Extract<ODataCreateBatchResponse>(callResult);
+
+			// Assert
+			callResult.IsError.Should().NotBeTrue(
+				because: "a bindable odata-create payload should return a structured tool response, not a protocol error");
+			response.Failed.Should().Be(1,
+				because: "the single row targets an endpoint that answered with HTML and must be reported as failed, not created");
+			ODataRowResult row = response.Results.Should().ContainSingle(
+				because: "the one-row batch should report exactly one per-row result").Subject;
+			row.Success.Should().BeFalse(
+				because: "an HTML odata response must never be reported as a successful create");
+			row.RecordCreated.Should().BeNull(
+				because: "the request never reached Creatio intact, so whether a post-insert handler already wrote the row is unknown");
+			row.Error.Should().Contain("was not JSON",
+				because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+		});
+	}
+
+	/// <summary>
+	/// Stands up the isolated clio home, the non-JSON odata stub, a real mcp-server session, and a
+	/// registered environment pointing at the stub, then runs <paramref name="act"/> against them.
+	/// Centralizes the arrange so the three write-tool tests do not each re-implement it.
+	/// </summary>
+	private static async Task RunAgainstNonJsonStubAsync(
+		Func<McpServerSession, string, CancellationToken, Task> act) {
+		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-odata-write-nonjson-e2e-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempHome);
+		try {
+			string envVarName = OperatingSystem.IsWindows() ? "LOCALAPPDATA" : "HOME";
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			settings.ProcessEnvironmentVariables[envVarName] = tempHome;
+			using TemporaryClioSettingsOverride settingsOverride = TemporaryClioSettingsOverride.ReplaceContent(
+				"""
+				{
+				  "ActiveEnvironmentKey": null,
+				  "Environments": {}
+				}
+				""",
+				settings.ClioProcessPath,
+				settings.ProcessEnvironmentVariables);
+			await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
+				new RuntimeDetectionStubServerConfiguration(
+					NetCoreHealthEnabled: true,
+					NetFrameworkHealthEnabled: true,
+					NetCoreServiceEnabled: false,
+					NetFrameworkServiceEnabled: true,
+					NetCoreUiMarkerEnabled: false,
+					NetFrameworkUiMarkerEnabled: true,
+					ODataNonJsonEntity: StubbedEntity));
+			using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
+			await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			string environmentName = $"odata-write-nonjson-{Guid.NewGuid():N}";
+			await RegisterEnvironmentAsync(session, environmentName, stubServer.BaseUrl, cancellationTokenSource.Token);
+
+			await act(session, environmentName, cancellationTokenSource.Token);
+		} finally {
+			TryDeleteDirectory(tempHome);
+		}
+	}
+
+	private static void TryDeleteDirectory(string path) {
+		try {
+			if (Directory.Exists(path)) {
+				Directory.Delete(path, recursive: true);
+			}
+		} catch {
+			// Best-effort cleanup of the isolated home directory; a leaked temp dir must not fail the test.
+		}
+	}
+
+	private static async Task RegisterEnvironmentAsync(
+		McpServerSession session,
+		string environmentName,
+		string baseUrl,
+		CancellationToken cancellationToken) {
+		IReadOnlyCollection<string> toolNames = await session.ListReachableToolNamesAsync(cancellationToken);
+		toolNames.Should().Contain(RegisterToolName,
+			because: $"the {RegisterToolName} MCP tool must be discoverable before the test can register the stub environment");
+
+		CallToolResult registerResult = await session.CallToolAsync(
+			RegisterToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["uri"] = baseUrl,
+					["login"] = "Supervisor",
+					["password"] = "Supervisor"
+				}
+			},
+			cancellationToken);
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(registerResult);
+		execution.ExitCode.Should().Be(0,
+			because: "the stub environment must register successfully before the odata-* write tools can be exercised against it");
+	}
+}

--- a/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
+++ b/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
@@ -63,6 +63,14 @@ internal sealed class RuntimeDetectionStubServer : IAsyncDisposable {
 	/// </summary>
 	public const string SelectQueryHtmlBodyMarker = "select-query-secret-marker";
 
+	/// <summary>
+	/// Marker embedded in the HTML body the stub returns for any odata request (GET/POST/PATCH/DELETE)
+	/// against <see cref="RuntimeDetectionStubServerConfiguration.ODataNonJsonEntity"/>. Mirrors the
+	/// IIS-served 404/401 pages observed in ENG-95971: the request reaches the stub but never reaches a
+	/// real OData controller, so the body is plain HTML instead of any recognized JSON shape.
+	/// </summary>
+	public const string ODataNonJsonBodyMarker = "odata-nonjson-secret-marker";
+
 	private static string BuildScript(RuntimeDetectionStubServerConfiguration configuration, int port) {
 		string configJson = JsonSerializer.Serialize(configuration);
 		return $$"""
@@ -145,6 +153,15 @@ http.createServer((request, response) => {
       sendText(response, 404, "Not Found");
       return;
     }
+    if (config.ODataNonJsonEntity && url.includes("/odata/" + config.ODataNonJsonEntity)) {
+      // ENG-95971: the stand answered an odata request (read or write) with an IIS-style HTML error
+      // page instead of JSON or a recognized error shape - the request reached the stub but never
+      // reached a real OData controller. Any HTTP method is matched: the same failure was observed on
+      // GET, PATCH, and DELETE alike.
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end("<!DOCTYPE html><html><head><title>404 - File or directory not found.</title></head><body>{{ODataNonJsonBodyMarker}}</body></html>");
+      return;
+    }
     if ((request.method === "GET" || request.method === "POST") && config.ODataRoutingErrorEntity && (url.includes("/odata/" + config.ODataRoutingErrorEntity + "?") || url.endsWith("/odata/" + config.ODataRoutingErrorEntity))) {
       // ASP.NET Web API 404 routing error shape for an unregistered/uncompiled OData controller.
       // Creatio returns this with HTTP 200 in the analyzed session, masking the failure as data.
@@ -177,4 +194,5 @@ internal sealed record RuntimeDetectionStubServerConfiguration(
 	bool NetCoreUiMarkerEnabled = false,
 	bool NetFrameworkUiMarkerEnabled = false,
 	string? ODataRoutingErrorEntity = null,
-	string? HtmlSelectQuerySchemaName = null);
+	string? HtmlSelectQuerySchemaName = null,
+	string? ODataNonJsonEntity = null);

--- a/clio.tests/Command/McpServer/ODataCreateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataCreateToolTests.cs
@@ -547,6 +547,32 @@ public sealed class ODataCreateToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[Description("A non-JSON response body (an IIS/proxy error page instead of Creatio's OData pipeline) leaves record-created unknown rather than reporting a successful create — the request never reached Creatio intact, so the row's side effect cannot be assumed.")]
+	public void Create_Should_Report_RecordCreated_Unknown_On_Non_Json_Response() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("<html><head><title>404 - File or directory not found.</title></head></html>");
+		ODataCreateTool tool = BuildTool(client);
+
+		// Act
+		ODataCreateBatchResponse response = tool.Create(new ODataCreateArgs {
+			EnvironmentName = "dev", Entity = "Account", Rows = Arr("[{\"Name\":\"Acme\"}]")
+		});
+
+		// Assert
+		response.Results[0].Success.Should().BeFalse(because: "an HTML error page proves the request never reached Creatio's OData pipeline");
+		response.Results[0].RecordCreated.Should().BeNull(
+			because: "the request did not reach Creatio intact, so whether a post-insert handler already wrote the row is unknown");
+		response.Results[0].RetryGuidance.Should().NotBeNullOrWhiteSpace(
+			because: "an unknown side effect must tell the caller to verify instead of retrying");
+		response.Results[0].Error.Should().Contain("was not JSON",
+			because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+		response.Unverified.Should().Be(1, because: "the batch must surface how many rows are unverified");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("A transport failure leaves record-created unknown, because the request may have been applied before the error surfaced on the client side.")]
 	public void Create_Should_Report_RecordCreated_Unknown_On_Transport_Failure() {
 		// Arrange

--- a/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
@@ -102,4 +102,53 @@ public sealed class ODataDeleteToolTests {
 		response.Error.Should().Be("entity is required.");
 		resolver.DidNotReceive().Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>());
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A non-JSON response body (an IIS/proxy error page instead of Creatio's OData pipeline) must never be reported as a successful delete — the write's transport layer never throws on a non-2xx status, so the body is the only signal available.")]
+	public void Delete_Should_Fail_When_Response_Is_Not_Json() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("<html><head><title>401 - Unauthorized: Access is denied due to invalid credentials.</title></head></html>");
+		ODataDeleteTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Delete(new ODataDeleteArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(because: "an HTML error page proves the request never reached Creatio's OData pipeline");
+		response.Error.Should().Contain("was not JSON", because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("An empty DELETE response body (Creatio's normal 204 No Content on success) is reported as success.")]
+	public void Delete_Should_Succeed_On_Empty_Response_Body() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(string.Empty);
+		ODataDeleteTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Delete(new ODataDeleteArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeTrue(because: "an empty body is Creatio's normal successful DELETE response");
+	}
 }

--- a/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command.McpServer;
 
 [TestFixture]
+[Property("Module", "McpServer")]
 public sealed class ODataDeleteToolTests {
 	private const string Guid = "8ecab4a1-0ca3-4515-9399-efe0a19390bd";
 
@@ -150,5 +151,30 @@ public sealed class ODataDeleteToolTests {
 
 		// Assert
 		response.Success.Should().BeTrue(because: "an empty body is Creatio's normal successful DELETE response");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A recognized Creatio OData error body returned with a non-failing HTTP status is reported as a failure, not swallowed as a successful delete — a before-delete business rule or an FK constraint rejection is the most likely non-empty DELETE body.")]
+	public void Delete_Should_Fail_When_Response_Is_ODataError() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("{\"error\":{\"code\":\"\",\"message\":\"The DELETE request violates a foreign key constraint\"}}");
+		ODataDeleteTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Delete(new ODataDeleteArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(because: "an OData error envelope must not be reported as a successful delete");
+		response.Error.Should().Be("The DELETE request violates a foreign key constraint");
 	}
 }

--- a/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace Clio.Tests.Command.McpServer;
 
 [TestFixture]
+[Property("Module", "McpServer")]
 public sealed class ODataUpdateToolTests {
 	private const string Guid = "8ecab4a1-0ca3-4515-9399-efe0a19390bd";
 	private static JsonElement Obj(string json) => JsonDocument.Parse(json).RootElement.Clone();
@@ -183,5 +184,30 @@ public sealed class ODataUpdateToolTests {
 		// Assert
 		response.Success.Should().BeFalse(because: "an OData error envelope must not be reported as a successful update");
 		response.Error.Should().Be("Column Name is required");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A valid JSON response body that is not one of the recognized Creatio error shapes is reported as success — this pins the third ValidateWriteResponse branch, so a broadened error detector cannot start failing every PATCH that answers with a plain body.")]
+	public void Update_Should_Succeed_When_Response_Is_Valid_Json_Without_Error() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("{}");
+		ODataUpdateTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Update(new ODataUpdateArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Data = Obj("{\"Name\":\"New\"}"), Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeTrue(because: "an empty JSON object carries none of the recognized error members, so it is consistent with a successful PATCH");
+		response.Error.Should().BeNull();
 	}
 }

--- a/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
@@ -110,4 +110,78 @@ public sealed class ODataUpdateToolTests {
 		response.Error.Should().Contain("data is required");
 		client.DidNotReceive().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("An empty PATCH response body (Creatio's normal 204 No Content on success) is reported as success.")]
+	public void Update_Should_Succeed_On_Empty_Response_Body() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(string.Empty);
+		ODataUpdateTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Update(new ODataUpdateArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Data = Obj("{\"Name\":\"New\"}"), Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeTrue(because: "an empty body is Creatio's normal successful PATCH response");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A non-JSON response body (an IIS/proxy error page instead of Creatio's OData pipeline) must never be reported as a successful update — the write's transport layer never throws on a non-2xx status, so the body is the only signal available.")]
+	public void Update_Should_Fail_When_Response_Is_Not_Json() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("<html><head><title>404 - File or directory not found.</title></head></html>");
+		ODataUpdateTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Update(new ODataUpdateArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Data = Obj("{\"Name\":\"New\"}"), Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(because: "an HTML error page proves the request never reached Creatio's OData pipeline");
+		response.Error.Should().Contain("was not JSON", because: "the diagnostic must point at the transport layer, not the request's OData/ESQ shape");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A recognized Creatio OData error body returned with a non-failing HTTP status is reported as a failure, not swallowed as a successful update.")]
+	public void Update_Should_Fail_When_Response_Is_ODataError() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
+		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("{\"error\":{\"code\":\"\",\"message\":\"Column Name is required\"}}");
+		ODataUpdateTool tool = new(resolver);
+
+		// Act
+		ODataWriteResponse response = tool.Update(new ODataUpdateArgs {
+			EnvironmentName = "dev", Entity = "Contact", Id = Guid, Data = Obj("{\"Name\":\"New\"}"), Confirm = true
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(because: "an OData error envelope must not be reported as a successful update");
+		response.Error.Should().Be("Column Name is required");
+	}
 }

--- a/clio/Command/McpServer/Tools/ODataCreateTool.cs
+++ b/clio/Command/McpServer/Tools/ODataCreateTool.cs
@@ -145,21 +145,24 @@ public sealed class ODataCreateTool(IToolCommandResolver commandResolver) {
 					Success = false,
 					RecordCreated = null,
 					RetryGuidance = UnknownSideEffectGuidance,
-					Error = SensitiveErrorTextRedactor.Redact($"OData create did not return a record Id. Response: {Truncate(json)}")
+					Error = SensitiveErrorTextRedactor.Redact($"OData create did not return a record Id. Response: {ODataResponseError.Truncate(json)}")
 				};
 			}
 			return new ODataRowResult { Index = index, Success = true, RecordCreated = true, Id = id };
 		} catch (JsonException) {
-			// A non-JSON body on a successful POST still means the record was created.
-			return new ODataRowResult { Index = index, Success = true, RecordCreated = true };
+			// A non-JSON body never comes from Creatio's OData pipeline by itself - even a server
+			// error is one of the JSON shapes ODataResponseError.TryDetect recognizes. This shape means
+			// the request did not reach Creatio intact (a proxy/IIS/routing error, or a session
+			// redirect), so the row's side effect is UNKNOWN, not a confirmed create - never report
+			// record-created here.
+			return new ODataRowResult {
+				Index = index,
+				Success = false,
+				RecordCreated = null,
+				RetryGuidance = UnknownSideEffectGuidance,
+				Error = SensitiveErrorTextRedactor.Redact(ODataResponseError.DescribeNonJsonResponse(json))
+			};
 		}
-	}
-
-	private static string Truncate(string value) {
-		if (string.IsNullOrEmpty(value)) {
-			return "<empty>";
-		}
-		return value.Length > 500 ? value[..500] + "..." : value;
 	}
 }
 

--- a/clio/Command/McpServer/Tools/ODataDeleteTool.cs
+++ b/clio/Command/McpServer/Tools/ODataDeleteTool.cs
@@ -38,7 +38,11 @@ public sealed class ODataDeleteTool(IToolCommandResolver commandResolver) {
 			}
 
 			(IApplicationClient client, string url) = ODataKeyedWrite.ResolveTarget(commandResolver, args.EnvironmentName, args.Entity, args.Id);
-			client.ExecuteDeleteRequest(url, string.Empty, 30_000);
+			string response = client.ExecuteDeleteRequest(url, string.Empty, 30_000);
+			string validationError = ODataKeyedWrite.ValidateWriteResponse(response);
+			if (validationError is not null) {
+				return ODataWriteResponse.Failure(validationError);
+			}
 			return new ODataWriteResponse(true, null, args.Id.Trim());
 		} catch (Exception ex) {
 			return ODataWriteResponse.Failure(SensitiveErrorTextRedactor.Redact(ex.Message));

--- a/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
+++ b/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
@@ -72,6 +72,11 @@ internal static class ODataKeyedWrite {
 	/// <param name="response">The raw response body returned by the PATCH/DELETE request.</param>
 	/// <returns>A redacted failure message, or <c>null</c> when the response is consistent with success.</returns>
 	internal static string ValidateWriteResponse(string response) {
+		// Whitespace counts as "no body", not as an unparsable body: a proxy that pads an otherwise
+		// empty 204 with a newline is the realistic source of a whitespace-only response, and Creatio
+		// itself always answers a genuine failure with one of the recognized JSON error shapes. Treating
+		// whitespace as a failure would therefore turn successful writes into false negatives, which is
+		// the worse outcome here - the caller would re-send an update that already landed.
 		if (string.IsNullOrWhiteSpace(response)) {
 			return null;
 		}

--- a/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
+++ b/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Clio.Common;
 
 namespace Clio.Command.McpServer.Tools;
@@ -57,5 +58,30 @@ internal static class ODataKeyedWrite {
 		IServiceUrlBuilder urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
 		string url = urlBuilder.Build(ODataKeyFormatter.KeyPath(entity, id));
 		return (client, url);
+	}
+
+	/// <summary>
+	/// Validates the response body of a keyed PATCH/DELETE write. Creatio normally answers a
+	/// successful update or delete with <c>204 No Content</c> (empty body), so an empty response is
+	/// success. The transport layer (<see cref="IApplicationClient"/>) returns whatever body came
+	/// back regardless of HTTP status - it never throws for a non-2xx response - so a body that IS
+	/// present must be inspected: a recognized Creatio error shape, or a body that fails to parse as
+	/// JSON at all (an IIS/proxy error page, a stale-session redirect), both mean the write must not
+	/// be reported as successful.
+	/// </summary>
+	/// <param name="response">The raw response body returned by the PATCH/DELETE request.</param>
+	/// <returns>A redacted failure message, or <c>null</c> when the response is consistent with success.</returns>
+	internal static string ValidateWriteResponse(string response) {
+		if (string.IsNullOrWhiteSpace(response)) {
+			return null;
+		}
+		try {
+			using JsonDocument doc = JsonDocument.Parse(response);
+			return ODataResponseError.TryDetect(doc.RootElement, out string serverError)
+				? SensitiveErrorTextRedactor.Redact(serverError)
+				: null;
+		} catch (JsonException) {
+			return SensitiveErrorTextRedactor.Redact(ODataResponseError.DescribeNonJsonResponse(response));
+		}
 	}
 }

--- a/clio/Command/McpServer/Tools/ODataResponseError.cs
+++ b/clio/Command/McpServer/Tools/ODataResponseError.cs
@@ -29,6 +29,35 @@ internal static class ODataResponseError {
 		+ "an entity deployed without compilation).";
 
 	/// <summary>
+	/// Hint appended when a write response body could not be parsed as JSON at all. Creatio's OData
+	/// pipeline never returns a non-JSON body by itself - even a server error comes back as one of the
+	/// shapes <see cref="TryDetect"/> recognizes. A non-JSON body (an HTML error page, a plain-text
+	/// block) therefore means the request did not reach Creatio's OData controller intact: a proxy/IIS
+	/// routing error, or a session redirect page the reauth executor did not recognize as expired.
+	/// Retrying immediately will not help with the former, and the side effect of the write itself is
+	/// unverified either way - the caller must confirm the actual state before retrying.
+	/// </summary>
+	internal const string NonJsonResponseHint =
+		"The response was not JSON, which Creatio's OData pipeline never returns by itself (even a server error "
+		+ "is one of the recognized JSON error shapes). This points to the request not reaching Creatio intact - "
+		+ "a proxy/IIS/routing error, or a session redirect - rather than a problem with the request's OData/ESQ "
+		+ "shape. Whether the change was actually applied is unverified; confirm with odata-read before retrying.";
+
+	/// <summary>
+	/// Builds the failure text for a write response body that failed to parse as JSON.
+	/// </summary>
+	internal static string DescribeNonJsonResponse(string body) =>
+		$"Creatio did not return a JSON response. {NonJsonResponseHint} Response: {Truncate(body)}";
+
+	/// <summary>Truncates a raw response body to a safe preview length for error messages.</summary>
+	internal static string Truncate(string value) {
+		if (string.IsNullOrEmpty(value)) {
+			return "<empty>";
+		}
+		return value.Length > 500 ? value[..500] + "..." : value;
+	}
+
+	/// <summary>
 	/// Attempts to recognize a Creatio error body that the transport returned with a non-failing
 	/// HTTP status, so the odata-* tools can report <c>success=false</c> instead of wrapping the
 	/// error as data.

--- a/clio/Command/McpServer/Tools/ODataUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/ODataUpdateTool.cs
@@ -43,7 +43,11 @@ public sealed class ODataUpdateTool(IToolCommandResolver commandResolver) {
 			}
 
 			(IApplicationClient client, string url) = ODataKeyedWrite.ResolveTarget(commandResolver, args.EnvironmentName, args.Entity, args.Id);
-			client.ExecutePatchRequest(url, data.GetRawText(), 30_000);
+			string response = client.ExecutePatchRequest(url, data.GetRawText(), 30_000);
+			string validationError = ODataKeyedWrite.ValidateWriteResponse(response);
+			if (validationError is not null) {
+				return ODataWriteResponse.Failure(validationError);
+			}
 			return new ODataWriteResponse(true, null, args.Id.Trim());
 		} catch (Exception ex) {
 			return ODataWriteResponse.Failure(SensitiveErrorTextRedactor.Redact(ex.Message));

--- a/docs/knowledge/McpServer/odata-write-transport-never-throws-on-non-2xx.md
+++ b/docs/knowledge/McpServer/odata-write-transport-never-throws-on-non-2xx.md
@@ -1,0 +1,43 @@
+---
+description: IApplicationClient.ExecuteGetRequest/ExecutePatchRequest/ExecutePostRequest/ExecuteDeleteRequest return the raw response body regardless of HTTP status - a write tool that does not inspect that body will report success even when the server never applied the change
+applies-to:
+  - clio/Command/McpServer/Tools/ODataUpdateTool.cs
+  - clio/Command/McpServer/Tools/ODataDeleteTool.cs
+  - clio/Command/McpServer/Tools/ODataCreateTool.cs
+  - clio/Command/McpServer/Tools/ODataKeyedWrite.cs
+  - clio/Command/McpServer/Tools/ODataResponseError.cs
+  - clio/Common/CreatioClientAdapter.cs
+ticket: ENG-95971
+date: 2026-08-25
+---
+
+**What is true** — `CreatioClientAdapter`'s `ExecuteGetRequest`/`ExecutePatchRequest`/
+`ExecutePostRequest`/`ExecuteDeleteRequest` do not throw on a non-2xx HTTP status; they return
+whatever body the transport received. An IIS/proxy error page (a 401 or 404 HTML page, observed
+alternating on the same entity in a client session) or a `{Message}`/`{error}` JSON fault therefore
+comes back as an ordinary string, indistinguishable from a real payload unless the caller parses it.
+`ODataReadTool` already does this (`JsonDocument.Parse` + `ODataResponseError.TryDetect`), so a bad
+response correctly surfaces as `success:false`. Before this ticket, `ODataUpdateTool` and
+`ODataDeleteTool` discarded the response entirely and returned `success:true` unconditionally, and
+`ODataCreateTool.ParseCreated` treated *any* non-JSON body as proof the record was created. A client
+reported "odata-update works, everything else is broken" — the write tools were not actually more
+reliable, they were blind to the same failure the read tools correctly reported.
+
+**Why it is this way** — a successful PATCH/DELETE against Creatio's OData v4 endpoint normally
+returns `204 No Content` (empty body), so "no exception, empty body" reads as a reasonable
+approximation of success. The gap is what happens when the body is non-empty but is not a real
+OData payload: nothing forced the write tools to look at it, because the transport layer's contract
+is "return the body, don't interpret it" — that responsibility sits entirely with the caller. The
+fix is `ODataKeyedWrite.ValidateWriteResponse`: empty body stays success, a body that fails to parse
+as JSON or matches `ODataResponseError.TryDetect` is a failure. `ODataCreateTool` shares the same
+`ODataResponseError.DescribeNonJsonResponse` diagnostic and now reports `record-created: null`
+(unknown, not created) on a non-JSON body, consistent with its existing "unknown side effect" model
+for a mid-flight server error.
+
+**What breaks if you ignore it** — any new odata-* write tool (or a change to an existing one) that
+calls `client.ExecutePatchRequest(...)`/`ExecutePostRequest(...)`/`ExecuteDeleteRequest(...)` and
+returns `success:true` without inspecting the response reintroduces silent data loss: a genuine
+server-side failure (auth/session issue, routing error, proxy/IIS error page) is reported to the
+agent and the user as a completed write. Route every new keyed write through
+`ODataKeyedWrite.ValidateWriteResponse`, and a batch/row-based write through the same
+`ODataResponseError.TryDetect` + `DescribeNonJsonResponse` pair `ODataCreateTool` uses.


### PR DESCRIPTION
🔗 **Jira:** [ENG-95971](https://creatio.atlassian.net/browse/ENG-95971)

## Summary
- `odata-update`/`odata-delete` discarded the HTTP response entirely and always reported `success:true`; `odata-create` treated any non-JSON response as proof the record was created. `IApplicationClient`'s `Execute*Request` methods never throw on a non-2xx status, so a genuine server-side failure (auth/session issue, routing error, IIS/proxy error page) was silently masked as a completed write — while `odata-read` correctly surfaced the same underlying failure, which is exactly the "reads are broken, writes work" symptom reported in ENG-95971.
- `ODataKeyedWrite.ValidateWriteResponse` (new) treats an empty body (Creatio's normal `204 No Content`) as success, and a body that fails to parse as JSON or matches a recognized Creatio error shape as failure. `odata-update`/`odata-delete` now route through it.
- `odata-create`'s non-JSON-response path now reports `record-created: null` (unknown, matching its existing unknown-side-effect model for a mid-flight server error) instead of a false-positive success.
- Shared diagnostic (`ODataResponseError.DescribeNonJsonResponse`) tells the caller the failure points at the transport layer (proxy/IIS/routing/session), not the request's OData/ESQ shape.

Root cause found by grepping the client's own Claude Code session transcript for the exact tool-call/response pairs — `odata-read` was hitting alternating IIS `401`/`404` HTML pages on the same entity, while `odata-update` never inspected its response at all.

## Root cause note
The demo environment's own IIS-level instability (alternating 401/404 HTML instead of JSON) is a separate, environment-side fact — not addressed here; recorded in the Jira comment for the reporter.

## Test plan
- [x] Unit: 38 tests in `ODataCreateToolTests`/`ODataUpdateToolTests`/`ODataDeleteToolTests` (new: empty-body success, non-JSON-body failure, recognized-OData-error failure)
- [x] E2E (real `mcp-server`, Node stub): `ODataWriteNonJsonResponseE2ETests` — odata-update/-delete/-create against a stub odata endpoint that answers with an IIS-style HTML page
- [x] `dotnet test --filter "Category=Unit&Module=McpServer"` — 3698 passed
- MCP reviewed: no tool contract/description/flag change — behavior-only fix

Validated: `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer"` (3698 passed); `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj --filter "FullyQualifiedName~ODataWriteNonJsonResponseE2ETests"` (3 passed)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[ENG-95971]: https://creatio.atlassian.net/browse/ENG-95971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ