### PR TITLE
Allow deploy-creatio to select an available configured port

### DIFF
--- a/clio.mcp.e2e/DeployCreatioToolE2ETests.cs
+++ b/clio.mcp.e2e/DeployCreatioToolE2ETests.cs
@@ -56,13 +56,15 @@ public sealed class DeployCreatioToolE2ETests : McpContractFixtureBase
 			because: "the deploy-creatio contract description should tell the agent to review full infrastructure first");
 		contract.Description.Should().Contain("show-passing-infrastructure",
 			because: "the deploy-creatio contract description should tell the agent to fetch deployable recommendations second");
-		contract.Description.Should().Contain("reserves and revalidates sitePort",
-			because: "the real discovery contract should disclose command-level concurrent IIS port protection");
+		contract.Description.Should().Contain("deploy-creatio-defaults.site-port-range",
+			because: "the real discovery contract should disclose automatic IIS port allocation");
 		contract.Description.Should().Contain("existing forced-password-change state",
 			because: "the real MCP contract should disclose the preserved database behavior used by Ring");
 		contract.InputSchema.Properties.Select(property => property.Name).Should().BeEquivalentTo(
 			["siteName", "zipFile", "sitePort", "dbServerName", "redisServerName", "useHttps"],
 			because: "the full deploy-creatio contract should only expose the six approved arguments");
+		contract.InputSchema.Required.Should().Equal(new[] { "siteName", "zipFile" },
+			because: "sitePort must be optional so the real MCP server can use the configured IIS range");
 		contract.InputSchema.Properties.Single(property => property.Name == "useHttps").Description.Should()
 			.Contain("falls back to HTTP",
 				because: "agents need the non-failing HTTPS fallback contract before invoking deployment");

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -45,6 +45,9 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		JsonObject appSettings = new() {
 			["Autoupdate"] = false,
 			["iis-clio-root-path"] = _iisRoot,
+			["deploy-creatio-defaults"] = new JsonObject {
+				["site-port-range"] = new JsonArray(40100, 40199)
+			},
 			["dbhub"] = new JsonObject {
 				["enabled"] = true,
 				["config-path"] = dbHubConfig,
@@ -172,6 +175,51 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 				because: "pre-mutation port collisions must still publish the deploy manifest");
 			events[^1].RunCompleted!.Outcome.Should().Be(ClioStageEventContract.RunOutcomes.Failure,
 				because: "the occupied port must terminate the typed progress stream as failure");
+		}
+		finally {
+			File.Delete(corruptZipFile);
+		}
+	}
+
+	[Test]
+	[Description("Invokes deploy-creatio without sitePort and verifies the real MCP command selects a configured-range IIS port before failing non-destructively at corrupt archive extraction.")]
+	[AllureTag(ToolName)]
+	[AllureName("Deploy creatio automatically reserves a configured-range IIS port")]
+	public async Task DeployCreatio_Should_Select_Configured_Range_Port_When_SitePort_Is_Omitted() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("IIS automatic port selection is Windows-specific.");
+		}
+		await using ArrangeContext arrangeContext = Arrange();
+		string siteName = $"automatic-port-{Guid.NewGuid():N}";
+		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
+		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive",
+			arrangeContext.CancellationTokenSource.Token);
+
+		try {
+			// Act
+			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["siteName"] = siteName,
+						["zipFile"] = corruptZipFile,
+						["dbServerName"] = "e2e-unused-before-unzip"
+					}
+				},
+				arrangeContext.CancellationTokenSource.Token);
+			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
+
+			// Assert
+			execution.ExitCode.Should().NotBe(0,
+				because: "the corrupt archive keeps this automatic-port E2E path non-destructive");
+			execution.Output.Should().Contain(message => message.Value != null
+				&& message.Value.Contains("first available in configured range [40100, 40199]", StringComparison.Ordinal),
+				because: "the real MCP process must disclose the automatically reserved configured-range port");
+			execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+				because: "the corrupt archive failure must remain a structured error outcome");
+			Directory.Exists(Path.Combine(_iisRoot, siteName)).Should().BeFalse(
+				because: "the corrupt archive must fail before a deployment directory or IIS site is created");
 		}
 		finally {
 			File.Delete(corruptZipFile);
@@ -387,6 +435,10 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 	private static async Task<ProgressToken> InvokeCorruptArchiveDeployAsync(ArrangeContext arrangeContext) {
 		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
 		ProgressToken progressToken = new($"clio-mcp-e2e-{Guid.NewGuid():N}");
+		using TcpListener listener = new(IPAddress.Loopback, 0);
+		listener.Start();
+		int sitePort = ((IPEndPoint)listener.LocalEndpoint).Port;
+		listener.Stop();
 		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive",
 			arrangeContext.CancellationTokenSource.Token);
 		try {
@@ -396,7 +448,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 					["args"] = new Dictionary<string, object?> {
 						["siteName"] = $"e2e-{Guid.NewGuid():N}",
 						["zipFile"] = corruptZipFile,
-						["sitePort"] = 5011,
+						["sitePort"] = sitePort,
 						// Cross the FakeKubernetes/no-defaults preflight on clean CI agents. The corrupt
 						// archive fails at unzip before this deliberately nonexistent server is resolved.
 						["dbServerName"] = "e2e-unused-before-unzip"

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Net;
 using System.Net.Sockets;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Progress;
@@ -192,7 +193,8 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 		if (!OperatingSystem.IsWindows()) {
 			Assert.Ignore("IIS automatic port selection is Windows-specific.");
 		}
-		await using ArrangeContext arrangeContext = Arrange();
+		await using ArrangeContext arrangeContext = AllureApi.Step(
+			"Arrange an MCP session for automatic IIS port selection", () => Arrange());
 		string siteName = $"automatic-port-{Guid.NewGuid():N}";
 		string corruptZipFile = Path.Combine(Path.GetTempPath(), $"corrupt-creatio-{Guid.NewGuid():N}.zip");
 		await File.WriteAllTextAsync(corruptZipFile, "not a zip archive",
@@ -200,28 +202,34 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 
 		try {
 			// Act
-			CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-				ToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["siteName"] = siteName,
-						["zipFile"] = corruptZipFile,
-						["dbServerName"] = "e2e-unused-before-unzip"
-					}
-				},
-				arrangeContext.CancellationTokenSource.Token);
+			CallToolResult callResult = await AllureApi.Step(
+				"Invoke deploy-creatio without sitePort",
+				async () => await arrangeContext.Session.CallToolAsync(
+					ToolName,
+					new Dictionary<string, object?> {
+						["args"] = new Dictionary<string, object?> {
+							["siteName"] = siteName,
+							["zipFile"] = corruptZipFile,
+							["dbServerName"] = "e2e-unused-before-unzip"
+						}
+					},
+					arrangeContext.CancellationTokenSource.Token));
 			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
 
 			// Assert
-			execution.ExitCode.Should().NotBe(0,
-				because: "the corrupt archive keeps this automatic-port E2E path non-destructive");
-			execution.Output.Should().Contain(message => message.Value != null
-				&& message.Value.Contains("first available in configured range [40100, 40199]", StringComparison.Ordinal),
-				because: "the real MCP process must disclose the automatically reserved configured-range port");
-			execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
-				because: "the corrupt archive failure must remain a structured error outcome");
-			Directory.Exists(Path.Combine(_iisRoot, siteName)).Should().BeFalse(
-				because: "the corrupt archive must fail before a deployment directory or IIS site is created");
+			AllureApi.Step("Assert the corrupt archive keeps deployment non-destructive", () =>
+				execution.ExitCode.Should().NotBe(0,
+					because: "the corrupt archive keeps this automatic-port E2E path non-destructive"));
+			AllureApi.Step("Assert the configured-range port was selected", () =>
+				execution.Output.Should().Contain(message => message.Value != null
+					&& message.Value.Contains("first available in configured range [40100, 40199]", StringComparison.Ordinal),
+					because: "the real MCP process must disclose the automatically reserved configured-range port"));
+			AllureApi.Step("Assert the archive failure remains structured", () =>
+				execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+					because: "the corrupt archive failure must remain a structured error outcome"));
+			AllureApi.Step("Assert no deployment directory or IIS site was created", () =>
+				Directory.Exists(Path.Combine(_iisRoot, siteName)).Should().BeFalse(
+					because: "the corrupt archive must fail before a deployment directory or IIS site is created"));
 		}
 		finally {
 			File.Delete(corruptZipFile);

--- a/clio.mcp.e2e/DeployUninstallProgressTests.cs
+++ b/clio.mcp.e2e/DeployUninstallProgressTests.cs
@@ -125,6 +125,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 	[Description("Invokes deploy-creatio while a real TCP listener owns the requested port and verifies the command fails before creating the deployment directory.")]
 	[AllureTag(ToolName)]
 	[AllureName("Deploy creatio rejects an occupied port before mutation")]
+	[AllureDescription("Uses an isolated real MCP process and a loopback listener to prove explicit IIS port collisions fail before any deployment directory is created.")]
 	public async Task DeployCreatio_Should_Fail_Before_Mutation_When_Port_Is_Occupied() {
 		// Arrange
 		if (!OperatingSystem.IsWindows()) {
@@ -185,6 +186,7 @@ public sealed class DeployUninstallProgressTests : McpContractFixtureBase {
 	[Description("Invokes deploy-creatio without sitePort and verifies the real MCP command selects a configured-range IIS port before failing non-destructively at corrupt archive extraction.")]
 	[AllureTag(ToolName)]
 	[AllureName("Deploy creatio automatically reserves a configured-range IIS port")]
+	[AllureDescription("Omits sitePort over the real MCP transport and uses a corrupt archive to prove configured-range selection without completing a destructive deployment.")]
 	public async Task DeployCreatio_Should_Select_Configured_Range_Port_When_SitePort_Is_Omitted() {
 		// Arrange
 		if (!OperatingSystem.IsWindows()) {

--- a/clio.tests/Command/CliOptionNamingBackwardCompatibilityTests.cs
+++ b/clio.tests/Command/CliOptionNamingBackwardCompatibilityTests.cs
@@ -1234,6 +1234,48 @@ internal sealed class CliOptionNamingBackwardCompatibilityTests {
 		PfInstallerOptions? opts = null;
 		result.WithParsed(o => opts = o);
 		opts!.SitePort.Should().Be(8080, because: "new --site-port must map to the SitePort property");
+		opts.SitePortWasSpecified.Should().BeTrue(
+			because: "the parser must preserve that a valid exact-port override was explicitly supplied");
+	}
+
+	[Test]
+	[Description("Omitting --site-port remains distinguishable from explicitly passing zero.")]
+	public void PfInstallerOptions_SitePort_Omission_DoesNotMarkPortAsSpecified() {
+		// Arrange
+		string[] arguments = ["--site-name", "mysite"];
+
+		// Act
+		ParserResult<PfInstallerOptions> result = Parser.Default.ParseArguments<PfInstallerOptions>(arguments);
+		PfInstallerOptions? options = null;
+		result.WithParsed(parsed => options = parsed);
+
+		// Assert
+		result.Tag.Should().Be(ParserResultType.Parsed,
+			because: "site-port is optional for automatic configured-range selection");
+		options!.SitePort.Should().Be(0,
+			because: "the existing unset sentinel remains zero for downstream defaults resolution");
+		options.SitePortWasSpecified.Should().BeFalse(
+			because: "omission must select defaults rather than trigger exact-port validation");
+	}
+
+	[Test]
+	[Description("Explicitly passing --site-port 0 marks it as supplied so deployment can reject the invalid exact override.")]
+	public void PfInstallerOptions_SitePort_ExplicitZeroMarksPortAsSpecified() {
+		// Arrange
+		string[] arguments = ["--site-port", "0"];
+
+		// Act
+		ParserResult<PfInstallerOptions> result = Parser.Default.ParseArguments<PfInstallerOptions>(arguments);
+		PfInstallerOptions? options = null;
+		result.WithParsed(parsed => options = parsed);
+
+		// Assert
+		result.Tag.Should().Be(ParserResultType.Parsed,
+			because: "range validation belongs to deployment rather than the generic parser");
+		options!.SitePort.Should().Be(0,
+			because: "the exact invalid value must reach deployment validation unchanged");
+		options.SitePortWasSpecified.Should().BeTrue(
+			because: "explicit zero must not fall back to automatic port selection");
 	}
 
 	[Test]

--- a/clio.tests/Command/ConfigCommandTests.cs
+++ b/clio.tests/Command/ConfigCommandTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Clio.Command;
 using Clio.Common;
 using Clio.UserEnvironment;
@@ -121,6 +123,39 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 		result.Should().Be(0, because: "a valid set operation succeeds");
 		_settingsRepository.Received(1).SetDeployCreatioDefaults(
 			Arg.Is<DeployCreatioDefaults>(d => d.SitePort == 40018));
+	}
+
+	[Test]
+	[Description("Persists a valid inclusive site-port range and clears a fixed port so automatic selection becomes effective.")]
+	public void Execute_ShouldPersistSitePortRangeAndClearFixedPort_WhenRangeSupplied() {
+		// Arrange
+		_settingsRepository.GetDeployCreatioDefaults()
+			.Returns(new DeployCreatioDefaults { SitePort = 40018 });
+		ConfigOptions options = new() { DeploySitePortRange = [41000, 41010] };
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "a valid inclusive range should be accepted");
+		_settingsRepository.Received(1).SetDeployCreatioDefaults(
+			Arg.Is<DeployCreatioDefaults>(defaults => defaults.SitePort == null
+				&& defaults.SitePortRange.SequenceEqual(new[] { 41000, 41010 })));
+	}
+
+	[TestCaseSource(nameof(InvalidSitePortRanges))]
+	[Description("Rejects site-port ranges that do not contain exactly two ordered valid TCP ports.")]
+	public void Execute_ShouldReturnError_WhenSitePortRangeInvalid(int[] range) {
+		// Arrange
+		ConfigOptions options = new() { DeploySitePortRange = range };
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		result.Should().Be(1, because: "invalid ranges must fail before settings are persisted");
+		_settingsRepository.DidNotReceive().SetDeployCreatioDefaults(Arg.Any<DeployCreatioDefaults>());
+		_logger.Received().WriteError(Arg.Is<string>(message => message.Contains("1 <= start <= end <= 65535")));
 	}
 
 	[Test]
@@ -251,5 +286,12 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 		// Assert
 		result.Should().Be(1, because: "invalid feedback policy must not be persisted as success");
 		_logger.Received(1).WriteError("Invalid feedback policy.");
+	}
+
+	private static IEnumerable<int[]> InvalidSitePortRanges() {
+		yield return [40100];
+		yield return [40199, 40100];
+		yield return [0, 40100];
+		yield return [40100, 65536];
 	}
 }

--- a/clio.tests/Command/ConfigCommandTests.cs
+++ b/clio.tests/Command/ConfigCommandTests.cs
@@ -53,8 +53,8 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 	}
 
 	[Test]
-	[Description("Clears the stored deploy-creatio defaults when --reset is supplied.")]
-	public void Execute_ShouldClearDefaults_WhenResetSupplied() {
+	[Description("Clears custom deploy-creatio defaults and restores the built-in site-port range when --reset is supplied.")]
+	public void Execute_ShouldRestoreBuiltInDefaults_WhenResetSupplied() {
 		// Arrange
 		ConfigOptions options = new() { Reset = true };
 
@@ -63,12 +63,13 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 
 		// Assert
 		result.Should().Be(0, because: "resetting the configuration always succeeds");
-		_settingsRepository.Received(1).SetDeployCreatioDefaults(null);
+		_settingsRepository.Received(1).SetDeployCreatioDefaults(
+			Arg.Is<DeployCreatioDefaults>(defaults => defaults.SitePortRange.SequenceEqual(new[] { 40100, 40199 })));
 	}
 
 	[Test]
-	[Description("Reset takes precedence over set arguments supplied in the same call.")]
-	public void Execute_ShouldClearDefaults_WhenResetAndSetArgumentsSupplied() {
+	[Description("Reset restores built-ins and takes precedence over set arguments supplied in the same call.")]
+	public void Execute_ShouldRestoreBuiltIns_WhenResetAndSetArgumentsSupplied() {
 		// Arrange
 		ConfigOptions options = new() { Reset = true, DeployDbServerName = "my-local-postgres" };
 
@@ -77,8 +78,9 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 
 		// Assert
 		result.Should().Be(0, because: "reset wins over set arguments and always succeeds");
-		_settingsRepository.Received(1).SetDeployCreatioDefaults(null);
-		_settingsRepository.DidNotReceive().SetDeployCreatioDefaults(Arg.Is<DeployCreatioDefaults>(d => d != null));
+		_settingsRepository.Received(1).SetDeployCreatioDefaults(
+			Arg.Is<DeployCreatioDefaults>(defaults => defaults.DbServerName == null
+				&& defaults.SitePortRange.SequenceEqual(new[] { 40100, 40199 })));
 	}
 
 	[Test]
@@ -140,6 +142,26 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 		result.Should().Be(0, because: "a valid inclusive range should be accepted");
 		_settingsRepository.Received(1).SetDeployCreatioDefaults(
 			Arg.Is<DeployCreatioDefaults>(defaults => defaults.SitePort == null
+				&& defaults.SitePortRange.SequenceEqual(new[] { 41000, 41010 })));
+	}
+
+	[Test]
+	[Description("Keeps a fixed site port active when fixed and range defaults are configured together.")]
+	public void Execute_ShouldPreferFixedSitePort_WhenFixedPortAndRangeSupplied() {
+		// Arrange
+		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults());
+		ConfigOptions options = new() {
+			DeploySitePort = 40018,
+			DeploySitePortRange = [41000, 41010]
+		};
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "both valid defaults can be persisted together");
+		_settingsRepository.Received(1).SetDeployCreatioDefaults(
+			Arg.Is<DeployCreatioDefaults>(defaults => defaults.SitePort == 40018
 				&& defaults.SitePortRange.SequenceEqual(new[] { 41000, 41010 })));
 	}
 

--- a/clio.tests/Command/ConfigCommandTests.cs
+++ b/clio.tests/Command/ConfigCommandTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Clio.Command;
 using Clio.Common;
 using Clio.UserEnvironment;
+using CommandLine;
 using ConsoleTables;
 using FluentAssertions;
 using NSubstitute;
@@ -125,6 +126,28 @@ public sealed class ConfigCommandTests : BaseCommandTests<ConfigOptions> {
 		result.Should().Be(0, because: "a valid set operation succeeds");
 		_settingsRepository.Received(1).SetDeployCreatioDefaults(
 			Arg.Is<DeployCreatioDefaults>(d => d.SitePort == 40018));
+	}
+
+	[Test]
+	[Description("Treats the parser's empty site-port range collection as an omitted option.")]
+	public void Execute_ShouldPersistSitePort_WhenParsedRangeOptionIsOmitted() {
+		// Arrange
+		ParserResult<ConfigOptions> parseResult = Parser.Default.ParseArguments<ConfigOptions>(
+			["--deploy-site-port", "40155"]);
+		ConfigOptions options = ((Parsed<ConfigOptions>)parseResult).Value;
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		parseResult.Tag.Should().Be(ParserResultType.Parsed,
+			because: "the regression must exercise the options produced by the real command-line parser");
+		options.DeploySitePortRange.Should().BeEmpty(
+			because: "the parser represents an omitted enumerable option with an empty collection");
+		result.Should().Be(0,
+			because: "an omitted range must not invalidate an otherwise valid fixed-port update");
+		_settingsRepository.Received(1).SetDeployCreatioDefaults(
+			Arg.Is<DeployCreatioDefaults>(defaults => defaults.SitePort == 40155));
 	}
 
 	[Test]

--- a/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
+++ b/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
@@ -187,6 +187,26 @@ public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 	}
 
 	[Test]
+	[Description("Keeps an explicit command-line site port ahead of both configured fixed and range defaults.")]
+	public void ApplyDefaults_ShouldPreferExplicitSitePort_WhenAllPortDefaultsConfigured() {
+		// Arrange
+		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults {
+			SitePort = 40018,
+			SitePortRange = [40100, 40199]
+		});
+		PfInstallerOptions options = new() { SitePort = 40004 };
+
+		// Act
+		_sut.ApplyDefaults(options);
+
+		// Assert
+		options.SitePort.Should().Be(40004,
+			because: "an explicit command-line override must remain the selected exact port");
+		options.SitePortRange.Should().BeNull(
+			because: "automatic allocation stays inactive when an explicit port is supplied");
+	}
+
+	[Test]
 	[Description("Overrides the parser 'auto' deployment default with the configured deployment method.")]
 	public void ApplyDefaults_ShouldOverrideAutoDeployment_WhenDefaultConfigured() {
 		// Arrange

--- a/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
+++ b/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
@@ -146,6 +146,47 @@ public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 	}
 
 	[Test]
+	[Description("Copies the configured site-port range when neither an explicit nor fixed default site port is present.")]
+	public void ApplyDefaults_ShouldFillSitePortRange_WhenSitePortUnset() {
+		// Arrange
+		int[] configuredRange = [40100, 40199];
+		_settingsRepository.GetDeployCreatioDefaults()
+			.Returns(new DeployCreatioDefaults { SitePortRange = configuredRange });
+		PfInstallerOptions options = new() { SitePort = 0 };
+
+		// Act
+		_sut.ApplyDefaults(options);
+
+		// Assert
+		options.SitePort.Should().Be(0,
+			because: "automatic allocation happens only when IIS deployment owns the reservation boundary");
+		options.SitePortRange.Should().Equal(new[] { 40100, 40199 },
+			because: "the configured inclusive range must reach the deployment service");
+		options.SitePortRange.Should().NotBeSameAs(configuredRange,
+			because: "command options must not expose the mutable settings-owned array");
+	}
+
+	[Test]
+	[Description("Keeps the configured fixed site port ahead of site-port-range for backward compatibility.")]
+	public void ApplyDefaults_ShouldPreferFixedSitePort_WhenFixedPortAndRangeConfigured() {
+		// Arrange
+		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults {
+			SitePort = 40018,
+			SitePortRange = [40100, 40199]
+		});
+		PfInstallerOptions options = new();
+
+		// Act
+		_sut.ApplyDefaults(options);
+
+		// Assert
+		options.SitePort.Should().Be(40018,
+			because: "existing configured fixed ports must retain precedence over automatic allocation");
+		options.SitePortRange.Should().BeNull(
+			because: "the range is inactive when a fixed port was resolved");
+	}
+
+	[Test]
 	[Description("Overrides the parser 'auto' deployment default with the configured deployment method.")]
 	public void ApplyDefaults_ShouldOverrideAutoDeployment_WhenDefaultConfigured() {
 		// Arrange

--- a/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
+++ b/clio.tests/Command/DeployCreatioDefaultsResolverTests.cs
@@ -135,7 +135,7 @@ public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 		// Arrange
 		_settingsRepository.GetDeployCreatioDefaults()
 			.Returns(new DeployCreatioDefaults { SitePort = 40018 });
-		PfInstallerOptions options = new() { SitePort = 0 };
+		PfInstallerOptions options = new();
 
 		// Act
 		_sut.ApplyDefaults(options);
@@ -152,7 +152,7 @@ public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 		int[] configuredRange = [40100, 40199];
 		_settingsRepository.GetDeployCreatioDefaults()
 			.Returns(new DeployCreatioDefaults { SitePortRange = configuredRange });
-		PfInstallerOptions options = new() { SitePort = 0 };
+		PfInstallerOptions options = new();
 
 		// Act
 		_sut.ApplyDefaults(options);
@@ -204,6 +204,28 @@ public sealed class DeployCreatioDefaultsResolverTests : BaseClioModuleTests {
 			because: "an explicit command-line override must remain the selected exact port");
 		options.SitePortRange.Should().BeNull(
 			because: "automatic allocation stays inactive when an explicit port is supplied");
+	}
+
+	[Test]
+	[Description("Preserves an explicitly supplied invalid zero site port so command validation can reject it.")]
+	public void ApplyDefaults_ShouldPreserveExplicitZeroSitePort_WhenDefaultsConfigured() {
+		// Arrange
+		_settingsRepository.GetDeployCreatioDefaults().Returns(new DeployCreatioDefaults {
+			SitePort = 40018,
+			SitePortRange = [40100, 40199]
+		});
+		PfInstallerOptions options = new() { SitePort = 0 };
+
+		// Act
+		_sut.ApplyDefaults(options);
+
+		// Assert
+		options.SitePort.Should().Be(0,
+			because: "an explicit invalid value must reach command validation instead of being replaced by a default");
+		options.SitePortRange.Should().BeNull(
+			because: "automatic allocation must remain inactive when any explicit port value was supplied");
+		options.SitePortWasSpecified.Should().BeTrue(
+			because: "the option setter records that zero came from an explicit command-line value");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/FindEmptyIisPortToolTests.cs
+++ b/clio.tests/Command/McpServer/FindEmptyIisPortToolTests.cs
@@ -86,7 +86,7 @@ public sealed class FindEmptyIisPortToolTests
 
 	[Test]
 	[Category("Unit")]
-	[Description("Prompt guidance for find-empty-iis-port tells the agent to run assertion and passing-infrastructure discovery before choosing a deploy-creatio sitePort.")]
+	[Description("Prompt guidance presents find-empty-iis-port as an optional explicit sitePort override after infrastructure discovery.")]
 	public void FindEmptyIisPortPrompt_Should_Mention_Preflight_Sequence()
 	{
 		// Arrange
@@ -101,5 +101,7 @@ public sealed class FindEmptyIisPortToolTests
 			because: "the prompt should direct the agent to pick passing DB and Redis targets before the port");
 		prompt.Should().Contain("deploy-creatio",
 			because: "the prompt should explain that the discovered port is intended for deploy-creatio");
+		prompt.Should().Contain("only when",
+			because: "the prompt should make the explicit sitePort override optional");
 	}
 }

--- a/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
+++ b/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
@@ -104,6 +104,8 @@ public sealed class InstallerCommandToolTests
 			because: "zip-file should map directly into PfInstallerOptions");
 		command.ReceivedOptions.SitePort.Should().Be(8080,
 			because: "site-port should map directly into PfInstallerOptions");
+		command.ReceivedOptions.SitePortWasSpecified.Should().BeTrue(
+			because: "an explicit MCP sitePort must be validated as an exact override");
 		command.ReceivedOptions.DbServerName.Should().Be("sql-main",
 			because: "local DB server selection should be forwarded when provided");
 		command.ReceivedOptions.RedisServerName.Should().Be("redis-main",
@@ -160,6 +162,8 @@ public sealed class InstallerCommandToolTests
 			because: "db-server-name must remain optional so Kubernetes can stay the default deployment path");
 		command.ReceivedOptions.SitePort.Should().Be(0,
 			because: "an omitted MCP sitePort must remain unset for the defaults resolver and IIS range allocator");
+		command.ReceivedOptions.SitePortWasSpecified.Should().BeFalse(
+			because: "omission must remain distinguishable from an explicit invalid zero");
 		command.ReceivedOptions.RedisDb.Should().Be(-1,
 			because: "redis-db should default to auto-detection when omitted");
 		typeof(DeployCreatioArgs).GetProperties().Select(property => property.Name).Should().BeEquivalentTo(

--- a/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
+++ b/clio.tests/Command/McpServer/InstallerCommandToolTests.cs
@@ -138,8 +138,8 @@ public sealed class InstallerCommandToolTests
 
 	[Test]
 	[Category("Unit")]
-	[Description("Keeps local server names optional and limits the deploy-creatio MCP argument type to the six approved fields.")]
-	public void DeployCreatio_Should_Keep_DbServerName_Optional_And_Expose_Only_Approved_Fields()
+	[Description("Keeps site port and local server names optional while limiting deploy-creatio to the six approved fields.")]
+	public void DeployCreatio_Should_Keep_SitePortAndServerNames_Optional_And_Expose_Only_Approved_Fields()
 	{
 		// Arrange
 		TestLogger logger = new();
@@ -148,10 +148,7 @@ public sealed class InstallerCommandToolTests
 			Substitute.For<IStageEventProgressForwarder>(), server: null!);
 		DeployCreatioArgs args = new(
 			SiteName: "creatio-app",
-			ZipFile: @"C:\temp\creatio.zip",
-			SitePort: 5000,
-			DbServerName: null,
-			RedisServerName: null);
+			ZipFile: @"C:\temp\creatio.zip");
 
 		// Act
 		tool.DeployCreatio((ProgressToken?)null, args);
@@ -161,6 +158,8 @@ public sealed class InstallerCommandToolTests
 			because: "the deploy-creatio tool should still execute when db-server-name is omitted");
 		command.ReceivedOptions!.DbServerName.Should().BeNull(
 			because: "db-server-name must remain optional so Kubernetes can stay the default deployment path");
+		command.ReceivedOptions.SitePort.Should().Be(0,
+			because: "an omitted MCP sitePort must remain unset for the defaults resolver and IIS range allocator");
 		command.ReceivedOptions.RedisDb.Should().Be(-1,
 			because: "redis-db should default to auto-detection when omitted");
 		typeof(DeployCreatioArgs).GetProperties().Select(property => property.Name).Should().BeEquivalentTo(
@@ -178,7 +177,7 @@ public sealed class InstallerCommandToolTests
 		// Arrange
 
 		// Act
-		string prompt = DeployCreatioPrompt.Prompt("site-a", @"C:\temp\creatio.zip", 8080);
+		string prompt = DeployCreatioPrompt.Prompt("site-a", @"C:\temp\creatio.zip");
 
 		// Assert
 		prompt.Should().Contain("assert-infrastructure",
@@ -186,7 +185,8 @@ public sealed class InstallerCommandToolTests
 		prompt.Should().Contain("show-passing-infrastructure",
 			because: "the prompt should direct the agent to retrieve deployable recommendations before deployment");
 		prompt.Should().Contain("find-empty-iis-port",
-			because: "the prompt should direct the agent to discover a safe local IIS port when sitePort selection matters");
+			because: "the prompt should preserve optional explicit port inspection guidance");
+		prompt.Should().Contain("configured", because: "the prompt should explain automatic range selection when sitePort is omitted");
 		prompt.Should().Contain("reserves and revalidates",
 			because: "the prompt should explain that port discovery is backed by command-level collision protection");
 		prompt.Should().Contain("deploy-creatio",

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -2256,18 +2256,17 @@ public sealed class ToolContractGetToolTests {
 
 		ToolContractDefinition deploy = result.Tools!.Single(contract =>
 			contract.Name == InstallerCommandTool.DeployCreatioToolName);
-		deploy.InputSchema.Required.Should().Contain(["siteName", "zipFile", "sitePort"],
-			because: "deploy-creatio requires the site name, build archive, and port");
+		deploy.InputSchema.Required.Should().Equal(["siteName", "zipFile"],
+			because: "deploy-creatio can select a local IIS port from the configured range when sitePort is omitted");
 		deploy.OutputContract.Kind.Should().Be("command-execution-result",
 			because: "deploy-creatio returns the standard command execution result payload");
 		deploy.PreferredFlow.Tools.Should().Equal(
 			new[] {
 				AssertInfrastructureTool.AssertInfrastructureToolName,
 				ShowPassingInfrastructureTool.ShowPassingInfrastructureToolName,
-				FindEmptyIisPortTool.FindEmptyIisPortToolName,
 				InstallerCommandTool.DeployCreatioToolName
 			},
-			because: "deploy-creatio should advertise the canonical deploy preflight order");
+			because: "deploy-creatio should advertise the required preflight without making optional port inspection mandatory");
 		deploy.Preconditions.Should().NotBeNullOrEmpty(
 			because: "the most consequential tool must spell out its preconditions");
 

--- a/clio.tests/Command/SettingsBootstrapServiceTests.cs
+++ b/clio.tests/Command/SettingsBootstrapServiceTests.cs
@@ -34,10 +34,12 @@ public sealed class SettingsBootstrapServiceTests {
 			because: "bootstrap must not auto-select a fallback environment — only the user may set the active environment");
 		result.Report.Issues.Should().ContainSingle(issue => issue.Code == "invalid-active-environment",
 			because: "the issue must be reported so diagnostics tools and error messages can surface it");
-		result.Report.RepairsApplied.Should().BeEmpty(
-			because: "no automatic repair should be applied — the user must explicitly call set-active-environment");
-		persistedContent.Should().Be(originalContent,
-			because: "appsettings.json must not be modified when bootstrap only detects issues without applying repairs");
+		result.Report.RepairsApplied.Should().ContainSingle(
+			repair => repair.Code == "deploy-creatio-site-port-range-added",
+			because: "the unrelated settings-version migration may run without repairing the invalid active environment");
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+		persisted.ActiveEnvironmentKey.Should().Be("wrong-dev",
+			because: "the settings migration must preserve the invalid key for an explicit user decision");
 	}
 
 	[Test]
@@ -199,7 +201,7 @@ public sealed class SettingsBootstrapServiceTests {
 			because: "the migration must surface that auto-update was re-enabled so the user is informed");
 		persisted.Autoupdate.Should().BeNull(
 			because: "the cleared value must be persisted — NullValueHandling.Ignore drops the key entirely");
-		persisted.SettingsVersion.Should().Be(1,
+		persisted.SettingsVersion.Should().Be(2,
 			because: "the settings version must be stamped so the one-time migration never runs again");
 		persistedContent.Should().NotContain("Autoupdate",
 			because: "a null Autoupdate is omitted from the file, restoring the pristine default state");
@@ -209,12 +211,15 @@ public sealed class SettingsBootstrapServiceTests {
 	[Category("Unit")]
 	[Description("A deliberate Autoupdate=false on a file already at the current settings version is preserved across bootstrap and never reverted — proving the opt-out is not broken.")]
 	public void GetResult_Should_Preserve_Deliberate_Autoupdate_False_After_Migration() {
-		// Arrange: file already migrated (SettingsVersion=1) with a deliberate opt-out
+		// Arrange: file already migrated (SettingsVersion=2) with a deliberate opt-out
 		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
 		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
 			{
 			  "Autoupdate": false,
-			  "SettingsVersion": 1,
+			  "SettingsVersion": 2,
+			  "deploy-creatio-defaults": {
+			    "site-port-range": [40100, 40199]
+			  },
 			  "Environments": {}
 			}
 			"""));
@@ -274,9 +279,80 @@ public sealed class SettingsBootstrapServiceTests {
 		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
 
 		// Assert
-		persisted.SettingsVersion.Should().Be(1,
+		persisted.SettingsVersion.Should().Be(2,
 			because: "new installs must be born at the current settings version so the legacy migration never runs for them");
 		result.Settings.Autoupdate.Should().BeNull(
 			because: "a fresh file has no Autoupdate key, so auto-update stays at the enabled opt-out default");
+		persisted.DeployCreatioDefaults.Should().NotBeNull(
+			because: "fresh installations must visibly persist deploy-creatio-defaults in appsettings.json");
+		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },
+			because: "fresh installations must receive the built-in inclusive automatic IIS port range");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Upgrading a version-1 settings file materializes deploy-creatio-defaults.site-port-range and preserves existing deployment defaults.")]
+	public void GetResult_Should_Add_Default_Site_Port_Range_When_Upgrading_Version_One_Settings() {
+		// Arrange
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
+			{
+			  "SettingsVersion": 1,
+			  "Environments": {},
+			  "deploy-creatio-defaults": {
+			    "db-server-name": "postgres-local",
+			    "site-port": 40018
+			  }
+			}
+			"""));
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		result.Report.RepairsApplied.Should().ContainSingle(
+			repair => repair.Code == "deploy-creatio-site-port-range-added",
+			because: "the version-2 migration should report the newly materialized automatic range");
+		persisted.SettingsVersion.Should().Be(2,
+			because: "the upgraded file must be stamped so the migration runs once");
+		persisted.DeployCreatioDefaults.DbServerName.Should().Be("postgres-local",
+			because: "upgrading the range must preserve the configured database default");
+		persisted.DeployCreatioDefaults.SitePort.Should().Be(40018,
+			because: "the backward-compatible fixed port must remain configured and take precedence");
+		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },
+			because: "an absent range must be visibly populated with Clio's built-in range");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Upgrading settings preserves a user-configured deploy-creatio site-port-range instead of replacing it with the built-in range.")]
+	public void GetResult_Should_Preserve_Custom_Site_Port_Range_When_Upgrading() {
+		// Arrange
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
+			{
+			  "SettingsVersion": 1,
+			  "Environments": {},
+			  "deploy-creatio-defaults": {
+			    "site-port-range": [41000, 41010]
+			  }
+			}
+			"""));
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 41000, 41010 },
+			because: "settings migration must never overwrite a user's configured range");
+		result.Report.RepairsApplied.Should().NotContain(
+			repair => repair.Code == "deploy-creatio-site-port-range-added",
+			because: "no range was added when a user-configured range already existed");
 	}
 }

--- a/clio.tests/Command/SettingsBootstrapServiceTests.cs
+++ b/clio.tests/Command/SettingsBootstrapServiceTests.cs
@@ -4,6 +4,7 @@ using Clio.Tests.Infrastructure;
 using Clio.UserEnvironment;
 using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -277,6 +278,7 @@ public sealed class SettingsBootstrapServiceTests {
 		SettingsBootstrapResult result = service.GetResult();
 		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
 		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+		JArray persistedRange = (JArray)JObject.Parse(persistedContent)["deploy-creatio-defaults"]!["site-port-range"]!;
 
 		// Assert
 		persisted.SettingsVersion.Should().Be(2,
@@ -287,6 +289,8 @@ public sealed class SettingsBootstrapServiceTests {
 			because: "fresh installations must visibly persist deploy-creatio-defaults in appsettings.json");
 		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },
 			because: "fresh installations must receive the built-in inclusive automatic IIS port range");
+		persistedRange.Values<int>().Should().Equal(new[] { 40100, 40199 },
+			because: "the generated JSON must use the exact documented site-port-range key");
 	}
 
 	[Test]
@@ -309,8 +313,9 @@ public sealed class SettingsBootstrapServiceTests {
 
 		// Act
 		SettingsBootstrapResult result = service.GetResult();
-		Settings persisted = JsonConvert.DeserializeObject<Settings>(
-			fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+		string persistedContent = fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
+		JArray persistedRange = (JArray)JObject.Parse(persistedContent)["deploy-creatio-defaults"]!["site-port-range"]!;
 
 		// Assert
 		result.Report.RepairsApplied.Should().ContainSingle(
@@ -324,6 +329,38 @@ public sealed class SettingsBootstrapServiceTests {
 			because: "the backward-compatible fixed port must remain configured and take precedence");
 		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },
 			because: "an absent range must be visibly populated with Clio's built-in range");
+		persistedRange.Values<int>().Should().Equal(new[] { 40100, 40199 },
+			because: "the migration must persist the exact documented site-port-range key");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Upgrading preserves an explicitly configured empty site-port range so deployment validation can report it instead of silently replacing it.")]
+	public void GetResult_ShouldPreserveEmptySitePortRange_WhenUpgrading() {
+		// Arrange
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
+			{
+			  "SettingsVersion": 1,
+			  "Environments": {},
+			  "deploy-creatio-defaults": {
+			    "site-port-range": []
+			  }
+			}
+			"""));
+		SettingsBootstrapService service = new(fileSystem);
+
+		// Act
+		SettingsBootstrapResult result = service.GetResult();
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		persisted.DeployCreatioDefaults.SitePortRange.Should().BeEmpty(
+			because: "migration must distinguish an invalid configured value from an absent value");
+		result.Report.RepairsApplied.Should().NotContain(
+			repair => repair.Code == "deploy-creatio-site-port-range-added",
+			because: "an explicitly configured range must not be overwritten during upgrade");
 	}
 
 	[Test]

--- a/clio.tests/Command/SettingsRepositoryDeployDefaultsTests.cs
+++ b/clio.tests/Command/SettingsRepositoryDeployDefaultsTests.cs
@@ -21,8 +21,8 @@ public sealed class SettingsRepositoryDeployDefaultsTests {
 	}
 
 	[Test]
-	[Description("GetDeployCreatioDefaults returns an empty, non-null instance when no defaults are configured.")]
-	public void GetDeployCreatioDefaults_ShouldReturnEmptyInstance_WhenNoneConfigured() {
+	[Description("GetDeployCreatioDefaults returns the migrated built-in site-port range when no deployment defaults were previously configured.")]
+	public void GetDeployCreatioDefaults_ShouldReturnBuiltInSitePortRange_WhenNoneConfigured() {
 		// Arrange
 		SettingsRepository sut = new(_fileSystem);
 
@@ -30,8 +30,9 @@ public sealed class SettingsRepositoryDeployDefaultsTests {
 		DeployCreatioDefaults result = sut.GetDeployCreatioDefaults();
 
 		// Assert
-		result.Should().NotBeNull(because: "the accessor must never return null so callers can inspect IsEmpty safely");
-		result.IsEmpty.Should().BeTrue(because: "no deploy-creatio defaults are configured in the base settings file");
+		result.Should().NotBeNull(because: "the accessor must never return null so callers can use deployment defaults safely");
+		result.SitePortRange.Should().Equal(new[] { 40100, 40199 },
+			because: "loading legacy settings should persist and expose the built-in automatic IIS port range");
 	}
 
 	[Test]
@@ -44,6 +45,7 @@ public sealed class SettingsRepositoryDeployDefaultsTests {
 			RedisServerName = "local-redis",
 			SiteName = "lcap-local",
 			SitePort = 40018,
+			SitePortRange = [41000, 41010],
 			DeploymentMethod = "iis"
 		};
 
@@ -57,6 +59,8 @@ public sealed class SettingsRepositoryDeployDefaultsTests {
 		result.RedisServerName.Should().Be("local-redis", because: "the configured redis server name must persist across repository instances");
 		result.SiteName.Should().Be("lcap-local", because: "the configured site name must persist across repository instances");
 		result.SitePort.Should().Be(40018, because: "the configured site port must persist across repository instances");
+		result.SitePortRange.Should().Equal(new[] { 41000, 41010 },
+			because: "the configured site-port range must persist across repository instances");
 		result.DeploymentMethod.Should().Be("iis", because: "the configured deployment method must persist across repository instances");
 	}
 

--- a/clio.tests/Command/SettingsRepositoryFeatureTests.cs
+++ b/clio.tests/Command/SettingsRepositoryFeatureTests.cs
@@ -111,6 +111,35 @@ public sealed class SettingsRepositoryFeatureTests {
 			because: "NuGet sources require a package identity and signing trust while Git sources do not");
 	}
 
+	[Test]
+	[Description("Documents every persisted deploy-creatio default and constrains the automatic site-port range shape.")]
+	public void AppSettingsSchema_ShouldDescribeDeployCreatioDefaults() {
+		// Arrange
+		string templatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tpl", "jsonschema", "schema.json.tpl");
+		JsonObject schema = JsonNode.Parse(File.ReadAllText(templatePath))!.AsObject();
+		JsonObject rootProperties = schema["properties"]!.AsObject();
+		JsonObject defaults = schema["definitions"]!["deploycreatiodefaults"]!.AsObject();
+		JsonObject properties = defaults["properties"]!.AsObject();
+		JsonObject range = properties["site-port-range"]!.AsObject();
+
+		// Act
+		string[] keys = properties.Select(property => property.Key).ToArray();
+		int[] defaultRange = range["default"]!.AsArray().Select(value => value!.GetValue<int>()).ToArray();
+
+		// Assert
+		rootProperties.Should().ContainKey("deploy-creatio-defaults",
+			because: "the generated settings file points editors at this bundled schema");
+		keys.Should().BeEquivalentTo([
+			"db-server-name", "redis-server-name", "site-name", "site-port", "site-port-range", "deployment"
+		], because: "editor completion must expose every deploy default persisted by SettingsRepository");
+		range["minItems"]!.GetValue<int>().Should().Be(2,
+			because: "runtime validation requires exactly a start and end port");
+		range["maxItems"]!.GetValue<int>().Should().Be(2,
+			because: "runtime validation rejects extra range values");
+		defaultRange.Should().Equal(new[] { 40100, 40199 },
+			because: "schema hover and completion must agree with the materialized built-in value");
+	}
+
 	private static string[] RequiredForTransport(JsonObject source, string transportType) => source["allOf"]!
 		.AsArray()
 		.Single(rule => rule!["if"]!["properties"]!["type"]!["const"]!.GetValue<string>() == transportType)!

--- a/clio.tests/Common/IIS/IisDeploymentPortReservationTests.cs
+++ b/clio.tests/Common/IIS/IisDeploymentPortReservationTests.cs
@@ -71,6 +71,41 @@ public sealed class IisDeploymentPortReservationTests {
 	}
 
 	[Test]
+	[Description("Continues to the next candidate when exact under-lock revalidation rejects the initially available port.")]
+	public void AcquireFirstAvailable_ShouldContinue_WhenFirstCandidateFailsRevalidation() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("Machine-wide IIS deployment reservations are Windows-specific.");
+		}
+		int firstPort = Random.Shared.Next(50000, 55000);
+		int secondPort = firstPort + 1;
+		IAvailableIisPortService availability = Substitute.For<IAvailableIisPortService>();
+		availability.FindAsync(firstPort, secondPort).Returns(new FindAvailableIisPortResult(
+			"available", "first initially looks free", firstPort, secondPort, firstPort, 0, 0));
+		availability.FindAsync(firstPort, firstPort).Returns(new FindAvailableIisPortResult(
+			"unavailable", "first became occupied", firstPort, firstPort, null, 1, 0));
+		FindAvailableIisPortResult secondAvailable = new(
+			"available", "second is free", secondPort, secondPort, secondPort, 0, 0);
+		availability.FindAsync(secondPort, secondPort).Returns(secondAvailable, secondAvailable);
+		IIisDeploymentPortReservation sut = new IisDeploymentPortReservation(availability);
+
+		// Act
+		using IisDeploymentPortLease lease = sut.AcquireFirstAvailable(firstPort, secondPort);
+		string firstLockPath = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+			"Creatio", "clio", "deployment-locks", $"iis-port-{firstPort}.lock");
+		using FileStream releasedFirstLease = new(
+			firstLockPath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
+
+		// Assert
+		lease.Port.Should().Be(secondPort,
+			because: "selection must continue after closing the TOCTOU window rejects the initial candidate");
+		releasedFirstLease.CanRead.Should().BeTrue(
+			because: "the rejected candidate lock must be released before the next candidate is returned");
+		availability.Received(2).FindAsync(secondPort, secondPort);
+	}
+
+	[Test]
 	[Description("Fails with the configured range when no IIS port can be reserved.")]
 	public void AcquireFirstAvailable_ShouldFailWithRange_WhenNoPortIsAvailable() {
 		// Arrange

--- a/clio.tests/Common/IIS/IisDeploymentPortReservationTests.cs
+++ b/clio.tests/Common/IIS/IisDeploymentPortReservationTests.cs
@@ -14,6 +14,84 @@ namespace Clio.Tests.Common.IIS;
 [Category("Integration")]
 [Property("Module", "Common")]
 public sealed class IisDeploymentPortReservationTests {
+	[Test]
+	[Description("Reserves the first available port reported in an inclusive range and exposes it through the lease.")]
+	public void AcquireFirstAvailable_ShouldReserveFirstAvailablePort_InAscendingRange() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("Machine-wide IIS deployment reservations are Windows-specific.");
+		}
+		int rangeStart = Random.Shared.Next(50000, 55000);
+		int selectedPort = rangeStart + 2;
+		int rangeEnd = rangeStart + 5;
+		IAvailableIisPortService availability = Substitute.For<IAvailableIisPortService>();
+		availability.FindAsync(rangeStart, rangeEnd).Returns(new FindAvailableIisPortResult(
+			"available", "free", rangeStart, rangeEnd, selectedPort, 0, 0));
+		availability.FindAsync(selectedPort, selectedPort).Returns(new FindAvailableIisPortResult(
+			"available", "free", selectedPort, selectedPort, selectedPort, 0, 0));
+		IIisDeploymentPortReservation sut = new IisDeploymentPortReservation(availability);
+
+		// Act
+		using IisDeploymentPortLease lease = sut.AcquireFirstAvailable(rangeStart, rangeEnd);
+
+		// Assert
+		lease.Port.Should().Be(selectedPort,
+			because: "the reservation lease must expose the first scanner-approved candidate");
+		availability.Received(1).FindAsync(selectedPort, selectedPort);
+	}
+
+	[Test]
+	[Description("Continues to the next available candidate when another clio process already owns the first candidate lock.")]
+	public void AcquireFirstAvailable_ShouldContinue_WhenFirstCandidateIsReserved() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("Machine-wide IIS deployment reservations are Windows-specific.");
+		}
+		int firstPort = Random.Shared.Next(55001, 60000);
+		int secondPort = firstPort + 1;
+		string lockPath = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+			"Creatio", "clio", "deployment-locks", $"iis-port-{firstPort}.lock");
+		Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+		using FileStream competingLease = new(lockPath, FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
+		IAvailableIisPortService availability = Substitute.For<IAvailableIisPortService>();
+		availability.FindAsync(firstPort, secondPort).Returns(new FindAvailableIisPortResult(
+			"available", "first looks free", firstPort, secondPort, firstPort, 0, 0));
+		availability.FindAsync(secondPort, secondPort).Returns(new FindAvailableIisPortResult(
+			"available", "second is free", secondPort, secondPort, secondPort, 0, 0));
+		IIisDeploymentPortReservation sut = new IisDeploymentPortReservation(availability);
+
+		// Act
+		using IisDeploymentPortLease lease = sut.AcquireFirstAvailable(firstPort, secondPort);
+
+		// Assert
+		lease.Port.Should().Be(secondPort,
+			because: "automatic allocation must skip a candidate atomically claimed by a concurrent clio deployment");
+		availability.Received(2).FindAsync(secondPort, secondPort);
+	}
+
+	[Test]
+	[Description("Fails with the configured range when no IIS port can be reserved.")]
+	public void AcquireFirstAvailable_ShouldFailWithRange_WhenNoPortIsAvailable() {
+		// Arrange
+		if (!OperatingSystem.IsWindows()) {
+			Assert.Ignore("Machine-wide IIS deployment reservations are Windows-specific.");
+		}
+		const int rangeStart = 40100;
+		const int rangeEnd = 40199;
+		IAvailableIisPortService availability = Substitute.For<IAvailableIisPortService>();
+		availability.FindAsync(rangeStart, rangeEnd).Returns(new FindAvailableIisPortResult(
+			"unavailable", "all occupied", rangeStart, rangeEnd, null, 1, 1));
+		IIisDeploymentPortReservation sut = new IisDeploymentPortReservation(availability);
+
+		// Act
+		Action act = () => sut.AcquireFirstAvailable(rangeStart, rangeEnd);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>()
+			.WithMessage("*[40100, 40199]*all occupied*",
+				because: "a full range must produce an actionable error naming the exact configured range");
+	}
 
 	[Test]
 	[Description("Rejects an IIS port when the fail-closed IIS and TCP scan does not prove it available.")]

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -476,6 +476,38 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 
 	[Test]
 	[Category("Unit")]
+	[Description("IIS deployment applies the automatically reserved port and releases its lease when a later stage fails.")]
+	public void Execute_ShouldApplySelectedRangePortAndReleaseLease_WhenUnzipFails() {
+		// Arrange
+		const int rangeStart = 40100;
+		const int rangeEnd = 40199;
+		const int selectedPort = 40123;
+		IDisposable reservation = Substitute.For<IDisposable>();
+		IisDeploymentPortLease lease = new(selectedPort, reservation);
+		_iisDeploymentPortReservation.AcquireFirstAvailable(rangeStart, rangeEnd).Returns(lease);
+		PfInstallerOptions options = new() {
+			SiteName = "automatic-port-success-probe",
+			SitePortRange = [rangeStart, rangeEnd],
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<Exception>(because: "the empty fixture archive deliberately stops deployment after reservation");
+		options.SitePort.Should().Be(selectedPort,
+			because: "the port carried by the acquired lease must become the IIS deployment port");
+		_iisDeploymentPortReservation.Received(1).AcquireFirstAvailable(rangeStart, rangeEnd);
+		reservation.Received(1).Dispose();
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("IIS deployment rejects an invalid configured site-port range before acquiring target or port reservations.")]
 	public void Execute_ShouldRejectInvalidConfiguredRange_BeforeReservations() {
 		// Arrange

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.Common.IIS;
@@ -48,6 +46,7 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 	private IProcessExecutor _processExecutor;
 	private IIisDeploymentPortReservation _iisDeploymentPortReservation;
 	private IDeploymentTargetReservation _deploymentTargetReservation;
+	private ITcpPortReservationReader _tcpPortReservationReader;
 
 	#endregion
 
@@ -67,6 +66,9 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 		containerBuilder.AddSingleton(_iisDeploymentPortReservation);
 		_deploymentTargetReservation = Substitute.For<IDeploymentTargetReservation>();
 		containerBuilder.AddSingleton(_deploymentTargetReservation);
+		_tcpPortReservationReader = Substitute.For<ITcpPortReservationReader>();
+		_tcpPortReservationReader.GetReservedPorts(Arg.Any<int>(), Arg.Any<int>()).Returns([]);
+		containerBuilder.AddSingleton(_tcpPortReservationReader);
 	}
 
 	protected override MockFileSystem CreateFs() {
@@ -577,15 +579,7 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 	[Description("Silent DotNet deployment never reads console input when its default port is occupied.")]
 	public void Execute_ShouldFailFast_WhenSilentDotNetDefaultPortIsOccupied() {
 		// Arrange
-		TcpListener? listener = null;
-		try {
-			listener = new TcpListener(IPAddress.Any, 8080);
-			listener.Start();
-		}
-		catch (SocketException exception) when (exception.SocketErrorCode == SocketError.AddressAlreadyInUse) {
-			listener?.Stop();
-			listener = null;
-		}
+		_tcpPortReservationReader.GetReservedPorts(8080, 8080).Returns([8080]);
 		PfInstallerOptions options = new() {
 			SiteName = "silent-dotnet-port-probe",
 			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
@@ -595,18 +589,14 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 			IsSilent = true
 		};
 
-		try {
-			// Act
-			Action act = () => _creatioInstallerService.Execute(options);
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
 
-			// Assert
-			act.Should().Throw<InvalidOperationException>().WithMessage("*8080*not available*--site-port*",
-				because: "silent and MCP invocations must fail instead of consuming console or JSON-RPC input");
-			_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
-		}
-		finally {
-			listener?.Stop();
-		}
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*8080*not available*--site-port*",
+			because: "silent and MCP invocations must fail instead of consuming console or JSON-RPC input");
+		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+		_tcpPortReservationReader.Received(1).GetReservedPorts(8080, 8080);
 	}
 
 	[Test]

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.Common.IIS;
@@ -568,6 +570,43 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 		act.Should().Throw<InvalidOperationException>().WithMessage("*requires --site-port*site-port-range*",
 			because: "silent and MCP invocations cannot answer an interactive port prompt");
 		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Silent DotNet deployment never reads console input when its default port is occupied.")]
+	public void Execute_ShouldFailFast_WhenSilentDotNetDefaultPortIsOccupied() {
+		// Arrange
+		TcpListener? listener = null;
+		try {
+			listener = new TcpListener(IPAddress.Any, 8080);
+			listener.Start();
+		}
+		catch (SocketException exception) when (exception.SocketErrorCode == SocketError.AddressAlreadyInUse) {
+			listener?.Stop();
+			listener = null;
+		}
+		PfInstallerOptions options = new() {
+			SiteName = "silent-dotnet-port-probe",
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "dotnet",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		try {
+			// Act
+			Action act = () => _creatioInstallerService.Execute(options);
+
+			// Assert
+			act.Should().Throw<InvalidOperationException>().WithMessage("*8080*not available*--site-port*",
+				because: "silent and MCP invocations must fail instead of consuming console or JSON-RPC input");
+			_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+		}
+		finally {
+			listener?.Stop();
+		}
 	}
 
 	[Test]

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -435,8 +435,64 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 			.WithMessage("*not available*",
 				because: "the machine-scoped port reservation is the first deployment mutation boundary");
 		_iisDeploymentPortReservation.Received(1).Acquire(port);
+		_iisDeploymentPortReservation.DidNotReceive().AcquireFirstAvailable(Arg.Any<int>(), Arg.Any<int>());
 		_deploymentTargetReservation.Received(1).Acquire(Arg.Is<string>(path =>
 			Path.IsPathFullyQualified(path) && path.EndsWith("collision-probe", StringComparison.Ordinal)));
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("IIS deployment uses the configured range when no explicit or fixed site port is present and fails before target mutation when the range is full.")]
+	public void Execute_ShouldUseConfiguredRangeAndFailBeforeMutation_WhenNoPortCanBeReserved() {
+		// Arrange
+		const int rangeStart = 40100;
+		const int rangeEnd = 40199;
+		string zipPath = Path.Combine(_localArtifactServerPath, "8.1.1",
+			"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip");
+		_iisDeploymentPortReservation.AcquireFirstAvailable(rangeStart, rangeEnd).Returns(_ =>
+			throw new InvalidOperationException("No available IIS port in [40100, 40199]."));
+		PfInstallerOptions options = new() {
+			SiteName = "automatic-port-probe",
+			SitePortRange = [rangeStart, rangeEnd],
+			ZipFile = zipPath,
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*[40100, 40199]*",
+			because: "an exhausted configured range must be reported without prompting or falling back");
+		_iisDeploymentPortReservation.Received(1).AcquireFirstAvailable(rangeStart, rangeEnd);
+		_iisDeploymentPortReservation.DidNotReceive().Acquire(Arg.Any<int>());
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("IIS deployment rejects an invalid configured site-port range before acquiring target or port reservations.")]
+	public void Execute_ShouldRejectInvalidConfiguredRange_BeforeReservations() {
+		// Arrange
+		PfInstallerOptions options = new() {
+			SiteName = "invalid-range-probe",
+			SitePortRange = [40199, 40100],
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*1 <= start <= end <= 65535*",
+			because: "invalid range configuration must fail before deployment can mutate the target");
+		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+		_iisDeploymentPortReservation.DidNotReceive().AcquireFirstAvailable(Arg.Any<int>(), Arg.Any<int>());
 	}
 
 	[Test]

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -497,6 +497,81 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 
 	[Test]
 	[Category("Unit")]
+	[Description("IIS deployment rejects an explicitly configured empty site-port range instead of treating it as absent.")]
+	public void Execute_ShouldRejectEmptyConfiguredRange_BeforeReservations() {
+		// Arrange
+		PfInstallerOptions options = new() {
+			SiteName = "empty-range-probe",
+			SitePortRange = [],
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*exactly two ports*",
+			because: "an empty configured range is invalid rather than an instruction to prompt or restore defaults");
+		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+		_iisDeploymentPortReservation.DidNotReceive().AcquireFirstAvailable(Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[TestCase(0)]
+	[TestCase(65536)]
+	[Category("Unit")]
+	[Description("IIS deployment rejects an invalid explicitly supplied site port instead of falling back to automatic selection.")]
+	public void Execute_ShouldRejectInvalidExplicitSitePort_BeforeReservations(int sitePort) {
+		// Arrange
+		PfInstallerOptions options = new() {
+			SiteName = "invalid-explicit-port-probe",
+			SitePort = sitePort,
+			SitePortRange = [40100, 40199],
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*Invalid explicit site port*",
+			because: "an explicit override must be validated exactly and never turn into omission");
+		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+		_iisDeploymentPortReservation.DidNotReceive().AcquireFirstAvailable(Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Silent IIS deployment fails fast when neither a fixed port nor a configured range is available.")]
+	public void Execute_ShouldFailFast_WhenSilentIisDeploymentHasNoPortConfiguration() {
+		// Arrange
+		PfInstallerOptions options = new() {
+			SiteName = "missing-port-config-probe",
+			ZipFile = Path.Combine(_localArtifactServerPath, "8.1.1",
+				"8.1.1.1417_Studio_Softkey_PostgreSQL_ENU.zip"),
+			DeploymentMethod = "iis",
+			AutoRun = false,
+			IsSilent = true
+		};
+
+		// Act
+		Action act = () => _creatioInstallerService.Execute(options);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*requires --site-port*site-port-range*",
+			because: "silent and MCP invocations cannot answer an interactive port prompt");
+		_deploymentTargetReservation.DidNotReceive().Acquire(Arg.Any<string>());
+	}
+
+	[Test]
+	[Category("Unit")]
 	[Description("Deployment target reservation is acquired before the IIS port or any target mutation.")]
 	public void Execute_ShouldFailBeforePortReservation_WhenDeploymentTargetIsAlreadyReserved() {
 		// Arrange

--- a/clio/Command/ConfigCommand.cs
+++ b/clio/Command/ConfigCommand.cs
@@ -123,8 +123,8 @@ public class ConfigCommand : Command<ConfigOptions> {
 	/// <inheritdoc/>
 	public override int Execute(ConfigOptions options) {
 		if (options.Reset) {
-			_settingsRepository.SetDeployCreatioDefaults(null);
-			_logger.WriteInfo("Deploy-creatio defaults were cleared.");
+			_settingsRepository.SetDeployCreatioDefaults(DeployCreatioDefaults.CreateWithDefaultSitePortRange());
+			_logger.WriteInfo("Custom deploy-creatio defaults were cleared and built-in defaults were restored.");
 			return 0;
 		}
 
@@ -235,12 +235,14 @@ public class ConfigCommand : Command<ConfigOptions> {
 		if (!string.IsNullOrWhiteSpace(options.DeploySiteName)) {
 			defaults.SiteName = options.DeploySiteName.Trim();
 		}
-		if (options.DeploySitePort.HasValue) {
-			defaults.SitePort = options.DeploySitePort.Value;
-		}
 		if (options.DeploySitePortRange is not null) {
 			defaults.SitePortRange = options.DeploySitePortRange.ToArray();
-			defaults.SitePort = null;
+			if (!options.DeploySitePort.HasValue) {
+				defaults.SitePort = null;
+			}
+		}
+		if (options.DeploySitePort.HasValue) {
+			defaults.SitePort = options.DeploySitePort.Value;
 		}
 		if (!string.IsNullOrWhiteSpace(options.DeployDeployment)) {
 			defaults.DeploymentMethod = options.DeployDeployment.Trim().ToLowerInvariant();

--- a/clio/Command/ConfigCommand.cs
+++ b/clio/Command/ConfigCommand.cs
@@ -176,8 +176,10 @@ public class ConfigCommand : Command<ConfigOptions> {
 		|| !string.IsNullOrWhiteSpace(options.DeployRedisServerName)
 		|| !string.IsNullOrWhiteSpace(options.DeploySiteName)
 		|| options.DeploySitePort.HasValue
-		|| options.DeploySitePortRange is not null
+		|| HasSitePortRange(options.DeploySitePortRange)
 		|| !string.IsNullOrWhiteSpace(options.DeployDeployment);
+
+	private static bool HasSitePortRange(IEnumerable<int> sitePortRange) => sitePortRange?.Any() == true;
 
 	private static bool HasKnowledgeFeedbackSetArguments(ConfigOptions options) =>
 		!string.IsNullOrWhiteSpace(options.KnowledgeFeedbackMode)
@@ -210,7 +212,7 @@ public class ConfigCommand : Command<ConfigOptions> {
 	}
 
 	private bool TryValidateSitePortRange(IEnumerable<int> sitePortRange) {
-		if (sitePortRange is null) {
+		if (!HasSitePortRange(sitePortRange)) {
 			return true;
 		}
 		int[] range = sitePortRange.ToArray();
@@ -235,7 +237,7 @@ public class ConfigCommand : Command<ConfigOptions> {
 		if (!string.IsNullOrWhiteSpace(options.DeploySiteName)) {
 			defaults.SiteName = options.DeploySiteName.Trim();
 		}
-		if (options.DeploySitePortRange is not null) {
+		if (HasSitePortRange(options.DeploySitePortRange)) {
 			defaults.SitePortRange = options.DeploySitePortRange.ToArray();
 			if (!options.DeploySitePort.HasValue) {
 				defaults.SitePort = null;

--- a/clio/Command/ConfigCommand.cs
+++ b/clio/Command/ConfigCommand.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.UserEnvironment;
@@ -45,6 +47,13 @@ public class ConfigOptions {
 	[Option("deploy-site-port", Required = false,
 		HelpText = "Default site port for deploy-creatio.")]
 	public int? DeploySitePort { get; set; }
+
+	/// <summary>
+	/// Gets or sets the inclusive automatic IIS site-port range applied when no fixed site port is configured.
+	/// </summary>
+	[Option("deploy-site-port-range", Required = false, Separator = ',',
+		HelpText = "Inclusive automatic IIS site-port range for deploy-creatio, for example 40100,40199.")]
+	public IEnumerable<int> DeploySitePortRange { get; set; }
 
 	/// <summary>
 	/// Gets or sets the default deployment method (<c>auto</c>, <c>iis</c>, or <c>dotnet</c>) applied when
@@ -131,7 +140,9 @@ public class ConfigCommand : Command<ConfigOptions> {
 			return 0;
 		}
 
-		if (!TryValidateDeploymentMethod(options.DeployDeployment) || !TryValidateSitePort(options.DeploySitePort)) {
+		if (!TryValidateDeploymentMethod(options.DeployDeployment)
+			|| !TryValidateSitePort(options.DeploySitePort)
+			|| !TryValidateSitePortRange(options.DeploySitePortRange)) {
 			return 1;
 		}
 
@@ -165,6 +176,7 @@ public class ConfigCommand : Command<ConfigOptions> {
 		|| !string.IsNullOrWhiteSpace(options.DeployRedisServerName)
 		|| !string.IsNullOrWhiteSpace(options.DeploySiteName)
 		|| options.DeploySitePort.HasValue
+		|| options.DeploySitePortRange is not null
 		|| !string.IsNullOrWhiteSpace(options.DeployDeployment);
 
 	private static bool HasKnowledgeFeedbackSetArguments(ConfigOptions options) =>
@@ -197,6 +209,22 @@ public class ConfigCommand : Command<ConfigOptions> {
 		return isValid;
 	}
 
+	private bool TryValidateSitePortRange(IEnumerable<int> sitePortRange) {
+		if (sitePortRange is null) {
+			return true;
+		}
+		int[] range = sitePortRange.ToArray();
+		bool isValid = range.Length == 2
+			&& range[0] is >= MinSitePort and <= MaxSitePort
+			&& range[1] is >= MinSitePort and <= MaxSitePort
+			&& range[0] <= range[1];
+		if (!isValid) {
+			_logger.WriteError(
+				$"Invalid site port range. Specify exactly two ports satisfying {MinSitePort} <= start <= end <= {MaxSitePort}.");
+		}
+		return isValid;
+	}
+
 	private static void ApplySetArguments(DeployCreatioDefaults defaults, ConfigOptions options) {
 		if (!string.IsNullOrWhiteSpace(options.DeployDbServerName)) {
 			defaults.DbServerName = options.DeployDbServerName.Trim();
@@ -209,6 +237,10 @@ public class ConfigCommand : Command<ConfigOptions> {
 		}
 		if (options.DeploySitePort.HasValue) {
 			defaults.SitePort = options.DeploySitePort.Value;
+		}
+		if (options.DeploySitePortRange is not null) {
+			defaults.SitePortRange = options.DeploySitePortRange.ToArray();
+			defaults.SitePort = null;
 		}
 		if (!string.IsNullOrWhiteSpace(options.DeployDeployment)) {
 			defaults.DeploymentMethod = options.DeployDeployment.Trim().ToLowerInvariant();
@@ -228,6 +260,9 @@ public class ConfigCommand : Command<ConfigOptions> {
 			table.Rows.Add(["redis-server-name", defaults.RedisServerName ?? string.Empty]);
 			table.Rows.Add(["site-name", defaults.SiteName ?? string.Empty]);
 			table.Rows.Add(["site-port", defaults.SitePort?.ToString() ?? string.Empty]);
+			table.Rows.Add(["site-port-range", defaults.SitePortRange is { Length: > 0 }
+				? $"[{string.Join(", ", defaults.SitePortRange)}]"
+				: string.Empty]);
 			table.Rows.Add(["deployment", defaults.DeploymentMethod ?? string.Empty]);
 			_logger.PrintTable(table);
 		}

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -1440,6 +1440,14 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			if (options.SitePort is > 0 and <= 65535) {
 				// Port already set, skip prompting
 			}
+			else if (options.IsSilent) {
+				const int defaultDotNetPort = 8080;
+				if (!IsPortAvailable(defaultDotNetPort)) {
+					throw new InvalidOperationException(
+						$"Default DotNet deployment port {defaultDotNetPort} is not available. Specify --site-port explicitly.");
+				}
+				options.ApplyConfiguredSitePort(defaultDotNetPort);
+			}
 			else {
 				bool portSelected = false;
 

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -4,8 +4,6 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
-using System.Net;
-using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -138,6 +136,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	private readonly ISettingsRepository _settingsRepository;
 	private readonly IStageEventEmitter _stageEventEmitter;
 	private readonly IDbHubSynchronizationService _dbHubSynchronizationService;
+	private readonly ITcpPortReservationReader _tcpPortReservationReader;
 	private readonly IIisDeploymentPortReservation _iisDeploymentPortReservation;
 	private readonly IDeploymentTargetReservation _deploymentTargetReservation;
 
@@ -167,6 +166,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 	/// <param name="creatioPackageVersionParser">Parser for version extraction from package filename.</param>
 	/// <param name="passwordResetScriptExecutor">Executor for post-restore password reset script.</param>
 	/// <param name="stageEventEmitter">Emitter that raises typed stage-progress events for the deploy run.</param>
+	/// <param name="tcpPortReservationReader">Reads active TCP reservations for DotNet port validation.</param>
 	/// <param name="iisDeploymentPortReservation">Machine-wide IIS port reservation held across deployment mutation.</param>
 	/// <param name="deploymentTargetReservation">Cross-process target-directory reservation held across deployment mutation.</param>
 	/// <param name="dbOperationLogContextAccessor">Accessor for the active database operation log session.</param>
@@ -184,6 +184,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		ICreatioPackageVersionParser creatioPackageVersionParser,
 		IPasswordResetScriptExecutor passwordResetScriptExecutor,
 		IStageEventEmitter stageEventEmitter,
+		ITcpPortReservationReader tcpPortReservationReader,
 		IIisDeploymentPortReservation iisDeploymentPortReservation,
 		IDeploymentTargetReservation deploymentTargetReservation,
 		IDbOperationLogContextAccessor dbOperationLogContextAccessor = null,
@@ -212,6 +213,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		_creatioPackageVersionParser = creatioPackageVersionParser;
 		_passwordResetScriptExecutor = passwordResetScriptExecutor;
 		_stageEventEmitter = stageEventEmitter;
+		_tcpPortReservationReader = tcpPortReservationReader;
 		_iisDeploymentPortReservation = iisDeploymentPortReservation;
 		_deploymentTargetReservation = deploymentTargetReservation;
 		_dbHubSynchronizationService = dbHubSynchronizationService;
@@ -686,22 +688,9 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 
 	private bool IsPortAvailable(int port) {
 		try {
-			IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-			TcpConnectionInformation[] tcpConnections = ipGlobalProperties.GetActiveTcpConnections();
-
-			foreach (TcpConnectionInformation tcpConnection in tcpConnections) {
-				if (tcpConnection.LocalEndPoint.Port == port) {
-					_logger.WriteWarning($"Port {port} is in use (active connection)");
-					return false;
-				}
-			}
-
-			IPEndPoint[] listeners = ipGlobalProperties.GetActiveTcpListeners();
-			foreach (IPEndPoint listener in listeners) {
-				if (listener.Port == port) {
-					_logger.WriteWarning($"Port {port} is in use (listening port)");
-					return false;
-				}
+			if (_tcpPortReservationReader.GetReservedPorts(port, port).Contains(port)) {
+				_logger.WriteWarning($"Port {port} is in use");
+				return false;
 			}
 
 			_logger.WriteInfo($"Port {port} is available");

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -1377,10 +1377,14 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		}
 
 		// Determine deployment strategy to know whether to use IIS or DotNet
+		if (options.SitePortWasSpecified && options.SitePort is <= 0 or > 65535) {
+			throw new InvalidOperationException(
+				$"Invalid explicit site port '{options.SitePort}'. Specify a value between 1 and 65535.");
+		}
 		IDeploymentStrategy strategy = SelectDeploymentStrategy(options);
 		bool isIisDeployment = strategy is IISDeploymentStrategy;
 		if (isIisDeployment && (options.SitePort is <= 0 or > 65535)
-			&& options.SitePortRange is { Length: > 0 }) {
+			&& options.SitePortRange is not null) {
 			ValidateSitePortRange(options.SitePortRange);
 		}
 
@@ -1411,7 +1415,11 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		// Only prompt for port on Windows IIS deployments
 		// DotNet deployments on macOS/Linux use default port or user-specified port
 		if (isIisDeployment) {
-			if (options.SitePortRange is not { Length: > 0 }) {
+			if (options.SitePortRange is null) {
+				if (options.IsSilent && options.SitePort is <= 0 or > 65535) {
+					throw new InvalidOperationException(
+						"IIS deployment requires --site-port or deploy-creatio-defaults.site-port-range in silent mode.");
+				}
 				while (options.SitePort is <= 0 or > 65535) {
 					_logger.WriteLine(
 						$"Please enter site port, Max value - 65535:{Environment.NewLine}(recommended range between 40000 and 40100)");
@@ -1684,7 +1692,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		ValidateSitePortRange(options.SitePortRange);
 		IisDeploymentPortLease lease = _iisDeploymentPortReservation.AcquireFirstAvailable(
 			options.SitePortRange[0], options.SitePortRange[1]);
-		options.SitePort = lease.Port;
+		options.ApplyConfiguredSitePort(lease.Port);
 		_logger.WriteInfo(
 			$"[Site Port] - {lease.Port} (first available in configured range "
 			+ $"[{options.SitePortRange[0]}, {options.SitePortRange[1]}])");

--- a/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
+++ b/clio/Command/CreatioInstallCommand/CreatioInstallerService.cs
@@ -1379,6 +1379,10 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		// Determine deployment strategy to know whether to use IIS or DotNet
 		IDeploymentStrategy strategy = SelectDeploymentStrategy(options);
 		bool isIisDeployment = strategy is IISDeploymentStrategy;
+		if (isIisDeployment && (options.SitePort is <= 0 or > 65535)
+			&& options.SitePortRange is { Length: > 0 }) {
+			ValidateSitePortRange(options.SitePortRange);
+		}
 
 		// STEP 1: Get a site name from a user
 		while (string.IsNullOrEmpty(options.SiteName)) {
@@ -1407,14 +1411,16 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		// Only prompt for port on Windows IIS deployments
 		// DotNet deployments on macOS/Linux use default port or user-specified port
 		if (isIisDeployment) {
-			while (options.SitePort is <= 0 or > 65535) {
-				_logger.WriteLine(
-					$"Please enter site port, Max value - 65535:{Environment.NewLine}(recommended range between 40000 and 40100)");
-				if (int.TryParse(Console.ReadLine(), out int value)) {
-					options.SitePort = value;
-				}
-				else {
-					_logger.WriteLine("Site port must be an in value");
+			if (options.SitePortRange is not { Length: > 0 }) {
+				while (options.SitePort is <= 0 or > 65535) {
+					_logger.WriteLine(
+						$"Please enter site port, Max value - 65535:{Environment.NewLine}(recommended range between 40000 and 40100)");
+					if (int.TryParse(Console.ReadLine(), out int value)) {
+						options.SitePort = value;
+					}
+					else {
+						_logger.WriteLine("Site port must be an in value");
+					}
 				}
 			}
 		}
@@ -1483,7 +1489,12 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			$"[OS Platform] - {(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macOS" : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "Linux" : "Windows")}");
 		_logger.WriteInfo($"[Is IIS Deployment] - {isIisDeployment}");
 		_logger.WriteInfo($"[Site Name] - {options.SiteName}");
-		_logger.WriteInfo($"[Site Port] - {options.SitePort}");
+		if (options.SitePort is > 0 and <= 65535) {
+			_logger.WriteInfo($"[Site Port] - {options.SitePort}");
+		}
+		else if (isIisDeployment) {
+			_logger.WriteInfo($"[Site Port Range] - [{string.Join(", ", options.SitePortRange)}]");
+		}
 
 		// Emit the up-front manifest (built from the resolved execution path) before any stage runs, then
 		// wrap each real stage boundary with the emitter. Emission is observational only: with no
@@ -1501,9 +1512,7 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 			// features. Hold the name and target leases while preparing it, then validate the port.
 			iisDeploymentStrategy.PrepareHost();
 		}
-		using IDisposable portReservation = isIisDeployment
-			? _iisDeploymentPortReservation.Acquire(options.SitePort)
-			: null;
+		using IDisposable portReservation = isIisDeployment ? ReserveIisPort(options) : null;
 
 		// Target and IIS-port reservations are held before the first deployment mutation and remain held
 		// through registration. Deployments to independent target paths and ports can still run in parallel.
@@ -1665,6 +1674,32 @@ public class CreatioInstallerService : Command<PfInstallerOptions>, ICreatioInst
 		}
 
 		return 0;
+	}
+
+	private IDisposable ReserveIisPort(PfInstallerOptions options) {
+		if (options.SitePort is > 0 and <= 65535) {
+			return _iisDeploymentPortReservation.Acquire(options.SitePort);
+		}
+
+		ValidateSitePortRange(options.SitePortRange);
+		IisDeploymentPortLease lease = _iisDeploymentPortReservation.AcquireFirstAvailable(
+			options.SitePortRange[0], options.SitePortRange[1]);
+		options.SitePort = lease.Port;
+		_logger.WriteInfo(
+			$"[Site Port] - {lease.Port} (first available in configured range "
+			+ $"[{options.SitePortRange[0]}, {options.SitePortRange[1]}])");
+		return lease;
+	}
+
+	private static void ValidateSitePortRange(int[] range) {
+		if (range is not { Length: 2 }
+			|| range[0] is <= 0 or > 65535
+			|| range[1] is <= 0 or > 65535
+			|| range[0] > range[1]) {
+			throw new InvalidOperationException(
+				"Invalid deploy-creatio-defaults.site-port-range. Specify exactly two ports satisfying "
+				+ "1 <= start <= end <= 65535.");
+		}
 	}
 
 	internal static void ThrowIfServerNotReady(bool isReady) {

--- a/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
+++ b/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
@@ -83,11 +83,11 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 		}
 
 		if (options.SitePort == 0 && defaults.SitePort is > 0) {
-			options.SitePort = defaults.SitePort.Value;
+			options.ApplyConfiguredSitePort(defaults.SitePort.Value);
 			_logger.WriteInfo($"[Config default] site-port = {defaults.SitePort.Value}");
 		}
 
-		if (options.SitePort == 0 && defaults.SitePortRange is { Length: > 0 }) {
+		if (options.SitePort == 0 && defaults.SitePortRange is not null) {
 			options.SitePortRange = [.. defaults.SitePortRange];
 			_logger.WriteInfo($"[Config default] site-port-range = [{string.Join(", ", defaults.SitePortRange)}]");
 		}

--- a/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
+++ b/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
@@ -82,12 +82,12 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 			_logger.WriteInfo($"[Config default] site-name = {defaults.SiteName}");
 		}
 
-		if (options.SitePort == 0 && defaults.SitePort is > 0) {
+		if (!options.SitePortWasSpecified && options.SitePort == 0 && defaults.SitePort is > 0) {
 			options.ApplyConfiguredSitePort(defaults.SitePort.Value);
 			_logger.WriteInfo($"[Config default] site-port = {defaults.SitePort.Value}");
 		}
 
-		if (options.SitePort == 0 && defaults.SitePortRange is not null) {
+		if (!options.SitePortWasSpecified && options.SitePort == 0 && defaults.SitePortRange is not null) {
 			options.SitePortRange = [.. defaults.SitePortRange];
 			_logger.WriteInfo($"[Config default] site-port-range = [{string.Join(", ", defaults.SitePortRange)}]");
 		}

--- a/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
+++ b/clio/Command/CreatioInstallCommand/DeployCreatioDefaultsResolver.cs
@@ -87,6 +87,11 @@ public class DeployCreatioDefaultsResolver : IDeployCreatioDefaultsResolver {
 			_logger.WriteInfo($"[Config default] site-port = {defaults.SitePort.Value}");
 		}
 
+		if (options.SitePort == 0 && defaults.SitePortRange is { Length: > 0 }) {
+			options.SitePortRange = [.. defaults.SitePortRange];
+			_logger.WriteInfo($"[Config default] site-port-range = [{string.Join(", ", defaults.SitePortRange)}]");
+		}
+
 		// DeploymentMethod carries the "auto" parser default, so "auto" is treated as "not explicitly chosen"
 		// and can be overridden by a configured default.
 		if (IsDeploymentMethodUnset(options.DeploymentMethod) && !string.IsNullOrWhiteSpace(defaults.DeploymentMethod)) {

--- a/clio/Command/CreatioInstallCommand/InstallerCommand.cs
+++ b/clio/Command/CreatioInstallCommand/InstallerCommand.cs
@@ -140,11 +140,23 @@ public class PfInstallerOptions : EnvironmentNameOptions{
 		set { if (!string.IsNullOrEmpty(value)) SiteName = value; }
 	}
 
+	private int _sitePort;
+
 	/// <summary>
 	/// Gets or sets the site port for the deployed application.
 	/// </summary>
 	[Option("site-port", Required = false, HelpText = "Site port")]
-	public int SitePort { get; set; }
+	public int SitePort {
+		get => _sitePort;
+		set {
+			_sitePort = value;
+			SitePortWasSpecified = true;
+		}
+	}
+
+	internal bool SitePortWasSpecified { get; private set; }
+
+	internal void ApplyConfiguredSitePort(int value) => _sitePort = value;
 
 	/// <summary>
 	/// Gets or sets the configured inclusive IIS site-port range used when <see cref="SitePort"/> is unset.
@@ -155,7 +167,7 @@ public class PfInstallerOptions : EnvironmentNameOptions{
 	[Option("SitePort", Required = false, Hidden = true, HelpText = "Alias for --site-port")]
 	public int SitePortAlias {
 		get => SitePort;
-		set { if (value != 0) SitePort = value; }
+		set => SitePort = value;
 	}
 
 	/// <summary>

--- a/clio/Command/CreatioInstallCommand/InstallerCommand.cs
+++ b/clio/Command/CreatioInstallCommand/InstallerCommand.cs
@@ -146,6 +146,12 @@ public class PfInstallerOptions : EnvironmentNameOptions{
 	[Option("site-port", Required = false, HelpText = "Site port")]
 	public int SitePort { get; set; }
 
+	/// <summary>
+	/// Gets or sets the configured inclusive IIS site-port range used when <see cref="SitePort"/> is unset.
+	/// This value comes from <c>deploy-creatio-defaults</c> and is not a command-line option.
+	/// </summary>
+	public int[] SitePortRange { get; set; }
+
 	[Option("SitePort", Required = false, Hidden = true, HelpText = "Alias for --site-port")]
 	public int SitePortAlias {
 		get => SitePort;

--- a/clio/Command/McpServer/Prompts/DeployCreatioPrompt.cs
+++ b/clio/Command/McpServer/Prompts/DeployCreatioPrompt.cs
@@ -23,24 +23,23 @@ public static class DeployCreatioPrompt
 		[Required]
 		[Description("Path to the Creatio archive file")]
 		string zipFile,
-		[Required]
-		[Description("Port where Creatio will be deployed")]
-		int sitePort,
+		[Description("Optional explicit port; omit for local IIS to use deploy-creatio-defaults.site-port-range")]
+		int? sitePort = null,
 		[Description("Prefer HTTPS for local IIS deployment; falls back to HTTP when no usable certificate is installed")]
 		bool useHttps = false) =>
 		$"""
 		 Before calling `{InstallerCommandTool.DeployCreatioToolName}`, first run `assert-infrastructure`
 		 to review all passing and failing infrastructure, then run `show-passing-infrastructure` to get
 		 deployable choices and the recommended `dbServerName` and `redisServerName` values.
-		 If you are deploying locally to IIS, run `{FindEmptyIisPortTool.FindEmptyIisPortToolName}` to pick
-		 a safe `sitePort` between {FindEmptyIisPortTool.RangeStart} and {FindEmptyIisPortTool.RangeEnd}.
-		 The deploy command then reserves and revalidates that IIS port before changing the target, so a
-		 concurrent collision fails safely. It also serializes deploy and uninstall operations resolving to
+		 For local IIS, omit `sitePort` to let clio reserve the first available port from the configured
+		 `deploy-creatio-defaults.site-port-range`. Run `{FindEmptyIisPortTool.FindEmptyIisPortToolName}` only
+		 when you want to inspect or explicitly choose a port. The deploy command reserves and revalidates
+		 the chosen port before changing the target. It also serializes deploy and uninstall operations resolving to
 		 the same environment name or physical directory; separate names, ports, and target directories can deploy in parallel.
 		 The deployment preserves the build database's existing forced-password-change state and does not
 		 clear it automatically.
 		 After that preflight, call `{InstallerCommandTool.DeployCreatioToolName}` with site name `{siteName}`,
-		 zip file `{zipFile}`, site port `{sitePort}`, useHttps `{useHttps.ToString().ToLowerInvariant()}`, and the selected or recommended server-name arguments.
+		 zip file `{zipFile}`, site port `{sitePort?.ToString() ?? "omitted (use configured range)"}`, useHttps `{useHttps.ToString().ToLowerInvariant()}`, and the selected or recommended server-name arguments.
 		 For local IIS, useHttps is opportunistic: clio uses one usable LocalMachine/My certificate matching
 		 the host, or warns and continues with HTTP when none is available.
 		 """;

--- a/clio/Command/McpServer/Prompts/FindEmptyIisPortPrompt.cs
+++ b/clio/Command/McpServer/Prompts/FindEmptyIisPortPrompt.cs
@@ -21,7 +21,8 @@ public static class FindEmptyIisPortPrompt
 		 1. Run `{AssertInfrastructureTool.AssertInfrastructureToolName}` to check infrastructure health and identify failing areas.
 		 2. Run `{ShowPassingInfrastructureTool.ShowPassingInfrastructureToolName}` to select passing database and Redis targets.
 		 3. Run `{FindEmptyIisPortTool.FindEmptyIisPortToolName}` to find an available port in range {FindEmptyIisPortTool.RangeStart}–{FindEmptyIisPortTool.RangeEnd}.
-		 4. Pass the returned port as `sitePort` to `{InstallerCommandTool.DeployCreatioToolName}`.
+		 4. Pass the returned port as `sitePort` to `{InstallerCommandTool.DeployCreatioToolName}` only when
+		    you want to override its configured automatic site-port range.
 		 This workflow ensures no port conflicts and validates all prerequisites before deployment.
 		 """;
 }

--- a/clio/Command/McpServer/Tools/FindEmptyIisPortTool.cs
+++ b/clio/Command/McpServer/Tools/FindEmptyIisPortTool.cs
@@ -39,7 +39,8 @@ public sealed class FindEmptyIisPortTool
 	[Description("""
 				 Finds the first free IIS deployment port between 40000 and 42000.
 
-				 Use this before `deploy-creatio` when you need a safe local IIS `sitePort`. Run
+				 Use this when you want to inspect or explicitly choose a safe local IIS `sitePort` for
+				 `deploy-creatio`; deployment can otherwise use its configured automatic range. Run
 				 `assert-infrastructure` for full visibility, run `show-passing-infrastructure` to choose
 				 database and Redis targets, and then run `find-empty-iis-port` to choose the local IIS port.
 				 """)]

--- a/clio/Command/McpServer/Tools/InstallerCommandTool.cs
+++ b/clio/Command/McpServer/Tools/InstallerCommandTool.cs
@@ -43,11 +43,14 @@ public class InstallerCommandTool(
 
 				 Before calling this tool, first run `assert-infrastructure` for full infrastructure visibility,
 				 then run `show-passing-infrastructure` for deployable choices and recommendations.
-				 If you are deploying locally to IIS, also run `find-empty-iis-port` to choose a safe `sitePort`.
+				 For local IIS, omit `sitePort` to let clio reserve the first available port from
+				 `deploy-creatio-defaults.site-port-range`; use `find-empty-iis-port` only when you want to
+				 inspect or explicitly choose a port.
 				 Review the failing areas from `assert-infrastructure`, prefer the recommended bundle from
 				 `show-passing-infrastructure`, and then call `deploy-creatio` with the selected arguments.
-				 For an IIS deployment, clio reserves and revalidates `sitePort` across concurrent clio
-				 processes before changing files, databases, or IIS. A collision fails the deployment;
+				 For an IIS deployment, clio reserves and revalidates the explicit or automatically selected
+				 port across concurrent clio processes before changing files, databases, or IIS. An explicit
+				 port collision fails; automatic selection continues through the configured range.
 				 deploy and uninstall are also serialized by environment name and physical target directory.
 				 Deployments on different names, ports, and target directories can proceed in parallel.
 				 Deployment preserves the build database's existing forced-password-change state and does not
@@ -70,7 +73,7 @@ public class InstallerCommandTool(
 		{
 			SiteName = args.SiteName,
 			ZipFile = args.ZipFile,
-			SitePort = args.SitePort,
+			SitePort = args.SitePort ?? 0,
 			DbServerName = args.DbServerName,
 			RedisServerName = args.RedisServerName,
 			UseHttps = args.UseHttps,
@@ -109,17 +112,16 @@ public sealed record DeployCreatioArgs(
 	string ZipFile,
 
 	[property: JsonPropertyName("sitePort")]
-	[property: Description("Port where Creatio will be deployed; IIS deployments reserve and validate it before mutation")]
-	[property: Required]
-	int SitePort,
+	[property: Description("Optional explicit deployment port; omit for local IIS to reserve the first available configured site-port-range value")]
+	int? SitePort = null,
 
 	[property: JsonPropertyName("dbServerName")]
 	[property: Description("Optional local database server configuration name; omit to keep the default Kubernetes deployment path")]
-	string? DbServerName,
+	string? DbServerName = null,
 
 	[property: JsonPropertyName("redisServerName")]
 	[property: Description("Optional local Redis server configuration name")]
-	string? RedisServerName,
+	string? RedisServerName = null,
 
 	[property: JsonPropertyName("useHttps")]
 	[property: Description("Prefer HTTPS for local IIS deployment; falls back to HTTP when no usable certificate is installed")]

--- a/clio/Command/McpServer/Tools/InstallerCommandTool.cs
+++ b/clio/Command/McpServer/Tools/InstallerCommandTool.cs
@@ -73,7 +73,6 @@ public class InstallerCommandTool(
 		{
 			SiteName = args.SiteName,
 			ZipFile = args.ZipFile,
-			SitePort = args.SitePort ?? 0,
 			DbServerName = args.DbServerName,
 			RedisServerName = args.RedisServerName,
 			UseHttps = args.UseHttps,
@@ -83,6 +82,9 @@ public class InstallerCommandTool(
 			IsSilent = true,
 			DropIfExists = true
 		};
+		if (args.SitePort.HasValue) {
+			options.SitePort = args.SitePort.Value;
+		}
 
 		// Subscribe the injected command (an IStageEventSource) so each ClioStageEvent is forwarded as a
 		// notifications/progress with the typed envelope in _meta.clioStageEvent. No-op when the caller

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5559,10 +5559,9 @@ internal static class ToolContractCatalog {
 				[
 					AssertInfrastructureTool.AssertInfrastructureToolName,
 					ShowPassingInfrastructureTool.ShowPassingInfrastructureToolName,
-					FindEmptyIisPortTool.FindEmptyIisPortToolName,
 					InstallerCommandTool.DeployCreatioToolName
 				],
-				"Canonical deploy preflight: assert full infrastructure, narrow to passing choices, pick a safe local IIS port, then deploy. See the deploy-lifecycle guidance topic via get-guidance."),
+				"Canonical deploy preflight: assert full infrastructure, narrow to passing choices, then deploy. Clio can select a local IIS port from its configured range. See the deploy-lifecycle guidance topic via get-guidance."),
 			[],
 			[]);
 	}
@@ -5600,7 +5599,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildFindEmptyIisPort() {
 		return new ToolContractDefinition(
 			FindEmptyIisPortTool.FindEmptyIisPortToolName,
-			"Finds the first free IIS deployment port between 40000 and 42000. Use this before deploy-creatio when you need a safe local IIS sitePort.",
+			"Finds the first free IIS deployment port between 40000 and 42000. Use this when you want to inspect or explicitly choose deploy-creatio sitePort; deploy-creatio can otherwise use its configured automatic range.",
 			new ToolInputSchemaContract([], []),
 			StructuredResultOutput(
 				Field("status", StringType, "Availability status for the requested range."),
@@ -5621,7 +5620,7 @@ internal static class ToolContractCatalog {
 					FindEmptyIisPortTool.FindEmptyIisPortToolName,
 					InstallerCommandTool.DeployCreatioToolName
 				],
-				"Pass firstAvailablePort as the deploy-creatio sitePort for a local IIS deployment."),
+				"Optionally pass firstAvailablePort as deploy-creatio sitePort to override its configured automatic range."),
 			[],
 			[]);
 	}
@@ -5629,13 +5628,13 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildDeployCreatio() {
 		return new ToolContractDefinition(
 			InstallerCommandTool.DeployCreatioToolName,
-			"Deploys Creatio from a zip archive using the real deploy-creatio command path. This is the most consequential, hardest-to-reverse lifecycle tool: it drops and recreates the target site. Run the deploy preflight first (assert-infrastructure -> show-passing-infrastructure -> find-empty-iis-port) and prefer the recommended bundle from show-passing-infrastructure. IIS deployment reserves and revalidates sitePort across concurrent clio processes before target mutation, and deploy/uninstall serialize by environment name and physical target directory. Deployment preserves the build database's existing forced-password-change state and does not clear it automatically.",
+			"Deploys Creatio from a zip archive using the real deploy-creatio command path. This is the most consequential, hardest-to-reverse lifecycle tool: it drops and recreates the target site. Run assert-infrastructure then show-passing-infrastructure and prefer the recommended bundle. For local IIS, omit sitePort to reserve the first available port from deploy-creatio-defaults.site-port-range, or pass an explicit override. IIS deployment reserves and revalidates the chosen port across concurrent clio processes before target mutation, and deploy/uninstall serialize by environment name and physical target directory. Deployment preserves the build database's existing forced-password-change state and does not clear it automatically.",
 			new ToolInputSchemaContract(
-				[SiteNameFieldName, ZipFileFieldName, SitePortFieldName],
+				[SiteNameFieldName, ZipFileFieldName],
 				[
 					Field(SiteNameFieldName, StringType, "Creatio instance name."),
 					Field(ZipFileFieldName, StringType, "Absolute path to the Creatio build archive (.zip). Pick a build from the configured creatio-products folder when the path is unknown."),
-					Field(SitePortFieldName, NumberType, "Port where Creatio will be deployed. Use find-empty-iis-port to choose a safe local IIS port."),
+					Field(SitePortFieldName, NumberType, "Optional explicit port. Omit for local IIS to reserve the first available port from deploy-creatio-defaults.site-port-range."),
 					Field(DbServerNameFieldName, StringType, "Optional local database server configuration name; omit to keep the default Kubernetes deployment path."),
 					Field(RedisServerNameFieldName, StringType, "Optional local Redis server configuration name."),
 					Field(UseHttpsFieldName, BooleanType, "Prefer HTTPS for local IIS deployment. Uses a matching usable LocalMachine/My certificate and falls back to HTTP with a warning when none is available.")
@@ -5648,7 +5647,6 @@ internal static class ToolContractCatalog {
 				Example("Deploy a local IIS instance after the deploy preflight", new Dictionary<string, object?> {
 					[SiteNameFieldName] = "creatio-app",
 					[ZipFileFieldName] = @"F:\CreatioBuilds\8.1.5.2176_StudioNet8_Softkey_PostgreSQL_ENU.zip",
-					[SitePortFieldName] = 40001,
 					[DbServerNameFieldName] = "postgres-local",
 					[RedisServerNameFieldName] = "redis-local",
 					[UseHttpsFieldName] = true
@@ -5658,7 +5656,6 @@ internal static class ToolContractCatalog {
 				[
 					AssertInfrastructureTool.AssertInfrastructureToolName,
 					ShowPassingInfrastructureTool.ShowPassingInfrastructureToolName,
-					FindEmptyIisPortTool.FindEmptyIisPortToolName,
 					InstallerCommandTool.DeployCreatioToolName
 				],
 				"Always run the full deploy preflight before deploy-creatio. After deployment, register the instance with reg-web-app and install cliogate with install-gate before using workspace tools."),
@@ -5666,7 +5663,7 @@ internal static class ToolContractCatalog {
 			[],
 			Preconditions: [
 				"assert-infrastructure was run and the targeted database/Redis sections pass (or were chosen from show-passing-infrastructure).",
-				"For a local IIS deployment, sitePort is a free port (use find-empty-iis-port).",
+				"For a local IIS deployment, omit sitePort to use the configured automatic range or pass a free explicit port (find-empty-iis-port can inspect one).",
 				"zipFile points at an existing Creatio build archive (pick one from the configured creatio-products folder)."
 			]);
 	}

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -524,7 +524,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="dc"></a>
 <a id="ic"></a>
 <a id="install-creatio"></a>
-- [`deploy-creatio`](docs/commands/deploy-creatio.md) - Install Creatio with collision-safe IIS port reservation and local infrastructure defaults, `dc`, `ic`, `install-creatio`
+- [`deploy-creatio`](docs/commands/deploy-creatio.md) - Install Creatio with automatic collision-safe IIS port selection and local infrastructure defaults, `dc`, `ic`, `install-creatio`
 <a id="deploy-identity"></a>
 - [`deploy-identity`](docs/commands/deploy-identity.md) - Deploy IdentityService to IIS and connect it to a Creatio environment
 <a id="get-identity-service-config"></a>
@@ -740,7 +740,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="register"></a>
 - [`register`](docs/commands/register.md) - Register clio shell integrations
 <a id="config"></a>
-- [`config`](docs/commands/config.md) - View and set clio configuration defaults (e.g. deploy-creatio defaults used by the Explorer context menu)
+- [`config`](docs/commands/config.md) - View and set clio configuration defaults, including the deploy-creatio IIS port range
 <a id="pin-certificate"></a>
 - [`pin-certificate`](docs/commands/pin-certificate.md) - Select the preferred local IIS certificate for HTTPS deployments
 <a id="set-app-icon"></a>

--- a/clio/Common/IIS/IisDeploymentPortReservation.cs
+++ b/clio/Common/IIS/IisDeploymentPortReservation.cs
@@ -28,18 +28,18 @@ public interface IIisDeploymentPortReservation {
 
 /// <summary>Represents an owned IIS deployment port reservation.</summary>
 public sealed class IisDeploymentPortLease : IDisposable {
-	private readonly FileStream _lockStream;
+	private readonly IDisposable _reservation;
 
-	internal IisDeploymentPortLease(int port, FileStream lockStream) {
+	internal IisDeploymentPortLease(int port, IDisposable reservation) {
 		Port = port;
-		_lockStream = lockStream;
+		_reservation = reservation;
 	}
 
 	/// <summary>Gets the reserved port.</summary>
 	public int Port { get; }
 
 	/// <inheritdoc />
-	public void Dispose() => _lockStream.Dispose();
+	public void Dispose() => _reservation.Dispose();
 }
 
 /// <summary>

--- a/clio/Common/IIS/IisDeploymentPortReservation.cs
+++ b/clio/Common/IIS/IisDeploymentPortReservation.cs
@@ -16,6 +16,30 @@ public interface IIisDeploymentPortReservation {
 	/// <returns>A lease that must remain alive until IIS has created the binding.</returns>
 	IDisposable Acquire(int port);
 
+	/// <summary>
+	/// Scans the inclusive range in ascending order and atomically reserves the first IIS port that remains free.
+	/// </summary>
+	/// <param name="rangeStart">Inclusive first candidate port.</param>
+	/// <param name="rangeEnd">Inclusive last candidate port.</param>
+	/// <returns>A lease exposing the selected port; keep it alive until IIS creates the binding.</returns>
+	IisDeploymentPortLease AcquireFirstAvailable(int rangeStart, int rangeEnd);
+
+}
+
+/// <summary>Represents an owned IIS deployment port reservation.</summary>
+public sealed class IisDeploymentPortLease : IDisposable {
+	private readonly FileStream _lockStream;
+
+	internal IisDeploymentPortLease(int port, FileStream lockStream) {
+		Port = port;
+		_lockStream = lockStream;
+	}
+
+	/// <summary>Gets the reserved port.</summary>
+	public int Port { get; }
+
+	/// <inheritdoc />
+	public void Dispose() => _lockStream.Dispose();
 }
 
 /// <summary>
@@ -29,33 +53,15 @@ public sealed class IisDeploymentPortReservation(IAvailableIisPortService availa
 
 	/// <inheritdoc />
 	public IDisposable Acquire(int port) {
-		if (port is <= 0 or > 65535) {
-			throw new ArgumentOutOfRangeException(nameof(port), port, "IIS port must be between 1 and 65535.");
-		}
-
-		string lockRoot = Path.Combine(
-			Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-			"Creatio", "clio", "deployment-locks");
-		FileStream lockStream;
-		try {
-			Directory.CreateDirectory(lockRoot);
-			lockStream = new FileStream(Path.Combine(lockRoot, $"iis-port-{port}.lock"),
-				FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
-		}
-		catch (IOException) {
+		ValidatePort(port, nameof(port));
+		FileStream lockStream = TryOpenLock(port);
+		if (lockStream is null) {
 			throw new InvalidOperationException(
 				$"IIS port {port} is already reserved by another clio deployment. Choose a different port.");
 		}
-		catch (UnauthorizedAccessException exception) {
-			throw new InvalidOperationException(
-				"Clio cannot access the machine-wide deployment lock directory. Run with an account that can read and create files under the shared Creatio clio data directory.",
-				exception);
-		}
 		try {
-			FindAvailableIisPortResult availability = _availableIisPortService.FindAsync(port, port)
-				.GetAwaiter().GetResult();
-			if (!string.Equals(availability.Status, "available", StringComparison.Ordinal)
-				|| availability.FirstAvailablePort != port) {
+			FindAvailableIisPortResult availability = Find(port, port);
+			if (!IsAvailable(availability, port)) {
 				throw new InvalidOperationException(
 					$"IIS port {port} is not available or could not be verified. {availability.Summary}");
 			}
@@ -65,6 +71,80 @@ public sealed class IisDeploymentPortReservation(IAvailableIisPortService availa
 		catch {
 			lockStream.Dispose();
 			throw;
+		}
+	}
+
+	/// <inheritdoc />
+	public IisDeploymentPortLease AcquireFirstAvailable(int rangeStart, int rangeEnd) {
+		ValidatePort(rangeStart, nameof(rangeStart));
+		ValidatePort(rangeEnd, nameof(rangeEnd));
+		if (rangeStart > rangeEnd) {
+			throw new ArgumentException("The IIS port range start must be less than or equal to its end.");
+		}
+
+		int candidateStart = rangeStart;
+		string lastSummary = "No port in the range was reported available.";
+		while (candidateStart <= rangeEnd) {
+			FindAvailableIisPortResult scan = Find(candidateStart, rangeEnd);
+			lastSummary = scan.Summary;
+			if (!string.Equals(scan.Status, "available", StringComparison.Ordinal)
+				|| scan.FirstAvailablePort is not int candidate) {
+				break;
+			}
+
+			FileStream lockStream = TryOpenLock(candidate);
+			if (lockStream is null) {
+				candidateStart = candidate + 1;
+				continue;
+			}
+			try {
+				FindAvailableIisPortResult revalidation = Find(candidate, candidate);
+				lastSummary = revalidation.Summary;
+				if (IsAvailable(revalidation, candidate)) {
+					return new IisDeploymentPortLease(candidate, lockStream);
+				}
+			}
+			catch {
+				lockStream.Dispose();
+				throw;
+			}
+			lockStream.Dispose();
+			candidateStart = candidate + 1;
+		}
+
+		throw new InvalidOperationException(
+			$"No available IIS port could be reserved in the configured range [{rangeStart}, {rangeEnd}]. {lastSummary}");
+	}
+
+	private FindAvailableIisPortResult Find(int rangeStart, int rangeEnd) =>
+		_availableIisPortService.FindAsync(rangeStart, rangeEnd).GetAwaiter().GetResult();
+
+	private static bool IsAvailable(FindAvailableIisPortResult result, int port) =>
+		string.Equals(result.Status, "available", StringComparison.Ordinal)
+		&& result.FirstAvailablePort == port;
+
+	private static FileStream TryOpenLock(int port) {
+		string lockRoot = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+			"Creatio", "clio", "deployment-locks");
+		try {
+			Directory.CreateDirectory(lockRoot);
+			return new FileStream(Path.Combine(lockRoot, $"iis-port-{port}.lock"),
+				FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
+		}
+		catch (IOException) {
+			return null;
+		}
+		catch (UnauthorizedAccessException exception) {
+			throw new InvalidOperationException(
+				"Clio cannot access the machine-wide deployment lock directory. Run with an account that can read and create files under the shared Creatio clio data directory.",
+				exception);
+		}
+	}
+
+	private static void ValidatePort(int port, string parameterName) {
+		if (port is <= 0 or > 65535) {
+			throw new ArgumentOutOfRangeException(parameterName, port, "IIS port must be between 1 and 65535.");
 		}
 	}
 

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -296,6 +296,12 @@ namespace Clio
 	/// </remarks>
 	public class DeployCreatioDefaults
 	{
+		/// <summary>Built-in inclusive start of the automatic IIS site-port range.</summary>
+		public const int DefaultSitePortRangeStart = 40100;
+
+		/// <summary>Built-in inclusive end of the automatic IIS site-port range.</summary>
+		public const int DefaultSitePortRangeEnd = 40199;
+
 		/// <summary>
 		/// Gets or sets the default local database server name (a key in the <c>db</c> settings block)
 		/// used when <c>--db-server-name</c> is omitted.
@@ -325,6 +331,13 @@ namespace Clio
 		public int? SitePort { get; set; }
 
 		/// <summary>
+		/// Gets or sets the inclusive IIS site-port range used when neither an explicit nor configured fixed
+		/// site port is available. The array must contain exactly the start and end ports.
+		/// </summary>
+		[JsonProperty("site-port-range")]
+		public int[] SitePortRange { get; set; }
+
+		/// <summary>
 		/// Gets or sets the default deployment method (<c>auto</c>, <c>iis</c>, or <c>dotnet</c>) used when
 		/// <c>--deployment</c> is omitted or left at its <c>auto</c> default.
 		/// </summary>
@@ -341,7 +354,14 @@ namespace Clio
 			&& string.IsNullOrWhiteSpace(RedisServerName)
 			&& string.IsNullOrWhiteSpace(SiteName)
 			&& !SitePort.HasValue
+			&& SitePortRange is not { Length: > 0 }
 			&& string.IsNullOrWhiteSpace(DeploymentMethod);
+
+		/// <summary>Creates deployment defaults containing Clio's built-in automatic IIS port range.</summary>
+		/// <returns>A new defaults object with an independent two-element range array.</returns>
+		public static DeployCreatioDefaults CreateWithDefaultSitePortRange() => new() {
+			SitePortRange = [DefaultSitePortRangeStart, DefaultSitePortRangeEnd]
+		};
 	}
 
 	/// <summary>

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -59,7 +59,7 @@ public sealed record SettingsBootstrapResult(
 public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	private const string SettingsFileUnreadableCode = "settings-file-unreadable";
 	private const string SettingsFileMissingCode = "settings-file-missing";
-	private const int CurrentSettingsVersion = 1;
+	private const int CurrentSettingsVersion = 2;
 
 	/// <summary>
 	/// Status reported when appsettings.json does not exist and the caller asked for no repair write.
@@ -111,7 +111,11 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	private SettingsBootstrapResult LoadUnlocked(bool applyRepairs) {
 		string settingsFilePath = SettingsRepository.AppSettingsFile;
 		if (!_fileSystem.File.Exists(settingsFilePath)) {
-			Settings emptySettings = new() { Environments = [], SettingsVersion = CurrentSettingsVersion };
+			Settings emptySettings = new() {
+				Environments = [],
+				SettingsVersion = CurrentSettingsVersion,
+				DeployCreatioDefaults = DeployCreatioDefaults.CreateWithDefaultSitePortRange()
+			};
 			if (applyRepairs) {
 				SettingsRepository.SaveSettings(_fileSystem, emptySettings, expectedContent: null,
 					verifyExpectedContent: true);
@@ -182,12 +186,26 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 		// silently disabling auto-update. Clear that legacy artifact so the opt-out default
 		// (enabled) applies again. Guarded by SettingsVersion, this runs once — a deliberate
 		// 'clio autoupdate --disable' made afterwards is preserved.
-		if (settings.Autoupdate == false) {
+		if ((settings.SettingsVersion ?? 0) < 1 && settings.Autoupdate == false) {
 			settings.Autoupdate = null;
 			repairs.Add(new SettingsRepair(
 				"autoupdate-legacy-default-reset",
 				"auto-update was disabled by a legacy default and has been re-enabled "
 				+ "(run 'clio autoupdate --disable' to opt out)"));
+		}
+		// Migration 2 makes automatic IIS port selection visible and immediately usable after an upgrade.
+		// Preserve a user-configured range; only materialize the built-in range when the setting was absent.
+		if ((settings.SettingsVersion ?? 0) < 2
+			&& settings.DeployCreatioDefaults?.SitePortRange is not { Length: > 0 }) {
+			settings.DeployCreatioDefaults ??= new DeployCreatioDefaults();
+			settings.DeployCreatioDefaults.SitePortRange = [
+				DeployCreatioDefaults.DefaultSitePortRangeStart,
+				DeployCreatioDefaults.DefaultSitePortRangeEnd
+			];
+			repairs.Add(new SettingsRepair(
+				"deploy-creatio-site-port-range-added",
+				$"deploy-creatio default site-port-range was set to "
+				+ $"[{DeployCreatioDefaults.DefaultSitePortRangeStart}, {DeployCreatioDefaults.DefaultSitePortRangeEnd}]"));
 		}
 		settings.SettingsVersion = CurrentSettingsVersion;
 		return true;

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -196,7 +196,7 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 		// Migration 2 makes automatic IIS port selection visible and immediately usable after an upgrade.
 		// Preserve a user-configured range; only materialize the built-in range when the setting was absent.
 		if ((settings.SettingsVersion ?? 0) < 2
-			&& settings.DeployCreatioDefaults?.SitePortRange is not { Length: > 0 }) {
+			&& settings.DeployCreatioDefaults?.SitePortRange is null) {
 			settings.DeployCreatioDefaults ??= new DeployCreatioDefaults();
 			settings.DeployCreatioDefaults.SitePortRange = [
 				DeployCreatioDefaults.DefaultSitePortRangeStart,

--- a/clio/docs/commands/config.md
+++ b/clio/docs/commands/config.md
@@ -13,7 +13,7 @@ config - View and set clio configuration defaults
 ```bash
 config
 config --show
-config --deploy-db-server-name <name> [--deploy-redis-server-name <name>] [--deploy-site-name <name>] [--deploy-site-port <port>] [--deploy-deployment <auto|iis|dotnet>]
+config --deploy-db-server-name <name> [--deploy-redis-server-name <name>] [--deploy-site-name <name>] [--deploy-site-port <port>] [--deploy-site-port-range <start,end>] [--deploy-deployment <auto|iis|dotnet>]
 config --knowledge-feedback-mode <ask|auto|off> [--knowledge-feedback-destination <repository-url>] [--knowledge-feedback-reporting-scope <full|sanitized>]
 config --reset
 ```
@@ -58,6 +58,12 @@ article changes, configured mode remains `auto` while effective mode becomes
                                    interactive deployment prompts for the site name.
 
 --deploy-site-port <port>          Default site port for deploy-creatio.
+								   Takes precedence over site-port-range.
+
+--deploy-site-port-range <start,end>
+								   Inclusive automatic IIS port range. Setting it clears
+								   the fixed site port. Fresh and upgraded settings use
+								   40100,40199 when no range was configured.
 
 --deploy-deployment <method>       Default deployment method for deploy-creatio: auto|iis|dotnet.
 
@@ -85,7 +91,7 @@ article changes, configured mode remains `auto` while effective mode becomes
 clio config
 
 # Configure local deployment defaults for the Explorer right-click action
-clio config --deploy-db-server-name my-local-postgres --deploy-site-port 40018 --deploy-deployment iis
+clio config --deploy-db-server-name my-local-postgres --deploy-site-port-range 40100,40199 --deploy-deployment iis
 
 # Add a default local Redis server name
 clio config --deploy-redis-server-name local-redis
@@ -114,6 +120,8 @@ the site name before deployment proceeds.
   tables for deploy-creatio defaults and the configured/effective knowledge-feedback policy.
 - With one or more `--deploy-*` arguments, updates only the supplied values,
   persists them, and prints the resulting defaults.
+- A configured fixed site port takes precedence over the range. Setting
+  `--deploy-site-port-range` clears that fixed port so automatic selection is active.
 - With `--reset`, removes the stored deploy-creatio defaults entirely.
 - `--reset` takes precedence over any `--deploy-*` arguments in the same call.
 - Knowledge-feedback policy can also be inspected with the non-resident

--- a/clio/docs/commands/config.md
+++ b/clio/docs/commands/config.md
@@ -78,7 +78,7 @@ article changes, configured mode remains `auto` while effective mode becomes
                                    full for comprehensive internal reports;
                                    sanitized for public-safe reports.
 
---reset                            Clear the stored deploy-creatio defaults.
+--reset                            Clear custom deploy-creatio defaults and restore built-ins.
 
 --show                             Show the current configuration defaults (default when no
                                    other arguments are supplied).
@@ -122,7 +122,7 @@ the site name before deployment proceeds.
   persists them, and prints the resulting defaults.
 - A configured fixed site port takes precedence over the range. Setting
   `--deploy-site-port-range` clears that fixed port so automatic selection is active.
-- With `--reset`, removes the stored deploy-creatio defaults entirely.
+- With `--reset`, removes custom deploy-creatio defaults and restores `site-port-range` `[40100, 40199]`.
 - `--reset` takes precedence over any `--deploy-*` arguments in the same call.
 - Knowledge-feedback policy can also be inspected with the non-resident
   `get-knowledge-feedback-policy` MCP tool and changed with

--- a/clio/docs/commands/deploy-creatio.md
+++ b/clio/docs/commands/deploy-creatio.md
@@ -18,14 +18,29 @@ Deploys Creatio application from a zip file. On Windows, deploys to Internet Inf
 Services (IIS) by default. On macOS and Linux, uses dotnet runtime. Supports cross-platform
 deployment with optional HTTPS configuration and automatic service management.
 
-For IIS deployments, clio reserves the requested port across concurrent clio
-processes before extracting files, restoring the database, or creating IIS
-objects. The command also checks existing IIS bindings and active listeners.
-If the port is already used or another clio deployment has reserved it, the
-deployment fails before changing the target. Clio also serializes deploy and
+For IIS deployments, an explicit `--site-port` wins. Otherwise a configured fixed
+`deploy-creatio-defaults.site-port` wins, followed by the first available port in
+`deploy-creatio-defaults.site-port-range`. Fresh and upgraded Clio settings persist
+the built-in inclusive range `[40100, 40199]` when no range was configured.
+
+Clio reserves the chosen port across concurrent processes before extracting files,
+restoring the database, or creating IIS objects. The command also checks existing
+IIS bindings and active listeners. An explicit used or reserved port fails; automatic
+selection continues to the next range candidate. Clio also serializes deploy and
 uninstall operations that use the same environment name or resolve to the same
 physical target directory. Deployments using different names, ports, and target
 directories can still run in parallel.
+
+The default persisted settings fragment is:
+
+```json
+{
+  "deploy-creatio-defaults": {
+    "site-port-range": [40100, 40199]
+  }
+}
+```
+
 On a clean Windows host, clio prepares required IIS features while holding the
 name and target reservations, then performs the IIS/TCP port validation.
 Site names must be safe single directory names. An explicit `--app-path` must be an
@@ -93,8 +108,10 @@ for this value. Silent deployment fails with a clear error instead of waiting
 for console input.
 
 --site-port PORT
-HTTP port number for the application
-Default: 80 (HTTP), 443 (HTTPS)
+Optional explicit application port. For IIS this overrides the configured fixed
+site port and automatic range. When omitted, Clio uses the fixed default when
+present or reserves the first available configured-range port. Dotnet deployment
+retains its existing interactive/default port behavior.
 
 --zip-file FILE_PATH
 Required. Path to Creatio zip file or directory
@@ -214,8 +231,8 @@ Default: false
 ## Examples
 
 ```bash
-1. Basic deployment with default settings (PostgreSQL, port 40001, auto-run):
-clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --site-port 40001 --silent
+1. Basic IIS deployment using the configured automatic port range:
+clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --silent
 
 2. Deploy with MS SQL and custom port:
 clio deploy-creatio --site-name "Production" --db mssql --site-port 8080 \\
@@ -317,7 +334,7 @@ Password Reset Script (Creatio >= 8.3.3):
 - Script errors do not block deployment (warning only)
 
 Windows (Default - IIS):
-- Reserves and validates the requested port before deployment changes begin
+- Reserves and validates the explicit, fixed-default, or automatically selected port before deployment changes begin
 - Creates IIS Application Pool
 - Creates IIS Website with exactly one HTTP or HTTPS binding
 - Treats required IIS creation failures as deployment failures

--- a/clio/help/en/config.txt
+++ b/clio/help/en/config.txt
@@ -73,7 +73,7 @@ OPTIONS
                                       full for comprehensive internal reports;
                                       sanitized for public-safe reports.
 
-    --reset                            Clear the stored deploy-creatio defaults.
+    --reset                            Clear custom deploy-creatio defaults and restore built-ins.
 
     --show                             Show the current configuration defaults.
                                        This is also the default when no other
@@ -108,7 +108,7 @@ BEHAVIOR
       persists them, and prints the resulting defaults.
 	- A configured fixed site port takes precedence over the range. Setting
 	  --deploy-site-port-range clears that fixed port so automatic selection is active.
-    - With --reset, removes the stored deploy-creatio defaults entirely.
+    - With --reset, removes custom deploy-creatio defaults and restores site-port-range [40100, 40199].
     - --reset takes precedence over any --deploy-* arguments in the same call.
     - Non-resident MCP tools get-knowledge-feedback-policy and
       configure-knowledge-feedback-policy expose the same policy through clio-run.

--- a/clio/help/en/config.txt
+++ b/clio/help/en/config.txt
@@ -9,6 +9,7 @@ SYNOPSIS
     config --show
     config --deploy-db-server-name <name> [--deploy-redis-server-name <name>]
            [--deploy-site-name <name>] [--deploy-site-port <port>]
+		   [--deploy-site-port-range <start,end>]
            [--deploy-deployment <auto|iis|dotnet>]
     config --knowledge-feedback-mode <ask|auto|off>
            [--knowledge-feedback-destination <repository-url>]
@@ -52,6 +53,12 @@ OPTIONS
                                        prompts for the site name.
 
     --deploy-site-port <port>          Default site port for deploy-creatio.
+									   Takes precedence over site-port-range.
+
+	--deploy-site-port-range <start,end>
+									   Inclusive automatic IIS port range. Setting it
+									   clears the configured fixed site port. Fresh and
+									   upgraded settings default to 40100,40199.
 
     --deploy-deployment <method>       Default deployment method for
                                        deploy-creatio: auto|iis|dotnet.
@@ -77,7 +84,7 @@ EXAMPLES
     config
 
     # Configure local deployment defaults for the Explorer right-click action
-    config --deploy-db-server-name my-local-postgres --deploy-site-port 40018 --deploy-deployment iis
+	config --deploy-db-server-name my-local-postgres --deploy-site-port-range 40100,40199 --deploy-deployment iis
 
     # Add a default local Redis server name
     config --deploy-redis-server-name local-redis
@@ -99,6 +106,8 @@ BEHAVIOR
       tables for deploy-creatio defaults and knowledge-feedback policy.
     - With one or more --deploy-* arguments, updates only the supplied values,
       persists them, and prints the resulting defaults.
+	- A configured fixed site port takes precedence over the range. Setting
+	  --deploy-site-port-range clears that fixed port so automatic selection is active.
     - With --reset, removes the stored deploy-creatio defaults entirely.
     - --reset takes precedence over any --deploy-* arguments in the same call.
     - Non-resident MCP tools get-knowledge-feedback-policy and

--- a/clio/help/en/deploy-creatio.txt
+++ b/clio/help/en/deploy-creatio.txt
@@ -13,13 +13,23 @@ DESCRIPTION
     Services (IIS) by default. On macOS and Linux, uses dotnet runtime. Supports cross-platform
     deployment with optional HTTPS configuration and automatic service management.
 
-    For IIS deployments, clio reserves the requested port across concurrent clio
-    processes before extracting files, restoring the database, or creating IIS
-    objects. Existing IIS bindings and active listeners are checked too. A used
-    or concurrently reserved port fails before target mutation. Deploy and uninstall
+	For IIS deployments, an explicit --site-port wins. Otherwise a configured fixed
+	deploy-creatio-defaults.site-port wins, followed by the first available port in
+	deploy-creatio-defaults.site-port-range. Fresh and upgraded Clio settings persist
+	the built-in inclusive range [40100, 40199] when no range was configured.
+	Clio reserves the chosen port across concurrent processes before extracting files,
+	restoring the database, or creating IIS objects. Existing IIS bindings and active
+	listeners are checked too. An explicit used or reserved port fails; automatic
+	selection continues to the next range candidate. Deploy and uninstall
     operations using the same environment name or resolving to the same physical
     directory are serialized; different names, ports, and target directories can
     still deploy in parallel.
+
+	Default appsettings.json fragment:
+	"deploy-creatio-defaults": {
+	  "site-port-range": [40100, 40199]
+	}
+
     On a clean Windows host, required IIS features are prepared while the name
     and target reservations are held, before IIS/TCP port validation.
     Site names must be safe single directory names. --app-path must be an absolute
@@ -73,8 +83,10 @@ OPTIONS
         instead of waiting for console input.
 
     --site-port PORT
-        HTTP port number for the application
-        Default: 80 (HTTP), 443 (HTTPS)
+		Optional explicit application port. For IIS this overrides the configured
+		fixed site-port and site-port-range. When omitted, Clio uses the fixed
+		default when present or reserves the first available configured-range port.
+		Dotnet deployment retains its existing interactive/default port behavior.
 
     --zip-file FILE_PATH
         Required. Path to Creatio zip file or directory
@@ -193,8 +205,8 @@ OPTIONS
 
 EXAMPLES
 
-    1. Basic deployment with default settings (PostgreSQL, port 40001, auto-run):
-       clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --site-port 40001 --silent
+	1. Basic IIS deployment using the configured automatic port range:
+	   clio deploy-creatio --site-name "Default" --zip-file "C:\creatio-app.zip" --silent
 
     2. Deploy with MS SQL and custom port:
        clio deploy-creatio --site-name "Production" --db mssql --site-port 8080 \\
@@ -296,7 +308,7 @@ BEHAVIOR
     - Script errors do not block deployment (warning only)
 
     Windows (Default - IIS):
-    - Reserves and validates the requested port before deployment changes begin
+	- Reserves and validates the explicit, fixed-default, or automatically selected port before deployment changes begin
     - Creates IIS Application Pool
     - Creates IIS Website with exactly one HTTP or HTTPS binding
     - Treats required IIS creation failures as deployment failures

--- a/clio/tpl/jsonschema/schema.json.tpl
+++ b/clio/tpl/jsonschema/schema.json.tpl
@@ -73,6 +73,10 @@
 			"type": "string",
 			"description": "Default local Redis server key from redis section when multiple servers are enabled"
 		},
+		"deploy-creatio-defaults": {
+			"$ref": "#/definitions/deploycreatiodefaults",
+			"description": "Defaults used when deploy-creatio command-line options are omitted"
+		},
 		"telemetry": {
 			"$ref": "#/definitions/telemetrysettings",
 			"description": "Product telemetry upload configuration for the MCP server"
@@ -113,6 +117,47 @@
 		"Environments"
 	],
 	"definitions": {
+		"deploycreatiodefaults": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"db-server-name": {
+					"type": "string",
+					"description": "Default local database server key from the db section"
+				},
+				"redis-server-name": {
+					"type": "string",
+					"description": "Default local Redis server key from the redis section"
+				},
+				"site-name": {
+					"type": "string",
+					"description": "Default deployed IIS site and registered environment name"
+				},
+				"site-port": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 65535,
+					"description": "Fixed IIS site port; takes precedence over site-port-range"
+				},
+				"site-port-range": {
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 2,
+					"items": {
+						"type": "integer",
+						"minimum": 1,
+						"maximum": 65535
+					},
+					"description": "Inclusive start and end ports scanned when no explicit or fixed site port is set",
+					"default": [40100, 40199]
+				},
+				"deployment": {
+					"type": "string",
+					"enum": ["auto", "iis", "dotnet"],
+					"description": "Default deployment method"
+				}
+			}
+		},
 		"knowledgefeedbacksettings": {
 			"type": "object",
 			"additionalProperties": false,

--- a/docs/knowledge/Common/iis-deployment-reservation-must-not-use-a-named-mutex.md
+++ b/docs/knowledge/Common/iis-deployment-reservation-must-not-use-a-named-mutex.md
@@ -7,13 +7,16 @@ date: 2026-08-21
 ---
 
 **What is true** — the per-port deployment reservation is an exclusively opened file under the
-machine-wide ProgramData directory. The stream stays open from preflight until the IIS deployment
-finishes and the operating system releases it if the clio process exits.
+machine-wide ProgramData directory. Explicit ports acquire that exact lease. Automatic range selection
+scans upward, exclusively opens the candidate lease, and revalidates IIS/TCP state while holding it;
+if another clio process already owns the candidate file, selection continues to the next port. The stream
+stays open from preflight until the IIS binding exists and the operating system releases it if clio exits.
 
 **Why it is this way** — a named `Mutex` is thread-affine on Windows. An async deployment can acquire
 it on one thread and resume its `finally` block on another, where `ReleaseMutex` throws
 `ApplicationException`. A file lease has process-wide ownership semantics and can be disposed from
-any continuation thread while still allowing unrelated ports to deploy concurrently.
+any continuation thread while still allowing unrelated ports to deploy concurrently. Holding the file
+between candidate selection and IIS binding creation closes the discovery-to-mutation race.
 
 **What breaks if you ignore it** — replacing the file lease with a named mutex makes successful
 deployments fail during cleanup or leaves the port reservation held until process exit, depending on


### PR DESCRIPTION
## Summary

- materialize `deploy-creatio-defaults.site-port-range` as `[40100, 40199]` for fresh settings and version-1 upgrades while preserving custom values
- let IIS `deploy-creatio` reserve the first available configured-range port when `--site-port` is omitted; explicit and configured fixed ports keep precedence
- hold a machine-wide Clio lease through IIS registration, validate races and invalid configuration before mutation, and keep silent/MCP execution non-interactive
- add `config --deploy-site-port-range`, restore built-ins on `config --reset`, and document the appsettings schema
- align CLI help, command docs, MCP tool/prompt/contracts, MCP E2E coverage, and internal reservation knowledge

Refs #1310
Blocked by the required guidance update in Advance-Technologies-Foundation/clio-knowledge#116.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit" --no-restore` — 10,081 passed, 24 skipped on exact head `5d857bc31`
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release --filter "FullyQualifiedName~DeployCreatioToolE2ETests|FullyQualifiedName~DeployUninstallProgressTests" --no-restore` — 9 passed on .NET 8 and 9 passed on .NET 10
- real CLI with isolated `CLIO_HOME` generated and displayed `deploy-creatio-defaults.site-port-range` `[40100, 40199]`
- `python scripts/check-knowledge-applies-to.py` — all records resolve and match schema

## Reviews

- comprehensive seven-lens agentic review completed on exact head `5d857bc31`; no actionable findings remain
- docs reviewed and updated
- MCP reviewed and updated, including required E2E coverage
- ClioRing compatibility reviewed: no Ring-consumed protocol shape changed; Ring still supplies an explicit site port
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 157 passed
- `dotnet publish .\clio-ring\ClioRing.Desktop\ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` — passed

## KISS check

The flow uses the existing settings migration, IIS availability scanner, and machine-wide port lock. The only new runtime object is the lease that returns the selected port while keeping its lock alive; there is no new protocol or state store.