### PR TITLE
Use browser-equivalent timezone offset on login

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageVersion Include="creatio.client" Version="1.0.38" />
+    <PackageVersion Include="creatio.client" Version="1.0.40" />
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.5" />
     <PackageVersion Include="ErrorOr" Version="2.1.1" />

--- a/clio/Command/McpServer/SessionContainerCache.cs
+++ b/clio/Command/McpServer/SessionContainerCache.cs
@@ -119,7 +119,7 @@ public static class SessionContainerCacheDefaults {
 /// <para>
 /// <b>Disposal / GC-safety (Story 8, AC-05 — decision (a)).</b> On eviction the child
 /// <see cref="IServiceProvider"/> is disposed, which is sufficient. Decompiling
-/// <c>Creatio.Client.CreatioClient</c> (creatio.client 1.0.38, netstandard2.0) shows it is declared
+/// <c>Creatio.Client.CreatioClient</c> (creatio.client 1.0.40, netstandard2.0) shows it is declared
 /// <c>class CreatioClient : ICreatioClient</c> — it does NOT implement <see cref="IDisposable"/> — and
 /// holds no long-lived per-instance transport: its only fields are <c>string</c>/<c>bool</c>,
 /// a <c>CookieContainer</c>, an <c>ICredentials</c> and a <c>RetryPolicy</c>. Every HTTP call creates

--- a/clio/Command/McpServer/SessionContainerCache.cs
+++ b/clio/Command/McpServer/SessionContainerCache.cs
@@ -121,7 +121,7 @@ public static class SessionContainerCacheDefaults {
 /// <see cref="IServiceProvider"/> is disposed, which is sufficient. Decompiling
 /// <c>Creatio.Client.CreatioClient</c> (creatio.client 1.0.40, netstandard2.0) shows it is declared
 /// <c>class CreatioClient : ICreatioClient</c> — it does NOT implement <see cref="IDisposable"/> — and
-/// holds no long-lived per-instance transport: its only fields are <c>string</c>/<c>bool</c>,
+/// holds no long-lived per-instance transport: its fields are managed scalar/configuration state,
 /// a <c>CookieContainer</c>, an <c>ICredentials</c> and a <c>RetryPolicy</c>. Every HTTP call creates
 /// and disposes its own <c>HttpClient</c>/<c>HttpClientHandler</c> inside a <c>using</c> block
 /// (per-request, no shared static or pooled handler), and the WebSocket listener

--- a/clio/Common/LoginDiagnostics.cs
+++ b/clio/Common/LoginDiagnostics.cs
@@ -13,7 +13,7 @@ internal sealed class LoginDiagnostics : ILoginDiagnostics {
 
 	/// <summary>
 	/// Prefix of the message <c>Creatio.Client.CreatioClient.Login()</c> throws when the login response
-	/// body contains <c>"Code":1</c> (verified against creatio.client 1.0.38, which builds it as
+	/// body contains <c>"Code":1</c> (verified against creatio.client 1.0.40, which builds it as
 	/// <c>"Unauthorized " + userName + " for " + AppUrl</c>). Matching it is how an implicit login
 	/// rejection is told apart from an ordinary request failure — the NuGet client offers no typed
 	/// signal for it. A future client that reworded the message would simply stop the implicit-login

--- a/docs/knowledge/Common/only-a-forms-auth-client-can-call-login.md
+++ b/docs/knowledge/Common/only-a-forms-auth-client-can-call-login.md
@@ -6,20 +6,20 @@ applies-to:
   - clio/Common/ApplicationClientFactory.cs
   - clio/Common/ServerReadinessWaiter.cs
 ticket: ENG-94417
-date: 2026-08-19
+date: 2026-08-30
 ---
 
 **What is true** — clio builds a `CreatioClient` in three shapes: forms auth
 (`new CreatioClient(uri, login, password, ...)`), OAuth (`CreatioClient.CreateOAuth20Client(...)`)
 and bearer passthrough (`new CreatioClient(uri, accessToken, isNetCore)`). Only the first holds a
-username and a password. `CreatioClient.Login()` posts those two fields, so on the other two shapes
-they are null and the call throws `UnauthorizedAccessException`. `Login()` also sets no request
+username and a password. `CreatioClient.Login()` posts those credentials plus `TimeZoneOffset`, so on
+the other two shapes the credentials are null and the call throws `UnauthorizedAccessException`. `Login()` also sets no request
 timeout, inheriting the library's ~100 s connect default plus a separate response-read timeout, and
 `IApplicationClient` exposes no overload that bounds it.
 
 **Why it is this way** — the interface hides the difference: `Login()` is one method on
 `IApplicationClient` and nothing in its signature says it is credential-shaped. The fact is only
-visible by decompiling `creatio.client`.
+visible in the `creatio.client` source.
 
 **What breaks if you ignore it** — any "authenticate first to prove the server is up" step fails on
 every OAuth and token-registered environment while the instance is perfectly healthy, and the caller

--- a/docs/knowledge/platform/password-login-timezone-follows-clio-host.md
+++ b/docs/knowledge/platform/password-login-timezone-follows-clio-host.md
@@ -8,8 +8,8 @@ date: 2026-08-30
 
 **What is true** — `creatio.client` 1.0.40 password login sends the current Clio process host offset
 as UTC-minus-local minutes, matching browser `Date.getTimezoneOffset()`. Creatio negates that value,
-selects a matching system time zone, and passes it into `UserConnection.Login`. OAuth client-credentials
-and NTLM authentication do not send this password-login field.
+selects a matching system time zone, and passes it into `UserConnection.Login`. OAuth client-credentials,
+bearer passthrough, and NTLM authentication do not send this password-login field.
 
 **Why it is this way** — the browser sends the same value on password login, while the Creatio server
 contract and resolution logic live outside this repository. Clio does not explicitly choose an offset,
@@ -17,4 +17,4 @@ so its forms-auth sessions intentionally follow the machine on which Clio is run
 
 **What breaks if you ignore it** — running Clio in a different time zone can change the session-local
 date/time conversions used by Creatio. An explicit offset requires direct use of the CreatioClient
-property or additive constructor; configuring OAuth credentials cannot carry this field.
+property or additive constructor; configuring OAuth credentials or passing a bearer token cannot carry it.

--- a/docs/knowledge/platform/password-login-timezone-follows-clio-host.md
+++ b/docs/knowledge/platform/password-login-timezone-follows-clio-host.md
@@ -1,0 +1,20 @@
+---
+description: creatio.client password login sends the Clio host TimeZoneOffset using the browser getTimezoneOffset sign convention, and Creatio applies it to the session UserConnection time zone
+applies-to:
+  - Directory.Packages.props
+ticket: "#930"
+date: 2026-08-30
+---
+
+**What is true** — `creatio.client` 1.0.40 password login sends the current Clio process host offset
+as UTC-minus-local minutes, matching browser `Date.getTimezoneOffset()`. Creatio negates that value,
+selects a matching system time zone, and passes it into `UserConnection.Login`. OAuth client-credentials
+and NTLM authentication do not send this password-login field.
+
+**Why it is this way** — the browser sends the same value on password login, while the Creatio server
+contract and resolution logic live outside this repository. Clio does not explicitly choose an offset,
+so its forms-auth sessions intentionally follow the machine on which Clio is running.
+
+**What breaks if you ignore it** — running Clio in a different time zone can change the session-local
+date/time conversions used by Creatio. An explicit offset requires direct use of the CreatioClient
+property or additive constructor; configuring OAuth credentials cannot carry this field.

--- a/docs/knowledge/platform/ping-app-is-an-authenticated-login-probe-on-net-core-stands.md
+++ b/docs/knowledge/platform/ping-app-is-an-authenticated-login-probe-on-net-core-stands.md
@@ -10,7 +10,7 @@ date: 2026-08-19
 
 **What is true** — `PingAppCommand.Execute` branches on `EnvironmentSettings.IsNetCore`: a .NET Core
 stand is probed with `ApplicationClient.ExecuteGetRequest`, a .NET Framework stand falls through to
-`RemoteCommand.Execute`. Inside the `creatio.client` package (pinned at `1.0.38` in
+`RemoteCommand.Execute`. Inside the `creatio.client` package (pinned at `1.0.40` in
 `Directory.Packages.props`), `ExecuteGetRequest` resolves the lazy `AuthCookie`, which calls
 `InitAuthCookie` and therefore `CreatioClient.Login` — the same login path `UploadFile` uses. So on
 a .NET Core environment a successful `ping-app` proves the configured credentials work, and a
@@ -19,7 +19,7 @@ what makes it usable as a readiness gate before an upload-based operation (see
 `ClioCliCommandRunner.WaitForLoginReadinessAsync`).
 
 **Why it is this way** — the login behaviour lives in an external nuget, not in this repository; it
-was established by decompiling `creatio.client` 1.0.38. Nothing in `PingCommand.cs` states it, and
+was re-verified from the `creatio.client` 1.0.40 source. Nothing in `PingCommand.cs` states it, and
 the `/ping` endpoint name suggests an unauthenticated liveness check.
 
 **What breaks if you ignore it** — two symmetric mistakes. Treating `ping-app` as a plain liveness


### PR DESCRIPTION
Fixes #930

Consumes Advance-Technologies-Foundation/creatioclient#14 and released package `creatio.client` 1.0.40.

## What changed

- Updated the central `creatio.client` pin from 1.0.38 to 1.0.40.
- Updated the package-sensitive internal knowledge record and documented the external password-login time-zone behavior.
- Added no Clio-specific constructor, option, or authentication plumbing: forms login inherits the browser-equivalent default from CreatioClient.

## Result

- Password login sends the current host offset as UTC-minus-local minutes, matching browser `Date.getTimezoneOffset()`.
- Direct CreatioClient callers can override the value through `TimeZoneOffset` or the additive constructor introduced in 1.0.40.
- Existing CreatioClient constructors remain intact.
- OAuth client-credentials and NTLM do not send the password-login `AuthToken.TimeZoneOffset` field and remain unchanged.

## Runtime proof

Using a credential-redacted custom logger against `vbg`:

- default/browser offset `-180` -> runtime `UserConnection` time zone `Jordan Standard Time`, `+3.0` hours;
- explicit constructor offset `-345` -> runtime `UserConnection` time zone `Nepal Standard Time`, `+5.75` hours.

Creatio server source confirms it negates the JavaScript-style value, selects a matching `TimeZoneInfo`, and passes it into `UserConnection.Login`.

## Validation

- `dotnet restore clio/clio.csproj --nologo`
- `dotnet build clio/clio.csproj -c Release --no-restore --nologo --disable-build-servers -m:1 -p:UseSharedCompilation=false`
- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit&Module=Common" --no-build --nologo` (1,137 passed, 3 platform skips)
- `python scripts/check-knowledge-applies-to.py` (all 131 records valid)

## Review

- Comprehensive pre-PR agentic review: code quality, security, performance, testing, bugs, intent, and KISS. The only finding was temporary NuGet propagation; it was closed by a successful clean restore/build after 1.0.40 became available.
- Claude consultation `rev_63f943c213884e79`: no P1/P2 findings on the complete CreatioClient implementation. Its minor timeout-overload coverage suggestion was accepted before release.
- Docs reviewed, no command documentation update required.
- MCP reviewed, no command or MCP contract changed.
- ClioRing compatibility reviewed; searches of `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json` found no Ring-consumed contract change.
