### PR TITLE
test: stabilize section-create waiter bound

### DIFF
--- a/clio.tests/Command/SectionCreateSerializationGuardTests.cs
+++ b/clio.tests/Command/SectionCreateSerializationGuardTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command;
@@ -299,48 +300,55 @@ public sealed class SectionCreateSerializationGuardTests {
 		using ManualResetEventSlim otherKeyEntered = new(false);
 		using SemaphoreSlim enteredWork = new(0);
 
+		// LongRunning tasks use dedicated threads rather than the thread pool: every participant here blocks
+		// inside its work or on the gate, so callerCount + 2 threads must exist simultaneously. On a small CI
+		// agent, thread-pool injection can otherwise push the first best-effort entry past SignalWait and fail
+		// the test on scheduling rather than behavior. Keeping Task wrappers also captures participant
+		// exceptions so guard regressions fail this test instead of terminating the whole test host.
 		// The holder occupies the per-key gate (in-flight = 1) so every subsequent same-key caller must queue.
-		Task holder = Task.Run(() => guard.Run("prod", "UsrApp", GenerousWait, () => {
+		Task holder = Task.Factory.StartNew(() => guard.Run("prod", "UsrApp", GenerousWait, () => {
 			holderEntered.Set();
 			releaseHolder.Wait(GenerousWait);
 			return 0;
-		}));
-		holderEntered.Wait(SignalWait).Should().BeTrue(
-			because: "the holder must occupy the per-key gate before the fan-out queues behind it");
+		}), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+		List<Task> participants = [holder];
+		try {
+			holderEntered.Wait(SignalWait).Should().BeTrue(
+				because: "the holder must occupy the per-key gate before the fan-out queues behind it");
 
-		// Act — fan out callerCount same-key callers; each signals when it ENTERS its work, then parks.
-		Task[] callers = new Task[callerCount];
-		for (int i = 0; i < callerCount; i++) {
-			callers[i] = Task.Run(() => guard.Run("prod", "UsrApp", GenerousWait, () => {
-				enteredWork.Release();
-				releaseCallers.Wait(GenerousWait);
+			// Act — fan out callerCount same-key callers; each signals when it ENTERS its work, then parks.
+			for (int i = 0; i < callerCount; i++) {
+				Task caller = Task.Factory.StartNew(() => guard.Run("prod", "UsrApp", GenerousWait, () => {
+					enteredWork.Release();
+					releaseCallers.Wait(GenerousWait);
+					return 0;
+				}), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+				participants.Add(caller);
+			}
+
+			// A different application key must never be affected by the same-key back-pressure.
+			Task otherKey = Task.Factory.StartNew(() => guard.Run("prod", "UsrOther", GenerousWait, () => {
+				otherKeyEntered.Set();
 				return 0;
-			}));
+			}), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+			participants.Add(otherKey);
+
+			// Assert
+			for (int i = 0; i < expectedBestEffort; i++) {
+				enteredWork.Wait(SignalWait).Should().BeTrue(
+					because: "each excess same-key caller past the bound must run best-effort without waiting for the holder to release");
+			}
+
+			enteredWork.Wait(NonEntryWindow).Should().BeFalse(
+				because: "callers within the bound must stay parked on the gate while the holder still holds it (serialization is preserved for them)");
+			otherKeyEntered.Wait(SignalWait).Should().BeTrue(
+				because: "a different application key must overlap freely — the same-key waiter bound must not spill onto it");
+		} finally {
+			releaseHolder.Set();
+			releaseCallers.Set();
+			Task.WaitAll([.. participants], GenerousWait).Should().BeTrue(
+				because: "releasing the holder must let every participant complete and surface any guard exception on the test thread");
 		}
-
-		// A different application key must never be affected by the same-key back-pressure.
-		Task otherKey = Task.Run(() => guard.Run("prod", "UsrOther", GenerousWait, () => {
-			otherKeyEntered.Set();
-			return 0;
-		}));
-
-		// Assert
-		for (int i = 0; i < expectedBestEffort; i++) {
-			enteredWork.Wait(SignalWait).Should().BeTrue(
-				because: "each excess same-key caller past the bound must run best-effort without waiting for the holder to release");
-		}
-
-		enteredWork.Wait(NonEntryWindow).Should().BeFalse(
-			because: "callers within the bound must stay parked on the gate while the holder still holds it (serialization is preserved for them)");
-		otherKeyEntered.Wait(SignalWait).Should().BeTrue(
-			because: "a different application key must overlap freely — the same-key waiter bound must not spill onto it");
-
-		releaseHolder.Set();
-		releaseCallers.Set();
-		Task[] all = [holder, otherKey, .. callers];
-		Action drain = () => Task.WaitAll(all, GenerousWait);
-		drain.Should().NotThrow(
-			because: "releasing the holder must let the parked callers complete with no SemaphoreFullException — the gate is never over-released");
 		logger.Received().WriteWarning(Arg.Is<string>(message =>
 			message.Contains("without serialization", StringComparison.OrdinalIgnoreCase)));
 	}


### PR DESCRIPTION
## Summary

- run the blocking same-key waiter-bound test participants on dedicated `LongRunning` tasks instead of relying on thread-pool ramp-up
- retain task exception propagation so guard failures surface through NUnit rather than terminating `testhost`
- always release and drain every started participant from `finally`

No production code or behavior changed.

## Evidence and validation

- unchanged master with `DOTNET_PROCESSOR_COUNT=2`: reproduced the reported failure (1 failed at the same five-second assertion)
- corrected regression test with `DOTNET_PROCESSOR_COUNT=2`: 20/20 consecutive passes, approximately 360 ms each
- Command unit module: 3,871 passed, 15 skipped, 0 failed
- full unit suite: 9,841 passed, 25 skipped, 0 failed
- knowledge validation: 130 records valid
- `git diff --check`

## Reviews

- Claude independently confirmed the low-core thread-pool diagnosis and that no production change is needed
- comprehensive agentic review covered correctness, security, performance, testing, quality, intent, and KISS
- the initial raw-thread form had one High test-host exception/lifecycle finding; the final `LongRunning` task + `finally` form resolves it and the complete re-review is clean
- docs reviewed, no update required
- MCP reviewed, no update required; no command or MCP behavior changed
- ClioRing compatibility reviewed, no Ring-consumed contract changed

Fixes #1256
