### PR TITLE
Page MCP list-packages responses

### DIFF
--- a/clio-ring/ClioRing.Tests/ClioWorkflowViewModelTests.cs
+++ b/clio-ring/ClioRing.Tests/ClioWorkflowViewModelTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using ClioRing.Ipc;
+using ClioRing.ViewModels;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ClioRing.Tests;
+
+[TestFixture]
+[Category("Unit")]
+public sealed class ClioWorkflowViewModelTests {
+	[Test]
+	[Description("Makes a truncated list-packages result visibly incomplete instead of presenting the first page as the full package list.")]
+	public void ParseRows_ShouldExposePackageCompleteness_WhenResponseIsTruncated() {
+		// Arrange
+		ClioToolCallResult result = new() {
+			RawText = """
+			          {"packages":[{"name":"Package00","version":"1.0.0","maintainer":"ATF"}],"count":1,"total":60,"offset":0,"limit":1,"truncated":true}
+			          """
+		};
+
+		// Act
+		string[] rows = ClioWorkflowViewModel.ParseRows("list-packages", result).ToArray();
+
+		// Assert
+		rows.Should().Contain("Showing 1 of 60 packages. More packages remain.",
+			because: "the Ring must not make a bounded MCP page look like the complete environment package list");
+		rows.Should().Contain(row => row.Contains("Package00"),
+			because: "making incompleteness visible must preserve the package rows returned by the MCP tool");
+	}
+}

--- a/clio-ring/ClioRing/ViewModels/ClioWorkflowViewModel.cs
+++ b/clio-ring/ClioRing/ViewModels/ClioWorkflowViewModel.cs
@@ -315,7 +315,7 @@ public sealed partial class ClioWorkflowViewModel : ViewModelBase {
 	}
 
 	// Parses list-packages / list-apps into human-readable card rows; other commands show raw output.
-	private static IEnumerable<string> ParseRows(string key, ClioToolCallResult result) {
+	internal static IEnumerable<string> ParseRows(string key, ClioToolCallResult result) {
 		if (string.IsNullOrWhiteSpace(result.RawText)) {
 			yield break;
 		}
@@ -332,6 +332,14 @@ public sealed partial class ClioWorkflowViewModel : ViewModelBase {
 				yield break;
 			}
 			if (key == "list-packages" && root.TryGetProperty("packages", out JsonElement pkgs) && pkgs.ValueKind == JsonValueKind.Array) {
+				if (root.TryGetProperty("truncated", out JsonElement truncated)
+					&& truncated.ValueKind == JsonValueKind.True
+					&& root.TryGetProperty("count", out JsonElement count)
+					&& count.TryGetInt32(out int pageCount)
+					&& root.TryGetProperty("total", out JsonElement total)
+					&& total.TryGetInt32(out int totalCount)) {
+					yield return $"Showing {pageCount} of {totalCount} packages. More packages remain.";
+				}
 				foreach (JsonElement p in pkgs.EnumerateArray()) {
 					yield return $"{Prop(p, "name", "Name")}  ·  {Prop(p, "version", "Version")}  ·  {Prop(p, "maintainer", "Maintainer")}";
 				}

--- a/clio.mcp.e2e/GetPkgListToolE2ETests.cs
+++ b/clio.mcp.e2e/GetPkgListToolE2ETests.cs
@@ -23,11 +23,11 @@ public sealed class GetPkgListToolE2ETests {
 	private const string ToolName = GetPkgListTool.GetPkgListToolName;
 
 	[Test]
-	[Description("Starts the real clio MCP server, invokes list-packages for the configured sandbox environment, and verifies that a structured non-empty package list is returned.")]
+	[Description("Starts the real clio MCP server, verifies the default package bound, then requests two explicit pages and verifies paging metadata and continuity.")]
 	[AllureTag(ToolName)]
-	[AllureName("Get package list returns structured sandbox packages")]
-	[AllureDescription("Uses the real clio MCP server to call list-packages against the configured sandbox environment and verifies the returned structured package list contains at least one item with non-empty name, version, and maintainer fields.")]
-	public async Task GetPkgList_Should_Return_Structured_Packages() {
+	[AllureName("Get package list returns bounded structured pages")]
+	[AllureDescription("Uses the real clio MCP server to verify omitted paging defaults to 50, then calls list-packages with limit 1 and offsets 0 and 1 to prove total, truncated, and page metadata make the full package set enumerable.")]
+	public async Task GetPkgList_ShouldReturnBoundedPages_WhenLimitAndOffsetAreSupplied() {
 		// Arrange
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
@@ -43,7 +43,7 @@ public sealed class GetPkgListToolE2ETests {
 
 		// Assert
 		AssertToolCallSucceeded(actResult);
-		AssertStructuredPackagesReturned(actResult);
+		AssertStructuredPagesReturned(actResult);
 	}
 
 	private static async Task<GetPkgListArrangeContext> ArrangeAsync(McpE2ESettings settings) {
@@ -64,7 +64,7 @@ public sealed class GetPkgListToolE2ETests {
 			tools.Select(tool => tool.Name).Should().Contain(ToolName,
 				because: "the list-packages MCP tool must be advertised before the end-to-end call can be executed");
 
-			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			CallToolResult defaultCallResult = await arrangeContext.Session.CallToolAsync(
 				ToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -72,27 +72,106 @@ public sealed class GetPkgListToolE2ETests {
 					}
 				},
 				arrangeContext.CancellationTokenSource.Token);
+			CallToolResult firstCallResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["limit"] = 1,
+						["offset"] = 0
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CallToolResult secondCallResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["limit"] = 1,
+						["offset"] = 1
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
 
-			IReadOnlyList<GetPkgListEnvelope> packages = GetPkgListResultParser.Extract(callResult);
-			return new GetPkgListActResult(callResult, packages);
+			GetPkgListResponseEnvelope defaultPage = GetPkgListResultParser.ExtractResponse(defaultCallResult);
+			GetPkgListResponseEnvelope firstPage = GetPkgListResultParser.ExtractResponse(firstCallResult);
+			GetPkgListResponseEnvelope secondPage = GetPkgListResultParser.ExtractResponse(secondCallResult);
+			CallToolResult terminalCallResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["limit"] = 1,
+						["offset"] = firstPage.Total
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			GetPkgListResponseEnvelope terminalPage = GetPkgListResultParser.ExtractResponse(terminalCallResult);
+			return new GetPkgListActResult(defaultCallResult, firstCallResult, secondCallResult, terminalCallResult,
+				defaultPage, firstPage, secondPage, terminalPage);
 		});
 	}
 
 	[AllureStep("Assert MCP tool result is successful")]
 	private static void AssertToolCallSucceeded(GetPkgListActResult actResult) {
-		actResult.CallResult.IsError.Should().NotBeTrue(
-			because: "list-packages should return a structured MCP payload for a valid sandbox environment");
+		actResult.DefaultCallResult.IsError.Should().NotBeTrue(
+			because: "list-packages should apply safe paging defaults when the caller omits limit and offset");
+		actResult.FirstCallResult.IsError.Should().NotBeTrue(
+			because: "the first list-packages page should be returned for a valid sandbox environment");
+		actResult.SecondCallResult.IsError.Should().NotBeTrue(
+			because: "the second list-packages page should be returned for a valid sandbox environment");
+		actResult.TerminalCallResult.IsError.Should().NotBeTrue(
+			because: "an offset at the filtered total should return a valid empty terminal page");
 	}
 
-	[AllureStep("Assert structured package list is present")]
-	private static void AssertStructuredPackagesReturned(GetPkgListActResult actResult) {
-		actResult.Packages.Should().NotBeEmpty(
-			because: "the sandbox environment should expose at least one package through list-packages");
-		actResult.Packages.Should().Contain(package =>
+	[AllureStep("Assert bounded package pages and completeness metadata")]
+	private static void AssertStructuredPagesReturned(GetPkgListActResult actResult) {
+		actResult.DefaultPage.Limit.Should().Be(GetPkgListTool.DefaultLimit,
+			because: "the real MCP binder must preserve the tool's default payload bound when limit is omitted");
+		actResult.DefaultPage.Offset.Should().Be(0,
+			because: "the real MCP binder must start at the first package when offset is omitted");
+		actResult.DefaultPage.Count.Should().BeLessThanOrEqualTo(GetPkgListTool.DefaultLimit,
+			because: "the default MCP response must never exceed its advertised package bound");
+		actResult.DefaultPage.Total.Should().BeGreaterThanOrEqualTo(actResult.DefaultPage.Count,
+			because: "the full package count cannot be smaller than the returned default page");
+		actResult.DefaultPage.Truncated.Should().Be(actResult.DefaultPage.Count < actResult.DefaultPage.Total,
+			because: "the completeness flag must reflect whether the configured sandbox has packages beyond the default page");
+		actResult.FirstPage.Packages.Should().ContainSingle(
+			because: "limit 1 should bound the first response to one package");
+		actResult.SecondPage.Packages.Should().ContainSingle(
+			because: "the sandbox should contain enough packages to retrieve a second one-package page");
+		actResult.FirstPage.Packages.Should().Contain(package =>
 				!string.IsNullOrWhiteSpace(package.Name)
 				&& !string.IsNullOrWhiteSpace(package.Version)
-				&& package.Maintainer != null,
+				&& package.Maintainer != null
+				&& !string.IsNullOrWhiteSpace(package.UId),
 			because: "the MCP tool should return at least one structured package record with usable fields for agents and assertions");
+		actResult.FirstPage.Total.Should().BeGreaterThan(1,
+			because: "the configured sandbox must expose more than one package to prove offset paging at the real MCP boundary");
+		actResult.SecondPage.Total.Should().Be(actResult.FirstPage.Total,
+			because: "total must describe the same full matching set independently of page offset");
+		actResult.FirstPage.Count.Should().Be(1, because: "count must describe the first returned page");
+		actResult.SecondPage.Count.Should().Be(1, because: "count must describe the second returned page");
+		actResult.FirstPage.Offset.Should().Be(0, because: "the first page should start at offset zero");
+		actResult.SecondPage.Offset.Should().Be(1, because: "the second page should apply the requested offset");
+		actResult.FirstPage.Limit.Should().Be(1, because: "the first response should expose the applied limit");
+		actResult.SecondPage.Limit.Should().Be(1, because: "the second response should expose the applied limit");
+		actResult.FirstPage.Truncated.Should().BeTrue(
+			because: "the first bounded page cannot be complete when the sandbox contains more than one package");
+		actResult.FirstPage.Packages[0].UId.Should().NotBe(actResult.SecondPage.Packages[0].UId,
+			because: "advancing the offset must return the next package rather than repeating the first page");
+		actResult.TerminalPage.Packages.Should().BeEmpty(
+			because: "an offset at the filtered total should produce a valid empty page rather than a parse failure");
+		actResult.TerminalPage.Count.Should().Be(0,
+			because: "count must describe the empty terminal page");
+		actResult.TerminalPage.Total.Should().Be(actResult.FirstPage.Total,
+			because: "the terminal page must preserve the full matching total");
+		actResult.TerminalPage.Offset.Should().Be(actResult.FirstPage.Total,
+			because: "the terminal response must echo the requested end offset");
+		actResult.TerminalPage.Limit.Should().Be(1,
+			because: "the terminal response must echo the requested page size even when no items remain");
+		actResult.TerminalPage.Truncated.Should().BeFalse(
+			because: "no matching packages remain after an offset at the filtered total");
 	}
 
 	private sealed record GetPkgListArrangeContext(
@@ -105,6 +184,12 @@ public sealed class GetPkgListToolE2ETests {
 	}
 
 	private sealed record GetPkgListActResult(
-		CallToolResult CallResult,
-		IReadOnlyList<GetPkgListEnvelope> Packages);
+		CallToolResult DefaultCallResult,
+		CallToolResult FirstCallResult,
+		CallToolResult SecondCallResult,
+		CallToolResult TerminalCallResult,
+		GetPkgListResponseEnvelope DefaultPage,
+		GetPkgListResponseEnvelope FirstPage,
+		GetPkgListResponseEnvelope SecondPage,
+		GetPkgListResponseEnvelope TerminalPage);
 }

--- a/clio.mcp.e2e/Support/Results/GetPkgListEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/GetPkgListEnvelope.cs
@@ -7,18 +7,31 @@ namespace Clio.Mcp.E2E.Support.Results;
 internal sealed record GetPkgListEnvelope(
 	[property: JsonPropertyName("name")] string Name,
 	[property: JsonPropertyName("version")] string Version,
-	[property: JsonPropertyName("maintainer")] string Maintainer);
+	[property: JsonPropertyName("maintainer")] string Maintainer,
+	[property: JsonPropertyName("uId")] string UId);
+
+internal sealed record GetPkgListResponseEnvelope(
+	[property: JsonPropertyName("packages")] GetPkgListEnvelope[] Packages,
+	[property: JsonPropertyName("count")] int Count,
+	[property: JsonPropertyName("total")] int Total,
+	[property: JsonPropertyName("offset")] int Offset,
+	[property: JsonPropertyName("limit")] int Limit,
+	[property: JsonPropertyName("truncated")] bool Truncated);
 
 internal static class GetPkgListResultParser {
 	public static IReadOnlyList<GetPkgListEnvelope> Extract(CallToolResult callResult) {
+		return ExtractResponse(callResult).Packages;
+	}
+
+	public static GetPkgListResponseEnvelope ExtractResponse(CallToolResult callResult) {
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelopeList(structuredContent, out IReadOnlyList<GetPkgListEnvelope>? structuredEnvelopes)) {
-			return structuredEnvelopes!;
+			TryExtractResponse(structuredContent, out GetPkgListResponseEnvelope? structuredResponse)) {
+			return structuredResponse!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelopeList(content, out IReadOnlyList<GetPkgListEnvelope>? contentEnvelopes)) {
-			return contentEnvelopes!;
+			TryExtractResponse(content, out GetPkgListResponseEnvelope? contentResponse)) {
+			return contentResponse!;
 		}
 
 		throw new InvalidOperationException("Could not parse list-packages MCP result.");
@@ -34,8 +47,8 @@ internal static class GetPkgListResultParser {
 		return true;
 	}
 
-	private static bool TryExtractEnvelopeList(JsonElement element, out IReadOnlyList<GetPkgListEnvelope>? envelopes) {
-		if (TryDeserializeList(element, out envelopes)) {
+	private static bool TryExtractResponse(JsonElement element, out GetPkgListResponseEnvelope? response) {
+		if (TryDeserializeResponse(element, out response)) {
 			return true;
 		}
 
@@ -44,7 +57,7 @@ internal static class GetPkgListResultParser {
 				if (TryGetTextPayload(item, out string? textPayload) &&
 					!string.IsNullOrWhiteSpace(textPayload) &&
 					TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserializeList(textPayloadElement, out envelopes)) {
+					TryDeserializeResponse(textPayloadElement, out response)) {
 					return true;
 				}
 			}
@@ -54,39 +67,32 @@ internal static class GetPkgListResultParser {
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
 				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserializeList(textPayloadElement, out envelopes)) {
+				TryDeserializeResponse(textPayloadElement, out response)) {
 				return true;
 			}
 		}
 
-		envelopes = null;
+		response = null;
 		return false;
 	}
 
-	private static bool TryDeserializeList(JsonElement element, out IReadOnlyList<GetPkgListEnvelope>? envelopes) {
+	private static bool TryDeserializeResponse(JsonElement element, out GetPkgListResponseEnvelope? response) {
 		try {
-			GetPkgListEnvelope[]? items = JsonSerializer.Deserialize<GetPkgListEnvelope[]>(
+			GetPkgListResponseEnvelope? parsed = JsonSerializer.Deserialize<GetPkgListResponseEnvelope>(
 				element.GetRawText(),
 				new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-			if (items is null || items.Length == 0 || !ContainsUsableEnvelope(items)) {
-				envelopes = null;
+			if (parsed?.Packages is null) {
+				response = null;
 				return false;
 			}
 
-			envelopes = items;
+			response = parsed;
 			return true;
 		}
 		catch (JsonException) {
-			envelopes = null;
+			response = null;
 			return false;
 		}
-	}
-
-	private static bool ContainsUsableEnvelope(IEnumerable<GetPkgListEnvelope> items) {
-		return items.Any(item =>
-			!string.IsNullOrWhiteSpace(item.Name) ||
-			!string.IsNullOrWhiteSpace(item.Version) ||
-			item.Maintainer is not null);
 	}
 
 	private static bool TryGetTextPayload(JsonElement element, out string? textPayload) {

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -18,6 +18,44 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 	[Test]
+	[Description("Returns the list-packages paging inputs, defaults, and completeness fields through the real MCP contract endpoint.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract advertises list-packages paging")]
+	[AllureDescription("Starts the real clio MCP server without a Creatio environment, requests the list-packages contract, and verifies that limit, offset, total, count, and truncated are discoverable before a live call.")]
+	public async Task ToolContractGet_ShouldAdvertisePackagePaging_WhenListPackagesIsRequested() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["tool-names"] = new[] { GetPkgListTool.GetPkgListToolName }
+			});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "the resident list-packages tool must expose a named full contract");
+		ToolContractDefinition contract = response.Tools.Should().ContainSingle(
+			because: "the named lookup should return exactly the requested list-packages contract").Which;
+		contract.InputSchema.Required.Should().Equal(["environment-name"],
+			because: "paging and filtering are optional while the registered environment remains required");
+		contract.InputSchema.Properties.Select(field => field.Name).Should().Contain(["filter", "limit", "offset"],
+			because: "agents must discover both page controls alongside the existing filter");
+		contract.Defaults.Should().Contain(value => value.Name == "limit" && value.Value == "50",
+			because: "the bounded default must be explicit before a caller invokes a large environment");
+		contract.Defaults.Should().Contain(value => value.Name == "offset" && value.Value == "0",
+			because: "the first-page offset must be explicit in the contract");
+		contract.OutputContract.Fields.Select(field => field.Name).Should().Contain(
+			["packages", "count", "total", "offset", "limit", "truncated"],
+			because: "the response contract must expose the data page and every completeness field needed to continue paging");
+		contract.OutputContract.Fields.Single(field => field.Name == "truncated").Description.Should()
+			.Contain("Advance offset by count",
+				because: "the contract must explain the deterministic continuation rule instead of leaving callers to guess");
+	}
+
+	[Test]
 	[Description("Returns the virtual entity create defaults and readback fields for both standalone and batched schema tools.")]
 	[AllureTag(ToolContractGetTool.ToolName)]
 	[AllureName("get-tool-contract advertises virtual entity schema support")]

--- a/clio.tests/Command/McpServer/GetPkgListToolTests.cs
+++ b/clio.tests/Command/McpServer/GetPkgListToolTests.cs
@@ -58,18 +58,96 @@ public sealed class GetPkgListToolTests {
 			.Returns(resolvedCommand);
 		GetPkgListTool tool = new(defaultCommand, logger, commandResolver);
 
-		IReadOnlyList<PackageListItemResult> result = tool.GetPkgList(new GetPkgListArgs("sandbox", "beta"));
+		PackageListResponse result = tool.GetPkgList(new GetPkgListArgs("sandbox", "beta"));
 
 		commandResolver.Received(1).Resolve<GetPkgListCommand>(Arg.Is<EnvironmentOptions>(options =>
 			options.Environment == "sandbox"));
-		result.Should().ContainSingle(because: "the filter should narrow the structured MCP payload to matching packages only");
-		PackageListItemResult package = result.Single();
+		result.Packages.Should().ContainSingle(because: "the filter should narrow the structured MCP payload to matching packages only");
+		result.Count.Should().Be(1, because: "count should describe the returned filtered page");
+		result.Total.Should().Be(1, because: "total should describe all packages matching the filter before paging");
+		result.Truncated.Should().BeFalse(because: "the single matching package fits in the default page");
+		PackageListItemResult package = result.Packages.Single();
 		package.Name.Should().Be("BetaPkg",
 			because: "the MCP tool should preserve the package name returned by the command");
 		package.Version.Should().Be("2.0.0",
 			because: "the structured MCP result should expose the package version for assertions and agents");
 		package.Maintainer.Should().Be("Maintainer B",
 			because: "the structured MCP result should expose the package maintainer for assertions and agents");
+	}
+
+	[TestCase(null)]
+	[TestCase(0)]
+	[Category("Unit")]
+	[Description("Applies the default 50-package limit and reports observable paging metadata when limit is omitted or zero.")]
+	public void GetPkgList_ShouldApplyDefaultLimit_WhenLimitIsOmittedOrZero(int? limit) {
+		// Arrange
+		IApplicationPackageListProvider packageListProvider = Substitute.For<IApplicationPackageListProvider>();
+		packageListProvider.GetPackages().Returns(Enumerable.Range(0, 60)
+			.Select(index => CreatePackageInfo($"Package{index:D2}", "1.0.0", "Maintainer")));
+		GetPkgListTool tool = CreateTool(packageListProvider);
+
+		// Act
+		PackageListResponse result = tool.GetPkgList(new GetPkgListArgs("sandbox", Limit: limit));
+
+		// Assert
+		result.Packages.Should().HaveCount(GetPkgListTool.DefaultLimit,
+			because: "an omitted limit must keep a large environment response within the default payload bound");
+		result.Count.Should().Be(GetPkgListTool.DefaultLimit,
+			because: "count must match the number of packages returned in this page");
+		result.Total.Should().Be(60, because: "total must preserve the full match count before paging");
+		result.Offset.Should().Be(0, because: "an omitted offset starts at the first matching package");
+		result.Limit.Should().Be(GetPkgListTool.DefaultLimit,
+			because: "the response must make the effective default limit observable");
+		result.Truncated.Should().BeTrue(because: "ten matching packages remain after the default page");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Returns the requested package window and reports the full filtered total when limit and offset are supplied.")]
+	public void GetPkgList_ShouldReturnRequestedPage_WhenLimitAndOffsetAreSupplied() {
+		// Arrange
+		IApplicationPackageListProvider packageListProvider = Substitute.For<IApplicationPackageListProvider>();
+		packageListProvider.GetPackages().Returns(Enumerable.Range(0, 6)
+			.Select(index => CreatePackageInfo($"Package{index:D2}", "1.0.0", "Maintainer")));
+		GetPkgListTool tool = CreateTool(packageListProvider);
+
+		// Act
+		PackageListResponse result = tool.GetPkgList(new GetPkgListArgs("sandbox", Limit: 2, Offset: 2));
+
+		// Assert
+		result.Packages.Select(package => package.Name).Should().Equal(["Package02", "Package03"],
+			because: "offset and limit must select a stable page from the name-ordered package set");
+		result.Count.Should().Be(2, because: "count must describe this page only");
+		result.Total.Should().Be(6, because: "total must remain independent of the requested page");
+		result.Offset.Should().Be(2, because: "the response must echo the applied page offset");
+		result.Limit.Should().Be(2, because: "the response must echo the applied page size");
+		result.Truncated.Should().BeTrue(because: "two more packages remain after this page");
+	}
+
+	[TestCase(-1, 0, "limit")]
+	[TestCase(1, -1, "offset")]
+	[Category("Unit")]
+	[Description("Rejects negative paging arguments before resolving or querying the target environment.")]
+	public void GetPkgList_ShouldRejectNegativePaging_WhenLimitOrOffsetIsNegative(
+		int limit, int offset, string expectedArgument) {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		ILogger logger = Substitute.For<ILogger>();
+		GetPkgListCommand defaultCommand = new(
+			new EnvironmentSettings(),
+			Substitute.For<IApplicationPackageListProvider>(),
+			Substitute.For<IJsonResponseFormater>(),
+			logger);
+		GetPkgListTool tool = new(defaultCommand, logger, commandResolver);
+
+		// Act
+		Action act = () => tool.GetPkgList(new GetPkgListArgs("sandbox", Limit: limit, Offset: offset));
+
+		// Assert
+		act.Should().Throw<ArgumentOutOfRangeException>()
+			.WithMessage($"*{expectedArgument} must be zero or greater*",
+				because: "invalid paging must fail with a caller-actionable argument name");
+		commandResolver.DidNotReceive().Resolve<GetPkgListCommand>(Arg.Any<EnvironmentOptions>());
 	}
 
 	[Test]
@@ -82,6 +160,23 @@ public sealed class GetPkgListToolTests {
 			because: "the prompt should reference the production MCP tool name");
 		prompt.Should().Contain("filter",
 			because: "agents should be reminded that the MCP tool supports narrowing the package list");
+		prompt.Should().Contain("offset + count",
+			because: "the prompt should explain how to advance through all result pages");
+		prompt.Should().Contain("truncated",
+			because: "the prompt should use the response completeness signal instead of guessing whether more packages exist");
+	}
+
+	private static GetPkgListTool CreateTool(IApplicationPackageListProvider packageListProvider) {
+		IJsonResponseFormater jsonResponseFormater = Substitute.For<IJsonResponseFormater>();
+		ILogger logger = Substitute.For<ILogger>();
+		GetPkgListCommand command = new(
+			new EnvironmentSettings(),
+			packageListProvider,
+			jsonResponseFormater,
+			logger);
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		commandResolver.Resolve<GetPkgListCommand>(Arg.Any<EnvironmentOptions>()).Returns(command);
+		return new GetPkgListTool(command, logger, commandResolver);
 	}
 
 	private static PackageInfo CreatePackageInfo(string name, string version, string maintainer) {

--- a/clio/Command/McpServer/Prompts/WorkspacePackagePrompt.cs
+++ b/clio/Command/McpServer/Prompts/WorkspacePackagePrompt.cs
@@ -85,16 +85,24 @@ public static class WorkspacePackagePrompt {
 		[Description("Creatio environment name")]
 		string environmentName,
 		[Description("Optional package-name filter")]
-		string? filter = null) =>
+		string? filter = null,
+		[Description("Optional page size; omit to use the default of 50")]
+		int? limit = null,
+		[Description("Optional zero-based package offset")]
+		int offset = 0) =>
 		string.IsNullOrWhiteSpace(filter)
 			? $"""
 			   Use clio mcp server `{GetPkgListTool.GetPkgListToolName}` tool to list packages installed in
 			   Creatio environment `{environmentName}`.
-			   Pass `environment-name` exactly as provided and omit `filter` when you need the full package list.
+			   Pass `environment-name` exactly as provided, `offset` `{offset}`, and
+			   `limit` `{limit?.ToString() ?? "<default 50>"}`. Omit `filter` to page through all packages.
+			   Continue with offset + count while the response reports `truncated: true`.
 			   """
 			: $"""
 			   Use clio mcp server `{GetPkgListTool.GetPkgListToolName}` tool to list packages installed in
 			   Creatio environment `{environmentName}`.
-			   Pass `environment-name` exactly as provided and use `filter` `{filter}` to narrow the result.
+			   Pass `environment-name` exactly as provided, use `filter` `{filter}`, `offset` `{offset}`, and
+			   `limit` `{limit?.ToString() ?? "<default 50>"}`. Continue with offset + count while the response
+			   reports `truncated: true`.
 			   """;
 }

--- a/clio/Command/McpServer/Tools/GetPkgListTool.cs
+++ b/clio/Command/McpServer/Tools/GetPkgListTool.cs
@@ -18,6 +18,10 @@ public sealed class GetPkgListTool(
 	ILogger logger,
 	IToolCommandResolver commandResolver)
 	: BaseTool<PkgListOptions>(command, logger, commandResolver) {
+	/// <summary>
+	/// Default maximum number of packages returned by one MCP call.
+	/// </summary>
+	internal const int DefaultLimit = 50;
 
 	/// <summary>
 	/// Stable MCP tool name for listing packages from a Creatio environment.
@@ -29,9 +33,17 @@ public sealed class GetPkgListTool(
 	/// </summary>
 	[McpServerTool(Name = GetPkgListToolName, ReadOnly = true, Destructive = false, Idempotent = true,
 		OpenWorld = false)]
-	[Description("Returns packages from the specified Creatio environment as structured JSON with package name, version, and maintainer.")]
-	public IReadOnlyList<PackageListItemResult> GetPkgList(
+	[Description("Returns a bounded page of packages from the specified Creatio environment as structured JSON. Results are ordered by package name and capped at 50 by default. The response always reports count, total, offset, limit, and truncated so callers can page through the full filtered set.")]
+	public PackageListResponse GetPkgList(
 		[Description("List-packages parameters")] [Required] GetPkgListArgs args) {
+		if (args.Limit < 0) {
+			throw new ArgumentOutOfRangeException(nameof(args), args.Limit,
+				$"limit must be zero or greater. Omit limit or pass 0 to use the default of {DefaultLimit}.");
+		}
+		if (args.Offset < 0) {
+			throw new ArgumentOutOfRangeException(nameof(args), args.Offset,
+				"offset must be zero or greater.");
+		}
 		PkgListOptions options = new() {
 			Environment = args.EnvironmentName,
 			SearchPattern = args.Filter ?? string.Empty
@@ -50,13 +62,24 @@ public sealed class GetPkgListTool(
 				.Where(value => !string.IsNullOrWhiteSpace(value)));
 			throw new InvalidOperationException(message);
 		}
-		return packages
+		int effectiveLimit = args.Limit is null or 0 ? DefaultLimit : args.Limit.Value;
+		IReadOnlyList<PackageListItemResult> packagePage = packages
+			.Skip(args.Offset)
+			.Take(effectiveLimit)
 			.Select(package => new PackageListItemResult(
 				package.Descriptor.Name,
 				package.Descriptor.PackageVersion,
 				package.Descriptor.Maintainer,
 				package.Descriptor.UId.ToString()))
 			.ToList();
+		bool truncated = (long)args.Offset + packagePage.Count < packages.Count;
+		return new PackageListResponse(
+			packagePage,
+			packagePage.Count,
+			packages.Count,
+			args.Offset,
+			effectiveLimit,
+			truncated);
 	}
 }
 
@@ -71,8 +94,27 @@ public sealed record GetPkgListArgs(
 
 	[property: JsonPropertyName("filter")]
 	[property: Description("Optional case-insensitive package-name filter")]
-	string? Filter = null
+	string? Filter = null,
+
+	[property: JsonPropertyName("limit")]
+	[property: Description("Maximum number of packages to return. Omit or pass 0 to use the default of 50. A negative value is rejected.")]
+	int? Limit = null,
+
+	[property: JsonPropertyName("offset")]
+	[property: Description("Number of matching packages to skip before returning this page. Defaults to 0. A negative value is rejected.")]
+	int Offset = 0
 );
+
+/// <summary>
+/// Structured paged response returned by the <c>list-packages</c> MCP tool.
+/// </summary>
+public sealed record PackageListResponse(
+	[property: JsonPropertyName("packages")] IReadOnlyList<PackageListItemResult> Packages,
+	[property: JsonPropertyName("count")] int Count,
+	[property: JsonPropertyName("total")] int Total,
+	[property: JsonPropertyName("offset")] int Offset,
+	[property: JsonPropertyName("limit")] int Limit,
+	[property: JsonPropertyName("truncated")] bool Truncated);
 
 /// <summary>
 /// Structured package-list item returned by the <c>list-packages</c> MCP tool.

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -499,7 +499,9 @@ internal static class ToolContractCatalog {
 	private const string ObjectType = "object";
 	private const string ComponentTypeFieldName = "component-type";
 	private const string OperationsFieldName = "operations";
+	private const string OffsetFieldName = "offset";
 	private const string PackageNameFieldName = "package-name";
+	private const string PackagesFieldName = "packages";
 	private const string PasswordFieldName = "password";
 	private const string PagesFieldName = "pages";
 	private const string PageSchemaNameFieldName = "page-schema-name";
@@ -606,6 +608,7 @@ internal static class ToolContractCatalog {
 			[ODataDeleteTool.ToolName] = BuildODataDelete(),
 			[SchemaSyncTool.ToolName] = BuildSchemaSync(),
 			[PageSyncTool.ToolName] = BuildPageSync(),
+			[GetPkgListTool.GetPkgListToolName] = BuildGetPkgList(),
 			[PageListTool.ToolName] = BuildPageList(),
 			[PageGetTool.ToolName] = BuildPageGet(),
 			[CreateLookupTool.CreateLookupToolName] = BuildCreateLookup(),
@@ -687,6 +690,7 @@ internal static class ToolContractCatalog {
 		ODataDeleteTool.ToolName,
 		SchemaSyncTool.ToolName,
 		PageSyncTool.ToolName,
+		GetPkgListTool.GetPkgListToolName,
 		PageListTool.ToolName,
 		PageGetTool.ToolName,
 		CreateLookupTool.CreateLookupToolName,
@@ -3895,6 +3899,60 @@ internal static class ToolContractCatalog {
 						],
 					"Fallback when single-page dry-run or legacy save is required after discovery.")
 			],
+			[]);
+	}
+
+	private static ToolContractDefinition BuildGetPkgList() {
+		return new ToolContractDefinition(
+			GetPkgListTool.GetPkgListToolName,
+			"Lists packages installed in a registered Creatio environment as bounded, name-ordered pages. " +
+			"The response always reports the full filtered total and whether more matches remain after the returned page.",
+			new ToolInputSchemaContract(
+				[EnvironmentNameFieldName],
+				[
+					Field(EnvironmentNameFieldName, StringType, RegisteredEnvironmentNameDescription),
+					Field("filter", StringType, "Optional case-insensitive package-name substring filter applied before paging."),
+					Field(LimitFieldName, NumberType,
+						$"Maximum packages in one page. Omit or pass 0 to use the default of {GetPkgListTool.DefaultLimit}; negative values are rejected."),
+					Field(OffsetFieldName, NumberType,
+						"Number of matching packages to skip before returning the page. Defaults to 0; negative values are rejected.")
+				]),
+			new ToolOutputContract(
+				"package-list-page",
+				null,
+				["MCP tool result isError == true"],
+				[
+					Field(PackagesFieldName, ArrayType,
+						"Packages in this page, each with name, version, maintainer, and uId."),
+					Field(CountFieldName, NumberType, "Number of packages returned in this page."),
+					Field("total", NumberType, "Total packages matching the filter before paging."),
+					Field(OffsetFieldName, NumberType, "Applied zero-based offset."),
+					Field(LimitFieldName, NumberType, "Applied page size, including the effective default."),
+					Field("truncated", BooleanType,
+						"True when more matching packages remain after this page. Advance offset by count and call again until false.")
+				]),
+			CommonErrorContract,
+			[],
+			[
+				Default(LimitFieldName, GetPkgListTool.DefaultLimit.ToString(),
+					"Keeps package discovery payloads bounded when the caller omits a page size."),
+				Default(OffsetFieldName, "0", "Starts from the first matching package.")
+			],
+			[
+				Example("Read the first package page", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName,
+					[LimitFieldName] = GetPkgListTool.DefaultLimit,
+					[OffsetFieldName] = 0
+				}),
+				Example("Read the next package page", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName,
+					[LimitFieldName] = GetPkgListTool.DefaultLimit,
+					[OffsetFieldName] = GetPkgListTool.DefaultLimit
+				})
+			],
+			Flow([GetPkgListTool.GetPkgListToolName],
+				"Read one bounded page. While truncated is true, add count to offset and call list-packages again with the same filter and limit."),
+			[],
 			[]);
 	}
 


### PR DESCRIPTION
## Summary
- cap MCP `list-packages` responses at 50 packages by default
- add `limit` and `offset` paging with `count`, `total`, `limit`, `offset`, and `truncated` metadata
- publish the paging contract through the prompt and `get-tool-contract`
- keep ClioRing from presenting a truncated package page as a complete list

## Validation
- `dotnet test clio.tests/clio.tests.csproj -c Debug --filter "Category=Unit&Module=McpServer" --no-restore` (3812 passed)
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug --filter "FullyQualifiedName~ToolContractGet_ShouldAdvertisePackagePaging_WhenListPackagesIsRequested" --no-restore` (passed on net8.0 and net10.0)
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` (157 passed)
- ClioRing read-only `--ipc-proof` harness against this branch (PASS)
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` (passed with no IL2026/IL3050 warnings)
- `python scripts/check-knowledge-applies-to.py --base origin/master` (advisory records reviewed; no knowledge change required)

The sandbox-backed `GetPkgListToolE2ETests` was updated for default, explicit, and terminal pages, but could not run locally because the configured disposable sandbox is not registered on this machine. The stand-free real MCP contract E2E passed on both supported runtimes.

## Reviews
- comprehensive agentic review: quality, security, performance, testing, bug/edge cases, intent, and KISS; all findings resolved
- docs reviewed, no update required because CLI command behavior and options are unchanged
- MCP reviewed and updated: tool, prompt, curated contract, unit tests, and E2E coverage
- ClioRing compatibility reviewed: direct consumer inspected, completeness signal added, tests/harness/AOT all passed

Closes #1217