### PR TITLE
fix(knowledge): unlink junctions before deleting a knowledge cache

### DIFF
--- a/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterFileSystemTests.cs
+++ b/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterFileSystemTests.cs
@@ -93,7 +93,8 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 
 		// Assert
 		Directory.Exists(_root).Should().BeFalse(
-			because: "a recursive delete unlinks the reparse point, so the managed root is still removable");
+			because: "the deleter unlinks the reparse point itself; a bare recursive delete cannot remove a "
+				+ "tree containing a junction, which is the whole reason the unlink exists");
 		File.Exists(outsideFile).Should().BeTrue(
 			because: "Directory.Delete unlinks a reparse point instead of emptying its target, so nothing "
 				+ "beyond the link is ever deleted");
@@ -127,19 +128,18 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 		process.ExitCode.Should().Be(0,
 			because: "mklink reports a failure only through its exit code");
 		// Directory.Exists is true for a PLAIN directory too, so checking it would let this test pass with
-		// no reparse point at all - which is the silent no-op the fallback exists to prevent.
+		// no reparse point at all - a silent no-op in the exact test that has to fail loudly.
 		(File.GetAttributes(path) & FileAttributes.ReparsePoint).Should().NotBe(default,
-			because: "without the ReparsePoint bit this test asserts nothing, and the guard it covers is the "
-				+ "one that keeps an untrusted checkout from being walked through");
+			because: "without the ReparsePoint bit this test asserts nothing, and it covers two guards at "
+				+ "once: the walk must not descend through the link, and the link must be unlinked so the "
+				+ "recursive delete never meets it");
 	}
 
 	[Test]
+	[Platform(Include = "Win", Reason = "A junction is a Windows-only reparse tag; the symlink shape is covered above.")]
 	[Description("Removes a knowledge cache that contains a directory junction, which a bare recursive delete cannot.")]
 	public void Delete_ShouldRemoveTheTree_WhenItContainsADirectoryJunction() {
 		// Arrange
-		if (!OperatingSystem.IsWindows()) {
-			Assert.Ignore("A junction is a Windows-only reparse tag; the symlink shape is covered above.");
-		}
 		Directory.CreateDirectory(_outside);
 		string outsideFile = Path.Combine(_outside, "protected.txt");
 		File.WriteAllText(outsideFile, "protected");
@@ -163,40 +163,144 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 	}
 
 	[Test]
-	[Description("Records that a bare recursive delete really does fail on a junction child, so a regression here is the platform's and not clio's.")]
-	public void RecursiveDelete_ShouldFail_OnAJunctionChild_WhichIsWhyTheDeleterUnlinksFirst() {
+	[Platform(Include = "Win", Reason = "Off Windows the shared reparse-point test already uses a symlink.")]
+	[Description("Removes a knowledge cache containing a directory symbolic link, the Windows tag recursive delete handles natively.")]
+	public void Delete_ShouldRemoveTheTree_WhenItContainsADirectorySymbolicLink() {
 		// Arrange
-		if (!OperatingSystem.IsWindows()) {
-			Assert.Ignore("A junction is a Windows-only reparse tag.");
-		}
 		Directory.CreateDirectory(_outside);
+		string outsideFile = Path.Combine(_outside, "protected.txt");
+		File.WriteAllText(outsideFile, "protected");
+		File.SetAttributes(outsideFile, FileAttributes.ReadOnly);
 		Directory.CreateDirectory(_root);
-		CreateJunction(Path.Combine(_root, "linked"), _outside);
+		try {
+			Directory.CreateSymbolicLink(Path.Combine(_root, "linked"), _outside);
+		} catch (Exception exception) when (exception is UnauthorizedAccessException or IOException) {
+			// Deliberate, and narrow: this is the EASY tag, the one recursive delete copes with natively.
+			// The hard tag has an unconditional junction test, so skipping here cannot hide the regression
+			// that cost a release.
+			Assert.Ignore($"SeCreateSymbolicLinkPrivilege is unavailable: {exception.Message}");
+		}
 
 		// Act
-		Exception captured = null;
-		try {
-			Directory.Delete(_root, recursive: true);
-		} catch (Exception exception) {
-			captured = exception;
-		}
+		_deleter.Delete(_root);
 
 		// Assert
-		captured.Should().NotBeNull(
-			because: "the deleter unlinks reparse points up front only because the framework cannot handle a "
-				+ "junction child; if this ever starts succeeding the workaround can be reconsidered");
+		Directory.Exists(_root).Should().BeFalse(
+			because: "making the helper always use a junction on Windows removed every Windows assertion "
+				+ "about the symlink tag, and the PR claims one rule covers both shapes");
+		File.Exists(outsideFile).Should().BeTrue(
+			because: "unlinking a symbolic link must not reach through to its target either");
+		File.GetAttributes(outsideFile).HasFlag(FileAttributes.ReadOnly).Should().BeTrue(
+			because: "nothing behind the link is deleted, so nothing behind it may be modified");
+	}
+
+	[Test]
+	[Platform(Include = "Win", Reason = "A junction is a Windows-only reparse tag.")]
+	[Description("Removes a knowledge source cache containing a junction through the recoverable path the store actually uses.")]
+	public void DeleteRecoverably_ShouldRemoveTheTree_WhenItContainsADirectoryJunction() {
+		// Arrange
+		Directory.CreateDirectory(_outside);
+		string outsideFile = Path.Combine(_outside, "protected.txt");
+		File.WriteAllText(outsideFile, "protected");
+		Directory.CreateDirectory(Path.Combine(_root, "repository"));
+		CreateJunction(Path.Combine(_root, "repository", "linked"), _outside);
+
+		// Act
+		_deleter.DeleteRecoverably(_root);
+
+		// Assert
+		Directory.Exists(_root).Should().BeFalse(
+			because: "KnowledgeSourceInstallationStore deletes a source cache through this path, not through "
+				+ "Delete - so a junction that breaks it is what a real user hits");
+		Directory.EnumerateDirectories(Path.GetTempPath(), QuarantineGlob())
+			.Should().BeEmpty(
+				because: "renaming aside is a step, not an outcome: a rename that succeeds while the empty "
+					+ "fails leaves the tree complete under a scratch name, which Directory.Exists cannot see");
+		File.Exists(outsideFile).Should().BeTrue(
+			because: "the rename moves the link but must never reach through to what it points at");
+	}
+
+	[Test]
+	[Platform(Include = "Win", Reason = "A junction is a Windows-only reparse tag.")]
+	[Description("Reclaims an abandoned scratch tree that contains a junction, which the swallowing sweep used to leak forever.")]
+	public void DeleteRecoverably_ShouldReclaimAnAbandonedQuarantine_WhenItContainsADirectoryJunction() {
+		// Arrange
+		Directory.CreateDirectory(_outside);
+		File.WriteAllText(Path.Combine(_outside, "protected.txt"), "protected");
+		string abandoned = Path.Combine(
+			Path.GetTempPath(),
+			$"{KnowledgeManagedTreeDeleter.QuarantinePrefix}{Path.GetFileName(_root)}-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(abandoned);
+		CreateJunction(Path.Combine(abandoned, "linked"), _outside);
+		Directory.CreateDirectory(_root);
+
+		// Act
+		_deleter.DeleteRecoverably(_root);
+
+		// Assert
+		Directory.Exists(abandoned).Should().BeFalse(
+			because: "the sweep swallows IOException, so before the unlink a junction inside an abandoned "
+				+ "scratch tree made it unreclaimable and silently permanent - nothing else enumerates it");
+	}
+
+	[Test]
+	[Platform(Include = "Win", Reason = "A junction is a Windows-only reparse tag.")]
+	[Description("Records whether a bare recursive delete still fails on a junction child; inconclusive when the platform is fixed, because removing the workaround is a decision and not a clio regression.")]
+	public void Delete_ShouldRemainNecessary_WhileTheFrameworkFailsOnAJunctionChild() {
+		// Arrange
+		Directory.CreateDirectory(_outside);
+		Directory.CreateDirectory(_root);
+		string link = Path.Combine(_root, "linked");
+		CreateJunction(link, _outside);
+		Action bareRecursiveDelete = () => Directory.Delete(_root, recursive: true);
+
+		// Act
+		Exception observed = Record(bareRecursiveDelete);
+
+		// Assert
+		// Inconclusive, NOT a failure. Clio is correct either way - unlinking a reparse point is harmless
+		// when the framework could also have handled it - so a platform fix must not turn red in the
+		// unfiltered release lane and read as a clio regression.
+		if (observed is null) {
+			Assert.Inconclusive(
+				"Directory.Delete(recursive: true) now handles a junction child. "
+				+ "KnowledgeManagedTreeDeleter's unlink may be removable - but only once the LOWEST shipped "
+				+ "target framework also copes (clio ships net8.0 and net10.0; clio.tests runs net10.0 only). "
+				+ "Decide deliberately and update "
+				+ "docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md. "
+				+ "This is NOT a clio regression.");
+		}
 		Directory.Exists(_root).Should().BeTrue(
 			because: "the framework removes the junction and then throws, so the tree is left behind - which "
 				+ "is exactly the failure a user sees as an undeletable knowledge cache");
+		Directory.Exists(link).Should().BeFalse(
+			because: "the junction is already gone when it throws, which is why a bare retry appears to work "
+				+ "and must not be used: a retry after a partial delete is the non-atomic behaviour "
+				+ "DeleteRecoverably renames the tree to avoid");
 	}
+
+	// No bare catch(Exception) in a test body - project-context.md forbids it, and it straddles Act/Assert.
+	private static Exception Record(Action action) {
+		try {
+			action();
+			return null;
+		} catch (Exception exception) {
+			return exception;
+		}
+	}
+
+	// The production shape is <parent>/.clio-deleting-<rootName>-<guid>. Derived from the constant so a
+	// hand-written glob cannot silently match nothing and turn an assertion into a no-op.
+	private string QuarantineGlob() =>
+		$"{KnowledgeManagedTreeDeleter.QuarantinePrefix}{Path.GetFileName(_root)}-*";
 
 	private static void ForceDelete(string path) {
 		if (!Directory.Exists(path)) {
 			return;
 		}
-		// TopDirectoryOnly with manual recursion, for the same reason the production deleter uses it: an
-		// AllDirectories walk descends through a reparse point and would clear the very bit a failing test
-		// is asserting on.
+		// TopDirectoryOnly with manual recursion, and unlink rather than skip - both for the same reasons the
+		// production deleter does it: an AllDirectories walk descends through a reparse point and would clear
+		// the very bit a failing test asserts on, and a junction left in place defeats the recursive delete.
 		foreach (string file in Directory.EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly)) {
 			try {
 				File.SetAttributes(file, FileAttributes.Normal);
@@ -204,9 +308,17 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 			}
 		}
 		foreach (string child in Directory.EnumerateDirectories(path)) {
-			if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) == 0) {
-				ForceDelete(child);
+			if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) != 0) {
+				// UNLINK, not skip. Skipping is what the production deleter used to do, and it hands a
+				// junction-bearing tree to the recursive delete below, which throws and is swallowed here -
+				// leaking the tree on exactly the runs where a test failed and left one behind.
+				try {
+					Directory.Delete(child, recursive: false);
+				} catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+				}
+				continue;
 			}
+			ForceDelete(child);
 		}
 		try {
 			Directory.Delete(path, recursive: true);

--- a/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterFileSystemTests.cs
+++ b/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterFileSystemTests.cs
@@ -103,19 +103,20 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 				+ "just rejected as untrusted");
 	}
 
-	// A symbolic link needs SeCreateSymbolicLinkPrivilege on Windows, which a non-elevated CI agent without
-	// Developer Mode does not have. A JUNCTION sets the same ReparsePoint bit and needs no privilege, so the
-	// invariant stays covered there instead of being silently ignored.
+	// DETERMINISTIC per platform, deliberately not "try the nicer one first". Choosing a symbolic link when
+	// the privilege happens to be available made this a lottery: on an elevated or Developer-Mode host the
+	// symlink branch ran, and a symlink is the shape recursive delete handles natively. The junction branch -
+	// the shape that actually breaks it - therefore first executed on a release runner, in a release.
+	// A junction needs no privilege, so Windows always gets one and always exercises the hard case.
 	private static void CreateDirectoryReparsePoint(string path, string target) {
-		try {
+		if (!OperatingSystem.IsWindows()) {
 			Directory.CreateSymbolicLink(path, target);
 			return;
-		} catch (Exception exception) when (exception is UnauthorizedAccessException or IOException
-				or PlatformNotSupportedException) {
-			if (!OperatingSystem.IsWindows()) {
-				Assert.Fail($"Creating a directory symbolic link failed: {exception.Message}");
-			}
 		}
+		CreateJunction(path, target);
+	}
+
+	private static void CreateJunction(string path, string target) {
 		// No output redirection: nothing drains those pipes, and mklink's output is not needed.
 		using Process process = Process.Start(new ProcessStartInfo("cmd.exe", $"/c mklink /J \"{path}\" \"{target}\"") {
 			UseShellExecute = false,
@@ -130,6 +131,63 @@ public sealed class KnowledgeManagedTreeDeleterFileSystemTests {
 		(File.GetAttributes(path) & FileAttributes.ReparsePoint).Should().NotBe(default,
 			because: "without the ReparsePoint bit this test asserts nothing, and the guard it covers is the "
 				+ "one that keeps an untrusted checkout from being walked through");
+	}
+
+	[Test]
+	[Description("Removes a knowledge cache that contains a directory junction, which a bare recursive delete cannot.")]
+	public void Delete_ShouldRemoveTheTree_WhenItContainsADirectoryJunction() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("A junction is a Windows-only reparse tag; the symlink shape is covered above.");
+		}
+		Directory.CreateDirectory(_outside);
+		string outsideFile = Path.Combine(_outside, "protected.txt");
+		File.WriteAllText(outsideFile, "protected");
+		File.SetAttributes(outsideFile, FileAttributes.ReadOnly);
+		string nested = Path.Combine(_root, "repository", ".git", "modules");
+		Directory.CreateDirectory(nested);
+		CreateJunction(Path.Combine(nested, "linked"), _outside);
+
+		// Act
+		_deleter.Delete(_root);
+
+		// Assert
+		Directory.Exists(_root).Should().BeFalse(
+			because: "a user whose knowledge checkout contains a junction must still be able to delete the "
+				+ "cache; a bare recursive delete removes the junction and then throws, leaving the tree and "
+				+ "with it the 'not owned by Clio' dead end");
+		File.Exists(outsideFile).Should().BeTrue(
+			because: "unlinking a junction must never reach through to what it points at");
+		File.GetAttributes(outsideFile).HasFlag(FileAttributes.ReadOnly).Should().BeTrue(
+			because: "nothing behind the link is deleted, so nothing behind it may be modified either");
+	}
+
+	[Test]
+	[Description("Records that a bare recursive delete really does fail on a junction child, so a regression here is the platform's and not clio's.")]
+	public void RecursiveDelete_ShouldFail_OnAJunctionChild_WhichIsWhyTheDeleterUnlinksFirst() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("A junction is a Windows-only reparse tag.");
+		}
+		Directory.CreateDirectory(_outside);
+		Directory.CreateDirectory(_root);
+		CreateJunction(Path.Combine(_root, "linked"), _outside);
+
+		// Act
+		Exception captured = null;
+		try {
+			Directory.Delete(_root, recursive: true);
+		} catch (Exception exception) {
+			captured = exception;
+		}
+
+		// Assert
+		captured.Should().NotBeNull(
+			because: "the deleter unlinks reparse points up front only because the framework cannot handle a "
+				+ "junction child; if this ever starts succeeding the workaround can be reconsidered");
+		Directory.Exists(_root).Should().BeTrue(
+			because: "the framework removes the junction and then throws, so the tree is left behind - which "
+				+ "is exactly the failure a user sees as an undeletable knowledge cache");
 	}
 
 	private static void ForceDelete(string path) {

--- a/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterTests.cs
+++ b/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterTests.cs
@@ -12,9 +12,11 @@ using NUnit.Framework;
 namespace Clio.Tests.Command.McpServer;
 
 /// <summary>
-/// Substituted-file-system coverage. These assert the walk's invariants on every host, including one with
-/// no privilege to create a symbolic link — see <see cref="KnowledgeManagedTreeDeleterFileSystemTests"/>
-/// for the real-filesystem half.
+/// Substituted-file-system coverage, and the ONLY tier that runs on every push: <c>build.yml</c> filters
+/// the push/PR job to <c>Category!=Integration</c> and gates the Integration job on <c>pull_request</c>, so
+/// an invariant pinned only in <see cref="KnowledgeManagedTreeDeleterFileSystemTests"/> first executes in
+/// the unfiltered release lane. Anything load-bearing belongs here as well as there — a junction cost a
+/// release exactly that way.
 /// </summary>
 [TestFixture]
 [Category("Unit")]
@@ -44,6 +46,53 @@ public sealed class KnowledgeManagedTreeDeleterTests {
 				because: "Directory.Delete unlinks a reparse point instead of emptying it, so descending would "
 					+ "clear read-only bits on files outside the managed root that are never deleted - including "
 					+ "on a checkout Clio has just rejected as untrusted");
+	}
+
+	[Test]
+	[Description("Unlinks a directory reparse point during the walk instead of leaving it for the recursive delete.")]
+	public void Delete_ShouldUnlinkAReparsePointChild_BeforeTheRecursiveDelete() {
+		// Arrange
+		IDirectoryInfo link = Directory(LinkPath, FileAttributes.Directory | FileAttributes.ReparsePoint);
+		IDirectoryInfo plain = Directory(Root + "/plain", FileAttributes.Directory);
+		IDirectoryInfo root = Directory(Root, FileAttributes.Directory, children: [link, plain]);
+		IFileSystem fileSystem = FileSystemFor(root, link, plain);
+		IKnowledgeManagedTreeDeleter deleter = Resolve(fileSystem);
+
+		// Act
+		deleter.Delete(Root);
+
+		// Assert
+		link.ReceivedCalls()
+			.Should().Contain(call => call.GetMethodInfo().Name == nameof(IDirectoryInfo.Delete)
+					&& (bool)call.GetArguments()[0] == false,
+				because: "a recursive delete that meets a junction child unlinks it and then throws anyway, "
+					+ "leaving the tree - so the link has to be unlinked here, non-recursively, before the "
+					+ "recursive delete ever sees it");
+		plain.ReceivedCalls()
+			.Should().NotContain(call => call.GetMethodInfo().Name == nameof(IDirectoryInfo.Delete),
+				because: "only reparse points are unlinked individually; an ordinary subdirectory is left for "
+					+ "the recursive delete, which handles it and is far cheaper");
+	}
+
+	[Test]
+	[Description("Still attempts the recursive delete when unlinking a reparse point fails.")]
+	public void Delete_ShouldStillDelete_WhenUnlinkingAReparsePointThrows() {
+		// Arrange
+		IDirectoryInfo link = Directory(LinkPath, FileAttributes.Directory | FileAttributes.ReparsePoint);
+		link.When(info => info.Delete(false))
+			.Do(_ => throw new UnauthorizedAccessException("Access to the path 'linked' is denied."));
+		IDirectoryInfo root = Directory(Root, FileAttributes.Directory, children: [link]);
+		IFileSystem fileSystem = FileSystemFor(root, link);
+		IKnowledgeManagedTreeDeleter deleter = Resolve(fileSystem);
+
+		// Act
+		deleter.Delete(Root);
+
+		// Assert
+		fileSystem.Directory.ReceivedCalls()
+			.Should().Contain(call => call.GetMethodInfo().Name == nameof(IDirectory.Delete),
+				because: "clearing and unlinking are best effort: a link that cannot be removed is left for "
+					+ "the delete itself to report, exactly as an unresettable read-only file is");
 	}
 
 	[TestCase(FileAttributes.ReadOnly, true, TestName = "A plain read-only file is cleared")]

--- a/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterTests.cs
+++ b/clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterTests.cs
@@ -75,6 +75,37 @@ public sealed class KnowledgeManagedTreeDeleterTests {
 	}
 
 	[Test]
+	[Description("Descends into a reparse point that is not a link, so read-only files behind it are still cleared.")]
+	public void Delete_ShouldDescend_WhenAReparsePointIsNotALink() {
+		// Arrange
+		// The third tag class: a OneDrive Files-On-Demand placeholder, a ProjFS/Scalar root, WCI, DFS. The
+		// ReparsePoint bit is set but there is no link target, and the framework's recursive delete descends
+		// into it - so this walk must too, or a read-only *.pack inside keeps its attribute and the cache
+		// becomes undeletable for a different reason.
+		IFileInfo behind = Substitute.For<IFileInfo>();
+		behind.Attributes.Returns(FileAttributes.ReadOnly);
+		IDirectoryInfo placeholder = Directory(
+			LinkPath, FileAttributes.Directory | FileAttributes.ReparsePoint, files: [behind]);
+		placeholder.ResolveLinkTarget(Arg.Any<bool>()).Returns((IFileSystemInfo)null);
+		IDirectoryInfo root = Directory(Root, FileAttributes.Directory, children: [placeholder]);
+		IFileSystem fileSystem = FileSystemFor(root, placeholder);
+		IKnowledgeManagedTreeDeleter deleter = Resolve(fileSystem);
+
+		// Act
+		deleter.Delete(Root);
+
+		// Assert
+		placeholder.ReceivedCalls()
+			.Should().NotContain(call => call.GetMethodInfo().Name == nameof(IDirectoryInfo.Delete),
+				because: "a non-name-surrogate tag is not a link: unlinking it fails as not-empty, and the "
+					+ "framework descends into it rather than refusing it");
+		behind.ReceivedCalls()
+			.Should().Contain(call => call.GetMethodInfo().Name == "set_IsReadOnly",
+				because: "the recursive delete will reach this file, so its read-only bit has to be cleared - "
+					+ "skipping the whole directory is what leaves an undeletable cache behind a placeholder");
+	}
+
+	[Test]
 	[Description("Still attempts the recursive delete when unlinking a reparse point fails.")]
 	public void Delete_ShouldStillDelete_WhenUnlinkingAReparsePointThrows() {
 		// Arrange

--- a/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
+++ b/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
@@ -51,7 +51,10 @@ internal interface IKnowledgeManagedTreeDeleter {
 	/// unelevated, and the exception differs by host — <c>IOException</c> "The parameter is incorrect" or
 	/// <c>UnauthorizedAccessException</c> "Access to the path is denied" — so neither the privilege level nor
 	/// the exception type can be relied on. A directory <em>symlink</em> is handled natively and never triggers
-	/// it; unlinking every reparse point up front covers both shapes without inspecting reparse tags.</para>
+	/// it. A tag that is not a name surrogate at all — a OneDrive Files-On-Demand placeholder, a ProjFS root,
+	/// WCI, DFS — is neither: the framework descends into it, so this walk descends too and clears the
+	/// read-only bits inside, which is what keeps a read-only pack file behind a placeholder folder from
+	/// becoming another undeletable cache.</para>
 	/// <para>Clearing is best effort: a file that cannot be reset is left for the delete itself to report, so a
 	/// genuine permission problem still surfaces as one rather than being masked, or — worse — thrown from the
 	/// enumerator before the delete that would have succeeded is ever reached.</para>
@@ -148,11 +151,11 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 			string directoryPath = pending.Pop();
 			try {
 				IDirectoryInfo directory = _fileSystem.DirectoryInfo.New(directoryPath);
-				// LOAD-BEARING, not redundant. Since reparse-point children are unlinked below and never
-				// pushed, the only reparse points that reach this check are the root itself and one swapped in
-				// after enumeration - and a failed unlink is silent, so surviving links do occur. Removing this
-				// as unreachable would let the walk descend through them.
-				if (!directory.Exists || (directory.Attributes & FileAttributes.ReparsePoint) != 0) {
+				// LOAD-BEARING, not redundant. Since name-surrogate children are unlinked below and never
+				// pushed, the only links that reach this check are the root itself and one swapped in after
+				// enumeration - and a failed unlink is silent, so surviving links do occur. Removing this as
+				// unreachable would let the walk descend through them.
+				if (!directory.Exists || IsLink(directory)) {
 					continue;
 				}
 				// TopDirectoryOnly, NOT SearchOption.AllDirectories: the framework's recursive enumeration
@@ -164,7 +167,7 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 						case IFileInfo file:
 							ClearReadOnlyAttribute(file);
 							break;
-						case IDirectoryInfo child when (child.Attributes & FileAttributes.ReparsePoint) != 0:
+						case IDirectoryInfo child when IsLink(child):
 							// Unlinked HERE, not left for the recursive delete. Directory.Delete(recursive: true)
 							// throws when it meets a JUNCTION anywhere inside the tree - it removes the link and
 							// then fails anyway, leaving the tree behind. The exception varies by host
@@ -172,16 +175,13 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 							// the path is denied"), and it happens elevated as well as not, so neither the type
 							// nor the privilege level can be relied on.
 							//
-							// There are THREE tag classes here, not two, and the framework keys on the
-							// name-surrogate bit: it unlinks a SYMLINK natively, refuses a MOUNT POINT
-							// (junction) as above, and DESCENDS INTO a non-name-surrogate tag - a OneDrive
-							// Files-On-Demand placeholder, ProjFS/Scalar root, WCI, DFS. This branch attempts to
-							// unlink that third class too; the attempt fails with a not-empty error, is
-							// swallowed, and the framework then descends as it always did. Residual, accepted:
-							// read-only bits inside such a directory are never cleared, so a read-only *.pack
-							// behind a placeholder folder remains an undeletable cache. Narrowing this to
-							// name-surrogates only (ResolveLinkTarget is not null) would fix that and needs the
-							// substitutes updated - deliberately not done in a release-blocking change.
+							// THREE tag classes, not two, and the framework keys on the name-surrogate bit: it
+							// unlinks a SYMLINK natively, mishandles a MOUNT POINT (junction) as above, and
+							// DESCENDS INTO a non-name-surrogate tag - a OneDrive Files-On-Demand placeholder,
+							// a ProjFS/Scalar root, WCI, DFS. IsLink separates them, so this branch takes only
+							// the first two and the third falls through to be walked exactly as the framework
+							// walks it - otherwise a read-only *.pack behind a placeholder folder would keep
+							// its attribute and stay an undeletable cache.
 							UnlinkReparsePoint(child);
 							break;
 						case IDirectoryInfo child:
@@ -198,6 +198,20 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 				// A concurrent removal or an unreadable subtree. Leave it to the delete to report: clearing
 				// attributes must never be the step that fails an otherwise removable tree.
 			}
+		}
+	}
+
+	// TRUE for a link, FALSE for a reparse point that is not one. Measured: ResolveLinkTarget returns a
+	// target for a JUNCTION as well as a symbolic link, so this does not accidentally exclude the mount-point
+	// tag - which is the only one that actually breaks the recursive delete. A non-name-surrogate tag
+	// (OneDrive placeholder, ProjFS, WCI, DFS) returns null and must be descended into rather than unlinked.
+	// Throwing counts as "not a link": the walk then leaves it alone, which is the pre-existing behaviour.
+	private static bool IsLink(IDirectoryInfo directory) {
+		try {
+			return (directory.Attributes & FileAttributes.ReparsePoint) != 0
+				&& directory.ResolveLinkTarget(returnFinalTarget: false) is not null;
+		} catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+			return false;
 		}
 	}
 
@@ -218,7 +232,7 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 			// link in between and steer this delete outside the managed root. One stat closes the cheap half of
 			// that race; the rest needs handle-relative traversal the framework does not expose.
 			IDirectoryInfo current = _fileSystem.DirectoryInfo.New(link.FullName);
-			if ((current.Attributes & FileAttributes.ReparsePoint) == 0) {
+			if (!IsLink(current)) {
 				return;
 			}
 			current.Delete(recursive: false);

--- a/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
+++ b/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
@@ -14,6 +14,11 @@ internal interface IKnowledgeManagedTreeDeleter {
 	/// Removes the tree rooted at <paramref name="root"/> directly, and does nothing when it does not exist.
 	/// Read-only attributes are cleared first. Use <see cref="DeleteRecoverably"/> when a partially removed root
 	/// would make later retries impossible.
+	/// <para>Every directory reparse point inside the tree is <em>unlinked</em> before the delete is attempted —
+	/// see <see cref="DeleteRecoverably"/> for why. Unlike that method this one walks the LIVE root with no
+	/// rename, so the unlink applies to the caller's own tree and is not undone when the delete then fails: a
+	/// reported failure leaves the tree in place minus its links. Every current caller is discarding the tree
+	/// outright, which is the only reason that is acceptable.</para>
 	/// </summary>
 	/// <param name="root">Path of the tree to remove.</param>
 	void Delete(string root);
@@ -34,9 +39,11 @@ internal interface IKnowledgeManagedTreeDeleter {
 	/// <para>Read-only attributes are cleared before the delete. Git marks pack files (<c>*.pack</c>,
 	/// <c>*.idx</c>) read-only on creation and Windows refuses to delete a read-only file, so every Git
 	/// knowledge checkout contains files a plain recursive delete cannot remove.</para>
-	/// <para>The walk never descends into a directory reparse point, and skips a file that is one: nothing behind
-	/// a link is ever deleted, so clearing read-only bits there would mutate state outside the managed root —
-	/// including on a checkout Clio has just rejected as untrusted.</para>
+	/// <para>The walk never descends into a directory reparse point, and skips a file that is one: absent a local
+	/// process racing the walk, nothing behind a link is deleted or modified, so clearing read-only bits there
+	/// would mutate state outside the managed root — including on a checkout Clio has just rejected as
+	/// untrusted. The residual race is accepted: closing it needs handle-relative traversal the framework does
+	/// not expose.</para>
 	/// <para>Instead of skipping a directory reparse point, the walk <em>unlinks</em> it with a non-recursive
 	/// delete, which removes the link and leaves its target untouched. This is not tidiness: a recursive
 	/// <see cref="System.IO.Directory.Delete(string, bool)"/> that meets a <b>junction</b> anywhere inside the
@@ -141,6 +148,10 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 			string directoryPath = pending.Pop();
 			try {
 				IDirectoryInfo directory = _fileSystem.DirectoryInfo.New(directoryPath);
+				// LOAD-BEARING, not redundant. Since reparse-point children are unlinked below and never
+				// pushed, the only reparse points that reach this check are the root itself and one swapped in
+				// after enumeration - and a failed unlink is silent, so surviving links do occur. Removing this
+				// as unreachable would let the walk descend through them.
 				if (!directory.Exists || (directory.Attributes & FileAttributes.ReparsePoint) != 0) {
 					continue;
 				}
@@ -159,9 +170,18 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 							// then fails anyway, leaving the tree behind. The exception varies by host
 							// (IOException "The parameter is incorrect" / UnauthorizedAccessException "Access to
 							// the path is denied"), and it happens elevated as well as not, so neither the type
-							// nor the privilege level can be relied on. A directory SYMLINK is handled natively;
-							// only the mount-point tag breaks. Unlinking every reparse point up front is the one
-							// rule that covers both without inspecting tags.
+							// nor the privilege level can be relied on.
+							//
+							// There are THREE tag classes here, not two, and the framework keys on the
+							// name-surrogate bit: it unlinks a SYMLINK natively, refuses a MOUNT POINT
+							// (junction) as above, and DESCENDS INTO a non-name-surrogate tag - a OneDrive
+							// Files-On-Demand placeholder, ProjFS/Scalar root, WCI, DFS. This branch attempts to
+							// unlink that third class too; the attempt fails with a not-empty error, is
+							// swallowed, and the framework then descends as it always did. Residual, accepted:
+							// read-only bits inside such a directory are never cleared, so a read-only *.pack
+							// behind a placeholder folder remains an undeletable cache. Narrowing this to
+							// name-surrogates only (ResolveLinkTarget is not null) would fix that and needs the
+							// substitutes updated - deliberately not done in a release-blocking change.
 							UnlinkReparsePoint(child);
 							break;
 						case IDirectoryInfo child:
@@ -184,9 +204,24 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 	// A NON-recursive delete of a directory reparse point removes the link and never touches its target -
 	// verified, including that a read-only payload behind the link keeps its attribute. Best effort, like the
 	// rest of the walk: if the link survives, the delete that follows is what reports it.
-	private static void UnlinkReparsePoint(IDirectoryInfo link) {
+	//
+	// DESTROYING things inside a walk named "clear attributes" is sound for exactly one reason: every caller
+	// deletes this same root immediately afterwards (Delete, DeleteRecoverably, SweepAbandonedQuarantines), so
+	// nothing unlinked here was going to survive the call. That makes two refactors unsafe even though both
+	// look like improvements - reusing this walk in a NON-deleting context ("make a tree writable first"), and
+	// moving it BEFORE DeleteRecoverably's Move, which would turn a failed rename from "nothing happened" into
+	// an unrecoverable link-stripping of a tree that then survives.
+	private void UnlinkReparsePoint(IDirectoryInfo link) {
 		try {
-			link.Delete(recursive: false);
+			// Re-read the attribute rather than trusting the enumeration's cached FIND_DATA: the parent was
+			// re-opened by name after its own fresh check, so a local process can swap a plain directory for a
+			// link in between and steer this delete outside the managed root. One stat closes the cheap half of
+			// that race; the rest needs handle-relative traversal the framework does not expose.
+			IDirectoryInfo current = _fileSystem.DirectoryInfo.New(link.FullName);
+			if ((current.Attributes & FileAttributes.ReparsePoint) == 0) {
+				return;
+			}
+			current.Delete(recursive: false);
 		} catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
 			// Left for the delete to report, exactly as an unresettable read-only file is.
 		}

--- a/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
+++ b/clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
@@ -34,10 +34,17 @@ internal interface IKnowledgeManagedTreeDeleter {
 	/// <para>Read-only attributes are cleared before the delete. Git marks pack files (<c>*.pack</c>,
 	/// <c>*.idx</c>) read-only on creation and Windows refuses to delete a read-only file, so every Git
 	/// knowledge checkout contains files a plain recursive delete cannot remove.</para>
-	/// <para>The attribute walk does not descend into a directory symlink or junction, and skips a file that is
-	/// one. <see cref="System.IO.Directory.Delete(string, bool)"/> unlinks a name-surrogate reparse point rather
-	/// than emptying its target, so a walk that descended would clear read-only bits on files outside the
-	/// managed root that are never deleted — including on a checkout Clio has just rejected as untrusted.</para>
+	/// <para>The walk never descends into a directory reparse point, and skips a file that is one: nothing behind
+	/// a link is ever deleted, so clearing read-only bits there would mutate state outside the managed root —
+	/// including on a checkout Clio has just rejected as untrusted.</para>
+	/// <para>Instead of skipping a directory reparse point, the walk <em>unlinks</em> it with a non-recursive
+	/// delete, which removes the link and leaves its target untouched. This is not tidiness: a recursive
+	/// <see cref="System.IO.Directory.Delete(string, bool)"/> that meets a <b>junction</b> anywhere inside the
+	/// tree removes the link and then throws anyway, leaving the tree on disk. It fails elevated as well as
+	/// unelevated, and the exception differs by host — <c>IOException</c> "The parameter is incorrect" or
+	/// <c>UnauthorizedAccessException</c> "Access to the path is denied" — so neither the privilege level nor
+	/// the exception type can be relied on. A directory <em>symlink</em> is handled natively and never triggers
+	/// it; unlinking every reparse point up front covers both shapes without inspecting reparse tags.</para>
 	/// <para>Clearing is best effort: a file that cannot be reset is left for the delete itself to report, so a
 	/// genuine permission problem still surfaces as one rather than being masked, or — worse — thrown from the
 	/// enumerator before the delete that would have succeeded is ever reached.</para>
@@ -146,6 +153,17 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 						case IFileInfo file:
 							ClearReadOnlyAttribute(file);
 							break;
+						case IDirectoryInfo child when (child.Attributes & FileAttributes.ReparsePoint) != 0:
+							// Unlinked HERE, not left for the recursive delete. Directory.Delete(recursive: true)
+							// throws when it meets a JUNCTION anywhere inside the tree - it removes the link and
+							// then fails anyway, leaving the tree behind. The exception varies by host
+							// (IOException "The parameter is incorrect" / UnauthorizedAccessException "Access to
+							// the path is denied"), and it happens elevated as well as not, so neither the type
+							// nor the privilege level can be relied on. A directory SYMLINK is handled natively;
+							// only the mount-point tag breaks. Unlinking every reparse point up front is the one
+							// rule that covers both without inspecting tags.
+							UnlinkReparsePoint(child);
+							break;
 						case IDirectoryInfo child:
 							pending.Push(child.FullName);
 							break;
@@ -160,6 +178,17 @@ internal sealed class KnowledgeManagedTreeDeleter : IKnowledgeManagedTreeDeleter
 				// A concurrent removal or an unreadable subtree. Leave it to the delete to report: clearing
 				// attributes must never be the step that fails an otherwise removable tree.
 			}
+		}
+	}
+
+	// A NON-recursive delete of a directory reparse point removes the link and never touches its target -
+	// verified, including that a read-only payload behind the link keeps its attribute. Best effort, like the
+	// rest of the walk: if the link survives, the delete that follows is what reports it.
+	private static void UnlinkReparsePoint(IDirectoryInfo link) {
+		try {
+			link.Delete(recursive: false);
+		} catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+			// Left for the delete to report, exactly as an unresettable read-only file is.
 		}
 	}
 

--- a/docs/knowledge/McpServer/the-read-only-walk-must-stop-where-directory-delete-stops.md
+++ b/docs/knowledge/McpServer/the-read-only-walk-must-stop-where-directory-delete-stops.md
@@ -1,5 +1,5 @@
 ---
-description: KnowledgeManagedTreeDeleter clears read-only with manual TopDirectoryOnly recursion and skips reparse points, because SearchOption.AllDirectories descends through symlinks and junctions that Directory.Delete only unlinks
+description: KnowledgeManagedTreeDeleter clears read-only with manual TopDirectoryOnly recursion and UNLINKS directory reparse points rather than skipping them, because SearchOption.AllDirectories descends through links and because a recursive Directory.Delete cannot remove a tree containing a junction
 applies-to:
   - clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
   - clio/Command/McpServer/Knowledge/KnowledgeSourceInstallationStore.cs
@@ -10,13 +10,21 @@ date: 2026-08-30
 
 **What is true** — deleting a knowledge tree has to clear the read-only attribute first (Git creates
 `*.pack` / `*.idx` read-only and Windows refuses to delete a read-only file), and that walk must use manual
-recursion with `SearchOption.TopDirectoryOnly`, skipping any directory whose `ReparsePoint` bit is set.
-`Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)` is the wrong tool for this and looks
+recursion with `SearchOption.TopDirectoryOnly`, never descending into a directory whose `ReparsePoint` bit is
+set. `Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)` is the wrong tool for this and looks
 right: it binds `EnumerationOptions.CompatibleRecursive` (`AttributesToSkip = 0`,
 `IgnoreInaccessible = false`), so it **descends into directory symlinks and junctions** — verified on
-Windows: a file behind a symlinked subdirectory is enumerated. `Directory.Delete(path, recursive: true)`
-does the opposite and unlinks the reparse point. The walk therefore reaches strictly further than the
-delete it prepares for.
+Windows: a file behind a symlinked subdirectory is enumerated. Nothing behind a link is ever deleted, so
+clearing read-only bits there mutates state outside the managed root.
+
+A directory reparse point the walk meets is **unlinked**, not merely skipped — with a non-recursive delete,
+which removes the link and leaves its target alone. This record used to say the opposite ("`Directory.Delete`
+does the opposite and unlinks the reparse point, so the walk reaches strictly further than the delete"), and
+that sentence was wrong in the one direction that costs money: a recursive delete meeting a **junction**
+removes the link and then throws, leaving the tree undeletable. That false premise shipped and blocked a
+release. See
+[recursive-directory-delete-throws-on-a-junction-child.md](../platform/recursive-directory-delete-throws-on-a-junction-child.md)
+for the measured matrix.
 
 **Why it is this way** — the two consumers (`KnowledgeSourceInstallationStore`,
 `KnowledgeSourceManagementService`) share one `IKnowledgeManagedTreeDeleter` rather than a copied private

--- a/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
+++ b/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
@@ -53,11 +53,21 @@ privilege — but accepted deliberately rather than unnoticed.
 
 **Three tag classes, not two.** The framework keys on the name-surrogate bit: it unlinks a symlink natively,
 mishandles a mount point as above, and **descends into** a non-name-surrogate tag — a OneDrive
-Files-On-Demand placeholder, a ProjFS/Scalar root, WCI, DFS. Clio's walk attempts to unlink that third class
-too; the attempt fails as not-empty, is swallowed, and the framework descends as before. Residual: read-only
-bits inside such a directory are never cleared, so a read-only `*.pack` behind a placeholder folder is still
-an undeletable cache. Narrowing the unlink to name-surrogates (`ResolveLinkTarget is not null`) would close
-it.
+Files-On-Demand placeholder, a ProjFS/Scalar root, WCI, DFS. Clio separates them with
+`ResolveLinkTarget(returnFinalTarget: false) is not null`: the first two are unlinked, and the third is
+walked exactly as the framework walks it, so a read-only `*.pack` behind a placeholder folder still has its
+attribute cleared instead of becoming an undeletable cache for a different reason.
+
+**`ResolveLinkTarget` returns a target for a JUNCTION, not only for a symbolic link** — measured, both
+`LinkTarget` and `ResolveLinkTarget`. That is what makes the split above usable: gating on it does not
+accidentally exclude the mount-point tag, which is the only one that actually breaks the delete. It also
+answers a question about a different guard: `OutputPathConfinement.IsReparsePoint` is implemented over
+`LinkTarget`, so `mklink /J` does **not** slip past the write-confinement check.
+
+**A substituted `IDirectoryInfo` does not return null here.** `ResolveLinkTarget` returns an interface, and
+NSubstitute auto-substitutes interface return types — so a mock link looks like a link without being
+configured, and a test for the non-link class must set `ResolveLinkTarget` to null explicitly. Assuming the
+default is null is how that branch ends up unpinned.
 
 **What breaks if you ignore it** — a user whose knowledge checkout contains a junction cannot delete the
 cache at all, and the error names only `'linked'`. Because the source is unregistered while its cache

--- a/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
+++ b/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
@@ -1,0 +1,47 @@
+---
+description: Directory.Delete(path, recursive true) on .NET 10 Windows throws when the tree contains a JUNCTION child - it unlinks the junction and then fails anyway, leaving the tree; a directory symlink is handled natively, the failure is not elevation-dependent, and the exception type varies by host
+applies-to:
+  - clio/Command/McpServer/Knowledge/KnowledgeManagedTreeDeleter.cs
+  - clio.tests/Command/McpServer/KnowledgeManagedTreeDeleterFileSystemTests.cs
+ticket: ENG-96211
+date: 2026-08-31
+---
+
+**What is true** — measured on .NET 10 / Windows, three runs of each shape:
+
+| tree | `Directory.Delete(root, recursive: true)` |
+|---|---|
+| contains a **junction** child, any depth | **throws**; the junction is unlinked, the root survives |
+| the path **is** a junction | succeeds; unlinked, target untouched |
+| contains a directory **symlink** child | succeeds |
+| contains a file **symlink** child | succeeds |
+
+Three details decide how you may react to it, and each one contradicts the obvious guess:
+
+- **It is not an elevation problem.** It fails identically in an elevated process. Do not write "when
+  non-elevated" — that tells the next reader an elevated machine is safe.
+- **The exception type is not stable.** A self-hosted release runner produced
+  `UnauthorizedAccessException: Access to the path 'linked' is denied`; a developer workstation produced
+  `IOException: The parameter is incorrect. : 'linked'`. Never key a catch or an assertion on the type.
+- **The junction is already gone when it throws.** So a bare "retry once" appears to work. Do not do that: a
+  retry after a partial delete is precisely the non-atomic behaviour `DeleteRecoverably` renames the tree to
+  avoid.
+
+The supported reaction is to unlink directory reparse points yourself, up front, with a **non-recursive**
+delete — which removes the link and leaves the target and its attributes untouched (verified) — so the
+recursive delete never meets one. `KnowledgeManagedTreeDeleter` does this during the read-only walk it
+already performs, which costs nothing extra.
+
+**Why it is this way** — a junction carries `IO_REPARSE_TAG_MOUNT_POINT`, the same tag as a volume mount
+point, while a symlink carries `IO_REPARSE_TAG_SYMLINK`. The framework's recursive delete distinguishes the
+two and refuses the mount-point tag rather than risk deleting through a mounted volume. Clio cannot tell it
+that a knowledge checkout's junction is not a mounted volume, so clio removes the link before asking.
+
+**What breaks if you ignore it** — a user whose knowledge checkout contains a junction cannot delete the
+cache at all, and the error names only `'linked'`. Because the source is unregistered while its cache
+survives, the next `add-knowledge-source` for that alias is refused with "not owned by Clio" — the dead end
+the whole deletion path was rebuilt to remove. It reached a release: the test that covers this branch chose
+a symlink whenever the privilege was available, so every developer machine with elevation or Developer Mode
+ran the easy shape and the release runner was the first host to execute the junction path. The fixture now
+always creates a junction on Windows for exactly that reason — if you make that helper "prefer" anything,
+you restore the lottery.

--- a/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
+++ b/docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md
@@ -7,7 +7,9 @@ ticket: ENG-96211
 date: 2026-08-31
 ---
 
-**What is true** — measured on .NET 10 / Windows, three runs of each shape:
+**What is true** — measured on .NET 10 / Windows, three runs of each shape. Note the scope: `clio.tests`
+targets net10.0 only, while `clio` ships net8.0 **and** net10.0, so a .NET 10 servicing fix does not release
+clio from the workaround — the lowest shipped target framework has to cope first.
 
 | tree | `Directory.Delete(root, recursive: true)` |
 |---|---|
@@ -32,10 +34,30 @@ delete — which removes the link and leaves the target and its attributes untou
 recursive delete never meets one. `KnowledgeManagedTreeDeleter` does this during the read-only walk it
 already performs, which costs nothing extra.
 
-**Why it is this way** — a junction carries `IO_REPARSE_TAG_MOUNT_POINT`, the same tag as a volume mount
-point, while a symlink carries `IO_REPARSE_TAG_SYMLINK`. The framework's recursive delete distinguishes the
-two and refuses the mount-point tag rather than risk deleting through a mounted volume. Clio cannot tell it
-that a knowledge checkout's junction is not a mounted volume, so clio removes the link before asking.
+**Why it is this way — and it is a bug, not a safety refusal.** A junction carries
+`IO_REPARSE_TAG_MOUNT_POINT`, the same tag as a volume mount point; a symlink carries
+`IO_REPARSE_TAG_SYMLINK`. For the mount-point tag the recursive delete first attempts an unmount via
+`DeleteVolumeMountPoint`. On an ordinary junction — which is not a mounted folder — that call fails and does
+nothing; the error is latched, `RemoveDirectory` still removes the link, and the latched error is thrown at
+the end. That is exactly the signature above: junction gone, tree left, message differing by host. It is
+[dotnet/runtime#86249](https://github.com/dotnet/runtime/issues/86249), open with an active fix, alongside
+the older [#23646](https://github.com/dotnet/runtime/issues/23646) on the missing name-surrogate check. Do
+not describe it as the framework protecting mounted volumes — it isn't, and believing that stops you
+checking what clio's replacement does.
+
+**What the replacement does NOT inherit.** `Directory.Delete(link, recursive: false)` is a bare
+`RemoveDirectory`: it never calls `DeleteVolumeMountPoint`. So for a *genuine* mounted folder inside the
+managed tree, clio strips the mount-point path without dismounting, leaving the volume mounted with no path.
+**Accepted**, because a mounted folder cannot arrive from remote checkout content — it needs local mount
+privilege — but accepted deliberately rather than unnoticed.
+
+**Three tag classes, not two.** The framework keys on the name-surrogate bit: it unlinks a symlink natively,
+mishandles a mount point as above, and **descends into** a non-name-surrogate tag — a OneDrive
+Files-On-Demand placeholder, a ProjFS/Scalar root, WCI, DFS. Clio's walk attempts to unlink that third class
+too; the attempt fails as not-empty, is swallowed, and the framework descends as before. Residual: read-only
+bits inside such a directory are never cleared, so a read-only `*.pack` behind a placeholder folder is still
+an undeletable cache. Narrowing the unlink to name-surrogates (`ResolveLinkTarget is not null`) would close
+it.
 
 **What breaks if you ignore it** — a user whose knowledge checkout contains a junction cannot delete the
 cache at all, and the error names only `'linked'`. Because the source is unregistered while its cache


### PR DESCRIPTION
Unblocks `release-to-nuget` for **8.1.0.115**, which failed twice deterministically on `Delete_ShouldNotClearReadOnlyBeyondADirectoryReparsePoint`.

The failing test was not wrong. It found a real product bug.

## The bug

`Directory.Delete(path, recursive: true)` on .NET 10 / Windows **throws when the tree contains a junction child** — it unlinks the junction and then fails anyway, leaving the tree on disk.

So a user whose knowledge checkout contains a junction cannot delete the cache at all. And because the source is unregistered while its cache survives, the next `add-knowledge-source` for that alias is refused with *"not owned by Clio"* — the dead end this whole deletion path was rebuilt to remove.

Measured on this workstation, three runs of each shape:

| tree | `Directory.Delete(root, recursive: true)` |
|---|---|
| contains a **junction** child, any depth | **throws**; junction unlinked, root survives |
| the path **is** a junction | succeeds; target untouched |
| contains a directory **symlink** child | succeeds |
| contains a file **symlink** child | succeeds |

## Three facts that shaped the fix, each against the obvious guess

- **Not an elevation problem.** It fails identically in an elevated process. Anything that says "when non-elevated" tells the next reader an elevated machine is safe.
- **The exception type is not stable.** The release runner reported `UnauthorizedAccessException: Access to the path 'linked' is denied`; this workstation reports `IOException: The parameter is incorrect. : 'linked'`. Nothing may key on the type.
- **The junction is already gone when it throws**, so a bare "retry once" appears to work. That would reintroduce exactly the non-atomic behaviour `DeleteRecoverably` renames the tree to avoid.

## The fix

The read-only walk already visits every directory, so it now **unlinks** a directory reparse point with a non-recursive delete instead of skipping it. That removes the link and leaves its target and attributes untouched (verified), and the recursive delete never meets one. No tag inspection, so it covers both junctions and symlinks.

## Why a release runner found this and no developer machine did

The fixture helper chose a symbolic link whenever the privilege was available. On an elevated or Developer-Mode host that meant the **symlink** shape ran — the one recursive delete handles natively — so the junction branch first executed on the release runner, in a release.

The helper is now deterministic per platform: **Windows always gets a junction**, which needs no privilege, so every Windows machine exercises the hard case. A second test pins the platform behaviour itself, so a future regression here is attributed to the framework rather than to clio.

## Verification

**Mutation:** with the unlink disabled, both junction tests fail with the same error the release run reported (`IOException: The parameter is incorrect. : 'linked'`) — so they pin the fix rather than passing either way.

| | |
|---|---|
| `Category=Unit` (the release lane's filter) | 9997 passed, 0 failed |
| `Category=Unit&Module=McpServer` | 3935 passed |
| `Category=Integration` | 47 passed |
| deleter fixture / unit twin | 5/5 · 17/17 |
| `make check-knowledge` | 138 records resolve |

Knowledge record added: `docs/knowledge/platform/recursive-directory-delete-throws-on-a-junction-child.md`, including the three counter-intuitive facts above so the next reader does not re-derive them.

Related: ENG-96211, [#1264](https://github.com/Advance-Technologies-Foundation/clio/pull/1264) (where the test came from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
