### PR TITLE
Fix false-empty schema and page discovery results

### DIFF
--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -1123,6 +1123,32 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 			because: "find-entity-schema should return package-name and package-maintainer directly so callers can chain follow-up MCP requests without list-packages");
 	}
 
+	[Category("McpE2E.Sandbox")]
+	[Test]
+	[Description("Finds an entity schema through a case-insensitive substring search over the real MCP server.")]
+	[AllureTag(FindEntitySchemaTool.FindEntitySchemaToolName)]
+	[AllureName("Find entity schema supports substring discovery")]
+	[AllureDescription("Calls find-entity-schema with a case-insensitive substring of Contact and verifies that the structured MCP response contains the matching schema.")]
+	public async Task FindEntitySchema_Should_Return_Substring_Matches() {
+		// Arrange
+		await using SandboxFindEntitySchemaArrangeContext arrangeContext = await ArrangeSandboxFindEntitySchemaAsync();
+
+		// Act
+		CallToolResult callResult = await CallFindEntitySchemaAsync(
+			arrangeContext.Session,
+			arrangeContext.EnvironmentName,
+			searchPattern: "ontac",
+			cancellationToken: arrangeContext.CancellationTokenSource.Token);
+		EntitySchemaSearchResult[] results = EntitySchemaStructuredResultParser.Extract<EntitySchemaSearchResult[]>(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: $"a valid substring search should return structured MCP data without a transport error. Content: {JsonSerializer.Serialize(callResult.Content)}");
+		results.Should().Contain(result =>
+			string.Equals(result.SchemaName, "Contact", StringComparison.OrdinalIgnoreCase),
+			because: "case-insensitive substring discovery should find the sandbox Contact schema");
+	}
+
 	[Category("McpE2E.NoEnvironment")]
 	[Test]
 	[Description("Reports a readable failure when find-entity-schema is invoked with an unknown environment name.")]

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -272,6 +272,44 @@ public sealed class PageGetToolE2ETests : McpContractFixtureBase {
 			because: "every returned page summary should expose stable schema and package selectors");
 	}
 
+	[Test]
+	[Description("Starts the real clio MCP server and verifies package-name page discovery using a package returned by the seeded application.")]
+	[AllureFeature(PageListTool.ToolName)]
+	[AllureTag(PageListTool.ToolName)]
+	[AllureName("list-pages discovers pages by package name")]
+	[AllureDescription("Resolves a seeded application page, calls list-pages again with that page's package-name, and verifies the package-scoped structured response.")]
+	public async Task PageListTool_Should_Return_Pages_By_PackageName() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
+		PageDiscoveryCandidate candidate = await ResolveSeededPageCandidateOrIgnoreAsync(
+			arrangeContext.Session,
+			arrangeContext.CancellationTokenSource.Token,
+			arrangeContext.EnvironmentName,
+			ApplicationCode);
+
+		// Act
+		(CallToolResult callResult, PageListResponse response) = await CallPageListByPackageAsync(
+			arrangeContext.Session,
+			arrangeContext.CancellationTokenSource.Token,
+			arrangeContext.EnvironmentName,
+			candidate.Page.PackageName!);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "a valid package-name query should complete through the real MCP transport");
+		response.Success.Should().BeTrue(
+			because: $"list-pages should accept a package returned by its own discovery response. Error: {response.Error}");
+		response.Pages.Should().NotBeNullOrEmpty(
+			because: "the selected package already contributed the seeded page used to arrange the test");
+		response.Pages.Should().OnlyContain(page => string.Equals(
+			page.PackageName,
+			candidate.Page.PackageName,
+			StringComparison.OrdinalIgnoreCase),
+			because: "package-name discovery must not leak pages owned by another package");
+	}
+
 	private async Task<ArrangeContext> ArrangeAsync(McpE2ESettings settings, TimeSpan timeout) {
 		CancellationTokenSource cancellationTokenSource = new(timeout);
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
@@ -332,6 +370,24 @@ public sealed class PageGetToolE2ETests : McpContractFixtureBase {
 			},
 			cancellationToken);
 		return EntitySchemaStructuredResultParser.Extract<PageListResponse>(callResult);
+	}
+
+	private static async Task<(CallToolResult CallResult, PageListResponse Response)> CallPageListByPackageAsync(
+		McpServerSession session,
+		CancellationToken cancellationToken,
+		string environmentName,
+		string packageName) {
+		CallToolResult callResult = await session.CallToolAsync(
+			PageListTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["package-name"] = packageName
+				}
+			},
+			cancellationToken);
+		PageListResponse response = EntitySchemaStructuredResultParser.Extract<PageListResponse>(callResult);
+		return (callResult, response);
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {

--- a/clio.tests/Command/FindEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/FindEntitySchemaCommandTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Clio.Command;
 using Clio.Common;
@@ -146,6 +147,32 @@ internal class FindEntitySchemaCommandTests : BaseCommandTests<FindEntitySchemaO
 			"the fast-path request should retain the requested server-side contains filter");
 		requests[1].Should().NotContain("reserv",
 			"the fallback request must remove the unreliable contains filter before filtering locally");
+	}
+
+	[Test]
+	[Description("FindSchemas refuses to confirm absence when the broader cross-check reaches its safety bound without a match.")]
+	public void FindSchemas_ShouldThrow_WhenBroaderCrossCheckReachesSafetyBoundWithoutMatch() {
+		// Arrange
+		FindEntitySchemaOptions options = new() { SearchPattern = "missing" };
+		IEnumerable<FindSchemaRow> cappedRows = Enumerable.Range(0, 10000)
+			.Select(index => new FindSchemaRow(
+				$"UsrSchema{index}",
+				Guid.NewGuid().ToString(),
+				"UsrPackage",
+				"Advance",
+				"BaseEntity"));
+		_applicationClient
+			.ExecutePostRequest("http://localhost/select", Arg.Any<string>())
+			.Returns(BuildSuccessJson([]), BuildSuccessJson(cappedRows));
+
+		// Act
+		Action act = () => _command.FindSchemas(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+			because: "a saturated broader query cannot prove that a non-returned schema is absent")
+			.WithMessage("*10000-row safety bound*--schema-name or --uid*",
+				because: "the failure should explain the bound and direct callers to an exact lookup");
 	}
 
 	[Test]

--- a/clio.tests/Command/FindEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/FindEntitySchemaCommandTests.cs
@@ -149,14 +149,15 @@ internal class FindEntitySchemaCommandTests : BaseCommandTests<FindEntitySchemaO
 			"the fallback request must remove the unreliable contains filter before filtering locally");
 	}
 
-	[Test]
-	[Description("FindSchemas refuses to confirm absence when the broader cross-check reaches its safety bound without a match.")]
-	public void FindSchemas_ShouldThrow_WhenBroaderCrossCheckReachesSafetyBoundWithoutMatch() {
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("FindSchemas refuses to return an incomplete result when the broader cross-check reaches its safety bound.")]
+	public void FindSchemas_ShouldThrow_WhenBroaderCrossCheckReachesSafetyBound(bool includesMatch) {
 		// Arrange
 		FindEntitySchemaOptions options = new() { SearchPattern = "missing" };
 		IEnumerable<FindSchemaRow> cappedRows = Enumerable.Range(0, 10000)
 			.Select(index => new FindSchemaRow(
-				$"UsrSchema{index}",
+				includesMatch && index == 0 ? "UsrMissingSchema" : $"UsrSchema{index}",
 				Guid.NewGuid().ToString(),
 				"UsrPackage",
 				"Advance",
@@ -170,7 +171,7 @@ internal class FindEntitySchemaCommandTests : BaseCommandTests<FindEntitySchemaO
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
-			because: "a saturated broader query cannot prove that a non-returned schema is absent")
+			because: "a saturated broader query cannot prove that all matching schemas were returned")
 			.WithMessage("*10000-row safety bound*--schema-name or --uid*",
 				because: "the failure should explain the bound and direct callers to an exact lookup");
 	}

--- a/clio.tests/Command/FindEntitySchemaCommandTests.cs
+++ b/clio.tests/Command/FindEntitySchemaCommandTests.cs
@@ -81,19 +81,23 @@ internal class FindEntitySchemaCommandTests : BaseCommandTests<FindEntitySchemaO
 		// Arrange
 		const int containsComparisonType = 11;
 		FindEntitySchemaOptions options = new() { SearchPattern = "Task" };
-		string json = BuildSuccessJson([]);
-		string? requestJson = null;
+		string json = BuildSuccessJson([
+			new FindSchemaRow("UsrTask", "aaa", "UsrTaskApp", "Advance", "BaseEntity")
+		]);
+		List<string> requests = [];
 		_applicationClient
-			.ExecutePostRequest(Arg.Any<string>(), Arg.Do<string>(request => requestJson = request))
+			.ExecutePostRequest(Arg.Any<string>(), Arg.Do<string>(request => requests.Add(request)))
 			.Returns(json);
 
 		// Act
 		_command.FindSchemas(options);
 
 		// Assert
-		requestJson.Should().NotBeNullOrWhiteSpace(
+		requests.Should().NotBeEmpty(
 			"the command should send a SelectQuery request to DataService");
-		using JsonDocument document = JsonDocument.Parse(requestJson!);
+		requests.Should().ContainSingle(
+			"a non-empty filtered result should remain on the normal one-query fast path");
+		using JsonDocument document = JsonDocument.Parse(requests[0]);
 		JsonElement? searchPatternFilter = null;
 		foreach (JsonProperty item in document
 			.RootElement
@@ -112,6 +116,36 @@ internal class FindEntitySchemaCommandTests : BaseCommandTests<FindEntitySchemaO
 		searchPatternFilter.Value.GetProperty("comparisonType").GetInt32().Should().Be(
 			containsComparisonType,
 			"search-pattern must use Creatio's contains comparison type");
+	}
+
+	[Test]
+	[Description("FindSchemas cross-checks an empty server-side pattern result with a broader query and filters it case-insensitively.")]
+	public void FindSchemas_ShouldCrossCheckBroaderQuery_WhenSearchPatternReturnsEmpty() {
+		// Arrange
+		FindEntitySchemaOptions options = new() { SearchPattern = "reserv" };
+		List<string> requests = [];
+		_applicationClient
+			.ExecutePostRequest("http://localhost/select", Arg.Do<string>(request => requests.Add(request)))
+			.Returns(
+				BuildSuccessJson([]),
+				BuildSuccessJson([
+					new FindSchemaRow("labReservation", "aaa", "labFORENOM", "Creatio", "BaseEntity"),
+					new FindSchemaRow("labOffer", "bbb", "labFORENOM", "Creatio", "BaseEntity")
+				]));
+
+		// Act
+		IReadOnlyList<EntitySchemaSearchResult> results = _command.FindSchemas(options);
+
+		// Assert
+		results.Should().ContainSingle(
+			result => result.SchemaName == "labReservation",
+			"an empty server-side contains result must be cross-checked before reporting the schema absent");
+		requests.Should().HaveCount(2,
+			"the broader read should run only after the filtered query returns no rows");
+		requests[0].Should().Contain("reserv",
+			"the fast-path request should retain the requested server-side contains filter");
+		requests[1].Should().NotContain("reserv",
+			"the fallback request must remove the unreliable contains filter before filtering locally");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -637,7 +637,9 @@ public class PageToolsTests
 		serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery").Returns("http://test/url");
 		var dataServiceResponse = new JObject {
 			["success"] = true,
-			["rows"] = new JArray()
+			["rows"] = new JArray {
+				new JObject { ["Name"] = "MyPage", ["UId"] = "page-uid", ["PackageName"] = "MyPackage" }
+			}
 		};
 		applicationClient.ExecutePostRequest(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
@@ -651,6 +653,55 @@ public class PageToolsTests
 			Arg.Any<string>(),
 			Arg.Is<string>(body => body.Contains("SysPackage.Name") && body.Contains("MyPackage")),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("TryListPages cross-checks an empty package filter with a broader query and filters package names case-insensitively")]
+	public void TryListPages_ShouldCrossCheckBroaderQuery_WhenPackageFilterReturnsEmpty() {
+		// Arrange
+		var applicationClient = Substitute.For<IApplicationClient>();
+		var serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		var logger = Substitute.For<ILogger>();
+		serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery").Returns("http://test/url");
+		var filteredResponse = new JObject {
+			["success"] = true,
+			["rows"] = new JArray()
+		};
+		var broaderResponse = new JObject {
+			["success"] = true,
+			["rows"] = new JArray {
+				new JObject { ["Name"] = "labReservation_FormPage", ["UId"] = "page-1", ["PackageName"] = "labFORENOM" },
+				new JObject { ["Name"] = "Other_FormPage", ["UId"] = "page-2", ["PackageName"] = "OtherPackage" }
+			}
+		};
+		List<string> requests = [];
+		applicationClient.ExecutePostRequest(
+			Arg.Any<string>(),
+			Arg.Do<string>(body => requests.Add(body)),
+			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(filteredResponse.ToString(), broaderResponse.ToString());
+		var command = new PageListCommand(applicationClient, serviceUrlBuilder, logger);
+		var options = new PageListOptions { PackageName = "labforenom", Limit = 50 };
+
+		// Act
+		bool result = command.TryListPages(options, out PageListResponse response);
+
+		// Assert
+		result.Should().BeTrue(
+			because: "the broader cross-check returned a page from the requested package");
+		response.Pages.Should().ContainSingle(
+			page => page.SchemaName == "labReservation_FormPage",
+			because: "package-name comparison should be ordinal-ignore-case and exclude other packages");
+		response.Total.Should().Be(1,
+			because: "the fallback total should count all locally matched package rows");
+		response.Truncated.Should().BeFalse(
+			because: "one matching page fits within the requested limit");
+		requests.Should().HaveCount(2,
+			because: "the broader query should run only after the filtered query returns no rows");
+		JObject.Parse(requests[0])["filters"]!["items"]!["PackageName"].Should().NotBeNull(
+			because: "the fast path should retain the server-side package filter");
+		JObject.Parse(requests[1])["filters"]!["items"]!["PackageName"].Should().BeNull(
+			because: "the fallback must remove the unreliable package filter before filtering locally");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -704,6 +704,73 @@ public class PageToolsTests
 			because: "the fallback must remove the unreliable package filter before filtering locally");
 	}
 
+	[TestCase("{\"success\":false}")]
+	[TestCase("not-json")]
+	[TestCase("{\"success\":true}")]
+	[Description("TryListPages refuses to confirm an empty package when its broader verification response is unsuccessful or malformed")]
+	public void TryListPages_ShouldFail_WhenBroaderVerificationCannotBeRead(string fallbackResponse) {
+		// Arrange
+		var applicationClient = Substitute.For<IApplicationClient>();
+		var serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		var logger = Substitute.For<ILogger>();
+		serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery").Returns("http://test/url");
+		string filteredResponse = new JObject {
+			["success"] = true,
+			["rows"] = new JArray()
+		}.ToString();
+		applicationClient.ExecutePostRequest(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(filteredResponse, fallbackResponse);
+		var command = new PageListCommand(applicationClient, serviceUrlBuilder, logger);
+		var options = new PageListOptions { PackageName = "labFORENOM", Limit = 50 };
+
+		// Act
+		bool result = command.TryListPages(options, out PageListResponse response);
+
+		// Assert
+		result.Should().BeFalse(
+			because: "absence cannot be confirmed when the broader verification response is unusable");
+		response.Success.Should().BeFalse(
+			because: "the response must not encode an unverified empty package as success");
+		response.Error.Should().Be(
+			"The package-filtered query returned no rows, and the broader verification query failed.",
+			because: "the caller needs an actionable but non-sensitive verification failure");
+	}
+
+	[Test]
+	[Description("TryListPages redacts fallback transport failures by returning a stable verification error")]
+	public void TryListPages_ShouldReturnStableError_WhenBroaderVerificationThrows() {
+		// Arrange
+		var applicationClient = Substitute.For<IApplicationClient>();
+		var serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		var logger = Substitute.For<ILogger>();
+		serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery").Returns("http://test/url");
+		string filteredResponse = new JObject {
+			["success"] = true,
+			["rows"] = new JArray()
+		}.ToString();
+		int requestCount = 0;
+		applicationClient.ExecutePostRequest(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(_ => ++requestCount == 1
+				? filteredResponse
+				: throw new InvalidOperationException("https://user:secret@example.test?token=sensitive"));
+		var command = new PageListCommand(applicationClient, serviceUrlBuilder, logger);
+		var options = new PageListOptions { PackageName = "labFORENOM", Limit = 50 };
+
+		// Act
+		bool result = command.TryListPages(options, out PageListResponse response);
+
+		// Assert
+		result.Should().BeFalse(
+			because: "a fallback transport exception prevents absence from being verified");
+		response.Error.Should().Be(
+			"The package-filtered query returned no rows, and the broader verification query failed.",
+			because: "connection details from the transport exception must not cross the command or MCP boundary");
+		response.Error.Should().NotContain("secret",
+			because: "credential material must not be exposed in the structured error");
+	}
+
 	[Test]
 	[Description("TryListPages resolves the primary package from app-code before querying pages")]
 	public void TryListPages_WhenAppCodeProvided_ResolvesPrimaryPackage_And_ReturnsPages() {

--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -647,7 +647,7 @@ public class PageToolsTests
 		var command = new PageListCommand(applicationClient, serviceUrlBuilder, logger);
 		var options = new PageListOptions { PackageName = "MyPackage", Limit = 50 };
 		command.TryListPages(options, out PageListResponse response);
-		// The data query returns zero rows (count 0 < limit 50), so the page is provably complete and
+		// The data query returns one row (count 1 < limit 50), so the page is provably complete and
 		// the supplementary count round-trip is skipped — only the single data query carries the filter.
 		applicationClient.Received(1).ExecutePostRequest(
 			Arg.Any<string>(),
@@ -754,7 +754,7 @@ public class PageToolsTests
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(_ => ++requestCount == 1
 				? filteredResponse
-				: throw new InvalidOperationException("https://user:secret@example.test?token=sensitive"));
+				: throw new System.Net.WebException("https://user:secret@example.test?token=sensitive"));
 		var command = new PageListCommand(applicationClient, serviceUrlBuilder, logger);
 		var options = new PageListOptions { PackageName = "labFORENOM", Limit = 50 };
 

--- a/clio/Command/FindEntitySchemaCommand.cs
+++ b/clio/Command/FindEntitySchemaCommand.cs
@@ -56,6 +56,7 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 {
 	private const string EntitySchemaManagerName = "EntitySchemaManager";
 	private const int ContainsComparisonType = 11;
+	private const int EmptyFilterFallbackRowCount = 10000;
 
 	private readonly IApplicationClient _applicationClient;
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
@@ -116,10 +117,15 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 			// server-side contains filter. Cross-check only an empty pattern result and apply the
 			// advertised ordinal-ignore-case substring comparison locally.
 			string searchPattern = options.SearchPattern.Trim();
-			results = ExecuteFindSchemasQuery(
-				BuildFindSchemasQuery(options, includeSearchPattern: false))
+			IReadOnlyList<EntitySchemaSearchResult> broaderResults = ExecuteFindSchemasQuery(
+				BuildFindSchemasQuery(options, includeSearchPattern: false));
+			results = broaderResults
 				.Where(result => result.SchemaName.Contains(searchPattern, StringComparison.OrdinalIgnoreCase))
 				.ToList();
+			if (results.Count == 0 && broaderResults.Count >= EmptyFilterFallbackRowCount) {
+				throw new InvalidOperationException(
+					$"No match for search pattern '{searchPattern}' could be confirmed because the broader verification query reached its {EmptyFilterFallbackRowCount}-row safety bound. Use --schema-name or --uid for an exact lookup.");
+			}
 		}
 		return results;
 	}
@@ -169,7 +175,7 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 		if (!string.IsNullOrWhiteSpace(options.Uid)) {
 			filters.Add(new("UId", options.Uid.Trim(), GuidDataValueType));
 		}
-		return BuildSelectQuery("SysSchema", SchemaColumns, filters);
+		return BuildSelectQuery("SysSchema", SchemaColumns, filters, EmptyFilterFallbackRowCount);
 	}
 
 	private sealed class FindSchemasResponse : SelectQueryResponseBaseDto

--- a/clio/Command/FindEntitySchemaCommand.cs
+++ b/clio/Command/FindEntitySchemaCommand.cs
@@ -48,8 +48,9 @@ public sealed record EntitySchemaSearchResult(
 );
 
 /// <summary>
-/// Finds entity schemas in a Creatio environment using a single DataService query on SysSchema.
-/// Accepts exact name, case-insensitive substring pattern, or UId as search criteria.
+/// Finds entity schemas in a Creatio environment using DataService queries on SysSchema.
+/// Accepts exact name, case-insensitive substring pattern, or UId as search criteria. An empty
+/// substring result is cross-checked once with a broader query before absence is reported.
 /// </summary>
 public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 {
@@ -108,7 +109,22 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 	public virtual IReadOnlyList<EntitySchemaSearchResult> FindSchemas(FindEntitySchemaOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
 		Validate(options);
-		object query = BuildFindSchemasQuery(options);
+		IReadOnlyList<EntitySchemaSearchResult> results = ExecuteFindSchemasQuery(
+			BuildFindSchemasQuery(options, includeSearchPattern: true));
+		if (results.Count == 0 && !string.IsNullOrWhiteSpace(options.SearchPattern)) {
+			// Issue #1213: a just-created schema was visible by exact identity but not by the
+			// server-side contains filter. Cross-check only an empty pattern result and apply the
+			// advertised ordinal-ignore-case substring comparison locally.
+			string searchPattern = options.SearchPattern.Trim();
+			results = ExecuteFindSchemasQuery(
+				BuildFindSchemasQuery(options, includeSearchPattern: false))
+				.Where(result => result.SchemaName.Contains(searchPattern, StringComparison.OrdinalIgnoreCase))
+				.ToList();
+		}
+		return results;
+	}
+
+	private IReadOnlyList<EntitySchemaSearchResult> ExecuteFindSchemasQuery(object query) {
 		FindSchemasResponse response = ExecuteSelectQuery<FindSchemasResponse>(
 			_applicationClient,
 			_serviceUrlBuilder,
@@ -136,7 +152,9 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 		}
 	}
 
-	private static object BuildFindSchemasQuery(FindEntitySchemaOptions options) {
+	private static object BuildFindSchemasQuery(
+		FindEntitySchemaOptions options,
+		bool includeSearchPattern) {
 		List<SelectQueryFilterDefinition> filters =
 		[
 			new("ManagerName", EntitySchemaManagerName, TextDataValueType)
@@ -144,7 +162,7 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 		if (!string.IsNullOrWhiteSpace(options.SchemaName)) {
 			filters.Add(new("Name", options.SchemaName.Trim(), TextDataValueType));
 		}
-		if (!string.IsNullOrWhiteSpace(options.SearchPattern)) {
+		if (includeSearchPattern && !string.IsNullOrWhiteSpace(options.SearchPattern)) {
 			filters.Add(new("Name", options.SearchPattern.Trim(), TextDataValueType,
 				ContainsComparisonType));
 		}

--- a/clio/Command/FindEntitySchemaCommand.cs
+++ b/clio/Command/FindEntitySchemaCommand.cs
@@ -122,9 +122,9 @@ public class FindEntitySchemaCommand : Command<FindEntitySchemaOptions>
 			results = broaderResults
 				.Where(result => result.SchemaName.Contains(searchPattern, StringComparison.OrdinalIgnoreCase))
 				.ToList();
-			if (results.Count == 0 && broaderResults.Count >= EmptyFilterFallbackRowCount) {
+			if (broaderResults.Count >= EmptyFilterFallbackRowCount) {
 				throw new InvalidOperationException(
-					$"No match for search pattern '{searchPattern}' could be confirmed because the broader verification query reached its {EmptyFilterFallbackRowCount}-row safety bound. Use --schema-name or --uid for an exact lookup.");
+					$"Complete results for search pattern '{searchPattern}' could not be confirmed because the broader verification query reached its {EmptyFilterFallbackRowCount}-row safety bound. Use --schema-name or --uid for an exact lookup.");
 			}
 		}
 		return results;

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -513,11 +513,9 @@ public sealed class FindEntitySchemaTool(
 	[McpServerTool(Name = FindEntitySchemaToolName, ReadOnly = true, Destructive = false, Idempotent = true,
 		OpenWorld = false)]
 	[Description(
-		"Searches for entity schemas in a Creatio environment without needing to know the package name. "
-		+ "Returns schema name, package, maintainer, and parent schema for each match. "
-		+ "An empty search-pattern result is cross-checked once with a broader query before absence is reported. "
-		+ "Use the returned 'package-name' field directly for follow-up MCP calls. "
-		+ "Use 'schema-name' for exact lookup, 'search-pattern' for substring search, or 'uid' for Guid lookup.")]
+		"Finds Creatio entity schemas without a package name. Returns schema, package, maintainer, and parent. "
+		+ "Empty pattern results get one broader check; capped checks fail. Use package-name in follow-ups. "
+		+ "Select by exact schema-name, substring search-pattern, or uid.")]
 	public IReadOnlyList<EntitySchemaSearchResult> FindEntitySchema(
 		[Description(
 			"Parameters: environment-name (required); exactly one of schema-name (exact match), "

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -515,6 +515,7 @@ public sealed class FindEntitySchemaTool(
 	[Description(
 		"Searches for entity schemas in a Creatio environment without needing to know the package name. "
 		+ "Returns schema name, package, maintainer, and parent schema for each match. "
+		+ "An empty search-pattern result is cross-checked once with a broader query before absence is reported. "
 		+ "Use the returned 'package-name' field directly for follow-up MCP calls. "
 		+ "Use 'schema-name' for exact lookup, 'search-pattern' for substring search, or 'uid' for Guid lookup.")]
 	public IReadOnlyList<EntitySchemaSearchResult> FindEntitySchema(

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -39,7 +39,7 @@ public sealed class PageListTool(
 	};
 
 	[McpServerTool(Name = ToolName, ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
-	[Description("List Freedom UI pages in Creatio with package and parent schema context. Results are capped (default 50); the response always reports total (full match count) and truncated so an incomplete result is observable. A negative limit is rejected. Prefer `environment-name`; keep direct connection args only for bootstrap or emergency fallback flows.")]
+	[Description("List Freedom UI pages in Creatio with package and parent schema context. An empty package-name result is cross-checked once with a broader bounded query before absence is reported. Results are capped (default 50); the response always reports total and truncated so an incomplete or unprovable result is observable. A negative limit is rejected. Prefer `environment-name`; keep direct connection args only for bootstrap or emergency fallback flows.")]
 	public PageListResponse ListPages([Description("Parameters: package-name, code, search-pattern, limit (optional); environment-name preferred; uri/login/password emergency fallback only.")] [Required] PageListArgs args) {
 		string? legacyAliasError = GetLegacyAliasError(args);
 		if (!string.IsNullOrWhiteSpace(legacyAliasError)) {

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -39,7 +39,7 @@ public sealed class PageListTool(
 	};
 
 	[McpServerTool(Name = ToolName, ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
-	[Description("List Freedom UI pages in Creatio with package and parent schema context. An empty package-name result is cross-checked once with a broader bounded query before absence is reported. Results are capped (default 50); the response always reports total and truncated so an incomplete or unprovable result is observable. A negative limit is rejected. Prefer `environment-name`; keep direct connection args only for bootstrap or emergency fallback flows.")]
+	[Description("Lists Freedom UI pages with package and parent context. Empty package results get one bounded cross-check; failed checks return success:false. Results default to 50 and report total/truncated. Negative limits fail. Prefer environment-name; direct connection args are emergency fallback.")]
 	public PageListResponse ListPages([Description("Parameters: package-name, code, search-pattern, limit (optional); environment-name preferred; uri/login/password emergency fallback only.")] [Required] PageListArgs args) {
 		string? legacyAliasError = GetLegacyAliasError(args);
 		if (!string.IsNullOrWhiteSpace(legacyAliasError)) {

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -3830,7 +3830,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildPageList() {
 		return new ToolContractDefinition(
 			PageListTool.ToolName,
-			"Lists Freedom UI pages for the requested package or installed app with schema, package, and parent schema context so the caller can discover candidate page schemas before inspection or mutation.",
+			"Lists Freedom UI pages for the requested package or installed app with schema, package, and parent schema context so the caller can discover candidate page schemas before inspection or mutation. An empty package-name result is cross-checked once with a broader bounded query before absence is reported.",
 			new ToolInputSchemaContract(
 				[],
 				EnvironmentOrExplicitConnectionFields(
@@ -3859,8 +3859,8 @@ internal static class ToolContractCatalog {
 				],
 				Field(SuccessFieldName, BooleanType, ToolSucceededDescription),
 				Field(CountFieldName, NumberType, "Number of pages returned (after the result cap is applied)."),
-				Field("total", NumberType, "Total pages matching the query before the cap. Compare to count to detect an incomplete result."),
-				Field("truncated", BooleanType, "True when total is greater than count, meaning more pages match than were returned. Raise limit or add a filter to retrieve the rest."),
+				Field("total", NumberType, "Known pages matching the query before the requested limit. When truncated is true because a bounded fallback reached its safety cap, this is the number observed rather than a proven complete total."),
+				Field("truncated", BooleanType, "True when more pages match than were returned or a bounded fallback reached its safety cap and completeness cannot be proved. Raise limit or add a filter to retrieve the rest."),
 				Field(PagesFieldName, ArrayType, "Discovered pages using `schema-name`, `uId`, `packageName`, and `parentSchemaName`."),
 				Field(ErrorFieldName, StringType, FailureMessageDescription)
 			),
@@ -5135,7 +5135,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildFindEntitySchema() {
 		return new ToolContractDefinition(
 			FindEntitySchemaTool.FindEntitySchemaToolName,
-			"Finds entity schemas in a Creatio environment by exact name, substring pattern, or UId without requiring the package name.",
+			"Finds entity schemas in a Creatio environment by exact name, substring pattern, or UId without requiring the package name. An empty substring result is cross-checked once with a broader query before absence is reported.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName],
 				[

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -3830,7 +3830,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildPageList() {
 		return new ToolContractDefinition(
 			PageListTool.ToolName,
-			"Lists Freedom UI pages for the requested package or installed app with schema, package, and parent schema context so the caller can discover candidate page schemas before inspection or mutation. An empty package-name result is cross-checked once with a broader bounded query before absence is reported.",
+			"Lists Freedom UI pages for the requested package or installed app with schema, package, and parent schema context so the caller can discover candidate page schemas before inspection or mutation. An empty package-name result is cross-checked once with a broader bounded query before absence is reported; failed verification returns success:false.",
 			new ToolInputSchemaContract(
 				[],
 				EnvironmentOrExplicitConnectionFields(
@@ -5135,7 +5135,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildFindEntitySchema() {
 		return new ToolContractDefinition(
 			FindEntitySchemaTool.FindEntitySchemaToolName,
-			"Finds entity schemas in a Creatio environment by exact name, substring pattern, or UId without requiring the package name. An empty substring result is cross-checked once with a broader query before absence is reported.",
+			"Finds entity schemas in a Creatio environment by exact name, substring pattern, or UId without requiring the package name. An empty substring result is cross-checked once with a broader query before absence is reported; a saturated cross-check fails and directs the caller to an exact lookup.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName],
 				[

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -33,6 +33,7 @@ namespace Clio.Command {
 		private const string ExpressionKey = "expression";
 		private const string SuccessKey = "success";
 		private const int ContainsComparisonType = 11;
+		private const int EmptyFilterFallbackRowCount = 10000;
 
 		/// <summary>
 		/// Result cap applied when <c>limit</c> is omitted or supplied as 0 ("use the default").
@@ -82,44 +83,7 @@ namespace Clio.Command {
 					["operationType"] = 0,
 					["filters"] = BuildPageFilters(packageName, nameFilter, options.UId),
 					["columns"] = new JObject {
-						[ItemsKey] = new JObject {
-							["Name"] = new JObject {
-								[ExpressionKey] = new JObject {
-									[ExpressionTypeKey] = 0,
-									[ColumnPathKey] = "Name"
-								},
-								["orderDirection"] = 0,
-								["orderPosition"] = -1,
-								["isVisible"] = true
-							},
-							["UId"] = new JObject {
-								[ExpressionKey] = new JObject {
-									[ExpressionTypeKey] = 0,
-									[ColumnPathKey] = "UId"
-								},
-								["orderDirection"] = 0,
-								["orderPosition"] = -1,
-								["isVisible"] = true
-							},
-							["PackageName"] = new JObject {
-								[ExpressionKey] = new JObject {
-									[ExpressionTypeKey] = 0,
-									[ColumnPathKey] = "SysPackage.Name"
-								},
-								["orderDirection"] = 0,
-								["orderPosition"] = -1,
-								["isVisible"] = true
-							},
-							["ParentSchemaName"] = new JObject {
-								[ExpressionKey] = new JObject {
-									[ExpressionTypeKey] = 0,
-									[ColumnPathKey] = "[SysSchema:Id:Parent].Name"
-								},
-								["orderDirection"] = 0,
-								["orderPosition"] = -1,
-								["isVisible"] = true
-							}
-						}
+						[ItemsKey] = BuildPageColumns()
 					},
 					["rowCount"] = effectiveLimit
 				};
@@ -133,13 +97,33 @@ namespace Clio.Command {
 				}
 				JArray rows = rawResponse["rows"] as JArray ?? [];
 				List<PageListItem> pages = rows
-					.Select(row => new PageListItem {
-						SchemaName = row["Name"]?.ToString(),
-						UId = row["UId"]?.ToString(),
-						PackageName = row["PackageName"]?.ToString(),
-						ParentSchemaName = row["ParentSchemaName"]?.ToString()
-					})
+					.Select(MapPage)
 					.ToList();
+				int? fallbackTotal = null;
+				bool fallbackMayBeCapped = false;
+				if (pages.Count == 0 && !string.IsNullOrWhiteSpace(packageName)) {
+					// Issue #1213: a freshly-created package returned no rows through the package-name
+					// relation filter while the same rows were already visible through an unscoped read.
+					// Cross-check an empty result once and filter the returned package names locally before
+					// treating the package as absent. The normal filtered query remains the fast path.
+					List<PageListItem>? broaderPages = TryQueryPages(
+						url,
+						packageName: string.Empty,
+						nameFilter,
+						options.UId,
+						EmptyFilterFallbackRowCount);
+					if (broaderPages is not null) {
+						fallbackMayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
+						List<PageListItem> packageMatches = broaderPages
+							.Where(page => string.Equals(
+								page.PackageName,
+								packageName,
+								StringComparison.OrdinalIgnoreCase))
+							.ToList();
+						fallbackTotal = packageMatches.Count;
+						pages = packageMatches.Take(effectiveLimit).ToList();
+					}
+				}
 				// The capped data query cannot reveal how many pages matched in total, so a caller
 				// could not otherwise tell a 50-item page from a complete result. Only when the page
 				// is provably full (count >= the cap) is a separate COUNT(Id) round-trip worth its
@@ -148,7 +132,11 @@ namespace Clio.Command {
 				// completeness, so the result must be reported as truncated.
 				int total;
 				bool truncated;
-				if (pages.Count < effectiveLimit) {
+				if (fallbackTotal.HasValue) {
+					total = fallbackTotal.Value;
+					truncated = fallbackMayBeCapped || total > pages.Count;
+				}
+				else if (pages.Count < effectiveLimit) {
 					total = pages.Count;
 					truncated = false;
 				}
@@ -199,6 +187,66 @@ namespace Clio.Command {
 				filters[ItemsKey]["UId"] = BuildComparisonFilter("UId", uId, 0, 3);
 			}
 			return filters;
+		}
+
+		private List<PageListItem>? TryQueryPages(
+			string url,
+			string packageName,
+			string nameFilter,
+			string uId,
+			int rowCount) {
+			try {
+				var query = new JObject {
+					["rootSchemaName"] = "SysSchema",
+					["operationType"] = 0,
+					["filters"] = BuildPageFilters(packageName, nameFilter, uId),
+					["columns"] = new JObject {
+						[ItemsKey] = BuildPageColumns()
+					},
+					["rowCount"] = rowCount
+				};
+				string responseJson = _applicationClient.ExecutePostRequest(url, query.ToString(Formatting.None));
+				var rawResponse = JObject.Parse(responseJson);
+				if (!(rawResponse[SuccessKey]?.Value<bool>() ?? false)) {
+					return null;
+				}
+				return (rawResponse["rows"] as JArray ?? [])
+					.Select(MapPage)
+					.ToList();
+			}
+			catch (Newtonsoft.Json.JsonException) {
+				return null;
+			}
+		}
+
+		private static JObject BuildPageColumns() {
+			return new JObject {
+				["Name"] = BuildPageColumn("Name"),
+				["UId"] = BuildPageColumn("UId"),
+				["PackageName"] = BuildPageColumn("SysPackage.Name"),
+				["ParentSchemaName"] = BuildPageColumn("[SysSchema:Id:Parent].Name")
+			};
+		}
+
+		private static JObject BuildPageColumn(string columnPath) {
+			return new JObject {
+				[ExpressionKey] = new JObject {
+					[ExpressionTypeKey] = 0,
+					[ColumnPathKey] = columnPath
+				},
+				["orderDirection"] = 0,
+				["orderPosition"] = -1,
+				["isVisible"] = true
+			};
+		}
+
+		private static PageListItem MapPage(JToken row) {
+			return new PageListItem {
+				SchemaName = row["Name"]?.ToString(),
+				UId = row["UId"]?.ToString(),
+				PackageName = row["PackageName"]?.ToString(),
+				ParentSchemaName = row["ParentSchemaName"]?.ToString()
+			};
 		}
 
 		/// <summary>

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -44,6 +44,18 @@ namespace Clio.Command {
 		private readonly IServiceUrlBuilder _serviceUrlBuilder;
 		private readonly ILogger _logger;
 
+		private sealed record PageQueryContext(
+			string Url,
+			string PackageName,
+			string NameFilter,
+			string UId,
+			int EffectiveLimit);
+
+		private sealed record PageFallbackResult(
+			List<PageListItem> Pages,
+			int Total,
+			bool MayBeCapped);
+
 		public PageListCommand(
 			IApplicationClient applicationClient,
 			IServiceUrlBuilder serviceUrlBuilder,
@@ -55,97 +67,33 @@ namespace Clio.Command {
 
 		public bool TryListPages(PageListOptions options, out PageListResponse response) {
 			try {
-				if (!string.IsNullOrWhiteSpace(options.PackageName) && !string.IsNullOrWhiteSpace(options.AppCode)) {
-					response = new PageListResponse {
-						Success = false,
-						Error = "Provide either package-name or app-code, not both."
-					};
+				if (!TryCreateQueryContext(options, out PageQueryContext context, out response)) {
 					return false;
 				}
-				// A negative limit must NOT silently disable the result cap (Creatio treats a
-				// negative rowCount as "no limit", which would return every page on the
-				// environment). Reject it; treat 0 as "use the default".
-				if (options.Limit < 0) {
-					response = new PageListResponse {
-						Success = false,
-						Error = $"limit must be zero or greater (got {options.Limit}). Omit limit or pass 0 to use the default of {DefaultLimit}."
-					};
-					return false;
-				}
-				int effectiveLimit = options.Limit == 0 ? DefaultLimit : options.Limit;
-				string packageName = options.PackageName;
-				if (string.IsNullOrWhiteSpace(packageName) && !string.IsNullOrWhiteSpace(options.AppCode)) {
-					packageName = ResolvePrimaryPackageName(options.AppCode);
-				}
-				string nameFilter = options.SearchPattern?.Trim('*', ' ') ?? string.Empty;
-				string url = _serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery");
 				List<PageListItem>? queriedPages = TryQueryPages(
-					url,
-					packageName,
-					nameFilter,
-					options.UId,
-					effectiveLimit);
+					context.Url,
+					context.PackageName,
+					context.NameFilter,
+					context.UId,
+					context.EffectiveLimit);
 				if (queriedPages is null) {
 					response = new PageListResponse { Success = false, Error = "Query failed" };
 					return false;
 				}
 				List<PageListItem> pages = queriedPages;
-				int? fallbackTotal = null;
-				bool fallbackMayBeCapped = false;
-				if (pages.Count == 0 && !string.IsNullOrWhiteSpace(packageName)) {
-					if (!TryCrossCheckEmptyPackagePages(
-						url,
-						packageName,
-						nameFilter,
-						options.UId,
-						effectiveLimit,
-						out pages,
-						out int verifiedTotal,
-						out fallbackMayBeCapped)) {
+				PageFallbackResult? fallback = null;
+				if (pages.Count == 0 && !string.IsNullOrWhiteSpace(context.PackageName)) {
+					fallback = CrossCheckEmptyPackagePages(context);
+					if (fallback is null) {
 						response = new PageListResponse {
 							Success = false,
 							Error = "The package-filtered query returned no rows, and the broader verification query failed."
 						};
 						return false;
 					}
-					fallbackTotal = verifiedTotal;
+					pages = fallback.Pages;
 				}
-				// The capped data query cannot reveal how many pages matched in total, so a caller
-				// could not otherwise tell a 50-item page from a complete result. Only when the page
-				// is provably full (count >= the cap) is a separate COUNT(Id) round-trip worth its
-				// cost: a short page (count < cap) is already complete, so issuing the count there is
-				// pure waste. When the page IS capped and the count query fails, we cannot prove
-				// completeness, so the result must be reported as truncated.
-				int total;
-				bool truncated;
-				if (fallbackTotal.HasValue) {
-					total = fallbackTotal.Value;
-					truncated = fallbackMayBeCapped || total > pages.Count;
-				}
-				else if (pages.Count < effectiveLimit) {
-					total = pages.Count;
-					truncated = false;
-				}
-				else {
-					(bool countSucceeded, int countTotal) = QueryTotalPageCount(url, packageName, nameFilter, options.UId, pages.Count);
-					if (countSucceeded) {
-						total = Math.Max(countTotal, pages.Count);
-						truncated = total > pages.Count;
-					}
-					else {
-						// The page filled the cap but the supplementary count failed, so completeness
-						// is unprovable — surface it as truncated rather than wrongly claiming a full set.
-						total = pages.Count;
-						truncated = true;
-					}
-				}
-				response = new PageListResponse {
-					Success = true,
-					Count = pages.Count,
-					Total = total,
-					Truncated = truncated,
-					Pages = pages
-				};
+				response = CreateSuccessResponse(pages, context, fallback);
 				return true;
 			}
 			catch (Exception ex) {
@@ -154,15 +102,43 @@ namespace Clio.Command {
 			}
 		}
 
-		private bool TryCrossCheckEmptyPackagePages(
-			string url,
-			string packageName,
-			string nameFilter,
-			string uId,
-			int effectiveLimit,
-			out List<PageListItem> pages,
-			out int total,
-			out bool mayBeCapped) {
+		private bool TryCreateQueryContext(
+			PageListOptions options,
+			out PageQueryContext context,
+			out PageListResponse response) {
+			context = null!;
+			if (!string.IsNullOrWhiteSpace(options.PackageName) && !string.IsNullOrWhiteSpace(options.AppCode)) {
+				response = new PageListResponse {
+					Success = false,
+					Error = "Provide either package-name or app-code, not both."
+				};
+				return false;
+			}
+			// A negative limit must NOT silently disable the result cap (Creatio treats a
+			// negative rowCount as "no limit", which would return every page on the
+			// environment). Reject it; treat 0 as "use the default".
+			if (options.Limit < 0) {
+				response = new PageListResponse {
+					Success = false,
+					Error = $"limit must be zero or greater (got {options.Limit}). Omit limit or pass 0 to use the default of {DefaultLimit}."
+				};
+				return false;
+			}
+			string packageName = options.PackageName;
+			if (string.IsNullOrWhiteSpace(packageName) && !string.IsNullOrWhiteSpace(options.AppCode)) {
+				packageName = ResolvePrimaryPackageName(options.AppCode);
+			}
+			context = new PageQueryContext(
+				_serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery"),
+				packageName,
+				options.SearchPattern?.Trim('*', ' ') ?? string.Empty,
+				options.UId,
+				options.Limit == 0 ? DefaultLimit : options.Limit);
+			response = null!;
+			return true;
+		}
+
+		private PageFallbackResult? CrossCheckEmptyPackagePages(PageQueryContext context) {
 			// Issue #1213: a freshly-created package returned no rows through the package-name
 			// relation filter while the same rows were already visible through an unscoped read.
 			// Cross-check an empty result once and filter the returned package names locally before
@@ -170,10 +146,10 @@ namespace Clio.Command {
 			List<PageListItem>? broaderPages;
 			try {
 				broaderPages = TryQueryPages(
-					url,
+					context.Url,
 					packageName: string.Empty,
-					nameFilter,
-					uId,
+					context.NameFilter,
+					context.UId,
 					EmptyFilterFallbackRowCount);
 			}
 			catch (Exception exception) when (exception is System.Net.Http.HttpRequestException
@@ -183,21 +159,57 @@ namespace Clio.Command {
 				broaderPages = null;
 			}
 			if (broaderPages is null) {
-				pages = [];
-				total = 0;
-				mayBeCapped = false;
-				return false;
+				return null;
 			}
-			mayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
 			List<PageListItem> packageMatches = broaderPages
 				.Where(page => string.Equals(
 					page.PackageName,
-					packageName,
+					context.PackageName,
 					StringComparison.OrdinalIgnoreCase))
 				.ToList();
-			total = packageMatches.Count;
-			pages = packageMatches.Take(effectiveLimit).ToList();
-			return true;
+			return new PageFallbackResult(
+				packageMatches.Take(context.EffectiveLimit).ToList(),
+				packageMatches.Count,
+				broaderPages.Count >= EmptyFilterFallbackRowCount);
+		}
+
+		private PageListResponse CreateSuccessResponse(
+			List<PageListItem> pages,
+			PageQueryContext context,
+			PageFallbackResult? fallback) {
+			// The capped data query cannot reveal how many pages matched in total, so a caller
+			// could not otherwise tell a 50-item page from a complete result. Only when the page
+			// is provably full (count >= the cap) is a separate COUNT(Id) round-trip worth its
+			// cost: a short page (count < cap) is already complete, so issuing the count there is
+			// pure waste. When the page IS capped and the count query fails, we cannot prove
+			// completeness, so the result must be reported as truncated.
+			if (fallback is not null) {
+				return CreateSuccessResponse(pages, fallback.Total, fallback.MayBeCapped || fallback.Total > pages.Count);
+			}
+			if (pages.Count < context.EffectiveLimit) {
+				return CreateSuccessResponse(pages, pages.Count, truncated: false);
+			}
+			(bool countSucceeded, int countTotal) = QueryTotalPageCount(
+				context.Url,
+				context.PackageName,
+				context.NameFilter,
+				context.UId,
+				pages.Count);
+			int total = countSucceeded ? Math.Max(countTotal, pages.Count) : pages.Count;
+			return CreateSuccessResponse(pages, total, !countSucceeded || total > pages.Count);
+		}
+
+		private static PageListResponse CreateSuccessResponse(
+			List<PageListItem> pages,
+			int total,
+			bool truncated) {
+			return new PageListResponse {
+				Success = true,
+				Count = pages.Count,
+				Total = total,
+				Truncated = truncated,
+				Pages = pages
+			};
 		}
 
 		private static JObject BuildPageFilters(string packageName, string nameFilter, string uId) {

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -78,27 +78,18 @@ namespace Clio.Command {
 					packageName = ResolvePrimaryPackageName(options.AppCode);
 				}
 				string nameFilter = options.SearchPattern?.Trim('*', ' ') ?? string.Empty;
-				var selectQuery = new JObject {
-					["rootSchemaName"] = "SysSchema",
-					["operationType"] = 0,
-					["filters"] = BuildPageFilters(packageName, nameFilter, options.UId),
-					["columns"] = new JObject {
-						[ItemsKey] = BuildPageColumns()
-					},
-					["rowCount"] = effectiveLimit
-				};
 				string url = _serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery");
-				string requestBody = selectQuery.ToString(Formatting.None);
-				string responseJson = _applicationClient.ExecutePostRequest(url, requestBody);
-				var rawResponse = JObject.Parse(responseJson);
-				if (!(rawResponse[SuccessKey]?.Value<bool>() ?? false)) {
+				List<PageListItem>? queriedPages = TryQueryPages(
+					url,
+					packageName,
+					nameFilter,
+					options.UId,
+					effectiveLimit);
+				if (queriedPages is null) {
 					response = new PageListResponse { Success = false, Error = "Query failed" };
 					return false;
 				}
-				JArray rows = rawResponse["rows"] as JArray ?? [];
-				List<PageListItem> pages = rows
-					.Select(MapPage)
-					.ToList();
+				List<PageListItem> pages = queriedPages;
 				int? fallbackTotal = null;
 				bool fallbackMayBeCapped = false;
 				if (pages.Count == 0 && !string.IsNullOrWhiteSpace(packageName)) {
@@ -106,23 +97,34 @@ namespace Clio.Command {
 					// relation filter while the same rows were already visible through an unscoped read.
 					// Cross-check an empty result once and filter the returned package names locally before
 					// treating the package as absent. The normal filtered query remains the fast path.
-					List<PageListItem>? broaderPages = TryQueryPages(
-						url,
-						packageName: string.Empty,
-						nameFilter,
-						options.UId,
-						EmptyFilterFallbackRowCount);
-					if (broaderPages is not null) {
-						fallbackMayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
-						List<PageListItem> packageMatches = broaderPages
-							.Where(page => string.Equals(
-								page.PackageName,
-								packageName,
-								StringComparison.OrdinalIgnoreCase))
-							.ToList();
-						fallbackTotal = packageMatches.Count;
-						pages = packageMatches.Take(effectiveLimit).ToList();
+					List<PageListItem>? broaderPages;
+					try {
+						broaderPages = TryQueryPages(
+							url,
+							packageName: string.Empty,
+							nameFilter,
+							options.UId,
+							EmptyFilterFallbackRowCount);
 					}
+					catch (Exception) {
+						broaderPages = null;
+					}
+					if (broaderPages is null) {
+						response = new PageListResponse {
+							Success = false,
+							Error = "The package-filtered query returned no rows, and the broader verification query failed."
+						};
+						return false;
+					}
+					fallbackMayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
+					List<PageListItem> packageMatches = broaderPages
+						.Where(page => string.Equals(
+							page.PackageName,
+							packageName,
+							StringComparison.OrdinalIgnoreCase))
+						.ToList();
+					fallbackTotal = packageMatches.Count;
+					pages = packageMatches.Take(effectiveLimit).ToList();
 				}
 				// The capped data query cannot reveal how many pages matched in total, so a caller
 				// could not otherwise tell a 50-item page from a complete result. Only when the page
@@ -195,28 +197,26 @@ namespace Clio.Command {
 			string nameFilter,
 			string uId,
 			int rowCount) {
-			try {
-				var query = new JObject {
-					["rootSchemaName"] = "SysSchema",
-					["operationType"] = 0,
-					["filters"] = BuildPageFilters(packageName, nameFilter, uId),
-					["columns"] = new JObject {
-						[ItemsKey] = BuildPageColumns()
-					},
-					["rowCount"] = rowCount
-				};
-				string responseJson = _applicationClient.ExecutePostRequest(url, query.ToString(Formatting.None));
-				var rawResponse = JObject.Parse(responseJson);
-				if (!(rawResponse[SuccessKey]?.Value<bool>() ?? false)) {
-					return null;
-				}
-				return (rawResponse["rows"] as JArray ?? [])
-					.Select(MapPage)
-					.ToList();
-			}
-			catch (Newtonsoft.Json.JsonException) {
+			var query = new JObject {
+				["rootSchemaName"] = "SysSchema",
+				["operationType"] = 0,
+				["filters"] = BuildPageFilters(packageName, nameFilter, uId),
+				["columns"] = new JObject {
+					[ItemsKey] = BuildPageColumns()
+				},
+				["rowCount"] = rowCount
+			};
+			string responseJson = _applicationClient.ExecutePostRequest(url, query.ToString(Formatting.None));
+			var rawResponse = JObject.Parse(responseJson);
+			if (!(rawResponse[SuccessKey]?.Value<bool>() ?? false)) {
 				return null;
 			}
+			if (rawResponse["rows"] is not JArray rows) {
+				return null;
+			}
+			return rows
+				.Select(MapPage)
+				.ToList();
 		}
 
 		private static JObject BuildPageColumns() {

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -106,7 +106,7 @@ namespace Clio.Command {
 			PageListOptions options,
 			out PageQueryContext context,
 			out PageListResponse response) {
-			context = null!;
+			context = null;
 			if (!string.IsNullOrWhiteSpace(options.PackageName) && !string.IsNullOrWhiteSpace(options.AppCode)) {
 				response = new PageListResponse {
 					Success = false,
@@ -134,7 +134,7 @@ namespace Clio.Command {
 				options.SearchPattern?.Trim('*', ' ') ?? string.Empty,
 				options.UId,
 				options.Limit == 0 ? DefaultLimit : options.Limit);
-			response = null!;
+			response = null;
 			return true;
 		}
 

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -106,7 +106,10 @@ namespace Clio.Command {
 							options.UId,
 							EmptyFilterFallbackRowCount);
 					}
-					catch (Exception) {
+					catch (Exception exception) when (exception is System.Net.Http.HttpRequestException
+						or System.Net.WebException
+						or TimeoutException
+						or Newtonsoft.Json.JsonException) {
 						broaderPages = null;
 					}
 					if (broaderPages is null) {

--- a/clio/Command/PageListOptions.cs
+++ b/clio/Command/PageListOptions.cs
@@ -93,41 +93,22 @@ namespace Clio.Command {
 				int? fallbackTotal = null;
 				bool fallbackMayBeCapped = false;
 				if (pages.Count == 0 && !string.IsNullOrWhiteSpace(packageName)) {
-					// Issue #1213: a freshly-created package returned no rows through the package-name
-					// relation filter while the same rows were already visible through an unscoped read.
-					// Cross-check an empty result once and filter the returned package names locally before
-					// treating the package as absent. The normal filtered query remains the fast path.
-					List<PageListItem>? broaderPages;
-					try {
-						broaderPages = TryQueryPages(
-							url,
-							packageName: string.Empty,
-							nameFilter,
-							options.UId,
-							EmptyFilterFallbackRowCount);
-					}
-					catch (Exception exception) when (exception is System.Net.Http.HttpRequestException
-						or System.Net.WebException
-						or TimeoutException
-						or Newtonsoft.Json.JsonException) {
-						broaderPages = null;
-					}
-					if (broaderPages is null) {
+					if (!TryCrossCheckEmptyPackagePages(
+						url,
+						packageName,
+						nameFilter,
+						options.UId,
+						effectiveLimit,
+						out pages,
+						out int verifiedTotal,
+						out fallbackMayBeCapped)) {
 						response = new PageListResponse {
 							Success = false,
 							Error = "The package-filtered query returned no rows, and the broader verification query failed."
 						};
 						return false;
 					}
-					fallbackMayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
-					List<PageListItem> packageMatches = broaderPages
-						.Where(page => string.Equals(
-							page.PackageName,
-							packageName,
-							StringComparison.OrdinalIgnoreCase))
-						.ToList();
-					fallbackTotal = packageMatches.Count;
-					pages = packageMatches.Take(effectiveLimit).ToList();
+					fallbackTotal = verifiedTotal;
 				}
 				// The capped data query cannot reveal how many pages matched in total, so a caller
 				// could not otherwise tell a 50-item page from a complete result. Only when the page
@@ -171,6 +152,52 @@ namespace Clio.Command {
 				response = new PageListResponse { Success = false, Error = ex.Message };
 				return false;
 			}
+		}
+
+		private bool TryCrossCheckEmptyPackagePages(
+			string url,
+			string packageName,
+			string nameFilter,
+			string uId,
+			int effectiveLimit,
+			out List<PageListItem> pages,
+			out int total,
+			out bool mayBeCapped) {
+			// Issue #1213: a freshly-created package returned no rows through the package-name
+			// relation filter while the same rows were already visible through an unscoped read.
+			// Cross-check an empty result once and filter the returned package names locally before
+			// treating the package as absent. The normal filtered query remains the fast path.
+			List<PageListItem>? broaderPages;
+			try {
+				broaderPages = TryQueryPages(
+					url,
+					packageName: string.Empty,
+					nameFilter,
+					uId,
+					EmptyFilterFallbackRowCount);
+			}
+			catch (Exception exception) when (exception is System.Net.Http.HttpRequestException
+				or System.Net.WebException
+				or TimeoutException
+				or Newtonsoft.Json.JsonException) {
+				broaderPages = null;
+			}
+			if (broaderPages is null) {
+				pages = [];
+				total = 0;
+				mayBeCapped = false;
+				return false;
+			}
+			mayBeCapped = broaderPages.Count >= EmptyFilterFallbackRowCount;
+			List<PageListItem> packageMatches = broaderPages
+				.Where(page => string.Equals(
+					page.PackageName,
+					packageName,
+					StringComparison.OrdinalIgnoreCase))
+				.ToList();
+			total = packageMatches.Count;
+			pages = packageMatches.Take(effectiveLimit).ToList();
+			return true;
 		}
 
 		private static JObject BuildPageFilters(string packageName, string nameFilter, string uId) {

--- a/clio/Command/PageModels.cs
+++ b/clio/Command/PageModels.cs
@@ -67,8 +67,9 @@ public sealed class PageListResponse {
 	public int Count { get; set; }
 
 	/// <summary>
-	/// Gets or sets the total number of pages matching the query before the result cap is applied.
-	/// Callers should compare this to <see cref="Count"/> to detect when the result is incomplete.
+	/// Gets or sets the known number of pages matching the query before the requested result limit
+	/// is applied. When a bounded fallback reaches its safety cap, this is the number observed and
+	/// <see cref="Truncated"/> is <c>true</c> because the complete total cannot be proved.
 	/// </summary>
 	[DataMember(Name = "total")]
 	[JsonProperty("total")]
@@ -76,9 +77,9 @@ public sealed class PageListResponse {
 	public int Total { get; set; }
 
 	/// <summary>
-	/// Gets or sets a value indicating whether the result was truncated by the limit
-	/// (<see cref="Total"/> is greater than <see cref="Count"/>). When <c>true</c>, raise the
-	/// limit or add a filter to retrieve the remaining pages.
+	/// Gets or sets a value indicating whether the result was truncated by the requested limit or
+	/// a bounded fallback reached its safety cap. When <c>true</c>, raise the limit or add a filter
+	/// to retrieve the remaining pages.
 	/// </summary>
 	[DataMember(Name = "truncated")]
 	[JsonProperty("truncated")]

--- a/clio/docs/commands/find-entity-schema.md
+++ b/clio/docs/commands/find-entity-schema.md
@@ -14,7 +14,7 @@ clio find-entity-schema --uid <guid> -e <env>
 
 Searches for entity schemas in the remote Creatio environment using DataService queries on `SysSchema`. Returns schema name, owning package, package maintainer, and parent schema for every match.
 
-A substring search normally uses one filtered query. If Creatio returns no rows, clio cross-checks once with a broader query and filters schema names locally before reporting that no matching schema exists. If the broader query reaches its 10,000-row safety bound without a match, the command fails instead of claiming the schema is absent; use `--schema-name` or `--uid` for an exact lookup.
+A substring search normally uses one filtered query. If Creatio returns no rows, clio cross-checks once with a broader query and filters schema names locally before reporting that no matching schema exists. If the broader query reaches its 10,000-row safety bound, the command fails instead of returning a potentially incomplete result; use `--schema-name` or `--uid` for an exact lookup.
 
 Exactly one of `--schema-name`, `--search-pattern`, or `--uid` must be provided.
 

--- a/clio/docs/commands/find-entity-schema.md
+++ b/clio/docs/commands/find-entity-schema.md
@@ -14,7 +14,7 @@ clio find-entity-schema --uid <guid> -e <env>
 
 Searches for entity schemas in the remote Creatio environment using DataService queries on `SysSchema`. Returns schema name, owning package, package maintainer, and parent schema for every match.
 
-A substring search normally uses one filtered query. If Creatio returns no rows, clio cross-checks once with a broader query and filters schema names locally before reporting that no matching schema exists.
+A substring search normally uses one filtered query. If Creatio returns no rows, clio cross-checks once with a broader query and filters schema names locally before reporting that no matching schema exists. If the broader query reaches its 10,000-row safety bound without a match, the command fails instead of claiming the schema is absent; use `--schema-name` or `--uid` for an exact lookup.
 
 Exactly one of `--schema-name`, `--search-pattern`, or `--uid` must be provided.
 

--- a/clio/docs/commands/find-entity-schema.md
+++ b/clio/docs/commands/find-entity-schema.md
@@ -12,7 +12,9 @@ clio find-entity-schema --uid <guid> -e <env>
 
 ## Description
 
-Searches for entity schemas in the remote Creatio environment using a single DataService query on `SysSchema`. Returns schema name, owning package, package maintainer, and parent schema for every match.
+Searches for entity schemas in the remote Creatio environment using DataService queries on `SysSchema`. Returns schema name, owning package, package maintainer, and parent schema for every match.
+
+A substring search normally uses one filtered query. If Creatio returns no rows, clio cross-checks once with a broader query and filters schema names locally before reporting that no matching schema exists.
 
 Exactly one of `--schema-name`, `--search-pattern`, or `--uid` must be provided.
 
@@ -68,7 +70,7 @@ The `| Parent: …` suffix is omitted when there is no parent.
 
 ## Notes
 
-- A single DataService request is used — no N+1 package enumeration.
+- The filtered query is the normal fast path. Only an empty substring result triggers one broader cross-check; no per-package enumeration is used.
 - The search does not require cliogate to be installed.
 - The CLI output is labeled for easier log and AI parsing. Read the `Package:` segment directly instead of inferring ownership from the maintainer text.
 - The MCP tool already returns structured `package-name`, `package-maintainer`, and `parent-schema-name` fields. MCP callers should use those fields directly instead of parsing CLI-style text.

--- a/clio/docs/commands/list-pages.md
+++ b/clio/docs/commands/list-pages.md
@@ -28,7 +28,8 @@ A package-name lookup normally uses one filtered query. If Creatio returns no
 rows, clio cross-checks once with a broader bounded query and matches returned
 package names locally before reporting an empty package. If the broader query
 reaches its safety bound, `truncated` is `true` because completeness cannot be
-proven.
+proven. If the broader query fails or returns an unusable response, the command
+fails instead of confirming that the package has no pages.
 
 ## Synopsis
 

--- a/clio/docs/commands/list-pages.md
+++ b/clio/docs/commands/list-pages.md
@@ -18,10 +18,17 @@ package names, and parent schema names. Use this command to discover
 candidate schema names before calling get-page.
 
 Results are capped by `--limit` (default 50). The response always reports
-`count` (pages returned), `total` (full number of matching pages before the
-cap), and `truncated` (true when `total` is greater than `count`), so an
-incomplete result is observable. Omit `--limit` or pass `0` to use the
-default of 50; a negative limit is rejected and never disables the cap.
+`count` (pages returned), `total` (known number of matching pages before the
+requested limit), and `truncated` (true when the result is incomplete or
+completeness cannot be proved), so a capped result is observable. Omit
+`--limit` or pass `0` to use the default of 50; a negative limit is rejected
+and never disables the cap.
+
+A package-name lookup normally uses one filtered query. If Creatio returns no
+rows, clio cross-checks once with a broader bounded query and matches returned
+package names locally before reporting an empty package. If the broader query
+reaches its safety bound, `truncated` is `true` because completeness cannot be
+proven.
 
 ## Synopsis
 

--- a/clio/help/en/find-entity-schema.txt
+++ b/clio/help/en/find-entity-schema.txt
@@ -8,10 +8,14 @@ SYNOPSIS
     clio find-entity-schema [OPTIONS]
 
 DESCRIPTION
-    Searches for entity schemas in the remote Creatio environment using a single
-    DataService query on SysSchema. Accepts an exact schema name, a case-insensitive
-    substring pattern, or a UId for lookup. Returns schema name, owning package,
-    package maintainer, and parent schema for each match.
+    Searches for entity schemas in the remote Creatio environment using DataService
+    queries on SysSchema. Accepts an exact schema name, a case-insensitive substring
+    pattern, or a UId for lookup. Returns schema name, owning package, package
+    maintainer, and parent schema for each match.
+
+    A substring search normally uses one filtered query. If Creatio returns no rows,
+    clio cross-checks once with a broader query and filters schema names locally before
+    reporting that no matching schema exists.
 
     Exactly one of --schema-name, --search-pattern, or --uid must be provided.
 

--- a/clio/help/en/find-entity-schema.txt
+++ b/clio/help/en/find-entity-schema.txt
@@ -15,7 +15,9 @@ DESCRIPTION
 
     A substring search normally uses one filtered query. If Creatio returns no rows,
     clio cross-checks once with a broader query and filters schema names locally before
-    reporting that no matching schema exists.
+    reporting that no matching schema exists. If the broader query reaches its
+    10,000-row safety bound without a match, the command fails instead of claiming
+    the schema is absent; use --schema-name or --uid for an exact lookup.
 
     Exactly one of --schema-name, --search-pattern, or --uid must be provided.
 

--- a/clio/help/en/find-entity-schema.txt
+++ b/clio/help/en/find-entity-schema.txt
@@ -16,8 +16,8 @@ DESCRIPTION
     A substring search normally uses one filtered query. If Creatio returns no rows,
     clio cross-checks once with a broader query and filters schema names locally before
     reporting that no matching schema exists. If the broader query reaches its
-    10,000-row safety bound without a match, the command fails instead of claiming
-    the schema is absent; use --schema-name or --uid for an exact lookup.
+    10,000-row safety bound, the command fails instead of returning a potentially
+    incomplete result; use --schema-name or --uid for an exact lookup.
 
     Exactly one of --schema-name, --search-pattern, or --uid must be provided.
 

--- a/clio/help/en/list-pages.txt
+++ b/clio/help/en/list-pages.txt
@@ -13,10 +13,15 @@ DESCRIPTION
     package names, and parent schema names. Use this command to discover
     candidate schema names before calling get-page.
 
-    The response always reports count (pages returned), total (full match
-    count before the cap), and truncated (true when total > count) so an
-    incomplete result is observable. Omit --limit or pass 0 to use the
-    default of 50; a negative limit is rejected and never disables the cap.
+    The response always reports count (pages returned), total (known match
+    count before the requested limit), and truncated (true when the result is
+    incomplete or completeness cannot be proved) so a capped result is
+    observable. Omit --limit or pass 0 to use the default of 50; a negative
+    limit is rejected and never disables the cap.
+
+    A package-name lookup normally uses one filtered query. If Creatio returns
+    no rows, clio cross-checks once with a broader bounded query and matches the
+    returned package names locally before reporting an empty package.
 
 SYNOPSIS
     clio list-pages [options]

--- a/clio/help/en/list-pages.txt
+++ b/clio/help/en/list-pages.txt
@@ -21,7 +21,8 @@ DESCRIPTION
 
     A package-name lookup normally uses one filtered query. If Creatio returns
     no rows, clio cross-checks once with a broader bounded query and matches the
-    returned package names locally before reporting an empty package.
+    returned package names locally before reporting an empty package. If that
+    verification query fails, the command fails instead of confirming absence.
 
 SYNOPSIS
     clio list-pages [options]

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -311,7 +311,8 @@ Implication for external AI:
 This is one of the strongest and most AI-friendly parts of the MCP surface.
 
 - `list-pages`
-  Discover candidate Freedom UI pages by package or schema pattern.
+  Discover candidate Freedom UI pages by package or schema pattern. An empty package-filtered
+  result is cross-checked once with a broader bounded read before absence is reported.
 - `get-page`
   Read a page as a merged bundle plus raw editable JavaScript body.
 - `update-page`

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -312,7 +312,8 @@ This is one of the strongest and most AI-friendly parts of the MCP surface.
 
 - `list-pages`
   Discover candidate Freedom UI pages by package or schema pattern. An empty package-filtered
-  result is cross-checked once with a broader bounded read before absence is reported.
+  result is cross-checked once with a broader bounded read before absence is reported; failed
+  verification returns a failure rather than a definitive empty result.
 - `get-page`
   Read a page as a merged bundle plus raw editable JavaScript body.
 - `update-page`


### PR DESCRIPTION
## Summary
- keep server-filtered schema/page discovery as the normal one-query fast path
- cross-check only empty substring/package results with one broader bounded read and filter locally with ordinal-ignore-case matching
- fail closed when verification fails or entity results reach the 10,000-row safety bound; expose page fallback truncation honestly
- align CLI help, command docs, MCP descriptions/contracts, capability map, unit coverage, and sandbox E2E smoke coverage

Fixes #1213

## Validation
- `dotnet build clio.tests/clio.tests.csproj -c Release --no-restore`
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "Category=Unit&(Module=Command|Module=McpServer)"` (7,718 passed, 14 skipped)
- built CLI against `issue-Forenom`: found `labReservation`/`labReservationStatus` and all 5 `labFORENOM` pages
- MCP E2E additions compile; local live run was environment-limited (entity test used a sandbox key not loaded by the already-running MCP server; page seed test skipped)
- knowledge applies-to check reviewed; recorded facts remain unchanged

## Review
- comprehensive agentic review: quality, security, performance/correctness, testing, bug/edge-case, intent, and KISS lenses completed; all findings resolved and rechecked
- Claude review `rev_56168b803efc412b`: no blocking findings; its stale-comment observation was corrected
- docs reviewed and updated; `Commands.md` and `WikiAnchors.txt` remain accurate
- MCP reviewed and updated; prompts, resources, shipped templates, and published guidance require no change
- ClioRing compatibility reviewed, no Ring-consumed contract changed (searched `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`)