### PR TITLE
ENG-94250: show the Beta heads-up as BETA MODE instead of Markdown bold

### DIFF
--- a/clio.tests/Command/ExperimentalCommandTests.cs
+++ b/clio.tests/Command/ExperimentalCommandTests.cs
@@ -147,7 +147,7 @@ public sealed class ExperimentalCommandTests : BaseCommandTests<ExperimentalOpti
 		result.Should().Be(0, because: "enabling a known feature succeeds");
 		_settingsRepository.Received(1).SetFeature("mobile-page-converter", true);
 		// enabling the mobile-page-converter feature must warn the user it activates Beta mode
-		_logger.Received().WriteWarning(Arg.Is<string>(message => message.Contains("Beta mode")));
+		_logger.Received().WriteWarning(Arg.Is<string>(message => message.Contains("BETA MODE")));
 	}
 
 	[Test]
@@ -163,7 +163,7 @@ public sealed class ExperimentalCommandTests : BaseCommandTests<ExperimentalOpti
 		result.Should().Be(0, because: "disabling a known feature succeeds");
 		_settingsRepository.Received(1).SetFeature("mobile-page-converter", false);
 		// the Beta-mode heads-up is shown only when the feature is turned on, never on disable
-		_logger.DidNotReceive().WriteWarning(Arg.Is<string>(message => message.Contains("Beta mode")));
+		_logger.DidNotReceive().WriteWarning(Arg.Is<string>(message => message.Contains("BETA MODE")));
 	}
 
 	[Test]
@@ -178,7 +178,7 @@ public sealed class ExperimentalCommandTests : BaseCommandTests<ExperimentalOpti
 		// Assert
 		result.Should().Be(0, because: "enabling any feature succeeds");
 		// only features with a registered enable notice emit the Beta-mode heads-up
-		_logger.DidNotReceive().WriteWarning(Arg.Is<string>(message => message.Contains("Beta mode")));
+		_logger.DidNotReceive().WriteWarning(Arg.Is<string>(message => message.Contains("BETA MODE")));
 	}
 
 	[Test]

--- a/clio/Command/ExperimentalCommand.cs
+++ b/clio/Command/ExperimentalCommand.cs
@@ -170,11 +170,13 @@ public class ExperimentalCommand : Command<ExperimentalOptions> {
 
 	// One-time warnings shown only when a feature is ENABLED (never on disable/list). Keyed
 	// case-insensitively. The mobile-page-converter Beta heads-up is TEMPORARY — remove that entry when
-	// the converter graduates out of Beta.
+	// the converter graduates out of Beta. Notice text is written verbatim to the console, the log file
+	// and every additional sink, so it carries no markup - Markdown asterisks would show up literally.
+	// Emphasize with UPPER CASE instead.
 	internal static readonly IReadOnlyDictionary<string, string> FeatureEnableNotices =
 		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
 			["mobile-page-converter"] =
-				"🔔 Heads up! Enabling this feature will activate the agent in **Beta mode**. "
+				"🔔 Heads up! Enabling this feature will activate the agent in BETA MODE. "
 				+ "Please be aware that behavior may vary and improvements are ongoing.",
 			[KnowledgeUnsequencedGitOptions.FeatureName] =
 				"🔔 Local development aid. While enabled, a Git knowledge source whose manifest omits "

--- a/clio/docs/commands/experimental.md
+++ b/clio/docs/commands/experimental.md
@@ -76,7 +76,7 @@ as an orphan so a leftover or renamed key stays visible and manageable.
 reports the new state. Toggling a key that nothing references is allowed
 but prints a warning.
 - Some features print a one-time notice when ENABLED (never on disable). For
-example, enabling `mobile-page-converter` warns that it runs in Beta mode.
+example, enabling `mobile-page-converter` warns that it runs in BETA MODE.
 - A key does not have to gate a command or an MCP tool: some keys change internal
 behavior instead. `knowledge-allow-unsequenced` is one - it lets a Git knowledge
 source whose `bundle-source.json` omits `sequence` load by deriving the sequence

--- a/clio/help/en/experimental.txt
+++ b/clio/help/en/experimental.txt
@@ -62,7 +62,7 @@ BEHAVIOR
       reports the new state. Toggling a key that nothing references is allowed
       but prints a warning.
     - Some features print a one-time notice when ENABLED (never on disable). For
-      example, enabling `mobile-page-converter` warns that it runs in Beta mode.
+      example, enabling `mobile-page-converter` warns that it runs in BETA MODE.
     - A key does not have to gate a command or an MCP tool: some keys change
       internal behavior instead. `knowledge-allow-unsequenced` is one - it lets a
       Git knowledge source whose bundle-source.json omits "sequence" load by


### PR DESCRIPTION
## Problem

`clio experimental --name mobile-page-converter --enable` printed:

```
[WAR] - 🔔 Heads up! Enabling this feature will activate the agent in **Beta mode**. Please be aware that behavior may vary and improvements are ongoing.
```

The console shows the raw asterisks — the intended bold never renders.

## Why not real bold

The notice string is written verbatim to the console **and** to the log file, the additional sinks and the Creatio log streamer (`ConsoleLogger.WriteWarningInternal`). ANSI bold codes would therefore land inside log files and MCP output, so the fallback the ticket allows — upper case — is used instead.

## Change

- `ExperimentalCommand.FeatureEnableNotices`: `**Beta mode**` → `BETA MODE`, plus a comment next to the notice table stating the sinks render no markup, so the emphasis is not reintroduced as Markdown.
- `clio.tests/Command/ExperimentalCommandTests.cs`: the three assertions match the new casing.
- `clio/docs/commands/experimental.md` and `clio/help/en/experimental.txt` reworded to match.

## Validation

- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Command"` — 3853 passed, 0 failed.
- Code review: skipped per the AGENTS.md triage tier — the diff is one user-facing string, one comment and two doc lines (zero-risk paths, no logic).
- MCP reviewed, no update required — `ExperimentalTool` executes the command and passes its output through; no MCP tool, prompt, resource or E2E test asserts the notice text.
- ClioRing compatibility reviewed, no Ring-consumed contract changed — the change is a warning string in `ExperimentalCommand`; Ring consumes no `experimental` tool contract or notice text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
