### PR TITLE
fix: ignore option order in issue claim readiness

### DIFF
--- a/.ai/skills/clio-issue-workflow/SKILL.md
+++ b/.ai/skills/clio-issue-workflow/SKILL.md
@@ -43,17 +43,17 @@ The provisioning contract is:
 - Name: `Mitigation stage`.
 - Type: `single_select`.
 - Visibility: `all` (Public).
-- Options, in order: `Investigating`, `Fixing`, `QA`, `Waiting for human approval`.
+- Required option names, regardless of order: `Investigating`, `Fixing`, `QA`, `Waiting for human approval`.
 - Pinned issue types: `Bug` and `Task`.
 
-Pinning is an administrator-facing presentation setting and is not returned by the issue-field REST list response. Treat it as provisioning guidance, not as a runtime readiness gate.
+Display order and pinning are administrator-facing presentation settings, not runtime readiness gates. The recommended display order is `Investigating`, `Fixing`, `QA`, `Waiting for human approval`. GitHub options carry a `priority` for display ordering; their position in the REST response array does not establish that order. Pinning is not returned by the issue-field REST list response.
 
-Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless the field exists with the required type, visibility, and all four exact option names. Report the mismatched property; do not try to repair organization settings.
+Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless the field exists with the required type, visibility, and all four exact option names. Check option names by membership, not by array position or priority. A different response order or display order must not block claiming an issue. Report the mismatched property; do not try to repair organization settings.
 
 Read and update it through GitHub's issue-field REST API:
 
 1. Send `X-GitHub-Api-Version: 2026-03-10` on every issue-field request.
-2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field name and verify the provisioning contract. Resolve the field id dynamically; do not hardcode it.
+2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field name and perform the readiness check above. Resolve the field id dynamically; do not hardcode it.
 3. `POST /repos/OWNER/REPO/issues/NUMBER/issue-field-values` with only `{"issue_field_values":[{"field_id":FIELD_ID,"value":"STAGE"}]}`. Do not use `PUT`, which replaces all issue-field values.
 4. `GET /repos/OWNER/REPO/issues/NUMBER/issue-field-values` and verify the stored value.
 


### PR DESCRIPTION
## Summary
Fixes #1237.

Contributors were blocked by the API returning Fixing before Investigating even though GitHub display priorities were correct. The canonical clio-issue-workflow skill now checks the four exact option names by membership. Display order and pinning remain administrator guidance, not readiness gates.

Required field identity, single_select type, public visibility, permissions, and stage-write verification are unchanged. Codex and Claude wrappers already delegate to this canonical skill. No GitHub organization settings or existing contributor issues were changed.

## Validation
- `python C:/Users/k.krylov/.codex/skills/.system/skill-creator/scripts/quick_validate.py .ai/skills/clio-issue-workflow` passed.
- `pwsh -NoProfile -File scripts/verify-agent-docs.ps1` passed.
- `git diff --check` passed.
- `python scripts/check-knowledge-applies-to.py --base origin/master` found no affected knowledge records.
- Live read-only GitHub evidence confirmed all required option names, type, visibility, and display priorities; response array order differs.
- Instruction-only change: no runtime modules changed, so .NET module tests are not applicable.

## Review and scope
Comprehensive parallel pre-PR review covers quality/testing, security, performance/correctness/edge cases, intent alignment, and KISS. Findings and final review status are recorded in the PR thread.

Collab MCP is unavailable in this session; conditional cross-vendor consultation was not run.
Docs reviewed; only the canonical skill required an update. MCP reviewed, no update required. No CLI/MCP or Ring-consumed contract changed.

KISS: one canonical instruction change, no new scripts, state, or coordination mechanisms.
