### PR TITLE
Harden issue and PR delivery policies

### DIFF
--- a/.ai/skills/claim-clio-issue/SKILL.md
+++ b/.ai/skills/claim-clio-issue/SKILL.md
@@ -9,29 +9,29 @@ Claiming means assigning the authenticated `gh` user. The linked branch provides
 
 ## Claim
 
-1. Run the `clio-issue-workflow` skill's read-only `Mitigation stage` readiness check. Stop before any GitHub write when the provisioning contract is not ready.
+1. Run the `clio-issue-workflow` skill's read-only workflow-field readiness check. Stop before any GitHub write when the provisioning contract is not ready.
 2. Read the live issue, assignees, state, linked branches, and linked pull requests from `Advance-Technologies-Foundation/clio`.
-3. Resolve the authenticated GitHub login from `gh`; use the login, never the display name.
+3. Resolve the authenticated GitHub login with `gh api user --jq .login`; use that explicit login for assignment and branch naming. Never pass the `@me` shorthand to PowerShell or another shell.
 4. Interpret the current state:
    - Closed issue: stop unless the user explicitly authorized reopening it.
-   - No assignee and no matching branch: assign `@me`, then continue.
+   - No assignee and no matching branch: assign the resolved login, then continue.
    - Current user assigned and the expected branch exists: resume idempotently.
    - Current user assigned but the branch is missing: create and link it.
    - Current user assigned and a different Development branch exists: resume that branch only after verifying it belongs to the same work; otherwise stop. Do not add a second branch.
    - Another user assigned: check for that user's linked `<assignee>/issue-<number>` branch, then stop. Report an existing branch as active work or a missing branch as incomplete visibility; neither state makes the issue free.
    - Multiple assignees, or a branch without an assignee: stop and report the ambiguity.
-5. After adding `@me`, re-read assignees once. Stop and report ambiguity if another assignee appeared; do not add coordination machinery beyond this check.
-6. Set the original issue's `Mitigation stage` to `Investigating` using the canonical field procedure in the `clio-issue-workflow` skill, and verify the stored value.
+5. After adding the resolved login, re-read assignees once. Stop and report ambiguity if another assignee appeared; do not add coordination machinery beyond this check.
+6. Read the original issue's field values. Preserve an existing `Start date`; if it is empty, set it to the current date. Set `Mitigation stage` to `Investigating` in the same additive `POST` when both values need updating, then verify both stored values through the canonical field procedure in the `clio-issue-workflow` skill.
 7. Name a new branch `<login>/issue-<number>`, for example `kirillkrylov/issue-1138`.
 8. Create the branch from the current canonical default branch and link it through GitHub's issue Development relationship. Use `gh issue develop` when available.
 9. Fetch the new remote branch before creating an isolated linked worktree named `issue-<number>` in the repository's task-worktree area. Track the remote branch and preserve the primary checkout and unrelated user changes.
 
 Do not inspect code, diagnose the report, or create a pull request before the claim is established.
 
-If the stage update, branch creation, Development linking, or worktree creation fails after assignment, leave the visible assignment and any successfully written stage in place, report the exact incomplete setup, and stop. Do not add rollback machinery.
+If the date or stage update, branch creation, Development linking, or worktree creation fails after assignment, leave the visible assignment and any successfully written fields in place, report the exact incomplete setup, and stop. Do not add rollback machinery.
 
 Do not post a routine claim comment when assignee, stage, and Development already communicate the same information. Comment only when an inconsistency or permission failure needs human attention.
 
 ## Handoff
 
-Return the issue URL, authenticated login, assignment result, branch name, Development-link result, worktree path, and mitigation stage. The `investigate-clio-issue` skill may proceed only after the issue is assigned to the current user and the linked branch exists.
+Return the issue URL, authenticated login, assignment result, start date, branch name, Development-link result, worktree path, and mitigation stage. The `investigate-clio-issue` skill may proceed only after the issue is assigned to the current user and the linked branch exists.

--- a/.ai/skills/claim-clio-issue/SKILL.md
+++ b/.ai/skills/claim-clio-issue/SKILL.md
@@ -9,29 +9,29 @@ Claiming means assigning the authenticated `gh` user. The linked branch provides
 
 ## Claim
 
-1. Run the `clio-issue-workflow` skill's read-only workflow-field readiness check. Stop before any GitHub write when the provisioning contract is not ready.
+1. Run the `clio-issue-workflow` skill's read-only `Mitigation stage` readiness check. Stop before any GitHub write when the provisioning contract is not ready.
 2. Read the live issue, assignees, state, linked branches, and linked pull requests from `Advance-Technologies-Foundation/clio`.
-3. Resolve the authenticated GitHub login with `gh api user --jq .login`; use that explicit login for assignment and branch naming. Never pass the `@me` shorthand to PowerShell or another shell.
+3. Resolve the authenticated GitHub login from `gh`; use the login, never the display name.
 4. Interpret the current state:
    - Closed issue: stop unless the user explicitly authorized reopening it.
-   - No assignee and no matching branch: assign the resolved login, then continue.
+   - No assignee and no matching branch: assign `@me`, then continue.
    - Current user assigned and the expected branch exists: resume idempotently.
    - Current user assigned but the branch is missing: create and link it.
    - Current user assigned and a different Development branch exists: resume that branch only after verifying it belongs to the same work; otherwise stop. Do not add a second branch.
    - Another user assigned: check for that user's linked `<assignee>/issue-<number>` branch, then stop. Report an existing branch as active work or a missing branch as incomplete visibility; neither state makes the issue free.
    - Multiple assignees, or a branch without an assignee: stop and report the ambiguity.
-5. After adding the resolved login, re-read assignees once. Stop and report ambiguity if another assignee appeared; do not add coordination machinery beyond this check.
-6. Read the original issue's field values. Preserve an existing `Start date`; if it is empty, set it to the current date. Set `Mitigation stage` to `Investigating` in the same additive `POST` when both values need updating, then verify both stored values through the canonical field procedure in the `clio-issue-workflow` skill.
+5. After adding `@me`, re-read assignees once. Stop and report ambiguity if another assignee appeared; do not add coordination machinery beyond this check.
+6. Set the original issue's `Mitigation stage` to `Investigating` using the canonical field procedure in the `clio-issue-workflow` skill, and verify the stored value.
 7. Name a new branch `<login>/issue-<number>`, for example `kirillkrylov/issue-1138`.
 8. Create the branch from the current canonical default branch and link it through GitHub's issue Development relationship. Use `gh issue develop` when available.
 9. Fetch the new remote branch before creating an isolated linked worktree named `issue-<number>` in the repository's task-worktree area. Track the remote branch and preserve the primary checkout and unrelated user changes.
 
 Do not inspect code, diagnose the report, or create a pull request before the claim is established.
 
-If the date or stage update, branch creation, Development linking, or worktree creation fails after assignment, leave the visible assignment and any successfully written fields in place, report the exact incomplete setup, and stop. Do not add rollback machinery.
+If the stage update, branch creation, Development linking, or worktree creation fails after assignment, leave the visible assignment and any successfully written stage in place, report the exact incomplete setup, and stop. Do not add rollback machinery.
 
 Do not post a routine claim comment when assignee, stage, and Development already communicate the same information. Comment only when an inconsistency or permission failure needs human attention.
 
 ## Handoff
 
-Return the issue URL, authenticated login, assignment result, start date, branch name, Development-link result, worktree path, and mitigation stage. The `investigate-clio-issue` skill may proceed only after the issue is assigned to the current user and the linked branch exists.
+Return the issue URL, authenticated login, assignment result, branch name, Development-link result, worktree path, and mitigation stage. The `investigate-clio-issue` skill may proceed only after the issue is assigned to the current user and the linked branch exists.

--- a/.ai/skills/clio-issue-workflow/SKILL.md
+++ b/.ai/skills/clio-issue-workflow/SKILL.md
@@ -27,8 +27,6 @@ Use GitHub's existing primitives only:
 - Assignee: who coordinates the issue.
 - Issue Type and labels: the evidence-backed classification, normalized before investigation hands work to repair or another owner.
 - `Mitigation stage` issue field: `Investigating`, `Fixing`, `QA`, or `Waiting for human approval`.
-- `Start date`: the date the issue was first claimed for active work.
-- `Completion date`: the date the completed repair was verified after merge.
 - Development: the linked branch and later the draft pull request.
 - Relationships: the original issue is `blocked by` an issue in another repository when that downstream issue owns work required to resolve the report.
 
@@ -36,7 +34,7 @@ Do not introduce claim records, leases, receipts, lock files, custom refs, or a 
 
 Missing Issue Type or labels do not block intake or claim. The `investigate-clio-issue` skill must set and verify exactly one relevant enabled Issue Type and at least one relevant existing repository label after diagnosis. Do not invent a type, create a label, or use a placeholder classification merely to satisfy the gate.
 
-The original issue's `Mitigation stage` is authoritative for the overall workflow. A closed issue needs no `Done` stage value; `Completion date` records when delivery actually finished.
+The original issue's `Mitigation stage` is authoritative for the overall workflow. A closed issue needs no `Done` field value.
 
 ### Canonical stage field
 
@@ -53,16 +51,14 @@ The provisioning contract is:
 
 Display order and pinning are administrator-facing presentation settings, not runtime readiness gates. The recommended display order is `Investigating`, `Fixing`, `QA`, `Waiting for human approval`. GitHub options carry a `priority` for display ordering; their position in the REST response array does not establish that order. Pinning is not returned by the issue-field REST list response.
 
-The workflow also requires the organization-level `Start date` and `Completion date` fields. Both must have type `date`. Their pinning and visibility control presentation, not workflow readiness; a field with a stored value appears on the issue even when it is not pinned to that issue type.
-
-Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless `Mitigation stage` exists with the required type, visibility, and all four exact option names, and both date fields exist with type `date`. Check option names by membership, not by array position or priority. A different response order or display order must not block claiming an issue. Report the mismatched property; do not try to repair organization settings.
+Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless the field exists with the required type, visibility, and all four exact option names. Check option names by membership, not by array position or priority. A different response order or display order must not block claiming an issue. Report the mismatched property; do not try to repair organization settings.
 
 Read and update it through GitHub's issue-field REST API:
 
 1. Send `X-GitHub-Api-Version: 2026-03-10` on every issue-field request.
-2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field names and perform the readiness check above. Resolve field ids dynamically; do not hardcode them.
-3. `POST /repos/OWNER/REPO/issues/NUMBER/issue-field-values` with only the values being added or updated, for example `{"issue_field_values":[{"field_id":FIELD_ID,"value":"STAGE"}]}`. Date values use `YYYY-MM-DD`. Do not use `PUT`, which replaces all issue-field values.
-4. `GET /repos/OWNER/REPO/issues/NUMBER/issue-field-values` and verify every stored value written by the workflow.
+2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field name and perform the readiness check above. Resolve the field id dynamically; do not hardcode it.
+3. `POST /repos/OWNER/REPO/issues/NUMBER/issue-field-values` with only `{"issue_field_values":[{"field_id":FIELD_ID,"value":"STAGE"}]}`. Do not use `PUT`, which replaces all issue-field values.
+4. `GET /repos/OWNER/REPO/issues/NUMBER/issue-field-values` and verify the stored value.
 
 If the field, option, permission, or API support is missing, report the exact failure. Do not silently substitute a label or a Projects field, and do not claim the stage changed when verification failed.
 
@@ -70,4 +66,4 @@ If the field, option, permission, or API support is missing, report the exact fa
 
 Report the original issue, assignee, current stage, linked branch or PR, owning repositories, blocking downstream issues, validation state, and any genuine human decision still required.
 
-Do not add coordination artifacts beyond the assignee, stage field, Development link, issue relationships, and normal issue or PR comments required to explain a blocker.
+Do not add coordination artifacts beyond the assignee, Issue Type, labels, stage field, Development link, issue relationships, and normal issue or PR comments required to explain a blocker.

--- a/.ai/skills/clio-issue-workflow/SKILL.md
+++ b/.ai/skills/clio-issue-workflow/SKILL.md
@@ -25,13 +25,18 @@ Do not duplicate the phase procedures here. Use the phase skills as the source o
 Use GitHub's existing primitives only:
 
 - Assignee: who coordinates the issue.
+- Issue Type and labels: the evidence-backed classification, normalized before investigation hands work to repair or another owner.
 - `Mitigation stage` issue field: `Investigating`, `Fixing`, `QA`, or `Waiting for human approval`.
+- `Start date`: the date the issue was first claimed for active work.
+- `Completion date`: the date the completed repair was verified after merge.
 - Development: the linked branch and later the draft pull request.
 - Relationships: the original issue is `blocked by` an issue in another repository when that downstream issue owns work required to resolve the report.
 
 Do not introduce claim records, leases, receipts, lock files, custom refs, or a separate state store.
 
-The original issue's `Mitigation stage` is authoritative for the overall workflow. A closed issue needs no `Done` field value.
+Missing Issue Type or labels do not block intake or claim. The `investigate-clio-issue` skill must set and verify exactly one relevant enabled Issue Type and at least one relevant existing repository label after diagnosis. Do not invent a type, create a label, or use a placeholder classification merely to satisfy the gate.
+
+The original issue's `Mitigation stage` is authoritative for the overall workflow. A closed issue needs no `Done` stage value; `Completion date` records when delivery actually finished.
 
 ### Canonical stage field
 
@@ -48,14 +53,16 @@ The provisioning contract is:
 
 Display order and pinning are administrator-facing presentation settings, not runtime readiness gates. The recommended display order is `Investigating`, `Fixing`, `QA`, `Waiting for human approval`. GitHub options carry a `priority` for display ordering; their position in the REST response array does not establish that order. Pinning is not returned by the issue-field REST list response.
 
-Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless the field exists with the required type, visibility, and all four exact option names. Check option names by membership, not by array position or priority. A different response order or display order must not block claiming an issue. Report the mismatched property; do not try to repair organization settings.
+The workflow also requires the organization-level `Start date` and `Completion date` fields. Both must have type `date`. Their pinning and visibility control presentation, not workflow readiness; a field with a stored value appears on the issue even when it is not pinned to that issue type.
+
+Before the first GitHub write in every workflow, perform one read-only readiness check. Stop without assigning, branching, or commenting unless `Mitigation stage` exists with the required type, visibility, and all four exact option names, and both date fields exist with type `date`. Check option names by membership, not by array position or priority. A different response order or display order must not block claiming an issue. Report the mismatched property; do not try to repair organization settings.
 
 Read and update it through GitHub's issue-field REST API:
 
 1. Send `X-GitHub-Api-Version: 2026-03-10` on every issue-field request.
-2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field name and perform the readiness check above. Resolve the field id dynamically; do not hardcode it.
-3. `POST /repos/OWNER/REPO/issues/NUMBER/issue-field-values` with only `{"issue_field_values":[{"field_id":FIELD_ID,"value":"STAGE"}]}`. Do not use `PUT`, which replaces all issue-field values.
-4. `GET /repos/OWNER/REPO/issues/NUMBER/issue-field-values` and verify the stored value.
+2. `GET /orgs/Advance-Technologies-Foundation/issue-fields`; select the exact field names and perform the readiness check above. Resolve field ids dynamically; do not hardcode them.
+3. `POST /repos/OWNER/REPO/issues/NUMBER/issue-field-values` with only the values being added or updated, for example `{"issue_field_values":[{"field_id":FIELD_ID,"value":"STAGE"}]}`. Date values use `YYYY-MM-DD`. Do not use `PUT`, which replaces all issue-field values.
+4. `GET /repos/OWNER/REPO/issues/NUMBER/issue-field-values` and verify every stored value written by the workflow.
 
 If the field, option, permission, or API support is missing, report the exact failure. Do not silently substitute a label or a Projects field, and do not claim the stage changed when verification failed.
 

--- a/.ai/skills/investigate-clio-issue/SKILL.md
+++ b/.ai/skills/investigate-clio-issue/SKILL.md
@@ -27,7 +27,18 @@ Confirm that the original issue is open, assigned to the current GitHub user, li
    - Insufficient evidence.
 7. Form the smallest evidence-backed diagnosis and explicit acceptance criteria.
 
-If the Collab MCP server is available, engage the other coding agent after forming the initial diagnosis: Claude when running as Codex, or Codex when running as Claude. Ask for an independent, read-only challenge to the root cause, repository ownership, missing evidence, and smallest sufficient repair. Verify its claims locally and distinguish accepted, rejected, and unresolved findings. If Collab is unavailable, record that and continue; cross-agent consultation is conditional, not a blocker.
+Do not routinely spend a cross-provider review during investigation. Engage the other coding agent only when the user explicitly requests it or a concrete high-risk ambiguity could materially change repository ownership or the repair: destructive/security/authentication behavior, concurrency, migration, public protocol compatibility, or unfamiliar Creatio platform behavior. Claude is the consultant when running as Codex; Codex is the consultant when running as Claude. Ask for a narrow, independent challenge to the current root cause and smallest repair, with concrete evidence rather than a broad audit. Verify its claims locally and distinguish accepted, rejected, and unresolved findings. If Collab is unavailable or quota-limited, record that and continue without retrying; investigation consultation is optional and is not a blocker.
+
+## Normalize issue metadata
+
+After the diagnosis is evidence-backed and before handing work to repair or another owner:
+
+1. Read the repository's current labels and the organization's enabled Issue Types. Do not rely on remembered names or ids.
+2. Set exactly one Issue Type that matches the diagnosis. Use `Bug` for a confirmed product defect and `Task` for actionable non-defect work when those enabled types apply; otherwise select the relevant enabled type without inventing one.
+3. Ensure the issue has at least one relevant existing repository label. For a confirmed Clio defect, apply the existing `bug` label as well as Issue Type `Bug`. Add labels that communicate the confirmed classification or affected area, remove labels contradicted by the diagnosis, and preserve other still-relevant labels.
+4. Re-read the issue and verify both the Issue Type and labels. Treat a successful write without matching readback as a failure.
+
+Missing metadata is allowed during intake and investigation, but a completed investigation cannot hand off to `Fixing`, downstream repair, or closure until this gate passes. If the evidence cannot support a relevant type or label, do not guess; keep the issue in `Investigating` or set `Waiting for human approval`, state the exact classification question, and report the metadata gate as unresolved.
 
 ## Route downstream work
 
@@ -58,4 +69,4 @@ Set and verify the original issue's stage using the `clio-issue-workflow` skill:
 - `Waiting for human approval` when investigation is complete but a human decision, permission, or missing answer blocks progress.
 - `Investigating` only while evidence gathering can still continue without human input.
 
-Return the diagnosis, evidence, affected repositories, existing or created downstream issues, relationships added, proposed repair boundary, cross-agent contribution or unavailability, and unresolved questions.
+Return the diagnosis, evidence, verified Issue Type and labels, affected repositories, existing or created downstream issues, relationships added, proposed repair boundary, cross-agent contribution or unavailability, and unresolved questions.

--- a/.ai/skills/investigate-clio-issue/SKILL.md
+++ b/.ai/skills/investigate-clio-issue/SKILL.md
@@ -46,8 +46,9 @@ For every repository that owns required work:
 
 1. Search for an existing issue before creating a duplicate.
 2. When no suitable issue exists, create one with the original Clio issue link, evidence, acceptance criteria, and exclusions when the target is owned by `Advance-Technologies-Foundation`. Require explicit user confirmation before writing to any third-party, customer-owned, or personal repository.
-3. Mark the original Clio issue as `blocked by` the downstream issue with `gh issue edit ORIGINAL --add-blocked-by DOWNSTREAM_URL`. Use `relates to` only when the downstream work is informative rather than required.
-4. Add a concise diagnosis comment to the original issue with the owning repository and downstream issue link. Do not duplicate the full downstream issue body.
+3. Before handoff, apply the same metadata normalization and readback gate to every existing or created downstream issue that owns repair work. If its repository has no relevant enabled Issue Type or existing label, or the workflow lacks authority to set them, stop and report the exact metadata blocker rather than starting repair from an unclassified issue.
+4. Mark the original Clio issue as `blocked by` the downstream issue with `gh issue edit ORIGINAL --add-blocked-by DOWNSTREAM_URL`. Use `relates to` only when the downstream work is informative rather than required.
+5. Add a concise diagnosis comment to the original issue with the owning repository and downstream issue link. Do not duplicate the full downstream issue body.
 
 Do not use parent-child relationships unless the original issue intentionally represents a larger planned body of work. For multiple required repositories, the original issue may be blocked by multiple downstream issues.
 

--- a/.ai/skills/repair-clio-issue/SKILL.md
+++ b/.ai/skills/repair-clio-issue/SKILL.md
@@ -9,7 +9,7 @@ Implement the smallest complete repair in each repository identified by the `inv
 
 ## Preconditions
 
-Confirm that the original issue is open, assigned to the current GitHub user, has one verified Development branch, has an evidence-backed ownership diagnosis, and has a verified `Mitigation stage = Fixing` using the `clio-issue-workflow` skill. Stop on mismatch rather than bypassing claim or investigation.
+Confirm that the original issue is open, assigned to the current GitHub user, has one verified Development branch, has an evidence-backed ownership diagnosis, has exactly one relevant enabled Issue Type and at least one relevant existing repository label verified by the investigation, and has a verified `Mitigation stage = Fixing` using the `clio-issue-workflow` skill. If metadata is missing or contradicts the diagnosis, return to the `investigate-clio-issue` metadata gate instead of guessing during repair. Stop on mismatch rather than bypassing claim or investigation.
 
 ## Establish each repair branch
 
@@ -28,7 +28,7 @@ Verify the original Clio issue's `Mitigation stage = Fixing` through the `clio-i
 ## Design and implement
 
 1. Restate the failure and smallest sufficient end-to-end fix.
-2. If Collab is available, ask the other coding agent for an independent, read-only design review after the local diagnosis and before editing: Claude when running as Codex, or Codex when running as Claude. Verify and disposition its advice; do not treat it as implementation authority. If unavailable, record that and continue.
+2. Do not add a routine pre-edit cross-agent review. Use one only when the user explicitly requests it or the investigation identified an unresolved high-risk ambiguity that could materially change the repair. Do not repeat an investigation consultation with the same target and focus. Verify and disposition any advice; do not treat it as implementation authority. If unavailable or quota-limited, record that and continue without retrying.
 3. Implement only the confirmed repair and required tests, documentation, generated artifacts, MCP alignment, or compatibility work mandated by the affected repository.
 4. Follow all repository-specific validation, review, and delivery policies.
 
@@ -39,16 +39,17 @@ After the first meaningful commit, run the affected repository's mandatory pre-P
 1. Run the proportionate tests and real-boundary validation required by the change.
 2. When implementation is complete and validation or final review begins, set and verify the original issue's `Mitigation stage = QA` through the `clio-issue-workflow` skill.
 3. If a genuine product decision or human approval is required, set and verify `Waiting for human approval`, state the exact question in the issue or PR, and stop. After approval, return to `Fixing` or `QA` according to the remaining work.
-4. If Collab is available, ask the other coding agent for an independent, read-only review of the final complete diff: Claude when running as Codex, or Codex when running as Claude. Verify every finding locally and record accepted, rejected, and unresolved findings.
-5. Run the repository-required agentic review and resolve all blocking findings before marking the PR ready.
-6. Do not wait for human review unless a repository rule or the user explicitly requires it.
+4. Run the repository-required agentic review first, resolve blocking findings, rerun affected tests, and stabilize the complete diff.
+5. If Collab is available, use one focused cross-agent review of that stable final diff: Claude when running as Codex, or Codex when running as Claude. Supply the exact revision and the load-bearing claims to challenge. Request only actionable correctness or security findings with exact evidence, not optional refactors. Verify every finding locally and record accepted, rejected, and unresolved findings.
+6. Do not automatically repeat the cross-agent review after ordinary corrections. Request one narrow recheck only when an accepted Blocker/High finding caused a material change to security, destructive behavior, architecture, or a public contract. If Collab is unavailable or quota-limited, record that and continue unless the user or affected repository explicitly made cross-provider review a blocking gate. Never retry an unchanged request.
+7. Do not wait for human review unless a repository rule or the user explicitly requires it.
 
 Close an unwanted draft PR rather than claiming it was deleted. Remove only its abandoned branch and worktree when authorized and safe.
 
 ## Complete
 
-Make the draft ready only when the repair is complete, validation is recorded, and no blocking review findings remain. For Clio pull requests, hand delivery to the repository's `pr-delivery-flow` skill when available; for other repositories, follow their equivalent delivery policy. Keep the original issue open while any required downstream issue or repair PR is unresolved. Close it only after all required PRs are merged and the reported outcome is verified.
+Make the draft ready only when the repair is complete, validation is recorded, and no blocking review findings remain. For Clio pull requests, hand delivery to the repository's `pr-delivery-flow` skill when available; for other repositories, follow their equivalent delivery policy. Keep the original issue open while any required downstream issue or repair PR is unresolved. After all required PRs are merged and the reported outcome is verified, set the original issue's `Completion date` to the current date and verify the stored value. Then close the issue if it did not close through the merged PR.
 
-Report each issue, repository, branch, worktree, PR, mitigation stage, validation result, cross-agent result or unavailability, final review result, and remaining external dependency.
+Report each issue, repository, branch, worktree, PR, start date, completion date when finished, mitigation stage, validation result, cross-agent result or unavailability, final review result, and remaining external dependency.
 
 Do not add coordination artifacts beyond those defined by the `clio-issue-workflow` skill.

--- a/.ai/skills/repair-clio-issue/SKILL.md
+++ b/.ai/skills/repair-clio-issue/SKILL.md
@@ -9,7 +9,7 @@ Implement the smallest complete repair in each repository identified by the `inv
 
 ## Preconditions
 
-Confirm that the original issue is open, assigned to the current GitHub user, has one verified Development branch, has an evidence-backed ownership diagnosis, has exactly one relevant enabled Issue Type and at least one relevant existing repository label verified by the investigation, and has a verified `Mitigation stage = Fixing` using the `clio-issue-workflow` skill. If metadata is missing or contradicts the diagnosis, return to the `investigate-clio-issue` metadata gate instead of guessing during repair. Stop on mismatch rather than bypassing claim or investigation.
+Confirm that the original issue is open, assigned to the current GitHub user, has one verified Development branch, has an evidence-backed ownership diagnosis, and has a verified `Mitigation stage = Fixing` using the `clio-issue-workflow` skill. Confirm that the original issue and every downstream issue that owns repair work have exactly one relevant enabled Issue Type and at least one relevant existing repository label verified by the investigation. If metadata is missing or contradicts the diagnosis, return to the `investigate-clio-issue` metadata gate instead of guessing during repair. Stop on mismatch rather than bypassing claim or investigation.
 
 ## Establish each repair branch
 
@@ -48,8 +48,8 @@ Close an unwanted draft PR rather than claiming it was deleted. Remove only its 
 
 ## Complete
 
-Make the draft ready only when the repair is complete, validation is recorded, and no blocking review findings remain. For Clio pull requests, hand delivery to the repository's `pr-delivery-flow` skill when available; for other repositories, follow their equivalent delivery policy. Keep the original issue open while any required downstream issue or repair PR is unresolved. After all required PRs are merged and the reported outcome is verified, set the original issue's `Completion date` to the current date and verify the stored value. Then close the issue if it did not close through the merged PR.
+Make the draft ready only when the repair is complete, validation is recorded, and no blocking review findings remain. For Clio pull requests, hand delivery to the repository's `pr-delivery-flow` skill when available; for other repositories, follow their equivalent delivery policy. Keep the original issue open while any required downstream issue or repair PR is unresolved. Close it only after all required PRs are merged and the reported outcome is verified.
 
-Report each issue, repository, branch, worktree, PR, start date, completion date when finished, mitigation stage, validation result, cross-agent result or unavailability, final review result, and remaining external dependency.
+Report each issue, repository, branch, worktree, PR, mitigation stage, validation result, cross-agent result or unavailability, final review result, and remaining external dependency.
 
 Do not add coordination artifacts beyond those defined by the `clio-issue-workflow` skill.

--- a/.codex/skills/pr-delivery-flow/SKILL.md
+++ b/.codex/skills/pr-delivery-flow/SKILL.md
@@ -6,7 +6,7 @@ description: Update a working branch from `master`, create or refresh a pull req
 # PR Delivery Flow
 
 Canonical-Source: docs/agent-instructions/pr-delivery-flow.md
-Canonical-Version: 2
+Canonical-Version: 4
 
 Follow the canonical instructions in `docs/agent-instructions/pr-delivery-flow.md`.
 
@@ -15,4 +15,4 @@ Skill-specific requirements:
 - After each push, re-check both PR comments and review thread state on the latest head commit.
 - Treat AI review feedback as real review feedback: validate it, fix it if needed, reply, and resolve the thread.
 - Resolve outdated review threads too if they are still unresolved and the feedback was addressed.
-- If the user wants the PR fully clean, inspect Sonar issues directly instead of relying only on the green quality gate badge.
+- Run `python .codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py --pr <number>` on the latest head and require exit code `0`. A green quality-gate badge is insufficient: no unresolved or accepted new Sonar issues are allowed before merge.

--- a/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
@@ -105,7 +105,7 @@ def sonar_check(head: str, pull_request: int, timeout: int) -> dict[str, Any]:
         check = max(checks, key=lambda item: int(item.get("id") or 0))
     except Unverified:
         raise
-    except (AttributeError, ValueError, json.JSONDecodeError, TypeError) as error:
+    except (AttributeError, ValueError, TypeError) as error:
         raise Unverified("GitHub check-run response had an unexpected shape.") from error
 
     check_head = str(check.get("head_sha") or "")
@@ -158,59 +158,83 @@ def get_json(url: str, timeout: int) -> dict[str, Any]:
     return payload
 
 
+def pagination(
+    payload: dict[str, Any],
+    requested_page: int,
+    expected_total: int | None,
+    expected_page_size: int | None,
+) -> tuple[int, int, list[Any]]:
+    paging, issues = payload.get("paging"), payload.get("issues")
+    if not isinstance(paging, dict) or not isinstance(issues, list):
+        raise Unverified("Sonar response omitted paging or issues data.")
+    try:
+        total = paging["total"]
+        page_index = paging["pageIndex"]
+        page_size = paging["pageSize"]
+    except KeyError as error:
+        raise Unverified("Sonar response omitted valid pagination data.") from error
+    if not all(type(value) is int for value in (total, page_index, page_size)):
+        raise Unverified("Sonar response contained invalid pagination types.")
+    if total < 0 or page_size <= 0 or page_index != requested_page:
+        raise Unverified("Sonar returned inconsistent pagination data.")
+    if expected_total is not None and total != expected_total:
+        raise Unverified("Sonar issue total changed during pagination.")
+    if expected_page_size is not None and page_size != expected_page_size:
+        raise Unverified("Sonar page size changed during pagination.")
+    if len(issues) > page_size:
+        raise Unverified("Sonar returned more issues than the declared page size.")
+    return total, page_size, issues
+
+
+def add_issues(
+    found: dict[str, dict[str, Any]], issues: list[Any]
+) -> None:
+    for issue in issues:
+        if not isinstance(issue, dict) or not issue.get("key"):
+            raise Unverified("Sonar returned a malformed issue.")
+        key = str(issue["key"])
+        if key in found:
+            raise Unverified("Sonar returned a duplicate issue during pagination.")
+        found[key] = issue
+
+
+def sonar_query(pull_request: int, page: int) -> str:
+    return urlencode(
+        {
+            "componentKeys": DEFAULT_PROJECT_KEY,
+            "pullRequest": pull_request,
+            "issueStatuses": BLOCKING_STATUSES,
+            "inNewCodePeriod": "true",
+            "p": page,
+            "ps": 500,
+        }
+    )
+
+
 def sonar_issues(pull_request: int, timeout: int) -> list[dict[str, Any]]:
     found: dict[str, dict[str, Any]] = {}
-    expected: int | None = None
+    expected_total: int | None = None
     expected_page_size: int | None = None
     page = 1
     while True:
-        query = urlencode(
-            {
-                "componentKeys": DEFAULT_PROJECT_KEY,
-                "pullRequest": pull_request,
-                "issueStatuses": BLOCKING_STATUSES,
-                "inNewCodePeriod": "true",
-                "p": page,
-                "ps": 500,
-            }
-        )
+        query = sonar_query(pull_request, page)
         payload = get_json(f"{DEFAULT_SONAR_URL}/api/issues/search?{query}", timeout)
-        paging, issues = payload.get("paging"), payload.get("issues")
-        if not isinstance(paging, dict) or not isinstance(issues, list):
-            raise Unverified("Sonar response omitted paging or issues data.")
-        try:
-            total = paging["total"]
-            page_index = paging["pageIndex"]
-            page_size = paging["pageSize"]
-        except KeyError as error:
-            raise Unverified("Sonar response omitted valid pagination data.") from error
-        if not all(type(value) is int for value in (total, page_index, page_size)):
-            raise Unverified("Sonar response contained invalid pagination types.")
-        if total < 0 or page_size <= 0 or page_index != page:
-            raise Unverified("Sonar returned inconsistent pagination data.")
-        if expected is not None and total != expected:
-            raise Unverified("Sonar issue total changed during pagination.")
-        if expected_page_size is not None and page_size != expected_page_size:
-            raise Unverified("Sonar page size changed during pagination.")
-        expected = total
-        expected_page_size = page_size
-        if len(issues) > page_size:
-            raise Unverified("Sonar returned more issues than the declared page size.")
-        for issue in issues:
-            if not isinstance(issue, dict) or not issue.get("key"):
-                raise Unverified("Sonar returned a malformed issue.")
-            key = str(issue["key"])
-            if key in found:
-                raise Unverified("Sonar returned a duplicate issue during pagination.")
-            found[key] = issue
-        page_count = max(1, (expected + page_size - 1) // page_size)
+        expected_total, expected_page_size, issues = pagination(
+            payload, page, expected_total, expected_page_size
+        )
+        add_issues(found, issues)
+        page_count = max(
+            1, (expected_total + expected_page_size - 1) // expected_page_size
+        )
         if page >= page_count:
             break
         if not issues:
             raise Unverified("Sonar pagination ended before every issue was returned.")
         page += 1
-    if len(found) != expected:
-        raise Unverified(f"Sonar reported {expected} issues but returned {len(found)}.")
+    if len(found) != expected_total:
+        raise Unverified(
+            f"Sonar reported {expected_total} issues but returned {len(found)}."
+        )
     return list(found.values())
 
 

--- a/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
@@ -14,14 +14,15 @@ import sys
 from collections.abc import Sequence
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 
 DEFAULT_REPO = "Advance-Technologies-Foundation/clio"
 DEFAULT_PROJECT_KEY = "Advance-Technologies-Foundation_clio"
 DEFAULT_SONAR_URL = "https://sonarcloud.io"
 SONAR_CHECK = "SonarCloud Code Analysis"
+SONAR_APP_SLUG = "sonarqubecloud"
 BLOCKING_STATUSES = "OPEN,CONFIRMED,ACCEPTED"
 
 
@@ -29,7 +30,17 @@ class Unverified(RuntimeError):
     """The zero-new-issues result could not be proven."""
 
 
-def gh(*arguments: str) -> str:
+class NoRedirectHandler(HTTPRedirectHandler):
+    """Prevent authenticated Sonar requests from crossing origins."""
+
+    def redirect_request(self, request: Request, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+SONAR_OPENER = build_opener(NoRedirectHandler)
+
+
+def gh(*arguments: str, timeout: int) -> str:
     try:
         result = subprocess.run(
             ["gh", *arguments],
@@ -38,38 +49,43 @@ def gh(*arguments: str) -> str:
             encoding="utf-8",
             errors="replace",
             check=False,
+            timeout=timeout,
         )
     except FileNotFoundError as error:
         raise Unverified("GitHub CLI 'gh' is not installed or not on PATH.") from error
+    except subprocess.TimeoutExpired as error:
+        raise Unverified(f"GitHub CLI timed out after {timeout} seconds.") from error
     if result.returncode:
         detail = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
         raise Unverified(f"GitHub CLI failed: {detail}")
     return result.stdout
 
 
-def pr_head(repository: str, pull_request: int) -> str:
+def pr_head(pull_request: int, timeout: int) -> str:
     head = gh(
         "pr",
         "view",
         str(pull_request),
         "--repo",
-        repository,
+        DEFAULT_REPO,
         "--json",
         "headRefOid",
         "--jq",
         ".headRefOid",
+        timeout=timeout,
     ).strip()
     if not head:
         raise Unverified("GitHub returned an empty PR head SHA.")
     return head
 
 
-def sonar_check(repository: str, head: str) -> dict[str, Any]:
+def sonar_check(head: str, pull_request: int, timeout: int) -> dict[str, Any]:
     raw = gh(
         "api",
-        f"repos/{repository}/commits/{head}/check-runs?per_page=100",
+        f"repos/{DEFAULT_REPO}/commits/{head}/check-runs?per_page=100",
         "--paginate",
         "--slurp",
+        timeout=timeout,
     )
     try:
         pages = json.loads(raw)
@@ -77,14 +93,21 @@ def sonar_check(repository: str, head: str) -> dict[str, Any]:
             check
             for page in pages
             for check in page.get("check_runs", [])
-            if check.get("name") == SONAR_CHECK
+            if isinstance(check, dict)
+            and check.get("name") == SONAR_CHECK
+            and isinstance(check.get("app"), dict)
+            and check["app"].get("slug") == SONAR_APP_SLUG
         ]
-    except (AttributeError, json.JSONDecodeError, TypeError) as error:
+        if not checks:
+            raise Unverified(
+                f"No trusted '{SONAR_CHECK}' check exists on head {head}."
+            )
+        check = max(checks, key=lambda item: int(item.get("id") or 0))
+    except Unverified:
+        raise
+    except (AttributeError, ValueError, json.JSONDecodeError, TypeError) as error:
         raise Unverified("GitHub check-run response had an unexpected shape.") from error
-    if not checks:
-        raise Unverified(f"No '{SONAR_CHECK}' check exists on head {head}.")
 
-    check = max(checks, key=lambda item: int(item.get("id") or 0))
     check_head = str(check.get("head_sha") or "")
     if check_head != head:
         raise Unverified(
@@ -96,17 +119,30 @@ def sonar_check(repository: str, head: str) -> dict[str, Any]:
         raise Unverified(f"Sonar analysis on head {head} is not complete ({status}).")
     if conclusion != "success":
         raise Unverified(f"Sonar analysis on head {head} did not succeed ({conclusion}).")
+    details = urlparse(str(check.get("details_url") or ""))
+    details_query = parse_qs(details.query)
+    if (
+        details.scheme != "https"
+        or details.netloc != "sonarcloud.io"
+        or details.path != "/dashboard"
+        or details_query.get("id") != [DEFAULT_PROJECT_KEY]
+        or details_query.get("pullRequest") != [str(pull_request)]
+    ):
+        raise Unverified("Sonar check details do not match the expected project and PR.")
     return check
 
 
 def get_json(url: str, timeout: int) -> dict[str, Any]:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "sonarcloud.io":
+        raise Unverified("Sonar API URL is outside the trusted SonarCloud origin.")
     headers = {"Accept": "application/json"}
     token = os.environ.get("SONAR_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     request = Request(url, headers=headers, method="GET")
     try:
-        with urlopen(request, timeout=timeout) as response:
+        with SONAR_OPENER.open(request, timeout=timeout) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace").strip()[:500]
@@ -115,26 +151,22 @@ def get_json(url: str, timeout: int) -> dict[str, Any]:
         ) from error
     except (URLError, TimeoutError) as error:
         raise Unverified(f"Sonar API request failed: {error}") from error
-    except json.JSONDecodeError as error:
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise Unverified("Sonar API response was not valid JSON.") from error
     if not isinstance(payload, dict):
         raise Unverified("Sonar API response had an unexpected shape.")
     return payload
 
 
-def sonar_issues(
-    sonar_url: str,
-    project_key: str,
-    pull_request: int,
-    timeout: int,
-) -> list[dict[str, Any]]:
+def sonar_issues(pull_request: int, timeout: int) -> list[dict[str, Any]]:
     found: dict[str, dict[str, Any]] = {}
     expected: int | None = None
+    expected_page_size: int | None = None
     page = 1
-    while expected is None or len(found) < expected:
+    while True:
         query = urlencode(
             {
-                "componentKeys": project_key,
+                "componentKeys": DEFAULT_PROJECT_KEY,
                 "pullRequest": pull_request,
                 "issueStatuses": BLOCKING_STATUSES,
                 "inNewCodePeriod": "true",
@@ -142,22 +174,35 @@ def sonar_issues(
                 "ps": 500,
             }
         )
-        payload = get_json(f"{sonar_url.rstrip('/')}/api/issues/search?{query}", timeout)
+        payload = get_json(f"{DEFAULT_SONAR_URL}/api/issues/search?{query}", timeout)
         paging, issues = payload.get("paging"), payload.get("issues")
         if not isinstance(paging, dict) or not isinstance(issues, list):
             raise Unverified("Sonar response omitted paging or issues data.")
         try:
             total = int(paging["total"])
+            page_index = int(paging["pageIndex"])
+            page_size = int(paging["pageSize"])
         except (KeyError, TypeError, ValueError) as error:
-            raise Unverified("Sonar response omitted a valid issue total.") from error
+            raise Unverified("Sonar response omitted valid pagination data.") from error
+        if total < 0 or page_size <= 0 or page_index != page:
+            raise Unverified("Sonar returned inconsistent pagination data.")
         if expected is not None and total != expected:
             raise Unverified("Sonar issue total changed during pagination.")
+        if expected_page_size is not None and page_size != expected_page_size:
+            raise Unverified("Sonar page size changed during pagination.")
         expected = total
+        expected_page_size = page_size
+        if len(issues) > page_size:
+            raise Unverified("Sonar returned more issues than the declared page size.")
         for issue in issues:
             if not isinstance(issue, dict) or not issue.get("key"):
                 raise Unverified("Sonar returned a malformed issue.")
-            found[str(issue["key"])] = issue
-        if len(found) >= expected:
+            key = str(issue["key"])
+            if key in found:
+                raise Unverified("Sonar returned a duplicate issue during pagination.")
+            found[key] = issue
+        page_count = max(1, (expected + page_size - 1) // page_size)
+        if page >= page_count:
             break
         if not issues:
             raise Unverified("Sonar pagination ended before every issue was returned.")
@@ -167,16 +212,16 @@ def sonar_issues(
     return list(found.values())
 
 
-def issue_text(issue: dict[str, Any], project_key: str) -> str:
+def issue_text(issue: dict[str, Any]) -> str:
     component = str(issue.get("component") or "unknown-component")
-    prefix = f"{project_key}:"
+    prefix = f"{DEFAULT_PROJECT_KEY}:"
     if component.startswith(prefix):
         component = component[len(prefix) :]
     line = issue.get("line")
     location = f"{component}:{line}" if line is not None else component
     return (
         f"[{issue.get('severity', 'UNKNOWN')}] {issue.get('rule', 'unknown-rule')} "
-        f"{issue.get('status', 'UNKNOWN')} {location} - "
+        f"{issue.get('issueStatus', issue.get('status', 'UNKNOWN'))} {location} - "
         f"{issue.get('message', 'No message supplied.')} ({issue.get('key')})"
     )
 
@@ -184,12 +229,9 @@ def issue_text(issue: dict[str, Any], project_key: str) -> str:
 def arguments(values: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--pr", type=int, required=True, help="GitHub pull request number.")
-    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub OWNER/REPO.")
     parser.add_argument(
-        "--project-key", default=DEFAULT_PROJECT_KEY, help="Sonar project key."
+        "--timeout", type=int, default=30, help="GitHub and Sonar timeout in seconds."
     )
-    parser.add_argument("--sonar-url", default=DEFAULT_SONAR_URL, help="Sonar base URL.")
-    parser.add_argument("--timeout", type=int, default=30, help="API timeout in seconds.")
     parsed = parser.parse_args(values)
     if parsed.pr <= 0 or parsed.timeout <= 0:
         parser.error("--pr and --timeout must be positive integers")
@@ -199,14 +241,15 @@ def arguments(values: Sequence[str]) -> argparse.Namespace:
 def main(values: Sequence[str] | None = None) -> int:
     options = arguments(values if values is not None else sys.argv[1:])
     try:
-        head = pr_head(options.repo, options.pr)
-        check = sonar_check(options.repo, head)
-        issues = sonar_issues(
-            options.sonar_url, options.project_key, options.pr, options.timeout
-        )
-        current_head = pr_head(options.repo, options.pr)
+        head = pr_head(options.pr, options.timeout)
+        check = sonar_check(head, options.pr, options.timeout)
+        issues = sonar_issues(options.pr, options.timeout)
+        current_head = pr_head(options.pr, options.timeout)
         if current_head != head:
             raise Unverified(f"PR head changed during verification: {head} -> {current_head}.")
+        current_check = sonar_check(head, options.pr, options.timeout)
+        if current_check.get("id") != check.get("id"):
+            raise Unverified("Sonar analysis changed during verification; run the check again.")
     except Unverified as error:
         print(f"UNVERIFIED: {error}", file=sys.stderr)
         return 2
@@ -217,7 +260,7 @@ def main(values: Sequence[str] | None = None) -> int:
         if details_url:
             print(f"Sonar analysis: {details_url}")
         for issue in issues:
-            print(issue_text(issue, options.project_key))
+            print(issue_text(issue))
         return 1
 
     print(f"PASSED: PR #{options.pr} head {head} has zero new Sonar issues.")

--- a/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
@@ -179,11 +179,13 @@ def sonar_issues(pull_request: int, timeout: int) -> list[dict[str, Any]]:
         if not isinstance(paging, dict) or not isinstance(issues, list):
             raise Unverified("Sonar response omitted paging or issues data.")
         try:
-            total = int(paging["total"])
-            page_index = int(paging["pageIndex"])
-            page_size = int(paging["pageSize"])
-        except (KeyError, TypeError, ValueError) as error:
+            total = paging["total"]
+            page_index = paging["pageIndex"]
+            page_size = paging["pageSize"]
+        except KeyError as error:
             raise Unverified("Sonar response omitted valid pagination data.") from error
+        if not all(type(value) is int for value in (total, page_index, page_size)):
+            raise Unverified("Sonar response contained invalid pagination types.")
         if total < 0 or page_size <= 0 or page_index != page:
             raise Unverified("Sonar returned inconsistent pagination data.")
         if expected is not None and total != expected:

--- a/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Require zero new Sonar issues on the latest GitHub PR head.
+
+Exit 0 means clean, 1 means issues remain, and 2 means the result is unverified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+DEFAULT_REPO = "Advance-Technologies-Foundation/clio"
+DEFAULT_PROJECT_KEY = "Advance-Technologies-Foundation_clio"
+DEFAULT_SONAR_URL = "https://sonarcloud.io"
+SONAR_CHECK = "SonarCloud Code Analysis"
+BLOCKING_STATUSES = "OPEN,CONFIRMED,ACCEPTED"
+
+
+class Unverified(RuntimeError):
+    """The zero-new-issues result could not be proven."""
+
+
+def gh(*arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["gh", *arguments],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise Unverified("GitHub CLI 'gh' is not installed or not on PATH.") from error
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+        raise Unverified(f"GitHub CLI failed: {detail}")
+    return result.stdout
+
+
+def pr_head(repository: str, pull_request: int) -> str:
+    head = gh(
+        "pr",
+        "view",
+        str(pull_request),
+        "--repo",
+        repository,
+        "--json",
+        "headRefOid",
+        "--jq",
+        ".headRefOid",
+    ).strip()
+    if not head:
+        raise Unverified("GitHub returned an empty PR head SHA.")
+    return head
+
+
+def sonar_check(repository: str, head: str) -> dict[str, Any]:
+    raw = gh(
+        "api",
+        f"repos/{repository}/commits/{head}/check-runs?per_page=100",
+        "--paginate",
+        "--slurp",
+    )
+    try:
+        pages = json.loads(raw)
+        checks = [
+            check
+            for page in pages
+            for check in page.get("check_runs", [])
+            if check.get("name") == SONAR_CHECK
+        ]
+    except (AttributeError, json.JSONDecodeError, TypeError) as error:
+        raise Unverified("GitHub check-run response had an unexpected shape.") from error
+    if not checks:
+        raise Unverified(f"No '{SONAR_CHECK}' check exists on head {head}.")
+
+    check = max(checks, key=lambda item: int(item.get("id") or 0))
+    check_head = str(check.get("head_sha") or "")
+    if check_head != head:
+        raise Unverified(
+            f"Sonar check belongs to head {check_head or 'unknown'}, expected {head}."
+        )
+    status = str(check.get("status") or "unknown").lower()
+    conclusion = str(check.get("conclusion") or "unknown").lower()
+    if status != "completed":
+        raise Unverified(f"Sonar analysis on head {head} is not complete ({status}).")
+    if conclusion != "success":
+        raise Unverified(f"Sonar analysis on head {head} did not succeed ({conclusion}).")
+    return check
+
+
+def get_json(url: str, timeout: int) -> dict[str, Any]:
+    headers = {"Accept": "application/json"}
+    token = os.environ.get("SONAR_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace").strip()[:500]
+        raise Unverified(
+            f"Sonar API returned HTTP {error.code}{f': {detail}' if detail else ''}"
+        ) from error
+    except (URLError, TimeoutError) as error:
+        raise Unverified(f"Sonar API request failed: {error}") from error
+    except json.JSONDecodeError as error:
+        raise Unverified("Sonar API response was not valid JSON.") from error
+    if not isinstance(payload, dict):
+        raise Unverified("Sonar API response had an unexpected shape.")
+    return payload
+
+
+def sonar_issues(
+    sonar_url: str,
+    project_key: str,
+    pull_request: int,
+    timeout: int,
+) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+    expected: int | None = None
+    page = 1
+    while expected is None or len(found) < expected:
+        query = urlencode(
+            {
+                "componentKeys": project_key,
+                "pullRequest": pull_request,
+                "issueStatuses": BLOCKING_STATUSES,
+                "inNewCodePeriod": "true",
+                "p": page,
+                "ps": 500,
+            }
+        )
+        payload = get_json(f"{sonar_url.rstrip('/')}/api/issues/search?{query}", timeout)
+        paging, issues = payload.get("paging"), payload.get("issues")
+        if not isinstance(paging, dict) or not isinstance(issues, list):
+            raise Unverified("Sonar response omitted paging or issues data.")
+        try:
+            total = int(paging["total"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise Unverified("Sonar response omitted a valid issue total.") from error
+        if expected is not None and total != expected:
+            raise Unverified("Sonar issue total changed during pagination.")
+        expected = total
+        for issue in issues:
+            if not isinstance(issue, dict) or not issue.get("key"):
+                raise Unverified("Sonar returned a malformed issue.")
+            found[str(issue["key"])] = issue
+        if len(found) >= expected:
+            break
+        if not issues:
+            raise Unverified("Sonar pagination ended before every issue was returned.")
+        page += 1
+    if len(found) != expected:
+        raise Unverified(f"Sonar reported {expected} issues but returned {len(found)}.")
+    return list(found.values())
+
+
+def issue_text(issue: dict[str, Any], project_key: str) -> str:
+    component = str(issue.get("component") or "unknown-component")
+    prefix = f"{project_key}:"
+    if component.startswith(prefix):
+        component = component[len(prefix) :]
+    line = issue.get("line")
+    location = f"{component}:{line}" if line is not None else component
+    return (
+        f"[{issue.get('severity', 'UNKNOWN')}] {issue.get('rule', 'unknown-rule')} "
+        f"{issue.get('status', 'UNKNOWN')} {location} - "
+        f"{issue.get('message', 'No message supplied.')} ({issue.get('key')})"
+    )
+
+
+def arguments(values: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--pr", type=int, required=True, help="GitHub pull request number.")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="GitHub OWNER/REPO.")
+    parser.add_argument(
+        "--project-key", default=DEFAULT_PROJECT_KEY, help="Sonar project key."
+    )
+    parser.add_argument("--sonar-url", default=DEFAULT_SONAR_URL, help="Sonar base URL.")
+    parser.add_argument("--timeout", type=int, default=30, help="API timeout in seconds.")
+    parsed = parser.parse_args(values)
+    if parsed.pr <= 0 or parsed.timeout <= 0:
+        parser.error("--pr and --timeout must be positive integers")
+    return parsed
+
+
+def main(values: Sequence[str] | None = None) -> int:
+    options = arguments(values if values is not None else sys.argv[1:])
+    try:
+        head = pr_head(options.repo, options.pr)
+        check = sonar_check(options.repo, head)
+        issues = sonar_issues(
+            options.sonar_url, options.project_key, options.pr, options.timeout
+        )
+        current_head = pr_head(options.repo, options.pr)
+        if current_head != head:
+            raise Unverified(f"PR head changed during verification: {head} -> {current_head}.")
+    except Unverified as error:
+        print(f"UNVERIFIED: {error}", file=sys.stderr)
+        return 2
+
+    details_url = str(check.get("details_url") or "")
+    if issues:
+        print(f"FAILED: PR #{options.pr} head {head} has {len(issues)} new Sonar issue(s).")
+        if details_url:
+            print(f"Sonar analysis: {details_url}")
+        for issue in issues:
+            print(issue_text(issue, options.project_key))
+        return 1
+
+    print(f"PASSED: PR #{options.pr} head {head} has zero new Sonar issues.")
+    if details_url:
+        print(f"Sonar analysis: {details_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py
@@ -82,6 +82,16 @@ class SonarNewIssueTests(unittest.TestCase):
 
         self.assertEqual(2, calls)
 
+    def test_sonar_issues_rejects_boolean_pagination_values(self) -> None:
+        payload = {
+            "paging": {"pageIndex": True, "pageSize": True, "total": False},
+            "issues": [],
+        }
+
+        with patch.object(checker, "get_json", return_value=payload):
+            with self.assertRaisesRegex(checker.Unverified, "pagination types"):
+                checker.sonar_issues(1264, 30)
+
     def test_main_rejects_replaced_analysis_on_same_head(self) -> None:
         error = io.StringIO()
 

--- a/.codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py
+++ b/.codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py
@@ -1,0 +1,135 @@
+"""Regression tests for the Sonar new-issue delivery gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).with_name("check_sonar_new_issues.py")
+SPEC = importlib.util.spec_from_file_location("check_sonar_new_issues", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT_PATH}")
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+def sonar_check(check_id: int = 1) -> dict[str, object]:
+    """Return a valid Sonar check-run payload."""
+    return {
+        "id": check_id,
+        "name": checker.SONAR_CHECK,
+        "head_sha": "head-sha",
+        "status": "completed",
+        "conclusion": "success",
+        "app": {"slug": checker.SONAR_APP_SLUG},
+        "details_url": (
+            "https://sonarcloud.io/dashboard?"
+            f"id={checker.DEFAULT_PROJECT_KEY}&pullRequest=1264"
+        ),
+    }
+
+
+class Response:
+    """Minimal context-managed HTTP response for decoding tests."""
+
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+class SonarNewIssueTests(unittest.TestCase):
+    """Exercise fail-closed behavior at the external boundaries."""
+
+    def test_sonar_check_ignores_same_name_run_from_untrusted_app(self) -> None:
+        trusted = sonar_check(1)
+        spoofed = {**sonar_check(999), "app": {"slug": "github-actions"}}
+        payload = json.dumps([{"check_runs": [trusted, spoofed]}])
+
+        with patch.object(checker, "gh", return_value=payload):
+            actual = checker.sonar_check("head-sha", 1264, 30)
+
+        self.assertEqual(1, actual["id"])
+
+    def test_sonar_issues_rejects_duplicate_page_without_looping(self) -> None:
+        calls = 0
+
+        def repeated_page(url: str, timeout: int) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            return {
+                "paging": {"pageIndex": calls, "pageSize": 1, "total": 2},
+                "issues": [{"key": "same-issue"}],
+            }
+
+        with patch.object(checker, "get_json", side_effect=repeated_page):
+            with self.assertRaisesRegex(checker.Unverified, "duplicate issue"):
+                checker.sonar_issues(1264, 30)
+
+        self.assertEqual(2, calls)
+
+    def test_main_rejects_replaced_analysis_on_same_head(self) -> None:
+        error = io.StringIO()
+
+        with (
+            patch.object(checker, "pr_head", side_effect=["head-sha", "head-sha"]),
+            patch.object(
+                checker,
+                "sonar_check",
+                side_effect=[sonar_check(1), sonar_check(2)],
+            ),
+            patch.object(checker, "sonar_issues", return_value=[]),
+            redirect_stderr(error),
+        ):
+            result = checker.main(["--pr", "1264"])
+
+        self.assertEqual(2, result)
+        self.assertIn("Sonar analysis changed", error.getvalue())
+
+    def test_get_json_rejects_invalid_utf8_as_unverified(self) -> None:
+        with patch.object(checker.SONAR_OPENER, "open", return_value=Response(b"\xff")):
+            with self.assertRaisesRegex(checker.Unverified, "not valid JSON"):
+                checker.get_json("https://sonarcloud.io/api/issues/search", 30)
+
+    def test_gh_timeout_is_unverified(self) -> None:
+        with patch.object(
+            checker.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["gh"], 3),
+        ):
+            with self.assertRaisesRegex(checker.Unverified, "timed out"):
+                checker.gh("api", "user", timeout=3)
+
+    def test_issue_text_prefers_current_issue_status(self) -> None:
+        issue = {
+            "key": "issue-key",
+            "component": f"{checker.DEFAULT_PROJECT_KEY}:file.cs",
+            "severity": "MAJOR",
+            "rule": "rule",
+            "issueStatus": "ACCEPTED",
+            "status": "RESOLVED",
+            "message": "message",
+        }
+
+        actual = checker.issue_text(issue)
+
+        self.assertIn("ACCEPTED", actual)
+        self.assertNotIn("RESOLVED", actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/agent-instructions/pr-delivery-flow.md
+++ b/docs/agent-instructions/pr-delivery-flow.md
@@ -61,7 +61,9 @@ successful `SonarCloud Code Analysis` check on that exact SHA, queries every
 page of Sonar PR issues with statuses `OPEN`, `CONFIRMED`, and `ACCEPTED`, and
 then re-reads the head to detect a concurrent push. Public projects are queried
 anonymously. When `SONAR_TOKEN` is present, it is sent only as a Bearer header
-and is never printed.
+to the fixed `https://sonarcloud.io` origin and is never printed. The checker is
+Clio-specific: its GitHub repository, Sonar project, trusted GitHub App, and
+Sonar origin are fixed, and authenticated redirects are rejected.
 
 - Exit `0`: analysis completed on the stable latest head and no new issues remain.
 - Exit `1`: new issues remain; every issue is printed with its rule, severity, status, file, line, and message.

--- a/docs/agent-instructions/pr-delivery-flow.md
+++ b/docs/agent-instructions/pr-delivery-flow.md
@@ -40,12 +40,38 @@ Always inspect all three sources below:
    - fetch review thread state explicitly, preferably including `isResolved` and `isOutdated`
    - treat AI comments the same as human comments until validated
 2. Checks and quality gates
-   - inspect `gh pr checks`
+   - inspect `gh pr checks --required` to identify the merge gates for the current head
+   - inspect other checks only for useful diagnostics; pending or failing advisory checks do not block merge
    - inspect GitHub Actions runs and logs for failures
-   - inspect Sonar or other quality gate outputs directly when available
-   - if Sonar says the quality gate passed, still inspect the issue list directly when the user expects the PR to be fully clean
+   - wait for the Sonar analysis attached to the latest head, then inspect its PR new-issue list directly
+   - require zero unresolved or accepted new Sonar issues; a green Sonar quality gate alone does not satisfy this policy
 3. Mergeability state
    - read PR merge state from GitHub
+
+### Sonar new-issue check
+
+Always run the bundled read-only checker from the repository root:
+
+```powershell
+python .codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py --pr <pr>
+```
+
+The checker resolves the current PR head through authenticated `gh`, requires a
+successful `SonarCloud Code Analysis` check on that exact SHA, queries every
+page of Sonar PR issues with statuses `OPEN`, `CONFIRMED`, and `ACCEPTED`, and
+then re-reads the head to detect a concurrent push. Public projects are queried
+anonymously. When `SONAR_TOKEN` is present, it is sent only as a Bearer header
+and is never printed.
+
+- Exit `0`: analysis completed on the stable latest head and no new issues remain.
+- Exit `1`: new issues remain; every issue is printed with its rule, severity, status, file, line, and message.
+- Exit `2`: the result could not be verified, including a missing/pending/failed analysis, API/authentication error, malformed response, incomplete pagination, or head change.
+
+Only exit `0` satisfies the delivery gate. On exit `1`, fix the code, push, wait
+for Sonar on the new head, and run the checker again. On exit `2`, do not infer
+zero issues from the green badge; report that the gate could not be verified.
+Do not mark an issue Accepted or False Positive merely to clear the gate; such
+classification requires explicit user approval and evidence.
 
 ## 4. Validate and fix findings
 
@@ -54,7 +80,7 @@ For every actionable comment or failing check:
 1. Verify whether the finding is still valid against the latest branch head.
 2. If valid, implement the fix.
 3. Run the smallest useful local verification first, then broader verification when needed.
-4. Push the fix and wait for the fresh PR checks on the new head commit.
+4. Push the fix and wait only for the fresh required PR checks on the new head commit.
 5. Re-read the PR head SHA from GitHub after the push and make sure subsequent checks/comments are evaluated against that latest head, not against an older green run.
 
 Do not treat old feedback as closed just because the code was updated locally.
@@ -78,28 +104,34 @@ The task is not complete until unresolved actionable review threads are zero.
 Before merging, confirm all of the following on the latest PR head:
 
 - required checks are green
-- Sonar/quality gate is green or has no blocking findings
-- Sonar direct issue query shows no remaining actionable new issues if the user asked for a fully clean PR
+- Sonar/quality gate is green
+- Sonar's direct PR issue query for the latest head returns zero unresolved or accepted new issues
 - unresolved actionable review threads are zero
 - no new AI review comments were added after the last push
 - PR merge state is clean
 
 If any of these are false, continue the loop from section 3.
 
+Do not wait for TeamCity or any other advisory check unless it is currently returned by `gh pr checks --required` or the user explicitly asks for it. Repository documentation calling a check advisory is useful context, but the live required-check result is the merge authority.
+
 ## 7. Polling guidance
 
-When the repository uses self-hosted runners or slow quality tools:
+When the repository uses self-hosted runners or slow required quality tools:
 
 1. Expect checks to sit in `QUEUED` or `IN_PROGRESS` for a while.
-2. Poll run status deliberately instead of assuming a hang.
-3. If a job completes successfully, still re-read the PR checks and quality tools once more before merging.
+2. Poll required run status deliberately instead of assuming a hang.
+3. Do not poll advisory TeamCity jobs merely to delay delivery.
+4. If a required job completes successfully, re-read the required PR checks and quality tools once more before merging.
 
 ## 8. Merge and verify
 
-1. Merge the PR only after the final re-check passes.
-2. Verify on GitHub that the PR state is actually `MERGED`.
-3. Record the merge commit SHA.
-4. If the user asked for release follow-up, continue with the release flow only after merge verification succeeds.
+1. Once the pull request is ready, validation and review are complete, and no known blocker remains, enable GitHub auto-merge whenever the repository allows it. Auto-merge may be armed while required checks are still pending; never arm it while the PR is a draft.
+2. Use the repository-approved merge method, for example `gh pr merge <number> --auto --merge`, and verify that auto-merge is enabled.
+3. Wait only for the required gates. Do not wait for advisory checks such as TeamCity unless they are live required gates or the user explicitly requested them.
+4. If auto-merge is unavailable, merge manually only after the final required-gate re-check passes.
+5. Verify on GitHub that the PR state is actually `MERGED`.
+6. Record the merge commit SHA.
+7. If the user asked for release follow-up, continue with the release flow only after merge verification succeeds.
 
 ## 9. Optional release follow-up
 
@@ -115,8 +147,9 @@ If the user asks for a release after merge:
 Do not say the PR is done if any of the following are still pending:
 
 - an AI or human review thread is unresolved
-- a check is pending or failing
+- a required check is pending or failing
 - Sonar/quality gate has unresolved blocking findings
+- Sonar's direct PR issue query contains any unresolved or accepted new issue, even when the quality gate is green
 - the PR checks are green but belong to an older head commit than the latest pushed fix
 - the PR was "ready to merge" but not actually merged yet
 


### PR DESCRIPTION
## Summary
- reserve routine Claude consultation for the stable final diff and use earlier consultation only for explicit requests or material high-risk ambiguity
- require the original issue and every downstream issue that owns repair work to leave investigation with a verified relevant Issue Type and existing repository labels
- add a fail-closed Clio-specific SonarCloud checker that binds the trusted app, project, PR, head, and origin, and blocks every unresolved or accepted new issue
- wait only for live required CI gates while retaining Sonar new issues as an explicit delivery blocker

## Validation
- `python .codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py -v` — 7 passed
- `python -m py_compile .codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py .codex/skills/pr-delivery-flow/scripts/test_check_sonar_new_issues.py` — passed
- `quick_validate.py` for `clio-issue-workflow`, `claim-clio-issue`, `investigate-clio-issue`, `repair-clio-issue`, and `pr-delivery-flow` — passed
- `python .codex/skills/pr-delivery-flow/scripts/check_sonar_new_issues.py --pr 1264` — correctly returned exit 1 and reported all 5 new Sonar issues
- `git diff --check` — passed

## Review
- mandatory comprehensive pre-PR agentic review: code quality, security, performance, testing, bugs/edge cases, intent, and KISS
- resolved findings covering unrelated date-field scope, downstream metadata, trusted Sonar identity/origin, redirects, pagination bounds/types, CLI timeout, same-head analysis replacement, and accepted-status output
- final comprehensive review found no remaining Blocker/High findings; the final pagination correction passed a focused recheck
- Claude review not repeated because the user reported the current quota exhausted; repository policy treats that consultation as non-blocking here

## Repository impact
- docs reviewed and updated
- MCP reviewed, no update required
- ClioRing compatibility reviewed, no Ring-consumed contract changed

Fixes #1267