### PR TITLE
Prevent tests from launching browser help

### DIFF
--- a/clio.tests/CommonProgramTest.cs
+++ b/clio.tests/CommonProgramTest.cs
@@ -6,7 +6,9 @@ using Clio.Command;
 using Clio.Common;
 using Clio.Tests.Command;
 using Clio.Tests.Extensions;
+using Clio.Utilities;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests;
@@ -519,16 +521,28 @@ internal class CommonProgramTest : BaseClioModuleTests{
 	[Test]
 	[Description("Keeps a disabled experimental command's --help output empty so the shared dispatch fix cannot leak feature-toggled-off command help (ENG-93886 risk: shared chokepoint blast radius).")]
 	public void ExecuteCommands_WithDisabledExperimentalCommandHelpSwitch_ShouldNotLeakCommandHelp() {
+		// Arrange
+		const string expectedUrl
+			= "https://github.com/Advance-Technologies-Foundation/clio/blob/master/clio/Commands.md#";
 		ThreadSafeStringWriter consoleOutput = new();
+		IWebBrowser webBrowser = Substitute.For<IWebBrowser>();
+		webBrowser.Enabled.Returns(true);
+		webBrowser.CheckUrl(Arg.Any<string>()).Returns(true);
 		Console.SetOut(consoleOutput);
 		Console.SetError(consoleOutput);
 
-		int exitCode = Program.ExecuteCommands(["ring", "--help"]);
+		// Act
+		int exitCode = Program.ExecuteCommands(
+			["ring", "--help"],
+			services => services.AddSingleton(webBrowser));
 		string output = consoleOutput.ToString();
 
+		// Assert
 		exitCode.Should().Be(1, because: "a feature-toggled-off command must remain indistinguishable from an unknown verb even through the new --help dispatch short-circuit");
 		output.Should().NotContain("Install, update, launch",
 			because: "the disabled ring command's help text must not leak through the new --help dispatch short-circuit");
+		webBrowser.Received(1).CheckUrl(expectedUrl);
+		webBrowser.Received(1).OpenUrl(expectedUrl);
 	}
 
 	[Test]

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -1460,14 +1460,24 @@ internal class Program {
 	/// </summary>
 	/// <param name="args">Command line arguments to process</param>
 	/// <returns>Exit code from the executed command, or a parse error code</returns>
-	internal static int ExecuteCommands(string[] args){
+	internal static int ExecuteCommands(string[] args) => ExecuteCommands(args, additionalRegistrations: null);
+
+	/// <summary>
+	/// Executes commands with optional service-registration overrides for a host or test boundary.
+	/// </summary>
+	/// <param name="args">Command line arguments to process.</param>
+	/// <param name="additionalRegistrations">Optional registrations applied after the default Clio services.</param>
+	/// <returns>Exit code from the executed command, or a parse error code.</returns>
+	internal static int ExecuteCommands(string[] args, Action<IServiceCollection> additionalRegistrations){
 		CreatioEnvironment creatioEnv = new();
 		const string helpFolderName = "help";
 		string envPath = creatioEnv.GetAssemblyFolderPath();
 		string helpDirectoryPath = Path.Combine(envPath ?? string.Empty, helpFolderName);
 		Parser.Default.Settings.ShowHeader = false;
 		Parser.Default.Settings.HelpDirectory = helpDirectoryPath;
-		IServiceProvider bm = new BindingsModule().Register(applyBootstrapRepairs: false);
+		IServiceProvider bm = new BindingsModule().Register(
+			additionalRegistrations: additionalRegistrations,
+			applyBootstrapRepairs: false);
 		if (TryHandleBuiltInHelp(args, bm, out int helpExitCode)) {
 			return helpExitCode;
 		}


### PR DESCRIPTION
## Summary

- add an internal service-registration seam to the program command-dispatch host
- replace `IWebBrowser` in the affected full-program test so it cannot launch the real system browser
- assert the exact help URL at the browser abstraction while retaining the existing process-executor contract tests

Fixes #1265

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "FullyQualifiedName~CommonProgramTest.ExecuteCommands_WithDisabledExperimentalCommandHelpSwitch_ShouldNotLeakCommandHelp"` (1 passed)
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "FullyQualifiedName~Clio.Tests.CommonProgramTest|FullyQualifiedName~Clio.Tests.Utilities.WebBrowserTests"` (51 passed)
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "Category=Unit"` (9,861 passed, 25 skipped)
- `python scripts/check-knowledge-applies-to.py` (all 131 records valid)

## Review and compatibility

- Mandatory pre-PR agentic review: comprehensive 7-lens parallel review, no findings
- Review tier: comprehensive because this is the required pre-PR gate and `Program.cs` is shared infrastructure
- docs reviewed, no update required
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed; inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`

## KISS check

The production one-argument flow remains unchanged. Tests add one final registration for the existing `IWebBrowser` seam, and existing `WebBrowserTests` continue to prove the corresponding `IProcessExecutor` launch request. No CI switch, environment flag, browser cleanup, or unrelated browser refactor was added.