### PR TITLE
test: accept empty compilation diagnostics

### DIFF
--- a/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
+++ b/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
@@ -127,9 +127,9 @@ public sealed class LastCompilationLogToolE2ETests : McpContractFixtureBase {
 			response.Diagnostics.Should().NotBeNull(
 				because: "the typed MCP response must always carry a diagnostics collection, including when it is empty"));
 		AllureApi.Step("Assert every diagnostic retains its severity", () =>
-			response.Diagnostics.Should().OnlyContain(
-				diagnostic => diagnostic.Severity == "error" || diagnostic.Severity == "warning",
-				because: "every compiler diagnostic must retain its error or warning classification"));
+			response.Diagnostics.Should().NotContain(
+				diagnostic => diagnostic.Severity != "error" && diagnostic.Severity != "warning",
+				because: "every returned compiler diagnostic must retain its error or warning classification"));
 		AllureApi.Step("Assert compilation outcome is serialized explicitly", () =>
 			serializedResult.Should().Contain("compilation-succeeded",
 				because: "the clio-run response must serialize compilation outcome explicitly even when it is false"));

--- a/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
+++ b/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
@@ -111,7 +111,7 @@ public sealed class LastCompilationLogToolE2ETests : McpContractFixtureBase {
 		CallToolResult callResult = await AllureApi.Step("Invoke last-compilation-log through clio-run", () =>
 			InvokeAsync(session, cts.Token, environmentName));
 		LastCompilationLogResponse response = ExtractResponse(callResult);
-		string serializedResult = JsonSerializer.Serialize(callResult.StructuredContent);
+		string serializedResult = JsonSerializer.Serialize(callResult);
 
 		// Assert
 		AllureApi.Step("Assert the MCP transport call succeeds", () =>


### PR DESCRIPTION
## Summary

- fix the sandbox E2E assertion added by #1258 so a successful compilation log with zero diagnostics is valid
- validate expected wire fields against the complete MCP `CallToolResult`, because `clio-run` may carry the typed JSON in textual `Content` while `StructuredContent` is null
- continue rejecting any returned diagnostic whose severity is neither error nor warning

## Why

TeamCity exposed two test-only assumptions after #1258 auto-merged. Run 15947890 showed that FluentAssertions `OnlyContain` rejects an empty collection. Run 15947942 showed that the MCP SDK can expose the valid typed response through textual `Content` while nullable `StructuredContent` remains null. The production tool response was valid in both cases; this follow-up corrects the E2E assertions.

## Validation

- local focused E2E: `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release --filter FullyQualifiedName~LastCompilationLogToolE2ETests --no-restore`
  - net10.0: 2 passed, 1 sandbox test skipped locally
  - net8.0: 2 passed, 1 sandbox test skipped locally
- TeamCity MCP E2E run [15948220](https://teamcity-rnd.bpmonline.com/buildConfiguration/Team_Atf_ClioMcpE2eTests/15948220) on head `d5a6e920687535514c8ccf1d936ab659368d8c6b`: 650 passed, 17 ignored, 0 failed
- required GitHub gates on the same head: Detect changes, Unit Tests, Integration Tests, and SonarCloud passed; Analyzer Tests correctly skipped
- direct SonarCloud PR issue query: 0 open, confirmed, or accepted new issues
- unresolved review threads: 0
- final comprehensive full-diff agentic review: code quality, security, performance/correctness, testing, bug/edge cases, intent alignment, and KISS; no findings

Review tier: comprehensive pre-PR gate, scoped incremental review for each test-only commit, and comprehensive final full-diff gate.

Docs reviewed, no update required. MCP reviewed, no contract update required. ClioRing compatibility reviewed, no Ring-consumed contract changed.