### PR TITLE
Upgrade CreatioClient to 2.0.1

### DIFF
--- a/.codex/skills/clio-local-e2e/SKILL.md
+++ b/.codex/skills/clio-local-e2e/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: clio-local-e2e
+description: Provision or safely reuse an exclusive local Creatio environment, install ClioGate and the real AutoTest fixtures, then run the complete clio MCP E2E suite. Use when preparing a local Creatio stand for clio.mcp.e2e or when proving the full E2E suite locally; do not use for shared stands or teardown.
+---
+
+# Clio Local E2E
+
+Produce one exclusively owned Creatio stand with the real E2E fixtures and a zero-failure full-suite result.
+
+## Safety boundary
+
+- Require exclusive ownership before deploying, changing FSM, installing packages, compiling, or running destructive tests.
+- Use a dedicated environment and workspace under `F:\Projects\Issue-Workspaces`; never mutate a shared stand.
+- Reuse an existing environment only after `clio get-info -e <environment>` succeeds and ownership is confirmed.
+- The runner accepts only `issue-*` environments backed by a Phase 1 workspace, requires the registered URL to match exactly, and holds an atomic endpoint lock for the full run.
+- Do not uninstall the environment when the run finishes unless the user explicitly requests teardown.
+
+## Deploy Creatio
+
+1. Use the `clio-creatio-phase-1` skill when it is available. Otherwise follow its operator-maintained inputs directly:
+   - create or reuse `F:\Projects\Issue-Workspaces\issue-<id>`;
+   - select the configured build from `F:\Projects\Issue-Workspaces\tie.toml`;
+   - copy and render `F:\Projects\Issue-Workspaces\Phase1.yaml`;
+   - run `clio run --file-name .\Phase1.yaml` from the workspace.
+2. Require successful ordered stages: `deploy-creatio`, `install-gate`, `turn-fsm`, `pkg-to-file-system`, and `compile-configuration`. Inspect stage output; the scenario exit code alone is insufficient proof.
+3. For the known FSM-readiness race only, require successful compilation and `clio get-info`, verify `fileDesignMode=true` and `UseStaticFileContent=false`, then retry `clio pkg-to-file-system -e <environment>` exactly once.
+4. Verify the stand before seeding:
+
+   ```powershell
+   clio get-info -e <environment>
+   clio list-packages -e <environment>
+   ```
+
+   `ClioGate` must be installed and reachable.
+
+## Install the real E2E fixtures
+
+The fixtures are not stored in Clio. Pull the known-good installed packages from a reachable donor environment that already contains `AutoTest` and `AutoTestClioMcp`; a synthetic application or a source-only compressed archive is invalid for this run.
+
+1. From the Clio repository root, build Clio and capture its executable path:
+
+   ```powershell
+   dotnet build .\clio\clio.csproj -c Debug -f net8.0
+   if ($LASTEXITCODE -ne 0) { throw "Clio build failed." }
+   $clioDll = (Resolve-Path .\clio\bin\Debug\net8.0\clio.dll).Path
+   $workspace = "F:\Projects\Issue-Workspaces\issue-<id>"
+
+   $donorJson = & dotnet $clioDll list-packages -e <fixture-donor-environment> --Json true
+   if ($LASTEXITCODE -ne 0) { throw "Could not inspect fixture donor packages." }
+   $donorPackages = ($donorJson | Out-String | ConvertFrom-Json).data
+   $expectedAutoTest = @($donorPackages | Where-Object { $_.Descriptor.Name -ceq "AutoTest" })[0].Descriptor
+   $expectedAutoTestClioMcp = @($donorPackages | Where-Object { $_.Descriptor.Name -ceq "AutoTestClioMcp" })[0].Descriptor
+   if (-not $expectedAutoTest -or -not $expectedAutoTestClioMcp) {
+       throw "The donor does not contain both required fixture packages."
+   }
+
+   function Assert-PackageIdentity($Expected, $InstalledPackages) {
+       $actual = @($InstalledPackages | Where-Object { $_.Descriptor.Name -ceq $Expected.Name })[0].Descriptor
+       if (-not $actual `
+           -or $actual.UId -ne $Expected.UId `
+           -or $actual.Name -cne $Expected.Name `
+           -or $actual.PackageVersion -ne $Expected.PackageVersion) {
+           throw "Installed package identity does not match donor package '$($Expected.Name)'."
+       }
+   }
+   ```
+
+2. Pull the packages from the donor into the issue workspace, preserving dependency order:
+
+   ```powershell
+   Push-Location $workspace
+   if ((Test-Path .\AutoTest.zip) -or (Test-Path .\AutoTestClioMcp.zip)) {
+       throw "Refusing to reuse existing fixture ZIPs; move or remove them after verifying their ownership."
+   }
+   dotnet $clioDll pull-pkg AutoTest -e <fixture-donor-environment>
+   if ($LASTEXITCODE -ne 0) { throw "AutoTest pull failed." }
+   dotnet $clioDll pull-pkg AutoTestClioMcp -e <fixture-donor-environment>
+   if ($LASTEXITCODE -ne 0) { throw "AutoTestClioMcp pull failed." }
+   Pop-Location
+   ```
+
+   Require `AutoTest.zip` and `AutoTestClioMcp.zip` to exist and be nonempty.
+
+3. Install `AutoTest` first. After every `push-pkg`, require three consecutive successful `get-info` probes within five minutes before continuing, then verify the installed package with `list-packages`:
+
+   ```powershell
+   function Wait-CreatioReady([string] $EnvironmentName) {
+       $deadline = [DateTimeOffset]::UtcNow.AddMinutes(5)
+       $consecutive = 0
+       while ([DateTimeOffset]::UtcNow -lt $deadline -and $consecutive -lt 3) {
+           & dotnet $clioDll get-info -e $EnvironmentName
+           $consecutive = if ($LASTEXITCODE -eq 0) { $consecutive + 1 } else { 0 }
+           if ($consecutive -lt 3) { Start-Sleep -Seconds 10 }
+       }
+       if ($consecutive -lt 3) { throw "Creatio did not reach three consecutive readiness probes." }
+   }
+
+   dotnet $clioDll push-pkg "$workspace\AutoTest.zip" -e <environment>
+   if ($LASTEXITCODE -ne 0) { throw "AutoTest install failed." }
+   Wait-CreatioReady <environment>
+   $installedJson = & dotnet $clioDll list-packages -e <environment> --Json true
+   if ($LASTEXITCODE -ne 0) { throw "Could not verify installed packages." }
+   Assert-PackageIdentity $expectedAutoTest (($installedJson | Out-String | ConvertFrom-Json).data)
+
+   dotnet $clioDll push-pkg "$workspace\AutoTestClioMcp.zip" -e <environment>
+   if ($LASTEXITCODE -ne 0) { throw "AutoTestClioMcp install failed." }
+   Wait-CreatioReady <environment>
+   $installedJson = & dotnet $clioDll list-packages -e <environment> --Json true
+   if ($LASTEXITCODE -ne 0) { throw "Could not verify installed packages." }
+   Assert-PackageIdentity $expectedAutoTestClioMcp (($installedJson | Out-String | ConvertFrom-Json).data)
+   ```
+
+4. Verify `AutoTest`, `AutoTestClioMcp`, and `ClioGate` with `list-packages`. Confirm the installed application code `AutoTestClioMcp` is discoverable before interpreting fixture-dependent skips.
+
+## Run the complete suite
+
+From the Clio repository, invoke the bundled runner:
+
+```powershell
+.\.codex\skills\clio-local-e2e\scripts\run-clio-e2e.ps1 `
+  -EnvironmentName <environment> `
+  -EnvironmentUrl https://host:port `
+  -SeedKeyPrefix LOCAL-<unique-run-id>
+```
+
+The runner performs its fail-closed workspace, registration, URL, HTTPS, and endpoint-lock preflight before it sets the destructive opt-in. It then builds `clio.mcp.e2e` for `net8.0` and runs the entire project with a TRX logger. Pass `-DatabaseProvider <name>` to opt into database-provider tests; otherwise the runner clears ambient provider configuration and those tests may skip.
+
+## Acceptance and handoff
+
+- Require zero failed tests in the full, unfiltered `clio.mcp.e2e` run.
+- Report passed, skipped, failed, total, duration, TRX path, environment name and URL, package verification, and any single bounded FSM recovery.
+- Explain configuration- or topology-driven skips. Never report a filtered run or a process exit code alone as complete E2E proof.

--- a/.codex/skills/clio-local-e2e/scripts/run-clio-e2e.ps1
+++ b/.codex/skills/clio-local-e2e/scripts/run-clio-e2e.ps1
@@ -1,0 +1,132 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $EnvironmentName,
+
+    [Parameter(Mandatory = $true)]
+    [uri] $EnvironmentUrl,
+
+    [string] $SeedKeyPrefix = "LOCAL-$([DateTimeOffset]::UtcNow.ToString('yyyyMMddHHmmss'))",
+
+    [ValidateSet("Debug", "Release")]
+    [string] $Configuration = "Debug",
+
+    [ValidateSet("net8.0", "net10.0")]
+    [string] $Framework = "net8.0",
+
+    [string] $DatabaseProvider,
+
+    [string] $LogFileName = "clio-mcp-e2e-local.trx"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")).Path
+if ($EnvironmentName -notmatch '^issue-[A-Za-z0-9][A-Za-z0-9._-]*$') {
+    throw "Destructive local E2E requires a dedicated issue-* environment name."
+}
+
+$workspacePath = "F:\Projects\Issue-Workspaces\$EnvironmentName"
+$phaseOnePath = Join-Path $workspacePath "Phase1.yaml"
+if (-not (Test-Path -LiteralPath $phaseOnePath -PathType Leaf)) {
+    throw "Phase 1 workspace marker was not found: $phaseOnePath"
+}
+
+$clioSettingsPath = Join-Path $env:LOCALAPPDATA "creatio\clio\appsettings.json"
+if (-not (Test-Path -LiteralPath $clioSettingsPath -PathType Leaf)) {
+    throw "Clio settings were not found: $clioSettingsPath"
+}
+$clioSettings = Get-Content -LiteralPath $clioSettingsPath -Raw | ConvertFrom-Json
+$environmentProperty = $clioSettings.Environments.PSObject.Properties[$EnvironmentName]
+if ($null -eq $environmentProperty) {
+    throw "Clio environment '$EnvironmentName' is not registered."
+}
+$registeredEnvironment = $environmentProperty.Value
+if ($null -eq $registeredEnvironment -or [string]::IsNullOrWhiteSpace($registeredEnvironment.Uri)) {
+    throw "Clio environment '$EnvironmentName' is not registered."
+}
+$registeredUri = [uri] $registeredEnvironment.Uri
+$expectedUrl = $EnvironmentUrl.AbsoluteUri.TrimEnd("/")
+$registeredUrl = $registeredUri.AbsoluteUri.TrimEnd("/")
+if (-not $registeredUrl.Equals($expectedUrl, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "EnvironmentUrl must exactly match the registered URI for '$EnvironmentName'."
+}
+if ($EnvironmentUrl.Scheme -ne [Uri]::UriSchemeHttps -and -not $EnvironmentUrl.IsLoopback) {
+    throw "Destructive local E2E requires HTTPS unless the registered environment is loopback."
+}
+
+$lockRoot = "F:\Projects\Issue-Workspaces\.locks"
+[IO.Directory]::CreateDirectory($lockRoot) > $null
+$hasher = [Security.Cryptography.SHA256]::Create()
+try {
+    $endpointHash = [BitConverter]::ToString(
+        $hasher.ComputeHash([Text.Encoding]::UTF8.GetBytes($registeredUrl.ToLowerInvariant())))
+        .Replace("-", "").ToLowerInvariant()
+}
+finally {
+    $hasher.Dispose()
+}
+$lockPath = Join-Path $lockRoot "clio-local-e2e-$endpointHash.lock"
+$lockStream = $null
+try {
+    $lockStream = [IO.File]::Open($lockPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+    $lockText = [Text.Encoding]::UTF8.GetBytes("$([Environment]::UserName) $PID $([DateTimeOffset]::UtcNow.ToString('O'))")
+    $lockStream.Write($lockText, 0, $lockText.Length)
+    $lockStream.Flush()
+}
+catch {
+    $lockStream?.Dispose()
+    throw "Could not acquire exclusive E2E ownership lock '$lockPath'. Remove it only after confirming no E2E run owns this workspace. $($_.Exception.Message)"
+}
+
+$variableNames = @(
+    "McpE2E__AllowDestructiveMcpTests",
+    "McpE2E__ClioProcessPath",
+    "McpE2E__Sandbox__EnvironmentName",
+    "McpE2E__Sandbox__EnvironmentUrl",
+    "McpE2E__Sandbox__SeedKeyPrefix",
+    "McpE2E__Sandbox__DatabaseProvider"
+)
+$previousValues = @{}
+foreach ($name in $variableNames) {
+    $previousValues[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+}
+
+try {
+    $env:McpE2E__AllowDestructiveMcpTests = "true"
+    Remove-Item Env:McpE2E__ClioProcessPath -ErrorAction SilentlyContinue
+    $env:McpE2E__Sandbox__EnvironmentName = $EnvironmentName
+    $env:McpE2E__Sandbox__EnvironmentUrl = $EnvironmentUrl.AbsoluteUri.TrimEnd("/")
+    $env:McpE2E__Sandbox__SeedKeyPrefix = $SeedKeyPrefix
+    if ([string]::IsNullOrWhiteSpace($DatabaseProvider)) {
+        Remove-Item Env:McpE2E__Sandbox__DatabaseProvider -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:McpE2E__Sandbox__DatabaseProvider = $DatabaseProvider
+    }
+
+    Push-Location $repoRoot
+    try {
+        dotnet build .\clio.mcp.e2e\clio.mcp.e2e.csproj -c $Configuration -f $Framework
+        if ($LASTEXITCODE -ne 0) {
+            throw "clio.mcp.e2e build failed with exit code $LASTEXITCODE."
+        }
+
+        dotnet test .\clio.mcp.e2e\clio.mcp.e2e.csproj -c $Configuration -f $Framework --no-build `
+            --logger "trx;LogFileName=$LogFileName"
+        if ($LASTEXITCODE -ne 0) {
+            throw "clio.mcp.e2e failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    foreach ($name in $variableNames) {
+        [Environment]::SetEnvironmentVariable($name, $previousValues[$name], "Process")
+    }
+    $lockStream.Dispose()
+    [IO.File]::Delete($lockPath)
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageVersion Include="creatio.client" Version="1.0.40" />
+    <PackageVersion Include="creatio.client" Version="2.0.0" />
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.5" />
     <PackageVersion Include="ErrorOr" Version="2.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@ See docs: https://devblogs.microsoft.com/dotnet/introducing-central-package-mana
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityModelVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageVersion Include="creatio.client" Version="2.0.0" />
+    <PackageVersion Include="creatio.client" Version="2.0.1" />
     <PackageVersion Include="CommandLineSDK" Version="1.0.11" />
     <PackageVersion Include="ATF.Repository" Version="2.0.3.5" />
     <PackageVersion Include="ErrorOr" Version="2.1.1" />

--- a/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
@@ -413,6 +413,10 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 				["push-workspace", "-e", environmentName],
 				workingDirectory: workspacePath,
 				cancellationToken: cancellationTokenSource.Token);
+			await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(
+				settings,
+				environmentName,
+				cancellationTokenSource.Token);
 			await ClioCliCommandRunner.RunAndAssertSuccessAsync(
 				settings,
 				["pkg-hotfix", packageName, "true", "-e", environmentName],
@@ -424,16 +428,12 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 				cancellationTokenSource.Token);
 		}
 
-		bool ownsSession = requireEnvironment;
-		McpServerSession session = ownsSession
-			? await McpServerSession.StartAsync(settings, cancellationTokenSource.Token)
-			: Session;
+		McpServerSession session = Session;
 		return new DataBindingDbArrangeContext(
 			rootDirectory,
 			workspacePath,
 			packageName,
 			environmentName,
-			ownsSession,
 			session,
 			cancellationTokenSource);
 	}
@@ -533,17 +533,14 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 		string WorkspacePath,
 		string PackageName,
 		string? EnvironmentName,
-		bool OwnsSession,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : System.IAsyncDisposable {
-		public async System.Threading.Tasks.ValueTask DisposeAsync() {
-			if (OwnsSession) {
-				await Session.DisposeAsync();
-			}
+		public System.Threading.Tasks.ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return System.Threading.Tasks.ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingDbToolE2ETests.cs
@@ -396,7 +396,7 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 		string workspaceName = $"workspace-{System.Guid.NewGuid():N}";
 		string workspacePath = Path.Combine(rootDirectory, workspaceName);
 		string packageName = $"Pkg{System.Guid.NewGuid():N}".Substring(0, 18);
-		CancellationTokenSource cancellationTokenSource = new(System.TimeSpan.FromMinutes(5));
+		CancellationTokenSource cancellationTokenSource = new(System.TimeSpan.FromMinutes(8));
 
 		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
 			settings,
@@ -418,14 +418,22 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 				["pkg-hotfix", packageName, "true", "-e", environmentName],
 				workingDirectory: workspacePath,
 				cancellationToken: cancellationTokenSource.Token);
+			await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(
+				settings,
+				environmentName,
+				cancellationTokenSource.Token);
 		}
 
-		McpServerSession session = Session;
+		bool ownsSession = requireEnvironment;
+		McpServerSession session = ownsSession
+			? await McpServerSession.StartAsync(settings, cancellationTokenSource.Token)
+			: Session;
 		return new DataBindingDbArrangeContext(
 			rootDirectory,
 			workspacePath,
 			packageName,
 			environmentName,
+			ownsSession,
 			session,
 			cancellationTokenSource);
 	}
@@ -525,14 +533,17 @@ public sealed class DataBindingDbToolE2ETests : McpContractFixtureBase {
 		string WorkspacePath,
 		string PackageName,
 		string? EnvironmentName,
+		bool OwnsSession,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : System.IAsyncDisposable {
-		public System.Threading.Tasks.ValueTask DisposeAsync() {
+		public async System.Threading.Tasks.ValueTask DisposeAsync() {
+			if (OwnsSession) {
+				await Session.DisposeAsync();
+			}
 			CancellationTokenSource.Dispose();
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
-			return System.Threading.Tasks.ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -56,13 +56,9 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	private string? _sharedEnvironmentName;
 	private string? _sharedPackageName;
 	private string? _sharedRootDirectory;
-	private McpServerSession? _sharedEnvironmentSession;
 
 	[OneTimeTearDown]
-	public async Task CleanupSharedSandboxPackage() {
-		if (_sharedEnvironmentSession is not null) {
-			await _sharedEnvironmentSession.DisposeAsync();
-		}
+	public void CleanupSharedSandboxPackage() {
 		if (_sharedRootDirectory is not null && Directory.Exists(_sharedRootDirectory)) {
 			Directory.Delete(_sharedRootDirectory, recursive: true);
 		}
@@ -1207,8 +1203,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 			// Each test gets its own schema inside the shared package so creates never collide; the
 			// column names are constants but live in distinct schemas, so they do not clash either.
 			string schemaName = $"Usr{Guid.NewGuid():N}";
-			_sharedEnvironmentSession ??=
-				await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new EntitySchemaArrangeContext(
 				_sharedRootDirectory!,
 				environmentName,
@@ -1217,7 +1212,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 				"UsrName",
 				"UsrSortOrder",
 				"UsrCode",
-				_sharedEnvironmentSession,
+				session,
 				cancellationTokenSource);
 		});
 	}
@@ -2321,7 +2316,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
 		public ValueTask DisposeAsync() {
 			// RootDirectory is the shared fixture workspace (see EnsureSharedSandboxPackageAsync); it is
-			// deleted once in [OneTimeTearDown], and Session is fixture-owned for the same reason.
+			// deleted once in [OneTimeTearDown], so per-test disposal must NOT remove it.
 			CancellationTokenSource.Dispose();
 			return ValueTask.CompletedTask;
 		}

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -56,9 +56,13 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	private string? _sharedEnvironmentName;
 	private string? _sharedPackageName;
 	private string? _sharedRootDirectory;
+	private McpServerSession? _sharedEnvironmentSession;
 
 	[OneTimeTearDown]
-	public void CleanupSharedSandboxPackage() {
+	public async Task CleanupSharedSandboxPackage() {
+		if (_sharedEnvironmentSession is not null) {
+			await _sharedEnvironmentSession.DisposeAsync();
+		}
 		if (_sharedRootDirectory is not null && Directory.Exists(_sharedRootDirectory)) {
 			Directory.Delete(_sharedRootDirectory, recursive: true);
 		}
@@ -1203,7 +1207,8 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 			// Each test gets its own schema inside the shared package so creates never collide; the
 			// column names are constants but live in distinct schemas, so they do not clash either.
 			string schemaName = $"Usr{Guid.NewGuid():N}";
-			McpServerSession session = Session;
+			_sharedEnvironmentSession ??=
+				await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 			return new EntitySchemaArrangeContext(
 				_sharedRootDirectory!,
 				environmentName,
@@ -1212,7 +1217,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 				"UsrName",
 				"UsrSortOrder",
 				"UsrCode",
-				session,
+				_sharedEnvironmentSession,
 				cancellationTokenSource);
 		});
 	}
@@ -1248,6 +1253,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationToken);
 		await AddPackageAsync(settings, workspacePath, packageName, cancellationToken);
 		await PushWorkspaceAsync(settings, workspacePath, environmentName, packageName, cancellationToken);
+		await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(settings, environmentName, cancellationToken);
 		await EnsureTextSysSettingAsync(
 			settings,
 			environmentName,
@@ -2315,7 +2321,7 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
 		public ValueTask DisposeAsync() {
 			// RootDirectory is the shared fixture workspace (see EnsureSharedSandboxPackageAsync); it is
-			// deleted once in [OneTimeTearDown], so per-test disposal must NOT remove it.
+			// deleted once in [OneTimeTearDown], and Session is fixture-owned for the same reason.
 			CancellationTokenSource.Dispose();
 			return ValueTask.CompletedTask;
 		}

--- a/clio.mcp.e2e/PageCreateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageCreateToolE2ETests.cs
@@ -350,7 +350,7 @@ public sealed class PageCreateToolE2ETests : McpContractFixtureBase {
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
-	[Description("Creates a desktop page from CentralAreaDesktopTemplate, reads it back via get-page to confirm the parent template, and deletes the schema (which auto-removes the platform-registered selector record).")]
+	[Description("Creates a desktop page from CentralAreaDesktopTemplate, reads it back via get-page to confirm the parent template, and deletes the schema on an FSM-off stand.")]
 	[AllureTag(ToolName)]
 	[AllureName("create-page creates a desktop from CentralAreaDesktopTemplate and get-page reads it back")]
 	public async Task PageCreateTool_Should_Create_Desktop_From_Desktop_Template() {
@@ -359,6 +359,15 @@ public sealed class PageCreateToolE2ETests : McpContractFixtureBase {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(5));
+		CallToolResult fsmResult = await arrangeContext.Session.CallToolAsync(
+			FsmModeTool.GetFsmModeToolName,
+			new Dictionary<string, object?> { ["environmentName"] = environmentName },
+			arrangeContext.CancellationTokenSource.Token);
+		FsmModeStatusEnvelope fsmStatus = FsmModeStatusResultParser.Extract(fsmResult);
+		if (string.Equals(fsmStatus.Mode, "on", StringComparison.OrdinalIgnoreCase)) {
+			Assert.Ignore(
+				"Creating a desktop through the remote designer API is not isolated on an FSM stand: the schema is not materialized in package storage and poisons later configuration saves. Run this test against an FSM-off sandbox.");
+		}
 		string schemaName = $"UsrE2E_Desktop_{Guid.NewGuid():N}".Substring(0, 40);
 
 		try {
@@ -402,7 +411,7 @@ public sealed class PageCreateToolE2ETests : McpContractFixtureBase {
 			getResponse.Page.ParentSchemaName.Should().Be("CentralAreaDesktopTemplate",
 				because: "the desktop page must inherit the platform desktop template");
 		} finally {
-			// Teardown: deleting the schema auto-removes its Desktop selector row (platform listener),
+			// On an FSM-off stand, deleting the schema auto-removes its Desktop selector row (platform listener),
 			// so the sandbox selector is not polluted by E2E desktops.
 			using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(2));
 			await ClioCliCommandRunner.RunAsync(

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -1248,6 +1248,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 	public async Task PageSyncTool_Should_Reject_Mobile_Body_With_Converters_When_Validate_Is_True() {
 		// Arrange
 		await using ArrangeContext context = await ArrangeAsync();
+		string environmentName = TestConfiguration.Load().Sandbox.EnvironmentName ?? "dev";
 		string mobileBodyWithConverters = """
 			{
 			  "viewConfigDiff": [],
@@ -1260,7 +1261,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 			ToolName,
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = "dev",
+					["environment-name"] = environmentName,
 					["pages"] = new[] {
 						new Dictionary<string, object?> {
 							["schema-name"] = "UsrMobile_FormPage",
@@ -1277,13 +1278,19 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		callResult.IsError.Should().NotBeTrue(
 			because: "sync-pages mobile validation failures should be surfaced as structured tool results");
 
-		if (TryExtractFailure(callResult, out PageSyncResponse? response) && response is not null) {
-			response.Pages.Should().ContainSingle(
-				because: "one page was submitted");
-			PageSyncPageResult page = response.Pages[0];
-			page.Validation!.ContentOk.Should().BeFalse(
-				because: "a mobile body containing 'converters' must fail mobile content validation");
-		}
+		TryExtractFailure(callResult, out PageSyncResponse? response).Should().BeTrue(
+			because: "a mobile validation rejection must use the structured sync-pages response contract");
+		response.Should().NotBeNull(
+			because: "the structured sync-pages response must be available for validation assertions");
+		response!.Pages.Should().ContainSingle(
+			because: "one page was submitted");
+		PageSyncPageResult page = response.Pages[0];
+		page.Validation.Should().NotBeNull(
+			because: $"a validation rejection must include its structured validation details. Error: {page.Error}");
+		page.Validation!.ContentOk.Should().BeFalse(
+			because: "a mobile body containing 'converters' must fail mobile content validation");
+		page.Validation.Errors.Should().Contain(error => error.Contains("converters", StringComparison.Ordinal),
+			because: "the rejection must identify the unsupported converters property rather than an unrelated validation failure");
 	}
 
 	[Test]
@@ -1294,6 +1301,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 	public async Task PageSyncTool_Should_Accept_Valid_Mobile_Body_Without_AMD_Marker_Errors() {
 		// Arrange
 		await using ArrangeContext context = await ArrangeAsync();
+		string environmentName = TestConfiguration.Load().Sandbox.EnvironmentName ?? "dev";
 		string mobileBody = """
 			{
 			  "viewConfigDiff": [],
@@ -1307,7 +1315,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 			ToolName,
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = "dev",
+					["environment-name"] = environmentName,
 					["pages"] = new[] {
 						new Dictionary<string, object?> {
 							["schema-name"] = "UsrMobile_FormPage",
@@ -1324,14 +1332,19 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		callResult.IsError.Should().NotBeTrue(
 			because: "a valid mobile body must not raise a protocol-level error");
 
-		if (TryExtractFailure(callResult, out PageSyncResponse? response) && response is not null) {
-			foreach (PageSyncPageResult page in response.Pages) {
-				if (page.Validation is not null) {
-					page.Validation.Errors.Should().NotContain(e => e.Contains("SCHEMA_"),
-						because: "AMD marker errors must not appear when the body is a mobile JSON object");
-				}
-			}
-		}
+		TryExtractFailure(callResult, out PageSyncResponse? response).Should().BeTrue(
+			because: "valid mobile validation must use the structured sync-pages response contract");
+		response.Should().NotBeNull(
+			because: "the structured sync-pages response must be available for validation assertions");
+		response!.Pages.Should().ContainSingle(
+			because: "one page was submitted");
+		PageSyncPageResult page = response.Pages[0];
+		page.Validation.Should().NotBeNull(
+			because: $"validation details must be returned for the submitted mobile body. Error: {page.Error}");
+		page.Validation!.ContentOk.Should().BeTrue(
+			because: "the plain mobile JSON object contains no unsupported properties");
+		page.Validation.Errors.Should().NotContain(e => e.Contains("SCHEMA_", StringComparison.Ordinal),
+			because: "AMD marker errors must not appear when the body is a mobile JSON object");
 	}
 
 		[Test]

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -47,13 +47,9 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 	private string? _sharedWorkspacePath;
 	private string? _sharedEnvironmentName;
 	private string? _sharedPackageName;
-	private McpServerSession? _sharedEnvironmentSession;
 
 	[OneTimeTearDown]
-	public async Task CleanupSharedSandboxPackage() {
-		if (_sharedEnvironmentSession is not null) {
-			await _sharedEnvironmentSession.DisposeAsync();
-		}
+	public void CleanupSharedSandboxPackage() {
 		if (_sharedRootDirectory is not null && Directory.Exists(_sharedRootDirectory)) {
 			Directory.Delete(_sharedRootDirectory, recursive: true);
 		}
@@ -674,11 +670,6 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 
 		(string environmentName, string packageName) =
 			await EnsureSharedSandboxPackageAsync(settings, cancellationTokenSource.Token);
-		// push-workspace/pkg-hotfix recycle Creatio. Start the environment-bound MCP process only after
-		// provisioning so it cannot retain an authentication session invalidated by that recycle.
-		_sharedEnvironmentSession ??=
-			await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
-		session = _sharedEnvironmentSession;
 
 		// Each environment-bound test gets its own entity and lookup schemas inside the shared package so
 		// concurrent creates never collide; the schema names are unique guids while the column names are

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -47,9 +47,13 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 	private string? _sharedWorkspacePath;
 	private string? _sharedEnvironmentName;
 	private string? _sharedPackageName;
+	private McpServerSession? _sharedEnvironmentSession;
 
 	[OneTimeTearDown]
-	public void CleanupSharedSandboxPackage() {
+	public async Task CleanupSharedSandboxPackage() {
+		if (_sharedEnvironmentSession is not null) {
+			await _sharedEnvironmentSession.DisposeAsync();
+		}
 		if (_sharedRootDirectory is not null && Directory.Exists(_sharedRootDirectory)) {
 			Directory.Delete(_sharedRootDirectory, recursive: true);
 		}
@@ -670,6 +674,11 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 
 		(string environmentName, string packageName) =
 			await EnsureSharedSandboxPackageAsync(settings, cancellationTokenSource.Token);
+		// push-workspace/pkg-hotfix recycle Creatio. Start the environment-bound MCP process only after
+		// provisioning so it cannot retain an authentication session invalidated by that recycle.
+		_sharedEnvironmentSession ??=
+			await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		session = _sharedEnvironmentSession;
 
 		// Each environment-bound test gets its own entity and lookup schemas inside the shared package so
 		// concurrent creates never collide; the schema names are unique guids while the column names are
@@ -720,6 +729,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		await CreateEmptyWorkspaceAsync(settings, rootDirectory, workspaceName, cancellationToken);
 		await AddPackageAsync(settings, workspacePath, packageName, cancellationToken);
 		await PushWorkspaceAsync(settings, workspacePath, environmentName, packageName, cancellationToken);
+		await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(settings, environmentName, cancellationToken);
 
 		_sharedRootDirectory = rootDirectory;
 		_sharedWorkspacePath = workspacePath;

--- a/clio.mcp.e2e/SchemaTransferToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaTransferToolE2ETests.cs
@@ -147,14 +147,14 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 	public async Task SchemaTransfer_Should_RoundTrip_Export_And_Import_Against_A_Live_Environment() {
 		// Arrange
 		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(15));
-		SandboxSchema sandbox = await ArrangeSandboxSchemaAsync(arrangeContext);
+		await using SandboxSchema sandbox = await ArrangeSandboxSchemaAsync(arrangeContext);
 		string destination = Path.Combine(Path.GetTempPath(), $"clio-schema-bundle-{Guid.NewGuid():N}");
 		string bundleDirectory = Path.Combine(destination, sandbox.SchemaName);
 		string foreignPackageName = $"Pkg{Guid.NewGuid():N}"[..18];
 
 		// Act
 		CommandExecutionEnvelope export = McpCommandExecutionParser.Extract(
-			await arrangeContext.Session.CallToolAsync(
+			await sandbox.Session.CallToolAsync(
 				ExportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -167,7 +167,7 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 				arrangeContext.CancellationTokenSource.Token));
 
 		CommandExecutionEnvelope replaceImport = McpCommandExecutionParser.Extract(
-			await arrangeContext.Session.CallToolAsync(
+			await sandbox.Session.CallToolAsync(
 				ImportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -179,7 +179,7 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 				arrangeContext.CancellationTokenSource.Token));
 
 		CommandExecutionEnvelope refusedImport = McpCommandExecutionParser.Extract(
-			await arrangeContext.Session.CallToolAsync(
+			await sandbox.Session.CallToolAsync(
 				ImportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -279,35 +279,44 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 			["pkg-hotfix", packageName, "true", "-e", environmentName],
 			workingDirectory: workspacePath,
 			cancellationToken: cancellationToken);
+		await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(settings, environmentName, cancellationToken);
 
 		string schemaName = $"Usr{Guid.NewGuid():N}";
-		CallToolResult syncResult = await context.Session.CallToolAsync(
-			SchemaSyncTool.ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = environmentName,
-					["package-name"] = packageName,
-					["operations"] = new object?[] {
-						new Dictionary<string, object?> {
-							["type"] = "create-entity",
-							["schema-name"] = schemaName,
-							["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Schema Transfer Entity" },
-							["columns"] = new object?[] {
-								new Dictionary<string, object?> {
-									["name"] = "UsrTitle",
-									["type"] = "Text",
-									["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Title" }
+		// Package provisioning recycles Creatio. Authenticate a new MCP process only after that recycle,
+		// then keep the same fresh process for create/export/import so the round trip is coherent.
+		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationToken);
+		try {
+			CallToolResult syncResult = await session.CallToolAsync(
+				SchemaSyncTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["package-name"] = packageName,
+						["operations"] = new object?[] {
+							new Dictionary<string, object?> {
+								["type"] = "create-entity",
+								["schema-name"] = schemaName,
+								["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Schema Transfer Entity" },
+								["columns"] = new object?[] {
+									new Dictionary<string, object?> {
+										["name"] = "UsrTitle",
+										["type"] = "Text",
+										["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Title" }
+									}
 								}
 							}
 						}
 					}
-				}
-			},
-			cancellationToken);
-		syncResult.IsError.Should().NotBeTrue(
-			because: "the round-trip needs a schema of its own on the stand; without it there is nothing to export");
+				},
+				cancellationToken);
+			syncResult.IsError.Should().NotBeTrue(
+				because: "the round-trip needs a schema of its own on the stand; without it there is nothing to export");
 
-		return new SandboxSchema(environmentName, packageName, schemaName);
+			return new SandboxSchema(environmentName, packageName, schemaName, session);
+		} catch {
+			await session.DisposeAsync();
+			throw;
+		}
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(
@@ -330,7 +339,13 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 	}
 
 	/// <summary>The live fixture the round-trip runs against.</summary>
-	private sealed record SandboxSchema(string EnvironmentName, string PackageName, string SchemaName);
+	private sealed record SandboxSchema(
+		string EnvironmentName,
+		string PackageName,
+		string SchemaName,
+		McpServerSession Session) : IAsyncDisposable {
+		public async ValueTask DisposeAsync() => await Session.DisposeAsync();
+	}
 
 	private static string DescribeExecution(CommandExecutionEnvelope execution) {
 		string messages = execution.Output is null

--- a/clio.mcp.e2e/SchemaTransferToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaTransferToolE2ETests.cs
@@ -147,14 +147,14 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 	public async Task SchemaTransfer_Should_RoundTrip_Export_And_Import_Against_A_Live_Environment() {
 		// Arrange
 		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(15));
-		await using SandboxSchema sandbox = await ArrangeSandboxSchemaAsync(arrangeContext);
+		SandboxSchema sandbox = await ArrangeSandboxSchemaAsync(arrangeContext);
 		string destination = Path.Combine(Path.GetTempPath(), $"clio-schema-bundle-{Guid.NewGuid():N}");
 		string bundleDirectory = Path.Combine(destination, sandbox.SchemaName);
 		string foreignPackageName = $"Pkg{Guid.NewGuid():N}"[..18];
 
 		// Act
 		CommandExecutionEnvelope export = McpCommandExecutionParser.Extract(
-			await sandbox.Session.CallToolAsync(
+			await arrangeContext.Session.CallToolAsync(
 				ExportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -167,7 +167,7 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 				arrangeContext.CancellationTokenSource.Token));
 
 		CommandExecutionEnvelope replaceImport = McpCommandExecutionParser.Extract(
-			await sandbox.Session.CallToolAsync(
+			await arrangeContext.Session.CallToolAsync(
 				ImportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -179,7 +179,7 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 				arrangeContext.CancellationTokenSource.Token));
 
 		CommandExecutionEnvelope refusedImport = McpCommandExecutionParser.Extract(
-			await sandbox.Session.CallToolAsync(
+			await arrangeContext.Session.CallToolAsync(
 				ImportToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
@@ -282,41 +282,33 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 		await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(settings, environmentName, cancellationToken);
 
 		string schemaName = $"Usr{Guid.NewGuid():N}";
-		// Package provisioning recycles Creatio. Authenticate a new MCP process only after that recycle,
-		// then keep the same fresh process for create/export/import so the round trip is coherent.
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationToken);
-		try {
-			CallToolResult syncResult = await session.CallToolAsync(
-				SchemaSyncTool.ToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["package-name"] = packageName,
-						["operations"] = new object?[] {
-							new Dictionary<string, object?> {
-								["type"] = "create-entity",
-								["schema-name"] = schemaName,
-								["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Schema Transfer Entity" },
-								["columns"] = new object?[] {
-									new Dictionary<string, object?> {
-										["name"] = "UsrTitle",
-										["type"] = "Text",
-										["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Title" }
-									}
+		CallToolResult syncResult = await context.Session.CallToolAsync(
+			SchemaSyncTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["package-name"] = packageName,
+					["operations"] = new object?[] {
+						new Dictionary<string, object?> {
+							["type"] = "create-entity",
+							["schema-name"] = schemaName,
+							["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Schema Transfer Entity" },
+							["columns"] = new object?[] {
+								new Dictionary<string, object?> {
+									["name"] = "UsrTitle",
+									["type"] = "Text",
+									["title-localizations"] = new Dictionary<string, object?> { ["en-US"] = "Title" }
 								}
 							}
 						}
 					}
-				},
-				cancellationToken);
-			syncResult.IsError.Should().NotBeTrue(
-				because: "the round-trip needs a schema of its own on the stand; without it there is nothing to export");
+				}
+			},
+			cancellationToken);
+		syncResult.IsError.Should().NotBeTrue(
+			because: "the round-trip needs a schema of its own on the stand; without it there is nothing to export");
 
-			return new SandboxSchema(environmentName, packageName, schemaName, session);
-		} catch {
-			await session.DisposeAsync();
-			throw;
-		}
+		return new SandboxSchema(environmentName, packageName, schemaName);
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(
@@ -339,13 +331,7 @@ public sealed class SchemaTransferToolE2ETests : McpContractFixtureBase {
 	}
 
 	/// <summary>The live fixture the round-trip runs against.</summary>
-	private sealed record SandboxSchema(
-		string EnvironmentName,
-		string PackageName,
-		string SchemaName,
-		McpServerSession Session) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() => await Session.DisposeAsync();
-	}
+	private sealed record SandboxSchema(string EnvironmentName, string PackageName, string SchemaName);
 
 	private static string DescribeExecution(CommandExecutionEnvelope execution) {
 		string messages = execution.Output is null

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -113,6 +113,37 @@ internal static class ClioCliCommandRunner {
 		return result.ExitCode == 0;
 	}
 
+	/// <summary>
+	/// Waits for Creatio to finish the delayed recycle triggered by package installation or hot-fix changes.
+	/// Three consecutive authenticated probes prevent a brief pre-shutdown success from releasing the next test step.
+	/// </summary>
+	public static async Task WaitForEnvironmentRecoveryAsync(
+		McpE2ESettings settings,
+		string environmentName,
+		CancellationToken cancellationToken = default) {
+		const int requiredConsecutiveSuccesses = 3;
+		const int maximumAttempts = 30;
+		int consecutiveSuccesses = 0;
+		ClioCliCommandResult? lastResult = null;
+		for (int attempt = 0; attempt < maximumAttempts; attempt++) {
+			lastResult = await RunAsync(
+				settings,
+				["ping-app", "-e", environmentName, "--timeout", "30000"],
+				cancellationToken: cancellationToken);
+			consecutiveSuccesses = lastResult.ExitCode == 0 ? consecutiveSuccesses + 1 : 0;
+			if (consecutiveSuccesses == requiredConsecutiveSuccesses) {
+				await WaitForCliogateHttpHandlersAsync(environmentName, cancellationToken);
+				return;
+			}
+			await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+		}
+
+		lastResult.Should().NotBeNull(
+			because: "environment recovery polling should capture its final authenticated probe");
+		consecutiveSuccesses.Should().Be(requiredConsecutiveSuccesses,
+			because: $"'{environmentName}' must remain authenticated for {requiredConsecutiveSuccesses} consecutive probes after its package-triggered recycle. Last exit code: {lastResult!.ExitCode}. stdout: {lastResult.StandardOutput}. stderr: {lastResult.StandardError}");
+	}
+
 	public static async Task RunAndAssertSuccessAsync(
 		McpE2ESettings settings,
 		IReadOnlyList<string> arguments,
@@ -468,6 +499,10 @@ internal static class ClioCliCommandRunner {
 		using HttpClient httpClient = new(handler) {
 			Timeout = CliogateHttpRequestTimeout
 		};
+		// Creatio's cookie-auth middleware redirects ordinary anonymous browser-like requests to
+		// the login page. Mark this as an AJAX/service request so a ready protected REST route returns
+		// 401 instead; the readiness probe can then distinguish it from a warming-up redirect.
+		httpClient.DefaultRequestHeaders.Add("X-Requested-With", "XMLHttpRequest");
 		ICliogateHttpReadinessProbe probe = new CliogateHttpReadinessProbe(
 			httpClient,
 			maxAttempts,

--- a/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
@@ -240,12 +240,15 @@ public sealed class WorkspaceSyncToolE2ETests {
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 			await EnsureSharedRestoreWorkspaceAsync(settings, cancellationTokenSource.Token);
 
+			string testRootDirectory = Path.Combine(Path.GetTempPath(), $"clio-workspace-restore-e2e-{Guid.NewGuid():N}");
+			string testWorkspacePath = Path.Combine(testRootDirectory, Path.GetFileName(_sharedWorkspacePath!));
+			CopyDirectory(_sharedWorkspacePath!, testWorkspacePath);
 			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 			return new WorkspaceSyncArrangeContext(
 				settings,
-				_sharedRootDirectory!,
-				_sharedWorkspacePath!,
-				Path.GetFileName(_sharedWorkspacePath!),
+				testRootDirectory,
+				testWorkspacePath,
+				Path.GetFileName(testWorkspacePath),
 				RestoreWorkspacePath: string.Empty,
 				RestoreWorkspaceName: string.Empty,
 				_sharedEnvironmentName!,
@@ -253,8 +256,18 @@ public sealed class WorkspaceSyncToolE2ETests {
 				_sharedPackageMetadata,
 				session,
 				cancellationTokenSource,
-				OwnsRootDirectory: false);
+				OwnsRootDirectory: true);
 		});
+	}
+
+	private static void CopyDirectory(string sourceDirectory, string destinationDirectory) {
+		Directory.CreateDirectory(destinationDirectory);
+		foreach (string filePath in Directory.EnumerateFiles(sourceDirectory)) {
+			File.Copy(filePath, Path.Combine(destinationDirectory, Path.GetFileName(filePath)));
+		}
+		foreach (string childDirectory in Directory.EnumerateDirectories(sourceDirectory)) {
+			CopyDirectory(childDirectory, Path.Combine(destinationDirectory, Path.GetFileName(childDirectory)));
+		}
 	}
 
 	/// <summary>
@@ -281,6 +294,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 		await AddPackageAsync(settings, workspacePath, packageName, cancellationToken);
 		PackageMetadata packageMetadata = ReadPackageMetadata(workspacePath, packageName);
 		await PushWorkspaceCliAsync(settings, workspacePath, environmentName, cancellationToken);
+		await ClioCliCommandRunner.WaitForEnvironmentRecoveryAsync(settings, environmentName, cancellationToken);
 
 		_sharedRootDirectory = rootDirectory;
 		_sharedWorkspacePath = workspacePath;
@@ -363,7 +377,11 @@ public sealed class WorkspaceSyncToolE2ETests {
 
 	[AllureStep("Assert command exit code")]
 	private static void AssertCommandExitCode(WorkspaceCommandActResult actResult, int expectedExitCode, string because) {
-		actResult.Execution.ExitCode.Should().Be(expectedExitCode, because: because);
+		string output = string.Join(
+			Environment.NewLine,
+			(actResult.Execution.Output ?? []).Select(message => $"{message.MessageType}: {message.Value}"));
+		actResult.Execution.ExitCode.Should().Be(expectedExitCode,
+			because: $"{because}. Actual output: {output}");
 	}
 
 	[AllureStep("Assert execution includes Error message")]

--- a/clio.tests/Command/ClassicEnumVocabularyResolverTests.cs
+++ b/clio.tests/Command/ClassicEnumVocabularyResolverTests.cs
@@ -35,6 +35,7 @@ public sealed class ClassicEnumVocabularyResolverTests {
 	private const string ZeroRootNuiLoginUrl = BaseUri + "/0/Login/NuiLogin.aspx";
 	private const string SiteRootSysEnumsUrl = BaseUri + "/core/" + Hash + "/Terrasoft/core/enums/sysenums.js";
 	private const string ZeroRootSysEnumsUrl = BaseUri + "/0/core/" + Hash + "/Terrasoft/core/enums/sysenums.js";
+	private const string FsmSysEnumsUrl = BaseUri + "/core/hash/Terrasoft/core/enums/sysenums.js";
 
 	private IClassicEnumVocabularySourceParser _parser;
 
@@ -90,6 +91,32 @@ public sealed class ClassicEnumVocabularyResolverTests {
 		requested.Should().Equal([CoreRootLoginUrl, SiteRootSysEnumsUrl],
 			because: "the runtime's own shape is tried first, so a healthy Core stand costs exactly one login-page request");
 		result.Enums.Should().BeSameAs(expected.Enums, because: "the resolver hands the parser's own result straight through when the fetch succeeds");
+		_parser.Received(1).Parse(sysEnumsBody);
+	}
+
+	[Test]
+	[Description("An FSM login page using the literal /core/hash/ route resolves sysenums.js instead of silently omitting enumVocabulary.")]
+	public void Resolve_ShouldUseLiteralHashRoute_WhenLoginPageUsesFsmStaticContent() {
+		// Arrange
+		const string sysEnumsBody = "Terrasoft.ViewItemType = { GRID_LAYOUT: 0 };";
+		var byUrl = new Dictionary<string, (HttpStatusCode, string)> {
+			[CoreRootLoginUrl] = (HttpStatusCode.OK, "<script src=\"/core/hash/Terrasoft/amd/bootstrap-loader.js\"></script>"),
+			[FsmSysEnumsUrl] = (HttpStatusCode.OK, sysEnumsBody)
+		};
+		ClassicEnumVocabularyParseResult expected = SingleEnum("ViewItemType", "GRID_LAYOUT", 0);
+		_parser.Parse(sysEnumsBody).Returns(expected);
+		var requested = new List<string>();
+		var resolver = new ClassicEnumVocabularyResolver(
+			Settings(isNetCore: true), FactoryReturning(byUrl, requested), _parser);
+
+		// Act
+		ClassicEnumVocabularyParseResult result = resolver.Resolve();
+
+		// Assert
+		requested.Should().Equal([CoreRootLoginUrl, FsmSysEnumsUrl],
+			because: "FSM serves static content through the literal hash route named by its login page");
+		result.Enums.Should().BeSameAs(expected.Enums,
+			because: "literal FSM routing must preserve the same parsed vocabulary contract as compiled hash routing");
 		_parser.Received(1).Parse(sysEnumsBody);
 	}
 

--- a/clio/Command/ClassicEnumVocabularyResolver.cs
+++ b/clio/Command/ClassicEnumVocabularyResolver.cs
@@ -269,12 +269,12 @@ internal sealed class ClassicEnumVocabularyResolver(
 	// reasoning as the component-registry client).
 	public const string HttpClientName = nameof(ClassicEnumVocabularyResolver);
 
-	// Case-insensitive: nothing about the hash's own casing is a documented platform contract, only that it is
-	// 32 hex characters, so matching only lowercase would silently omit enumVocabulary on a stand that happens to
-	// serve an uppercase-hex marker. The optional leading '/0' is CAPTURED rather than merely tolerated, so a login
-	// page that already spells its static root is echoed back verbatim and can never be double-prefixed.
+	// Case-insensitive: current FSM stands use the stable literal "hash" route while compiled-content stands use
+	// a 32-character hex hash. The optional leading '/0' is CAPTURED rather than merely tolerated, so a login page
+	// that already spells its static root is echoed back verbatim and can never be double-prefixed.
 	private static readonly Regex ContentHashPathRegex = new(
-		"((?:/0)?)/core/([0-9a-fA-F]{32})/", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+		"((?:/0)?)/core/([0-9a-fA-F]{32}|hash)/", RegexOptions.Compiled | RegexOptions.IgnoreCase,
+		TimeSpan.FromSeconds(1));
 
 	// Login-page locations, ordered by the environment's declared runtime: .NET Core serves /Login/Login.html off the
 	// site root, .NET Framework serves /0/Login/NuiLogin.aspx behind its application root

--- a/docs/knowledge/McpServer/fsm-desktop-remote-lifecycle-poisons-later-saves.md
+++ b/docs/knowledge/McpServer/fsm-desktop-remote-lifecycle-poisons-later-saves.md
@@ -1,0 +1,12 @@
+---
+description: the remote create and delete lifecycle for an FSM desktop can leave a missing-item reference that poisons later configuration saves
+applies-to:
+  - clio.mcp.e2e/PageCreateToolE2ETests.cs
+date: 2026-08-31
+---
+
+**What is true** — On the local Creatio 10.1 FSM stand, the remote designer create/read/delete lifecycle for a desktop based on `CentralAreaDesktopTemplate` left configuration publishing resolving that schema name as a missing item after the creating process exited. The desktop E2E therefore skips this lifecycle when `get-fsm-mode` reports `on`.
+
+**Why it is this way** — The observed test performed both remote creation and cleanup, so the individual operation that persists the bad reference is not isolated. Restarting Creatio did not repair it, proving persisted platform state rather than only a stale in-memory schema-manager cache. The same lifecycle remains covered on an FSM-off sandbox, where the schema uses the database-backed package path.
+
+**What breaks if you ignore it** — Every later schema or page save can fail with `Item with name "UsrE2E_Desktop_..." not found`, making unrelated E2E tests fail until the environment is redeployed.


### PR DESCRIPTION
## Summary
- upgrade the centrally managed `creatio.client` package from 1.0.40 to the corrected public 2.0.1 release
- rely on CreatioClient's bounded stale-session recovery instead of restarting MCP sessions after Creatio package operations
- wait for actual environment readiness where package operations temporarily recycle Creatio
- isolate restore-workspace cases, make mobile validation assertions fail closed, and support Creatio 10.1 FSM's literal `/core/hash/` sysenums route
- add the guarded `clio-local-e2e` skill for deploying/reusing an exclusive Creatio stand, installing ClioGate plus donor-backed AutoTest fixtures, and running the complete suite

## CreatioClient dependency
- fix PR: https://github.com/Advance-Technologies-Foundation/creatioclient/pull/17 (merged)
- release: https://github.com/Advance-Technologies-Foundation/creatioclient/releases/tag/v2.0.1
- NuGet flat-container package verified public; package version 2.0.1 and assembly version 2.0.1.0
- Clio was force-restored with `--no-cache` after moving the locally built cache entry aside, then rebuilt successfully from the public package

## Local validation
- `dotnet test clio.tests/clio.tests.csproj -c Debug --filter "Category=Unit"` — 9,992 passed, 24 skipped, 0 failed
- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net8.0 --no-restore` after public NuGet restore — passed
- full unfiltered local net8 MCP E2E against Creatio 10.1.585 at `issue-2026083006`, with AutoTest, AutoTestClioMcp, and ClioGate installed — 653 passed, 124 expected configuration/feature skips, 0 failed (777 total, 30m51s)
- FSM-off desktop E2E — 1 passed, 0 skipped, 0 failed
- skill quick validation and PowerShell parser validation — passed
- knowledge-base check — passed

## Reviews
- comprehensive seven-lens agentic review: code quality, security, performance, testing, bug/edge cases, intent, and KISS — no remaining findings
- docs reviewed, no update required
- MCP reviewed, no update required
- ClioRing compatibility reviewed; no Ring-consumed contract changed (searched `ClioRing.Ipc`, `ClioRing`, and `ClioRing.Desktop/actions.json`)