### PR TITLE
Fix deploy-identity MCP binding and PostgreSQL database selection

### DIFF
--- a/clio.mcp.e2e/DeployIdentityToolE2ETests.cs
+++ b/clio.mcp.e2e/DeployIdentityToolE2ETests.cs
@@ -1,5 +1,7 @@
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
+using Allure.Net.Commons;
+using Clio.Common;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
@@ -64,6 +66,8 @@ public sealed class DeployIdentityToolE2ETests
 			because: "agents should know zipFile can be omitted when IdentityService.zip is under the registered environment");
 		FieldDescription(contract, "identitySitePort").Should().Contain("40001-40100",
 			because: "agents should know identitySitePort can be omitted and auto-selected from the default range");
+		FieldDescription(contract, "overwrite").Should().Contain("target directory",
+			because: "agents should know overwrite replaces an existing IdentityService deployment directory");
 		FieldDescription(contract, "noApp").Should().Contain("without creating a clio OAuth app",
 			because: "agents should know they can deploy and connect IdentityService without creating an OAuth app");
 		FieldDescription(contract, "createTechUser").Should().Contain("technical user",
@@ -77,6 +81,7 @@ public sealed class DeployIdentityToolE2ETests
 				"identityArchivePathInBundle",
 				"identitySiteName",
 				"identityPath",
+				"overwrite",
 				"configurationMode",
 				"clientName",
 				"clientApplicationUrl",
@@ -89,6 +94,86 @@ public sealed class DeployIdentityToolE2ETests
 		contract.InputSchema.Required.Should().BeEquivalentTo(
 			["environment-name"],
 			because: "deploy-identity should allow zipFile and identitySitePort to default from EnvironmentPath and the IIS port scanner");
+	}
+
+	[Test]
+	[Description("Passes the published environment-name and overwrite fields through the real MCP server into deploy-identity resolution.")]
+	[AllureTag(ToolName)]
+	[AllureName("Deploy identity binds published environment and overwrite fields")]
+	[AllureDescription("Calls the destructive long-tail tool with its curated contract shape and verifies the requested missing environment reaches resolution instead of being silently dropped during MCP binding.")]
+	public async Task DeployIdentity_Should_Bind_Published_Environment_And_Overwrite_Fields()
+	{
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		string clioHome = CreateClioHomeWithDeployIdentityEnabled();
+		settings.ProcessEnvironmentVariables["CLIO_HOME"] = clioHome;
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		string missingEnvironment = $"missing-{Guid.NewGuid():N}";
+
+		// Act
+		CallToolResult callResult = await AllureApi.Step("Call deploy-identity through the real MCP server", () =>
+			session.CallDestructiveAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["environment-name"] = missingEnvironment,
+					["overwrite"] = true
+				},
+				cancellationTokenSource.Token));
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+
+		// Assert
+		AllureApi.Step("Assert the call returns a structured command result", () =>
+			callResult.IsError.Should().NotBeTrue(
+				because: "a valid contract-shaped call should return a structured command result"));
+		AllureApi.Step("Assert the missing environment prevents deployment", () =>
+			execution.ExitCode.Should().Be(1,
+				because: "the deliberately missing registered environment cannot be deployed"));
+		AllureApi.Step("Assert the published environment reaches resolution", () =>
+			execution.Output.Should().Contain(message => message.Value != null
+				&& message.Value.Contains(missingEnvironment, StringComparison.Ordinal),
+				because: "the MCP binder must preserve the requested environment-name instead of falling back to the active environment"));
+		AllureApi.Step("Assert the command failure is classified as error output", () =>
+			execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+				because: "the rejected environment should remain an actionable command error rather than a transport failure"));
+	}
+
+	[Test]
+	[Description("Rejects the obsolete environmentName field without falling back to the active environment.")]
+	[AllureTag(ToolName)]
+	[AllureName("Deploy identity rejects obsolete environment alias")]
+	[AllureDescription("Calls deploy-identity with the obsolete camel-case environment field and verifies the real MCP server refuses it before active-environment fallback.")]
+	public async Task DeployIdentity_Should_Reject_Obsolete_EnvironmentName_Field()
+	{
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		string clioHome = CreateClioHomeWithDeployIdentityEnabled();
+		settings.ProcessEnvironmentVariables["CLIO_HOME"] = clioHome;
+		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+
+		// Act
+		CallToolResult callResult = await AllureApi.Step("Call deploy-identity with the obsolete field", () =>
+			session.CallDestructiveAsync(
+				ToolName,
+				new Dictionary<string, object?> { ["environmentName"] = "obsolete-target" },
+				cancellationTokenSource.Token));
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+
+		// Assert
+		AllureApi.Step("Assert the stale call returns a structured result", () =>
+			callResult.IsError.Should().NotBeTrue(
+				because: "an obsolete argument is a caller-correctable validation error, not an MCP transport failure"));
+		AllureApi.Step("Assert the stale contract call is refused", () =>
+			execution.ExitCode.Should().Be(1,
+				because: "the obsolete field must not allow deploy-identity to use the active environment"));
+		AllureApi.Step("Assert the correction names the published field", () =>
+			execution.Output.Should().Contain(message => message.Value != null
+				&& message.Value.Contains("environment-name", StringComparison.Ordinal),
+				because: "the caller needs the canonical field name to correct the request"));
+		AllureApi.Step("Assert the stale argument is classified as error output", () =>
+			execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+				because: "the rejected alias should remain an actionable command error"));
 	}
 
 	private static string FieldDescription(ToolContractDefinition contract, string fieldName)

--- a/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
+++ b/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
@@ -63,6 +63,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 			.Returns(Task.FromResult(new ProcessExecutionResult { ExitCode = 0 }));
 		IAvailableIisPortService availableIisPortService = Substitute.For<IAvailableIisPortService>();
 		IIdentityServiceRoleGrantService roleGrantService = Substitute.For<IIdentityServiceRoleGrantService>();
+		IDeploymentTargetReservation targetReservation = CreateTargetReservation();
 		IdentityServiceDeploymentService service = new(
 			settingsRepository,
 			archiveResolver,
@@ -73,6 +74,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 			availableIisPortService,
 			roleGrantService,
 			systemUserResolver,
+			targetReservation,
 			Substitute.For<ILogger>());
 		DeployIdentityOptions options = new() {
 			Environment = "bank",
@@ -96,6 +98,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 		creatioClient.DidNotReceive().CreateTechnicalUser(Arg.Any<string>());
 		systemUserResolver.Received(1).ResolveSystemUserId(persistedEnvironment, "Supervisor");
 		roleGrantService.DidNotReceive().GrantSystemAdministratorRole(Arg.Any<EnvironmentSettings>(), Arg.Any<string>());
+		targetReservation.Received(1).Acquire(options.IdentityPath);
 	}
 
 	[Test]
@@ -151,6 +154,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 			availableIisPortService,
 			roleGrantService,
 			systemUserResolver,
+			CreateTargetReservation(),
 			Substitute.For<ILogger>());
 		DeployIdentityOptions options = new() {
 			Environment = "bank",
@@ -316,17 +320,244 @@ public sealed class IdentityServiceDeploymentServiceTests
 				because: "user binding is irrelevant when OAuth app creation is skipped");
 	}
 
-	private static string CreateCreatioEnvironmentPath()
+	[Test]
+	[Description("Uses the runtime db connection when both db and the legacy dbPostgreSql connection are present.")]
+	public void ReadCreatioDbConnectionString_Should_Prefer_Db_When_Both_Connections_Are_Present()
+	{
+		// Arrange
+		const string runtimeConnection = "Host=runtime;Database=creatio;Username=postgres;Password=secret";
+		string environmentPath = CreateCreatioEnvironmentPath($$"""
+			<connectionStrings>
+			  <add name="dbPostgreSql" connectionString="Host=legacy;Database=stale;Username=postgres;Password=secret" />
+			  <add name="db" connectionString="{{runtimeConnection}}" />
+			</connectionStrings>
+			""");
+		EnvironmentSettings environment = new() { EnvironmentPath = environmentPath };
+
+		// Act
+		string connectionString = IdentityServiceDeploymentService.ReadCreatioDbConnectionString(environment);
+
+		// Assert
+		connectionString.Should().Be(runtimeConnection,
+			because: "IdentityService must target the same database Creatio uses at runtime");
+	}
+
+	[Test]
+	[Description("Falls back to the legacy dbPostgreSql connection when a runtime db connection is absent.")]
+	public void ReadCreatioDbConnectionString_Should_Fallback_To_DbPostgreSql_When_Db_Is_Absent()
+	{
+		// Arrange
+		const string legacyConnection = "Host=legacy;Database=creatio;Username=postgres;Password=secret";
+		string environmentPath = CreateCreatioEnvironmentPath($$"""
+			<connectionStrings>
+			  <add name="dbPostgreSql" connectionString="{{legacyConnection}}" />
+			</connectionStrings>
+			""");
+		EnvironmentSettings environment = new() { EnvironmentPath = environmentPath };
+
+		// Act
+		string connectionString = IdentityServiceDeploymentService.ReadCreatioDbConnectionString(environment);
+
+		// Assert
+		connectionString.Should().Be(legacyConnection,
+			because: "older Creatio installations may expose only dbPostgreSql");
+	}
+
+	[Test]
+	[Description("Refuses to overwrite a non-empty directory that is not an existing IdentityService deployment.")]
+	public void ExtractIdentityService_Should_Reject_Unrecognized_NonEmpty_Target()
+	{
+		// Arrange
+		string archivePath = CreateIdentityArchive();
+		string targetPath = CreateIdentityTargetPath();
+		Directory.CreateDirectory(targetPath);
+		string unrelatedFile = Path.Combine(targetPath, "unrelated.txt");
+		File.WriteAllText(unrelatedFile, "keep");
+
+		// Act
+		Action act = () => CreateService().ExtractIdentityService(
+			archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*not a recognized IdentityService deployment*",
+				because: "overwrite must not recursively delete or overlay an unrelated directory");
+		File.Exists(unrelatedFile).Should().BeTrue(
+			because: "a refused overwrite must leave unrelated files intact");
+	}
+
+	[Test]
+	[Description("Replaces a recognized IdentityService directory so files absent from the new archive cannot remain stale.")]
+	public void ExtractIdentityService_Should_Replace_Recognized_Target()
+	{
+		// Arrange
+		string archivePath = CreateIdentityArchive();
+		string targetPath = CreateIdentityTargetPath();
+		Directory.CreateDirectory(targetPath);
+		File.WriteAllText(Path.Combine(targetPath, "IdentityService.dll"), "old");
+		File.WriteAllText(Path.Combine(targetPath, "appsettings.json"), "{}");
+		string obsoleteFile = Path.Combine(targetPath, "obsolete-extension.dll");
+		File.WriteAllText(obsoleteFile, "old");
+
+		// Act
+		CreateService().ExtractIdentityService(
+			archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+		// Assert
+		File.Exists(Path.Combine(targetPath, "appsettings.json")).Should().BeTrue(
+			because: "the replacement archive should be extracted into the recognized target");
+		File.Exists(obsoleteFile).Should().BeFalse(
+			because: "a recognized deployment should be replaced cleanly so stale assemblies cannot survive an upgrade");
+	}
+
+	[Test]
+	[Description("Keeps the working IdentityService directory intact when a replacement archive cannot be extracted.")]
+	public void ExtractIdentityService_Should_Preserve_Recognized_Target_When_Staging_Fails()
+	{
+		// Arrange
+		string archivePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
+		using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Create)) {
+			archive.CreateEntry("conflict");
+			archive.CreateEntry("conflict/file.txt");
+		}
+		string targetPath = CreateIdentityTargetPath();
+		Directory.CreateDirectory(targetPath);
+		File.WriteAllText(Path.Combine(targetPath, "IdentityService.dll"), "old");
+		File.WriteAllText(Path.Combine(targetPath, "appsettings.json"), "{}");
+		string workingFile = Path.Combine(targetPath, "working.txt");
+		File.WriteAllText(workingFile, "original");
+
+		// Act
+		Action act = () => CreateService().ExtractIdentityService(
+			archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+		// Assert
+		act.Should().Throw<IOException>(
+			because: "the conflicting archive entries cannot both be extracted into the staging directory");
+		File.ReadAllText(workingFile).Should().Be("original",
+			because: "the working deployment must remain untouched until the replacement archive extracts successfully");
+	}
+
+	[Test]
+	[Description("Keeps the working IdentityService directory intact when the replacement ZIP is not an IdentityService archive.")]
+	public void ExtractIdentityService_Should_Preserve_Recognized_Target_When_Archive_Is_Unrelated()
+	{
+		// Arrange
+		string archivePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
+		using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Create)) {
+			archive.CreateEntry("unrelated.txt");
+		}
+		string targetPath = CreateIdentityTargetPath();
+		Directory.CreateDirectory(targetPath);
+		File.WriteAllText(Path.Combine(targetPath, "IdentityService.dll"), "old");
+		File.WriteAllText(Path.Combine(targetPath, "appsettings.json"), "{}");
+		string workingFile = Path.Combine(targetPath, "working.txt");
+		File.WriteAllText(workingFile, "original");
+
+		// Act
+		Action act = () => CreateService().ExtractIdentityService(
+			archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*does not contain IdentityService.dll and appsettings.json*",
+				because: "a valid but unrelated ZIP must not replace a working IdentityService deployment");
+		File.ReadAllText(workingFile).Should().Be("original",
+			because: "the working deployment must remain untouched until staged content is identified as IdentityService");
+	}
+
+	[Test]
+	[Description("Keeps the working IdentityService directory intact when staged appsettings.json is malformed.")]
+	public void ExtractIdentityService_Should_Preserve_Recognized_Target_When_AppSettings_Is_Malformed()
+	{
+		// Arrange
+		string archivePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.zip");
+		using (ZipArchive archive = ZipFile.Open(archivePath, ZipArchiveMode.Create)) {
+			archive.CreateEntry("IdentityService.dll");
+			ZipArchiveEntry appsettings = archive.CreateEntry("appsettings.json");
+			using StreamWriter writer = new(appsettings.Open());
+			writer.Write("not-json");
+		}
+		string targetPath = CreateIdentityTargetPath();
+		Directory.CreateDirectory(targetPath);
+		File.WriteAllText(Path.Combine(targetPath, "IdentityService.dll"), "old");
+		File.WriteAllText(Path.Combine(targetPath, "appsettings.json"), "{}");
+		string workingFile = Path.Combine(targetPath, "working.txt");
+		File.WriteAllText(workingFile, "original");
+
+		// Act
+		Action act = () => CreateService().ExtractIdentityService(
+			archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+		// Assert
+		act.Should().Throw<JsonException>(
+			because: "malformed staged configuration must fail before the working deployment is moved");
+		File.ReadAllText(workingFile).Should().Be("original",
+			because: "the working deployment must remain intact until staged configuration succeeds");
+	}
+
+	[Test]
+	[Description("Refuses an IdentityService target that is redirected through a filesystem reparse point.")]
+	public void ExtractIdentityService_Should_Reject_Reparse_Point_Target()
+	{
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("Windows directory-link credential redirection is Windows-specific.");
+		}
+		string rootPath = Path.Combine(Path.GetTempPath(), $"identity-link-{Guid.NewGuid():N}");
+		string externalPath = Path.Combine(rootPath, "external");
+		string targetPath = Path.Combine(rootPath, "target");
+		Directory.CreateDirectory(externalPath);
+		try {
+			try {
+				Directory.CreateSymbolicLink(targetPath, externalPath);
+			}
+			catch (Exception exception) when (exception is UnauthorizedAccessException or IOException) {
+				Assert.Ignore($"Directory-link creation is unavailable: {exception.Message}");
+			}
+			string archivePath = CreateIdentityArchive();
+
+			// Act
+			Action act = () => CreateService().ExtractIdentityService(
+				archivePath, targetPath, overwrite: true, CreateEnvironmentSettings());
+
+			// Assert
+			act.Should().Throw<InvalidOperationException>().WithMessage("*filesystem reparse point*",
+				because: "deployment files and database credentials must not be redirected outside the selected target");
+			Directory.EnumerateFileSystemEntries(externalPath).Should().BeEmpty(
+				because: "a rejected link target must receive neither binaries nor configured credentials");
+		}
+		finally {
+			if (Directory.Exists(targetPath)) {
+				Directory.Delete(targetPath);
+			}
+			if (Directory.Exists(rootPath)) {
+				Directory.Delete(rootPath, recursive: true);
+			}
+		}
+	}
+
+	private static string CreateCreatioEnvironmentPath(string? connectionStrings = null)
 	{
 		string path = Path.Combine(Path.GetTempPath(), $"creatio-env-{Guid.NewGuid():N}");
 		Directory.CreateDirectory(path);
 		File.WriteAllText(Path.Combine(path, "ConnectionStrings.config"),
-			"""
+			connectionStrings ?? """
 			<connectionStrings>
 			  <add name="dbPostgreSql" connectionString="Server=localhost;Port=5432;Database=bank;User ID=postgres;Password=secret;" />
 			</connectionStrings>
 			""");
 		return path;
+	}
+
+	private static EnvironmentSettings CreateEnvironmentSettings() => new() {
+		EnvironmentPath = CreateCreatioEnvironmentPath()
+	};
+
+	private static IDeploymentTargetReservation CreateTargetReservation() {
+		IDeploymentTargetReservation reservation = Substitute.For<IDeploymentTargetReservation>();
+		reservation.Acquire(Arg.Any<string>()).Returns(Substitute.For<IDisposable>());
+		return reservation;
 	}
 
 	private static string CreateIdentityArchive()
@@ -379,6 +610,7 @@ public sealed class IdentityServiceDeploymentServiceTests
 			availableIisPortService,
 			roleGrantService ?? Substitute.For<IIdentityServiceRoleGrantService>(),
 			systemUserResolver ?? Substitute.For<IIdentityServiceSystemUserResolver>(),
+			CreateTargetReservation(),
 			Substitute.For<ILogger>());
 	}
 

--- a/clio.tests/Command/McpServer/DeployIdentityToolTests.cs
+++ b/clio.tests/Command/McpServer/DeployIdentityToolTests.cs
@@ -1,7 +1,11 @@
+using System.Linq;
 using System.Reflection;
+using System.Text.Json;
+using Clio.Common;
 using Clio.Command.McpServer.Tools;
 using FluentAssertions;
 using ModelContextProtocol.Server;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command.McpServer;
@@ -11,6 +15,68 @@ namespace Clio.Tests.Command.McpServer;
 [Property("Module", "McpServer")]
 public sealed class DeployIdentityToolTests
 {
+	[Test]
+	[Description("Keeps the curated deploy-identity contract aligned with its required environment and supported overwrite arguments.")]
+	public void DeployIdentityContract_Should_Expose_Environment_And_Overwrite_Fields()
+	{
+		// Arrange
+		string[] toolNames = [DeployIdentityTool.DeployIdentityToolName];
+
+		// Act
+		ToolContractGetResponse response = ToolContractCatalog.GetContracts(toolNames);
+		ToolContractDefinition contract = response.Tools!.Single();
+
+		// Assert
+		contract.InputSchema.Properties.Select(property => property.Name).Should().Contain(
+			["environment-name", "overwrite"],
+			because: "the curated contract must advertise the fields that deploy-identity binds and executes");
+		contract.InputSchema.Required.Should().BeEquivalentTo(
+			["environment-name"],
+			because: "the target environment is required while overwrite remains optional");
+	}
+
+	[Test]
+	[Description("Binds the published deploy-identity environment and overwrite fields through the production MCP serializer.")]
+	public void DeployIdentityArgs_Should_Bind_Published_Environment_And_Overwrite_Fields()
+	{
+		// Arrange
+		JsonSerializerOptions options = Clio.BindingsModule.CreateMcpSerializerOptions();
+		const string json = """
+			{"environment-name":"bank","overwrite":true}
+			""";
+
+		// Act
+		DeployIdentityArgs? args = JsonSerializer.Deserialize<DeployIdentityArgs>(json, options);
+
+		// Assert
+		args.Should().NotBeNull(
+			because: "the published deploy-identity contract must deserialize through the production MCP serializer");
+		args!.EnvironmentName.Should().Be("bank",
+			because: "environment-name is the required field advertised by get-tool-contract");
+		args.Overwrite.Should().BeTrue(
+			because: "the published overwrite flag must reach deploy-identity execution");
+	}
+
+	[Test]
+	[Description("Rejects a missing MCP environment instead of allowing deploy-identity to fall back to the active environment.")]
+	public void DeployIdentity_Should_Fail_Closed_When_Environment_Is_Missing()
+	{
+		// Arrange
+		DeployIdentityTool tool = new(
+			Substitute.For<ILogger>(),
+			Substitute.For<IToolCommandResolver>());
+		DeployIdentityArgs args = new(null!);
+
+		// Act
+		CommandExecutionResult result = tool.DeployIdentity(args);
+
+		// Assert
+		result.ExitCode.Should().Be(1,
+			because: "a missing MCP target is a caller-actionable validation error");
+		result.Output.Should().Contain(message => message.Value.ToString()!.Contains("environment-name is required"),
+			because: "deploy-identity must fail before the command can select the active environment");
+	}
+
 	[Test]
 	[Description("Advertises the stable deploy-identity MCP tool name so agents can target the deployment contract without drift.")]
 	public void DeployIdentity_Should_Advertise_Stable_Tool_Name()

--- a/clio/Command/IdentityServiceDeployment/DeployIdentityCommand.cs
+++ b/clio/Command/IdentityServiceDeployment/DeployIdentityCommand.cs
@@ -42,17 +42,18 @@ public sealed class DeployIdentityOptions : EnvironmentNameOptions
 	public int? IdentitySitePort { get; set; }
 
 	/// <summary>
-	/// Gets or sets the target directory where IdentityService files are deployed.
+	/// Gets or sets the target directory where IdentityService files are deployed. Filesystem reparse
+	/// points are refused in the target path so deployment cannot be redirected to another location.
 	/// </summary>
 	[Option("identity-path", Required = false,
-		HelpText = "Target IdentityService directory. Defaults to a sibling <environment>-identity folder")]
+		HelpText = "Target IdentityService directory. Filesystem reparse points are refused. Defaults to a sibling <environment>-identity folder")]
 	public string IdentityPath { get; set; }
 
 	/// <summary>
 	/// Gets or sets a value indicating whether an existing target directory can be overwritten.
 	/// </summary>
 	[Option("overwrite", Required = false, Default = false,
-		HelpText = "Overwrite existing IdentityService files in --identity-path")]
+		HelpText = "Overwrite IdentityService files in an empty or recognized existing --identity-path")]
 	public bool Overwrite { get; set; }
 
 	/// <summary>

--- a/clio/Command/IdentityServiceDeployment/IdentityServiceDeploymentService.cs
+++ b/clio/Command/IdentityServiceDeployment/IdentityServiceDeploymentService.cs
@@ -219,35 +219,12 @@ public sealed class IdentityServiceRoleGrantService : IIdentityServiceRoleGrantS
 		if (!Guid.TryParse(systemUserId, out Guid userId) || userId == Guid.Empty) {
 			throw new ArgumentException("System user id must be a non-empty GUID.", nameof(systemUserId));
 		}
-		string connectionString = ReadCreatioDbConnectionString(environment);
-		if (IsPostgres(connectionString)) {
+		string connectionString = IdentityServiceDeploymentService.ReadCreatioDbConnectionString(environment);
+		if (IdentityServiceDeploymentService.IsPostgres(connectionString)) {
 			GrantSystemAdministratorRolePostgres(connectionString, userId);
 		} else {
 			GrantSystemAdministratorRoleSqlServer(connectionString, userId);
 		}
-	}
-
-	private static bool IsPostgres(string connectionString) =>
-		connectionString.Contains("Host=", StringComparison.OrdinalIgnoreCase)
-		|| (connectionString.Contains("Server=", StringComparison.OrdinalIgnoreCase)
-			&& connectionString.Contains("Port=", StringComparison.OrdinalIgnoreCase)
-			&& !connectionString.Contains("Data Source=", StringComparison.OrdinalIgnoreCase));
-
-	private static string ReadCreatioDbConnectionString(EnvironmentSettings environment) {
-		if (string.IsNullOrWhiteSpace(environment.EnvironmentPath)) {
-			throw new InvalidOperationException("The target environment does not have EnvironmentPath configured.");
-		}
-		string connectionStringsPath = Path.Combine(environment.EnvironmentPath, "ConnectionStrings.config");
-		if (!File.Exists(connectionStringsPath)) {
-			throw new FileNotFoundException("Creatio ConnectionStrings.config was not found.", connectionStringsPath);
-		}
-		XDocument document = XDocument.Load(connectionStringsPath);
-		XElement element = document.Root?.Elements("add")
-			.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "dbPostgreSql", StringComparison.OrdinalIgnoreCase))
-			?? document.Root?.Elements("add")
-				.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "db", StringComparison.OrdinalIgnoreCase));
-		return element?.Attribute("connectionString")?.Value
-			?? throw new InvalidOperationException("ConnectionStrings.config does not contain db/dbPostgreSql.");
 	}
 
 	private static void GrantSystemAdministratorRolePostgres(string connectionString, Guid userId) {
@@ -370,6 +347,7 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 	private readonly IIdentityServiceArchiveResolver _archiveResolver;
 	private readonly IAvailableIisPortService _availableIisPortService;
 	private readonly IIdentityServiceCreatioClient _creatioClient;
+	private readonly IDeploymentTargetReservation _deploymentTargetReservation;
 	private readonly IHttpClientFactory _httpClientFactory;
 	private readonly ILogger _logger;
 	private readonly IProcessExecutor _processExecutor;
@@ -391,6 +369,7 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		IAvailableIisPortService availableIisPortService,
 		IIdentityServiceRoleGrantService roleGrantService,
 		IIdentityServiceSystemUserResolver systemUserResolver,
+		IDeploymentTargetReservation deploymentTargetReservation,
 		ILogger logger) {
 		_settingsRepository = settingsRepository ?? throw new ArgumentNullException(nameof(settingsRepository));
 		_archiveResolver = archiveResolver ?? throw new ArgumentNullException(nameof(archiveResolver));
@@ -402,6 +381,8 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 			?? throw new ArgumentNullException(nameof(availableIisPortService));
 		_roleGrantService = roleGrantService ?? throw new ArgumentNullException(nameof(roleGrantService));
 		_systemUserResolver = systemUserResolver ?? throw new ArgumentNullException(nameof(systemUserResolver));
+		_deploymentTargetReservation = deploymentTargetReservation
+			?? throw new ArgumentNullException(nameof(deploymentTargetReservation));
 		_logger = logger ?? throw new ArgumentNullException(nameof(logger));
 	}
 
@@ -427,8 +408,8 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 
 		string zipFile = ResolveZipFile(options, environment, identityArchivePathInBundle);
 		string standaloneArchive = _archiveResolver.Resolve(zipFile, identityArchivePathInBundle);
-		ExtractIdentityService(standaloneArchive, identityPath, options.Overwrite);
-		ConfigureAppSettings(identityPath, environment);
+		using IDisposable targetReservation = _deploymentTargetReservation.Acquire(identityPath);
+		ExtractIdentityService(standaloneArchive, identityPath, options.Overwrite, environment);
 		GenerateCertificateIfScriptExists(identityPath);
 		CreateIisSite(identityPath, siteName, identitySitePort);
 		VerifyIdentityDiscovery(identityUrl);
@@ -559,16 +540,120 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		return Path.Combine(Environment.CurrentDirectory, siteName);
 	}
 
-	private static void ExtractIdentityService(string archivePath, string identityPath, bool overwrite) {
-		if (Directory.Exists(identityPath)) {
-			if (!overwrite) {
+	internal void ExtractIdentityService(
+		string archivePath,
+		string identityPath,
+		bool overwrite,
+		EnvironmentSettings environment) {
+		EnsurePathHasNoReparsePoints(identityPath);
+		ValidateExistingIdentityTarget(identityPath, overwrite);
+		string parentPath = Directory.GetParent(identityPath)?.FullName
+			?? throw new InvalidOperationException("IdentityService cannot replace a filesystem root directory.");
+		string directoryName = Path.GetFileName(identityPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+		string operationId = Guid.NewGuid().ToString("N");
+		string stagingPath = Path.Combine(parentPath, $".{directoryName}.staging-{operationId}");
+		string backupPath = Path.Combine(parentPath, $".{directoryName}.backup-{operationId}");
+		Directory.CreateDirectory(stagingPath);
+		try {
+			EnsurePathHasNoReparsePoints(stagingPath);
+			ZipFile.ExtractToDirectory(archivePath, stagingPath, overwriteFiles: false);
+			if (!IsIdentityServiceDirectory(stagingPath)) {
 				throw new InvalidOperationException(
-					$"IdentityService target '{identityPath}' already exists. Pass --overwrite to replace files.");
+					"The replacement archive does not contain IdentityService.dll and appsettings.json at its root.");
 			}
-			Directory.Delete(identityPath, recursive: true);
+			ConfigureAppSettings(stagingPath, environment);
+			EnsurePathHasNoReparsePoints(identityPath);
+			bool targetExists = Directory.Exists(identityPath);
+			bool replaceRecognizedTarget = targetExists && IsIdentityServiceDirectory(identityPath);
+			ValidateExistingIdentityTarget(identityPath, overwrite);
+			if (replaceRecognizedTarget) {
+				Directory.Move(identityPath, backupPath);
+			}
+			else if (targetExists) {
+				Directory.Delete(identityPath);
+			}
+			try {
+				Directory.Move(stagingPath, identityPath);
+			}
+			catch {
+				if (Directory.Exists(backupPath) && !Directory.Exists(identityPath)) {
+					Directory.Move(backupPath, identityPath);
+				}
+				throw;
+			}
+			if (Directory.Exists(backupPath)) {
+				DeleteBackupBestEffort(backupPath);
+			}
 		}
-		Directory.CreateDirectory(identityPath);
-		ZipFile.ExtractToDirectory(archivePath, identityPath, overwriteFiles: true);
+		finally {
+			if (Directory.Exists(stagingPath)) {
+				Directory.Delete(stagingPath, recursive: true);
+			}
+		}
+	}
+
+	private static void ValidateExistingIdentityTarget(string identityPath, bool overwrite) {
+		if (!Directory.Exists(identityPath)) {
+			return;
+		}
+		if (!overwrite) {
+			throw new InvalidOperationException(
+				$"IdentityService target '{identityPath}' already exists. Pass --overwrite to replace files.");
+		}
+		bool hasContent = Directory.EnumerateFileSystemEntries(identityPath).Any();
+		if (hasContent && !IsIdentityServiceDirectory(identityPath)) {
+			throw new InvalidOperationException(
+				$"IdentityService target '{identityPath}' is not empty and is not a recognized IdentityService deployment.");
+		}
+	}
+
+	private void DeleteBackupBestEffort(string backupPath) {
+		try {
+			Directory.Delete(backupPath, recursive: true);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+			try {
+				ClearReadOnlyAttributes(backupPath);
+				Directory.Delete(backupPath, recursive: true);
+			}
+			catch (Exception retryException) when (retryException is IOException or UnauthorizedAccessException) {
+				_logger.WriteWarning(
+					$"IdentityService was replaced, but the previous deployment backup '{backupPath}' could not be removed: {retryException.Message}");
+			}
+		}
+	}
+
+	private static void ClearReadOnlyAttributes(string path) {
+		EnumerationOptions options = new() {
+			RecurseSubdirectories = true,
+			AttributesToSkip = FileAttributes.ReparsePoint
+		};
+		foreach (string filePath in Directory.EnumerateFiles(path, "*", options)) {
+			FileAttributes attributes = File.GetAttributes(filePath);
+			if (attributes.HasFlag(FileAttributes.ReadOnly)) {
+				File.SetAttributes(filePath, attributes & ~FileAttributes.ReadOnly);
+			}
+		}
+	}
+
+	private static bool IsIdentityServiceDirectory(string path) =>
+		File.Exists(Path.Combine(path, "IdentityService.dll"))
+		&& File.Exists(Path.Combine(path, "appsettings.json"));
+
+	private static void EnsurePathHasNoReparsePoints(string path) {
+		for (string? currentPath = Path.GetFullPath(path);
+			currentPath is not null;
+			currentPath = Directory.GetParent(currentPath)?.FullName) {
+			try {
+				if (File.GetAttributes(currentPath).HasFlag(FileAttributes.ReparsePoint)) {
+					throw new InvalidOperationException(
+						$"IdentityService target '{path}' cannot be inside or be a filesystem reparse point.");
+				}
+			}
+			catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException) {
+				// Continue with the nearest existing ancestor.
+			}
+		}
 	}
 
 	private static void ConfigureAppSettings(string identityPath, EnvironmentSettings environment) {
@@ -601,9 +686,9 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		}
 		XDocument document = XDocument.Load(connectionStringsPath);
 		XElement element = document.Root?.Elements("add")
-			.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "dbPostgreSql", StringComparison.OrdinalIgnoreCase))
+			.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "db", StringComparison.OrdinalIgnoreCase))
 			?? document.Root?.Elements("add")
-				.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "db", StringComparison.OrdinalIgnoreCase));
+				.FirstOrDefault(item => string.Equals(item.Attribute("name")?.Value, "dbPostgreSql", StringComparison.OrdinalIgnoreCase));
 		return element?.Attribute("connectionString")?.Value
 			?? throw new InvalidOperationException("ConnectionStrings.config does not contain db/dbPostgreSql.");
 	}

--- a/clio/Command/McpServer/Tools/DeployIdentityTool.cs
+++ b/clio/Command/McpServer/Tools/DeployIdentityTool.cs
@@ -46,6 +46,10 @@ public sealed class DeployIdentityTool(
 		[Required]
 		DeployIdentityArgs args)
 	{
+		if (string.IsNullOrWhiteSpace(args.EnvironmentName)) {
+			return CommandExecutionResult.FromValidationError(
+				"environment-name is required and cannot be empty.");
+		}
 		DeployIdentityOptions options = new() {
 			Environment = args.EnvironmentName,
 			ZipFile = args.ZipFile,
@@ -72,7 +76,7 @@ public sealed class DeployIdentityTool(
 /// MCP arguments for the <c>deploy-identity</c> tool.
 /// </summary>
 public sealed record DeployIdentityArgs(
-	[property: JsonPropertyName("environmentName")]
+	[property: JsonPropertyName("environment-name")]
 	[property: Description("Registered clio environment name")]
 	[property: Required]
 	string EnvironmentName,

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5460,6 +5460,7 @@ internal static class ToolContractCatalog {
 	private const string IdentitySitePortFieldName = "identitySitePort";
 	private const string IdentitySiteNameFieldName = "identitySiteName";
 	private const string IdentityPathFieldName = "identityPath";
+	private const string OverwriteFieldName = "overwrite";
 	private const string IdentityArchivePathInBundleFieldName = "identityArchivePathInBundle";
 	private const string ConfigurationModeFieldName = "configurationMode";
 	private const string ClientNameFieldName = "clientName";
@@ -5616,7 +5617,8 @@ internal static class ToolContractCatalog {
 					Field(IdentitySitePortFieldName, NumberType, "Optional HTTP port where IdentityService will listen. When omitted, deploy-identity selects the first free IIS port in range 40001-40100."),
 					Field(IdentityArchivePathInBundleFieldName, StringType, "Nested IdentityService archive path when zipFile is a Creatio bundle, and the relative path preferred under EnvironmentPath when zipFile is omitted. Default: IdentityService.zip."),
 					Field(IdentitySiteNameFieldName, StringType, "Optional IIS site and app pool name. Defaults to <environment>-identity."),
-					Field(IdentityPathFieldName, StringType, "Optional target directory for IdentityService files."),
+					Field(IdentityPathFieldName, StringType, "Optional target directory for IdentityService files. Filesystem reparse points are refused anywhere in the target path."),
+					Field(OverwriteFieldName, BooleanType, "Overwrite IdentityService files in an empty or recognized existing target directory."),
 					Field(ConfigurationModeFieldName, StringType, "Creatio connection mode: db-first, rest, or db. db-first currently falls back to REST/sys-settings until direct DB seeding is proven."),
 					Field(ClientNameFieldName, StringType, "OAuth client display name created for clio."),
 					Field(ClientApplicationUrlFieldName, StringType, "OAuth client application URL."),

--- a/clio/docs/commands/deploy-identity.md
+++ b/clio/docs/commands/deploy-identity.md
@@ -61,10 +61,12 @@ Default: <environment>-identity
 
 --identity-path PATH
 Target IdentityService directory.
+Filesystem reparse points are refused anywhere in the target path.
 Default: sibling <environment>-identity folder next to the Creatio EnvironmentPath
 
 --overwrite
-Replace the existing IdentityService target directory.
+Overwrite IdentityService files in an empty or recognized existing target directory.
+Unrelated non-empty directories are refused and are never recursively deleted.
 Default: false
 
 --configuration-mode MODE

--- a/clio/help/en/deploy-identity.txt
+++ b/clio/help/en/deploy-identity.txt
@@ -51,10 +51,12 @@ OPTIONS
 
     --identity-path PATH
         Target IdentityService directory.
+        Filesystem reparse points are refused anywhere in the target path.
         Default: sibling <environment>-identity folder next to the Creatio EnvironmentPath
 
     --overwrite
-        Replace the existing IdentityService target directory.
+        Overwrite IdentityService files in an empty or recognized existing target directory.
+        Unrelated non-empty directories are refused and are never recursively deleted.
         Default: false
 
     --configuration-mode MODE


### PR DESCRIPTION
Fixes #1198

## Summary

- align the deploy-identity MCP binding with the published required `environment-name` field and expose `overwrite` in the curated contract
- fail closed when the required environment is absent or the obsolete `environmentName` alias is used
- select Creatio's runtime `db` connection before the legacy `dbPostgreSql` fallback so OAuth user lookup targets the real application database
- centralize the IdentityService role grant on the resolved environment
- make overwrite safe: refuse unrelated targets and reparse paths, serialize deployments, stage and validate configuration, publish atomically, and retain rollback for recognized deployments
- align CLI help, detailed command docs, XML/HelpText, and the curated MCP field descriptions

## Validation

- `dotnet build clio.tests/clio.tests.csproj -c Release -f net10.0 --no-restore`
- `dotnet test clio.tests/clio.tests.csproj -c Release -f net10.0 --no-build --filter "Category=Unit&(Module=Command|Module=McpServer)"` — 7,707 passed, 15 skipped
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release -f net10.0 --no-build --filter "FullyQualifiedName~DeployIdentityToolE2ETests"` — 3 passed
- focused IdentityService deployment tests — 19 passed, including the Windows directory-link regression
- `python scripts/check-knowledge-applies-to.py --base origin/master` — advisory records reviewed; their facts remain accurate
- `git diff --check`

## Review

- comprehensive seven-lens agentic review completed on the full final diff; no Blocker, High, or Medium findings remain
- the review found and drove fixes for fail-open environment fallback, unsafe overwrite/replacement, staged-content validation, cleanup behavior, and filesystem alias handling
- independent Claude review was requested twice on the final iterations but the provider reported its session limit; an earlier stable iteration had no P1/P2 findings, and the final diff received the complete seven-lens review
- docs reviewed and updated
- MCP reviewed and updated with unit and real-process E2E coverage
- clio-knowledge guidance reviewed; no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`

## KISS check

The intent is to make the published MCP call work and make default PostgreSQL OAuth deployment use the real Creatio database. The flow remains one command and one MCP tool; staging, reservation, and atomic publication exist only to prevent demonstrated destructive overwrite and credential-redirection failures. No new protocol, registry, or persistent coordination state was introduced.