### PR TITLE
Validate temporal parameters in execute-esq

### DIFF
--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -1,5 +1,6 @@
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
+using Allure.Net.Commons;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
@@ -86,18 +87,28 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 			because: "the structured failure should identify the missing environment name");
 	}
 
-	[Test]
-	[Description("Rejects a plain ISO DateTime parameter through the real stdio MCP server with a path-specific accepted-format diagnostic before environment resolution.")]
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("Rejects a malformed or missing DateTime parameter through the real stdio MCP server with a path-specific accepted-format diagnostic before environment resolution.")]
 	[AllureTag(ExecuteEsqTool.ToolName)]
 	[AllureName("execute-esq explains the required DateTime parameter encoding")]
-	[AllureDescription("Invokes execute-esq through the real stdio MCP server with a nested plain ISO DateTime value and verifies the structured response names the exact query path and required JSON-encoded shape without contacting an environment.")]
-	public async Task ExecuteEsq_ShouldRejectPlainDateTimeParameter_WhenCalledOverStdio() {
+	[AllureDescription("Invokes execute-esq through the real stdio MCP server with a nested malformed or missing DateTime value and verifies the structured response names the exact query path and required JSON-encoded shape without contacting an environment.")]
+	public async Task ExecuteEsq_ShouldRejectMalformedDateTimeParameter_WhenCalledOverStdio(bool includePlainValue) {
 		// Arrange
-		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(3));
+		await using var arrangeContext = await AllureApi.Step(
+			"Arrange a real stdio MCP session",
+			() => Task.FromResult(Arrange(TimeSpan.FromMinutes(3))));
 		string invalidEnvironmentName = $"missing-esq-date-env-{Guid.NewGuid():N}";
 
 		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+		Dictionary<string, object?> parameter = new() {
+			["dataValueType"] = 7
+		};
+		if (includePlainValue) {
+			parameter["value"] = "2026-08-10T00:00:00Z";
+		}
+		CallToolResult callResult = await AllureApi.Step("Act by submitting a malformed DateTime parameter", async () =>
+			await arrangeContext.Session.CallToolAsync(
 			ExecuteEsqTool.ToolName,
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
@@ -109,10 +120,7 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 								["ModifiedAfter"] = new Dictionary<string, object?> {
 									["rightExpression"] = new Dictionary<string, object?> {
 										["expressionType"] = 2,
-										["parameter"] = new Dictionary<string, object?> {
-											["dataValueType"] = 7,
-											["value"] = "2026-08-10T00:00:00Z"
-										}
+										["parameter"] = parameter
 									}
 								}
 							}
@@ -120,20 +128,32 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 					}
 				}
 			},
-			arrangeContext.CancellationTokenSource.Token);
+			arrangeContext.CancellationTokenSource.Token));
 		ExecuteEsqResponse response = EntitySchemaStructuredResultParser.Extract<ExecuteEsqResponse>(callResult);
 
 		// Assert
-		callResult.IsError.Should().NotBeTrue(
-			because: "query validation failures should use the structured execute-esq response contract");
-		response.Success.Should().BeFalse(
-			because: "a plain ISO DateTime parameter is not a valid SelectQuery temporal value");
-		response.Error.Should().Contain("$.filters.items.ModifiedAfter.rightExpression.parameter.value",
-			because: "the stdio response should identify the exact malformed query location");
-		response.Error.Should().Contain("JSON-encoded strings",
-			because: "the stdio caller should receive the accepted temporal value format");
-		response.Error.Should().NotContain(invalidEnvironmentName,
-			because: "temporal validation should finish before environment resolution or network access");
+		await AllureApi.Step("Assert validation uses the structured tool response", () => {
+			callResult.IsError.Should().NotBeTrue(
+				because: "query validation failures should use the structured execute-esq response contract");
+			response.Success.Should().BeFalse(
+				because: "a plain or missing DateTime parameter is not a valid SelectQuery temporal value");
+			return Task.CompletedTask;
+		});
+		await AllureApi.Step("Assert the exact query path is reported", () => {
+			response.Error.Should().Contain("$.filters.items.ModifiedAfter.rightExpression.parameter.value",
+				because: "the stdio response should identify the exact malformed query location");
+			return Task.CompletedTask;
+		});
+		await AllureApi.Step("Assert the accepted temporal format is explained", () => {
+			response.Error.Should().Contain("JSON-encoded strings",
+				because: "the stdio caller should receive the accepted temporal value format");
+			return Task.CompletedTask;
+		});
+		await AllureApi.Step("Assert validation precedes environment access", () => {
+			response.Error.Should().NotContain(invalidEnvironmentName,
+				because: "temporal validation should finish before environment resolution or network access");
+			return Task.CompletedTask;
+		});
 	}
 
 }

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -154,7 +154,7 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 		});
 		await AllureApi.Step("Assert the reusable example survives passthrough redaction", () => {
 			response.Error.Should().Contain(
-				"value text '2026-01-01T00:00:00.000Z' including the two single quote characters",
+				"value text [double quote]2026-01-01T00:00:00.000Z[double quote]",
 				because: "the complete reusable value example must survive MCP passthrough redaction");
 			return Task.CompletedTask;
 		});

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -87,13 +87,15 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 			because: "the structured failure should identify the missing environment name");
 	}
 
-	[TestCase(true)]
-	[TestCase(false)]
+	[TestCase(true, "ModifiedAfter")]
+	[TestCase(false, "ModifiedAfter")]
+	[TestCase(true, "Modified😀.After[0]\n")]
 	[Description("Rejects a malformed or missing DateTime parameter through the real stdio MCP server with a path-specific accepted-format diagnostic before environment resolution.")]
 	[AllureTag(ExecuteEsqTool.ToolName)]
 	[AllureName("execute-esq explains the required DateTime parameter encoding")]
 	[AllureDescription("Invokes execute-esq through the real stdio MCP server with a nested malformed or missing DateTime value and verifies the structured response names the exact query path and required JSON-encoded shape without contacting an environment.")]
-	public async Task ExecuteEsq_ShouldRejectMalformedDateTimeParameter_WhenCalledOverStdio(bool includePlainValue) {
+	public async Task ExecuteEsq_ShouldRejectMalformedDateTimeParameter_WhenCalledOverStdio(
+		bool includePlainValue, string filterName) {
 		// Arrange
 		await using var arrangeContext = await AllureApi.Step(
 			"Arrange a real stdio MCP session",
@@ -117,7 +119,7 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 						["rootSchemaName"] = "SysSchema",
 						["filters"] = new Dictionary<string, object?> {
 							["items"] = new Dictionary<string, object?> {
-								["ModifiedAfter"] = new Dictionary<string, object?> {
+								[filterName] = new Dictionary<string, object?> {
 									["rightExpression"] = new Dictionary<string, object?> {
 										["expressionType"] = 2,
 										["parameter"] = parameter
@@ -130,6 +132,9 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 			},
 			arrangeContext.CancellationTokenSource.Token));
 		ExecuteEsqResponse response = EntitySchemaStructuredResultParser.Extract<ExecuteEsqResponse>(callResult);
+		string expectedPath = filterName == "ModifiedAfter"
+			? "$.filters.items.ModifiedAfter.rightExpression.parameter.value"
+			: "$.filters.items['Modified😀.After[0][U+000A]'].rightExpression.parameter.value";
 
 		// Assert
 		await AllureApi.Step("Assert validation uses the structured tool response", () => {
@@ -143,7 +148,7 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 			return Task.CompletedTask;
 		});
 		await AllureApi.Step("Assert the exact query path is reported", () => {
-			response.Error.Should().Contain("$.filters.items.ModifiedAfter.rightExpression.parameter.value",
+			response.Error.Should().Contain(expectedPath,
 				because: "the stdio response should identify the exact malformed query location");
 			return Task.CompletedTask;
 		});

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -134,7 +134,7 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 		ExecuteEsqResponse response = EntitySchemaStructuredResultParser.Extract<ExecuteEsqResponse>(callResult);
 		string expectedPath = filterName == "ModifiedAfter"
 			? "$.filters.items.ModifiedAfter.rightExpression.parameter.value"
-			: "$.filters.items['Modified😀.After[0][U+000A]'].rightExpression.parameter.value";
+			: "$.filters.items['Modified😀.After[U+005B]0[U+005D][U+000A]'].rightExpression.parameter.value";
 
 		// Assert
 		await AllureApi.Step("Assert validation uses the structured tool response", () => {

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -135,6 +135,9 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 		await AllureApi.Step("Assert validation uses the structured tool response", () => {
 			callResult.IsError.Should().NotBeTrue(
 				because: "query validation failures should use the structured execute-esq response contract");
+			return Task.CompletedTask;
+		});
+		await AllureApi.Step("Assert the structured response reports failure", () => {
 			response.Success.Should().BeFalse(
 				because: "a plain or missing DateTime parameter is not a valid SelectQuery temporal value");
 			return Task.CompletedTask;
@@ -147,6 +150,9 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 		await AllureApi.Step("Assert the accepted temporal format is explained", () => {
 			response.Error.Should().Contain("JSON-encoded strings",
 				because: "the stdio caller should receive the accepted temporal value format");
+			response.Error.Should().Contain(
+				"value text '2026-01-01T00:00:00.000Z' including the two single quote characters",
+				because: "the complete reusable value example must survive MCP passthrough redaction");
 			return Task.CompletedTask;
 		});
 		await AllureApi.Step("Assert validation precedes environment access", () => {

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -86,4 +86,54 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 			because: "the structured failure should identify the missing environment name");
 	}
 
+	[Test]
+	[Description("Rejects a plain ISO DateTime parameter through the real stdio MCP server with a path-specific accepted-format diagnostic before environment resolution.")]
+	[AllureTag(ExecuteEsqTool.ToolName)]
+	[AllureName("execute-esq explains the required DateTime parameter encoding")]
+	[AllureDescription("Invokes execute-esq through the real stdio MCP server with a nested plain ISO DateTime value and verifies the structured response names the exact query path and required JSON-encoded shape without contacting an environment.")]
+	public async Task ExecuteEsq_ShouldRejectPlainDateTimeParameter_WhenCalledOverStdio() {
+		// Arrange
+		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(3));
+		string invalidEnvironmentName = $"missing-esq-date-env-{Guid.NewGuid():N}";
+
+		// Act
+		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			ExecuteEsqTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = invalidEnvironmentName,
+					["query"] = new Dictionary<string, object?> {
+						["rootSchemaName"] = "SysSchema",
+						["filters"] = new Dictionary<string, object?> {
+							["items"] = new Dictionary<string, object?> {
+								["ModifiedAfter"] = new Dictionary<string, object?> {
+									["rightExpression"] = new Dictionary<string, object?> {
+										["expressionType"] = 2,
+										["parameter"] = new Dictionary<string, object?> {
+											["dataValueType"] = 7,
+											["value"] = "2026-08-10T00:00:00Z"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		ExecuteEsqResponse response = EntitySchemaStructuredResultParser.Extract<ExecuteEsqResponse>(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "query validation failures should use the structured execute-esq response contract");
+		response.Success.Should().BeFalse(
+			because: "a plain ISO DateTime parameter is not a valid SelectQuery temporal value");
+		response.Error.Should().Contain("$.filters.items.ModifiedAfter.rightExpression.parameter.value",
+			because: "the stdio response should identify the exact malformed query location");
+		response.Error.Should().Contain("JSON-encoded strings",
+			because: "the stdio caller should receive the accepted temporal value format");
+		response.Error.Should().NotContain(invalidEnvironmentName,
+			because: "temporal validation should finish before environment resolution or network access");
+	}
+
 }

--- a/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteEsqToolE2ETests.cs
@@ -150,6 +150,9 @@ public sealed class ExecuteEsqToolE2ETests : McpContractFixtureBase {
 		await AllureApi.Step("Assert the accepted temporal format is explained", () => {
 			response.Error.Should().Contain("JSON-encoded strings",
 				because: "the stdio caller should receive the accepted temporal value format");
+			return Task.CompletedTask;
+		});
+		await AllureApi.Step("Assert the reusable example survives passthrough redaction", () => {
 			response.Error.Should().Contain(
 				"value text '2026-01-01T00:00:00.000Z' including the two single quote characters",
 				because: "the complete reusable value example must survive MCP passthrough redaction");

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -287,7 +287,7 @@ public sealed class ExecuteEsqToolTests {
 			because: "the validation error should identify the exact malformed parameter");
 		response.Error.Should().Contain("JSON-encoded strings",
 			because: "the caller should be told which temporal value encoding the endpoint accepts");
-		response.Error.Should().Contain("value text '2026-01-01T00:00:00.000Z' including the two single quote characters",
+		response.Error.Should().Contain("value text [double quote]2026-01-01T00:00:00.000Z[double quote]",
 			because: "the diagnostic should include a directly reusable valid value example");
 		commandResolver.ReceivedCalls().Should().BeEmpty(
 			because: "temporal validation must finish before resolving an environment or constructing a request");
@@ -414,6 +414,38 @@ public sealed class ExecuteEsqToolTests {
 			because: "an oversized property name should be visibly truncated");
 		response.Error.Length.Should().BeLessThan(1_000,
 			because: "an adversarial property name must not amplify the MCP diagnostic without bound");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects an oversized query before traversing attacker-controlled property names or resolving an environment.")]
+	public void Execute_ShouldRejectOversizedQuery_BeforeTemporalTraversal() {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		ExecuteEsqTool tool = new(commandResolver);
+		string oversizedName = $"Modified.After[0]\n{new string('x', ExecuteEsqTool.MaxQuerySizeBytes)}";
+		JsonElement query = Json($$"""
+			{
+			  "rootSchemaName": "SysSchema",
+			  "filters": { "items": { {{JsonSerializer.Serialize(oversizedName)}}: {} } }
+			}
+			""");
+
+		// Act
+		long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
+			EnvironmentName = "missing-environment",
+			Query = query
+		});
+		long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+		// Assert
+		response.Error.Should().Contain("200000-byte MCP safety limit",
+			because: "oversized untrusted queries must fail before recursive validation allocates diagnostic paths");
+		allocatedBytes.Should().BeLessThan(1_000_000,
+			because: "the size gate should make at most one bounded linear copy of the already parsed query");
+		commandResolver.ReceivedCalls().Should().BeEmpty(
+			because: "an oversized query must not resolve environment-bound services");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -287,16 +287,17 @@ public sealed class ExecuteEsqToolTests {
 			because: "the validation error should identify the exact malformed parameter");
 		response.Error.Should().Contain("JSON-encoded strings",
 			because: "the caller should be told which temporal value encoding the endpoint accepts");
-		response.Error.Should().Contain("\"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\"",
+		response.Error.Should().Contain("value text '2026-01-01T00:00:00.000Z' including the two single quote characters",
 			because: "the diagnostic should include a directly reusable valid value example");
-		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IApplicationClient>(default!);
-		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IServiceUrlBuilder>(default!);
+		commandResolver.ReceivedCalls().Should().BeEmpty(
+			because: "temporal validation must finish before resolving an environment or constructing a request");
 	}
 
 	[TestCase(7, "\"2026-08-10T00:00:00.000Z\"")]
 	[TestCase(8, "\"2026-08-10\"")]
 	[TestCase(9, "\"2026-08-10T11:06:00.000Z\"")]
 	[TestCase(7, "'2026-08-10T00:00:00.000Z'")]
+	[TestCase(7, "  \"2026-08-10T00:00:00.000Z\"  ")]
 	[Category("Unit")]
 	[Description("Passes accepted double-quoted DateTime, Date, and Time values and the compatible single-quoted form through to Creatio without rewriting.")]
 	public void Execute_ShouldPreserveJsonEncodedTemporalParameter_WhenValueHasAcceptedShape(
@@ -369,8 +370,8 @@ public sealed class ExecuteEsqToolTests {
 			because: "a temporal parameter without value would reach Creatio as null");
 		response.Error.Should().Contain("invalid or missing value",
 			because: "the failure should distinguish a missing temporal value from environment resolution");
-		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IApplicationClient>(default!);
-		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IServiceUrlBuilder>(default!);
+		commandResolver.ReceivedCalls().Should().BeEmpty(
+			because: "a missing temporal value must be rejected before resolving any environment-bound service");
 	}
 
 	[Test]
@@ -403,7 +404,7 @@ public sealed class ExecuteEsqToolTests {
 		});
 
 		// Assert
-		response.Error.Should().Contain("['Modified.After[0]\\n",
+		response.Error.Should().Contain("[\"Modified.After[0]\\n",
 			because: "unsafe property names should use escaped bracket notation in the diagnostic path");
 		response.Error.Should().NotContain("Modified.After[0]\n",
 			because: "control characters from untrusted property names must not create transcript lines");

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -332,8 +332,10 @@ public sealed class ExecuteEsqToolTests {
 		// Assert
 		response.Success.Should().BeTrue(
 			because: "the documented JSON-encoded DateTime value is accepted by the SelectQuery endpoint");
-		client.Received(1).ExecutePostRequest(
-			Arg.Any<string>(), query.GetRawText(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.ReceivedCalls().Should().ContainSingle(call =>
+			call.GetMethodInfo().Name == nameof(IApplicationClient.ExecutePostRequest)
+			&& Equals(call.GetArguments()[1], query.GetRawText()),
+			because: "the accepted temporal value must be posted exactly once without rewriting the query body");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -383,7 +383,7 @@ public sealed class ExecuteEsqToolTests {
 		// Arrange
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		ExecuteEsqTool tool = new(commandResolver);
-		string unsafeFilterName = $"Modified.After[0]\n{new string('x', 2_000)}";
+		string unsafeFilterName = $"Modified😀.After[0]\n{new string('x', 2_000)}";
 		JsonElement query = Json($$"""
 			{
 			  "rootSchemaName": "SysSchema",
@@ -406,46 +406,14 @@ public sealed class ExecuteEsqToolTests {
 		});
 
 		// Assert
-		response.Error.Should().Contain("[\"Modified.After[0]\\n",
+		response.Error.Should().Contain("[\"Modified\\uD83D\\uDE00.After[0]\\n",
 			because: "unsafe property names should use escaped bracket notation in the diagnostic path");
-		response.Error.Should().NotContain("Modified.After[0]\n",
+		response.Error.Should().NotContain("Modified😀.After[0]\n",
 			because: "control characters from untrusted property names must not create transcript lines");
 		response.Error.Should().Contain("...",
 			because: "an oversized property name should be visibly truncated");
 		response.Error.Length.Should().BeLessThan(1_000,
 			because: "an adversarial property name must not amplify the MCP diagnostic without bound");
-	}
-
-	[Test]
-	[Category("Unit")]
-	[Description("Rejects an oversized query before traversing attacker-controlled property names or resolving an environment.")]
-	public void Execute_ShouldRejectOversizedQuery_BeforeTemporalTraversal() {
-		// Arrange
-		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
-		ExecuteEsqTool tool = new(commandResolver);
-		string oversizedName = $"Modified.After[0]\n{new string('x', ExecuteEsqTool.MaxQuerySizeBytes)}";
-		JsonElement query = Json($$"""
-			{
-			  "rootSchemaName": "SysSchema",
-			  "filters": { "items": { {{JsonSerializer.Serialize(oversizedName)}}: {} } }
-			}
-			""");
-
-		// Act
-		long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
-			EnvironmentName = "missing-environment",
-			Query = query
-		});
-		long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
-
-		// Assert
-		response.Error.Should().Contain("200000-byte MCP safety limit",
-			because: "oversized untrusted queries must fail before recursive validation allocates diagnostic paths");
-		allocatedBytes.Should().BeLessThan(1_000_000,
-			because: "the size gate should make at most one bounded linear copy of the already parsed query");
-		commandResolver.ReceivedCalls().Should().BeEmpty(
-			because: "an oversized query must not resolve environment-bound services");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -406,7 +406,7 @@ public sealed class ExecuteEsqToolTests {
 		});
 
 		// Assert
-		response.Error.Should().Contain("[\"Modified\\uD83D\\uDE00.After[0]\\n",
+		response.Error.Should().Contain("['Modified😀.After[0][U+000A]",
 			because: "unsafe property names should use escaped bracket notation in the diagnostic path");
 		response.Error.Should().NotContain("Modified😀.After[0]\n",
 			because: "control characters from untrusted property names must not create transcript lines");

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -251,7 +251,8 @@ public sealed class ExecuteEsqToolTests {
 	[Description("Rejects plain DateTime, Date, and Time parameter strings with the exact query path before resolving an environment or sending a request.")]
 	public void Execute_ShouldRejectPlainTemporalParameterValue_WhenDataValueTypeIsTemporal(int dataValueType) {
 		// Arrange
-		(ExecuteEsqTool tool, IApplicationClient client, _) = BuildTool("{\"success\":true,\"rows\":[]}");
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		ExecuteEsqTool tool = new(commandResolver);
 		JsonElement query = Json($$"""
 			{
 			  "rootSchemaName": "SysSchema",
@@ -288,16 +289,21 @@ public sealed class ExecuteEsqToolTests {
 			because: "the caller should be told which temporal value encoding the endpoint accepts");
 		response.Error.Should().Contain("\"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\"",
 			because: "the diagnostic should include a directly reusable valid value example");
-		client.DidNotReceiveWithAnyArgs().ExecutePostRequest(default!, default!, default, default, default);
+		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IApplicationClient>(default!);
+		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IServiceUrlBuilder>(default!);
 	}
 
-	[Test]
+	[TestCase(7, "\"2026-08-10T00:00:00.000Z\"")]
+	[TestCase(8, "\"2026-08-10\"")]
+	[TestCase(9, "\"2026-08-10T11:06:00.000Z\"")]
+	[TestCase(7, "'2026-08-10T00:00:00.000Z'")]
 	[Category("Unit")]
-	[Description("Passes a JSON-encoded DateTime parameter through to Creatio without rewriting its value or timezone.")]
-	public void Execute_ShouldPreserveJsonEncodedDateTimeParameter_WhenValueHasAcceptedShape() {
+	[Description("Passes accepted double-quoted DateTime, Date, and Time values and the compatible single-quoted form through to Creatio without rewriting.")]
+	public void Execute_ShouldPreserveJsonEncodedTemporalParameter_WhenValueHasAcceptedShape(
+		int dataValueType, string encodedValue) {
 		// Arrange
 		(ExecuteEsqTool tool, IApplicationClient client, _) = BuildTool("{\"success\":true,\"rows\":[]}");
-		JsonElement query = Json("""
+		JsonElement query = Json($$"""
 			{
 			  "rootSchemaName": "SysSchema",
 			  "filters": {
@@ -306,8 +312,8 @@ public sealed class ExecuteEsqToolTests {
 			        "rightExpression": {
 			          "expressionType": 2,
 			          "parameter": {
-			            "dataValueType": 7,
-			            "value": "\"2026-08-10T00:00:00.000Z\""
+			            "dataValueType": {{dataValueType}},
+			            "value": {{JsonSerializer.Serialize(encodedValue)}}
 			          }
 			        }
 			      }
@@ -327,6 +333,84 @@ public sealed class ExecuteEsqToolTests {
 			because: "the documented JSON-encoded DateTime value is accepted by the SelectQuery endpoint");
 		client.Received(1).ExecutePostRequest(
 			Arg.Any<string>(), query.GetRawText(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects a missing temporal parameter value before resolving an environment or sending a request.")]
+	public void Execute_ShouldRejectMissingTemporalParameterValue_WhenDataValueTypeIsDateTime() {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		ExecuteEsqTool tool = new(commandResolver);
+		JsonElement query = Json("""
+			{
+			  "rootSchemaName": "SysSchema",
+			  "filters": {
+			    "items": {
+			      "ModifiedAfter": {
+			        "rightExpression": {
+			          "expressionType": 2,
+			          "parameter": { "dataValueType": 7 }
+			        }
+			      }
+			    }
+			  }
+			}
+			""");
+
+		// Act
+		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
+			EnvironmentName = "missing-environment",
+			Query = query
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "a temporal parameter without value would reach Creatio as null");
+		response.Error.Should().Contain("invalid or missing value",
+			because: "the failure should distinguish a missing temporal value from environment resolution");
+		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IApplicationClient>(default!);
+		commandResolver.DidNotReceiveWithAnyArgs().Resolve<IServiceUrlBuilder>(default!);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Escapes unsafe filter names and bounds the rendered query path in temporal validation errors.")]
+	public void Execute_ShouldEscapeAndBoundDiagnosticPath_WhenFilterNameContainsControlText() {
+		// Arrange
+		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
+		ExecuteEsqTool tool = new(commandResolver);
+		string unsafeFilterName = $"Modified.After[0]\n{new string('x', 2_000)}";
+		JsonElement query = Json($$"""
+			{
+			  "rootSchemaName": "SysSchema",
+			  "filters": {
+			    "items": {
+			      {{JsonSerializer.Serialize(unsafeFilterName)}}: {
+			        "rightExpression": {
+			          "parameter": { "dataValueType": 7, "value": "2026-08-10T00:00:00Z" }
+			        }
+			      }
+			    }
+			  }
+			}
+			""");
+
+		// Act
+		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
+			EnvironmentName = "missing-environment",
+			Query = query
+		});
+
+		// Assert
+		response.Error.Should().Contain("['Modified.After[0]\\n",
+			because: "unsafe property names should use escaped bracket notation in the diagnostic path");
+		response.Error.Should().NotContain("Modified.After[0]\n",
+			because: "control characters from untrusted property names must not create transcript lines");
+		response.Error.Should().Contain("...",
+			because: "an oversized property name should be visibly truncated");
+		response.Error.Length.Should().BeLessThan(1_000,
+			because: "an adversarial property name must not amplify the MCP diagnostic without bound");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -383,7 +383,7 @@ public sealed class ExecuteEsqToolTests {
 		// Arrange
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		ExecuteEsqTool tool = new(commandResolver);
-		string unsafeFilterName = $"Modified😀.After[0]\n{new string('x', 2_000)}";
+		string unsafeFilterName = $"Modified😀.After[0]\n[U+000A]{new string('x', 2_000)}";
 		JsonElement query = Json($$"""
 			{
 			  "rootSchemaName": "SysSchema",
@@ -406,8 +406,9 @@ public sealed class ExecuteEsqToolTests {
 		});
 
 		// Assert
-		response.Error.Should().Contain("['Modified😀.After[0][U+000A]",
-			because: "unsafe property names should use escaped bracket notation in the diagnostic path");
+		response.Error.Should().Contain(
+			"['Modified😀.After[U+005B]0[U+005D][U+000A][U+005B]U+000A[U+005D]",
+			because: "unsafe property names should distinguish control tokens from identical literal token text");
 		response.Error.Should().NotContain("Modified😀.After[0]\n",
 			because: "control characters from untrusted property names must not create transcript lines");
 		response.Error.Should().Contain("...",

--- a/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteEsqToolTests.cs
@@ -244,6 +244,91 @@ public sealed class ExecuteEsqToolTests {
 			Arg.Any<int>());
 	}
 
+	[TestCase(7)]
+	[TestCase(8)]
+	[TestCase(9)]
+	[Category("Unit")]
+	[Description("Rejects plain DateTime, Date, and Time parameter strings with the exact query path before resolving an environment or sending a request.")]
+	public void Execute_ShouldRejectPlainTemporalParameterValue_WhenDataValueTypeIsTemporal(int dataValueType) {
+		// Arrange
+		(ExecuteEsqTool tool, IApplicationClient client, _) = BuildTool("{\"success\":true,\"rows\":[]}");
+		JsonElement query = Json($$"""
+			{
+			  "rootSchemaName": "SysSchema",
+			  "filters": {
+			    "items": {
+			      "ModifiedAfter": {
+			        "rightExpressions": [
+			          {
+			            "expressionType": 2,
+			            "parameter": {
+			              "dataValueType": {{dataValueType}},
+			              "value": "2026-08-10T00:00:00Z"
+			            }
+			          }
+			        ]
+			      }
+			    }
+			  }
+			}
+			""");
+
+		// Act
+		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
+			EnvironmentName = "missing-environment",
+			Query = query
+		});
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "a plain temporal string cannot be deserialized by the Creatio SelectQuery endpoint");
+		response.Error.Should().Contain("$.filters.items.ModifiedAfter.rightExpressions[0].parameter.value",
+			because: "the validation error should identify the exact malformed parameter");
+		response.Error.Should().Contain("JSON-encoded strings",
+			because: "the caller should be told which temporal value encoding the endpoint accepts");
+		response.Error.Should().Contain("\"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\"",
+			because: "the diagnostic should include a directly reusable valid value example");
+		client.DidNotReceiveWithAnyArgs().ExecutePostRequest(default!, default!, default, default, default);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Passes a JSON-encoded DateTime parameter through to Creatio without rewriting its value or timezone.")]
+	public void Execute_ShouldPreserveJsonEncodedDateTimeParameter_WhenValueHasAcceptedShape() {
+		// Arrange
+		(ExecuteEsqTool tool, IApplicationClient client, _) = BuildTool("{\"success\":true,\"rows\":[]}");
+		JsonElement query = Json("""
+			{
+			  "rootSchemaName": "SysSchema",
+			  "filters": {
+			    "items": {
+			      "ModifiedAfter": {
+			        "rightExpression": {
+			          "expressionType": 2,
+			          "parameter": {
+			            "dataValueType": 7,
+			            "value": "\"2026-08-10T00:00:00.000Z\""
+			          }
+			        }
+			      }
+			    }
+			  }
+			}
+			""");
+
+		// Act
+		ExecuteEsqResponse response = tool.Execute(new ExecuteEsqArgs {
+			EnvironmentName = "dev",
+			Query = query
+		});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "the documented JSON-encoded DateTime value is accepted by the SelectQuery endpoint");
+		client.Received(1).ExecutePostRequest(
+			Arg.Any<string>(), query.GetRawText(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
 	[Test]
 	[Category("Unit")]
 	[Description("Surfaces a DataService failure envelope as a failure with the server message.")]

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -24,6 +24,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	private const int DefaultTimeoutMs = 30_000;
 	private const int MinTimeoutMs = 1_000;
 	private const int MaxTimeoutMs = 120_000;
+	private const int MaxDiagnosticPathLength = 500;
 	internal const int MaxResponseSizeBytes = 200_000;
 	internal const string ResultTooLargeErrorClass = "result-too-large";
 
@@ -44,7 +45,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 			if (!TryNormalizeQuery(args.Query, out JsonElement query, out string queryError)) {
 				return ExecuteEsqResponse.Failure(queryError);
 			}
-			if (!TryValidateTemporalParameterValues(query, "$", out string temporalParameterError)) {
+			if (!TryValidateTemporalParameterValues(query, [], out string temporalParameterError)) {
 				return ExecuteEsqResponse.Failure(temporalParameterError);
 			}
 			if (!query.TryGetProperty("rootSchemaName", out JsonElement rootSchema)
@@ -87,28 +88,31 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	}
 
 	private static bool TryValidateTemporalParameterValues(
-		JsonElement element, string path, out string error) {
+		JsonElement element, List<(string? PropertyName, int? ArrayIndex)> path, out string error) {
 		error = string.Empty;
 		switch (element.ValueKind) {
 			case JsonValueKind.Object:
 				foreach (JsonProperty property in element.EnumerateObject()) {
-					string propertyPath = $"{path}.{property.Name}";
+					path.Add((property.Name, null));
 					if (property.NameEquals("parameter")
 						&& property.Value.ValueKind == JsonValueKind.Object
-						&& !TryValidateTemporalParameter(property.Value, propertyPath, out error)) {
+						&& !TryValidateTemporalParameter(property.Value, path, out error)) {
 						return false;
 					}
-					if (!TryValidateTemporalParameterValues(property.Value, propertyPath, out error)) {
+					if (!TryValidateTemporalParameterValues(property.Value, path, out error)) {
 						return false;
 					}
+					path.RemoveAt(path.Count - 1);
 				}
 				return true;
 			case JsonValueKind.Array:
 				int index = 0;
 				foreach (JsonElement item in element.EnumerateArray()) {
-					if (!TryValidateTemporalParameterValues(item, $"{path}[{index}]", out error)) {
+					path.Add((null, index));
+					if (!TryValidateTemporalParameterValues(item, path, out error)) {
 						return false;
 					}
+					path.RemoveAt(path.Count - 1);
 					index++;
 				}
 				return true;
@@ -117,32 +121,104 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		}
 	}
 
-	private static bool TryValidateTemporalParameter(JsonElement parameter, string path, out string error) {
+	private static bool TryValidateTemporalParameter(
+		JsonElement parameter, IReadOnlyList<(string? PropertyName, int? ArrayIndex)> path, out string error) {
 		error = string.Empty;
 		if (!parameter.TryGetProperty("dataValueType", out JsonElement dataValueType)
 			|| !dataValueType.TryGetInt32(out int dataValueTypeCode)
-			|| dataValueTypeCode is not (7 or 8 or 9)
-			|| !parameter.TryGetProperty("value", out JsonElement value)) {
+			|| dataValueTypeCode is not (7 or 8 or 9)) {
 			return true;
 		}
 
-		bool isJsonEncodedString = false;
-		if (value.ValueKind == JsonValueKind.String) {
-			try {
-				using JsonDocument decoded = JsonDocument.Parse(value.GetString() ?? string.Empty);
-				isJsonEncodedString = decoded.RootElement.ValueKind == JsonValueKind.String;
-			} catch (JsonException) {
-				// The server accepts temporal values only when the outer JSON string contains another JSON string.
-			}
-		}
+		bool isJsonEncodedString = parameter.TryGetProperty("value", out JsonElement value)
+			&& IsJsonEncodedString(value);
 		if (isJsonEncodedString) {
 			return true;
 		}
 
-		error = $"query temporal parameter at '{path}.value' has an invalid value for dataValueType "
-			+ $"{dataValueTypeCode}. Date, DateTime, and Time values must be JSON-encoded strings, for example "
-			+ "\"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\". A plain ISO string is not accepted. "
+		string renderedPath = RenderJsonPath(path);
+		error = $"query temporal parameter at '{renderedPath}.value' has an invalid or missing value for "
+			+ $"dataValueType {dataValueTypeCode}. Date, DateTime, and Time values must be JSON-encoded strings, "
+			+ "for example \"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\". A plain ISO string is not accepted. "
 			+ "See the 'esq' and 'esq-filters-frontend' guidance.";
+		return false;
+	}
+
+	private static bool IsJsonEncodedString(JsonElement value) {
+		if (value.ValueKind == JsonValueKind.String) {
+			string raw = value.GetString() ?? string.Empty;
+			if (raw.Length < 2
+				|| raw[0] is not ('"' or '\'')
+				|| raw[^1] != raw[0]) {
+				return false;
+			}
+			try {
+				return Newtonsoft.Json.JsonConvert.DeserializeObject<string>(raw) is not null;
+			} catch (Newtonsoft.Json.JsonException) {
+				return false;
+			}
+		}
+		return false;
+	}
+
+	private static string RenderJsonPath(
+		IReadOnlyList<(string? PropertyName, int? ArrayIndex)> segments) {
+		StringBuilder builder = new("$");
+		foreach ((string? propertyName, int? arrayIndex) in segments) {
+			if (arrayIndex is not null) {
+				if (!TryAppendBounded(builder, $"[{arrayIndex.Value}]")) {
+					break;
+				}
+				continue;
+			}
+			if (!TryAppendPropertyName(builder, propertyName ?? string.Empty)) {
+				break;
+			}
+		}
+		return builder.ToString();
+	}
+
+	private static bool TryAppendPropertyName(StringBuilder builder, string propertyName) {
+		bool isIdentifier = propertyName.Length > 0
+			&& (char.IsLetter(propertyName[0]) || propertyName[0] == '_')
+			&& propertyName.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
+		if (isIdentifier) {
+			return TryAppendBounded(builder, ".") && TryAppendBounded(builder, propertyName);
+		}
+
+		if (!TryAppendBounded(builder, "['")) {
+			return false;
+		}
+		foreach (char character in propertyName) {
+			string escaped = character switch {
+				'\\' => "\\\\",
+				'\'' => "\\'",
+				'\n' => "\\n",
+				'\r' => "\\r",
+				'\t' => "\\t",
+				_ when char.IsControl(character) => $"\\u{(int)character:x4}",
+				_ => character.ToString()
+			};
+			if (!TryAppendBounded(builder, escaped)) {
+				return false;
+			}
+		}
+		return TryAppendBounded(builder, "']");
+	}
+
+	private static bool TryAppendBounded(StringBuilder builder, string value) {
+		int remaining = MaxDiagnosticPathLength - builder.Length;
+		if (value.Length <= remaining) {
+			builder.Append(value);
+			return true;
+		}
+		const string truncationMarker = "...";
+		if (remaining < truncationMarker.Length) {
+			builder.Length = MaxDiagnosticPathLength - truncationMarker.Length;
+		} else {
+			builder.Append(value, 0, remaining - truncationMarker.Length);
+		}
+		builder.Append(truncationMarker);
 		return false;
 	}
 

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -44,6 +44,9 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 			if (!TryNormalizeQuery(args.Query, out JsonElement query, out string queryError)) {
 				return ExecuteEsqResponse.Failure(queryError);
 			}
+			if (!TryValidateTemporalParameterValues(query, "$", out string temporalParameterError)) {
+				return ExecuteEsqResponse.Failure(temporalParameterError);
+			}
 			if (!query.TryGetProperty("rootSchemaName", out JsonElement rootSchema)
 				|| rootSchema.ValueKind != JsonValueKind.String
 				|| string.IsNullOrWhiteSpace(rootSchema.GetString())) {
@@ -81,6 +84,66 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		} catch (Exception ex) {
 			return ExecuteEsqResponse.Failure(SensitiveErrorTextRedactor.Redact(ex.Message));
 		}
+	}
+
+	private static bool TryValidateTemporalParameterValues(
+		JsonElement element, string path, out string error) {
+		error = string.Empty;
+		switch (element.ValueKind) {
+			case JsonValueKind.Object:
+				foreach (JsonProperty property in element.EnumerateObject()) {
+					string propertyPath = $"{path}.{property.Name}";
+					if (property.NameEquals("parameter")
+						&& property.Value.ValueKind == JsonValueKind.Object
+						&& !TryValidateTemporalParameter(property.Value, propertyPath, out error)) {
+						return false;
+					}
+					if (!TryValidateTemporalParameterValues(property.Value, propertyPath, out error)) {
+						return false;
+					}
+				}
+				return true;
+			case JsonValueKind.Array:
+				int index = 0;
+				foreach (JsonElement item in element.EnumerateArray()) {
+					if (!TryValidateTemporalParameterValues(item, $"{path}[{index}]", out error)) {
+						return false;
+					}
+					index++;
+				}
+				return true;
+			default:
+				return true;
+		}
+	}
+
+	private static bool TryValidateTemporalParameter(JsonElement parameter, string path, out string error) {
+		error = string.Empty;
+		if (!parameter.TryGetProperty("dataValueType", out JsonElement dataValueType)
+			|| !dataValueType.TryGetInt32(out int dataValueTypeCode)
+			|| dataValueTypeCode is not (7 or 8 or 9)
+			|| !parameter.TryGetProperty("value", out JsonElement value)) {
+			return true;
+		}
+
+		bool isJsonEncodedString = false;
+		if (value.ValueKind == JsonValueKind.String) {
+			try {
+				using JsonDocument decoded = JsonDocument.Parse(value.GetString() ?? string.Empty);
+				isJsonEncodedString = decoded.RootElement.ValueKind == JsonValueKind.String;
+			} catch (JsonException) {
+				// The server accepts temporal values only when the outer JSON string contains another JSON string.
+			}
+		}
+		if (isJsonEncodedString) {
+			return true;
+		}
+
+		error = $"query temporal parameter at '{path}.value' has an invalid value for dataValueType "
+			+ $"{dataValueTypeCode}. Date, DateTime, and Time values must be JSON-encoded strings, for example "
+			+ "\"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\". A plain ISO string is not accepted. "
+			+ "See the 'esq' and 'esq-filters-frontend' guidance.";
+		return false;
 	}
 
 	private static bool TryNormalizeQuery(JsonElement query, out JsonElement normalized, out string error) {

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -24,6 +24,8 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	private const int DefaultTimeoutMs = 30_000;
 	private const int MinTimeoutMs = 1_000;
 	private const int MaxTimeoutMs = 120_000;
+	private const int MaxDiagnosticPathLength = 500;
+	internal const int MaxQuerySizeBytes = 200_000;
 	internal const int MaxResponseSizeBytes = 200_000;
 	internal const string ResultTooLargeErrorClass = "result-too-large";
 
@@ -43,6 +45,11 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		try {
 			if (!TryNormalizeQuery(args.Query, out JsonElement query, out string queryError)) {
 				return ExecuteEsqResponse.Failure(queryError);
+			}
+			string queryJson = query.GetRawText();
+			if (Encoding.UTF8.GetByteCount(queryJson) > MaxQuerySizeBytes) {
+				return ExecuteEsqResponse.Failure(
+					$"query exceeds the {MaxQuerySizeBytes}-byte MCP safety limit; reduce selected columns or filters.");
 			}
 			if (!TryValidateTemporalParameterValues(query, [], out string temporalParameterError)) {
 				return ExecuteEsqResponse.Failure(temporalParameterError);
@@ -66,7 +73,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 			IServiceUrlBuilder urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
 
 			string url = urlBuilder.Build(ServiceUrlBuilder.KnownRoute.Select);
-			string responseJson = client.ExecutePostRequest(url, query.GetRawText(), timeout);
+			string responseJson = client.ExecutePostRequest(url, queryJson, timeout);
 			bool responseIsTooLarge = responseJson.Length > MaxResponseSizeBytes
 				|| Encoding.UTF8.GetByteCount(responseJson) > MaxResponseSizeBytes;
 			if (responseIsTooLarge) {
@@ -138,7 +145,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		string renderedPath = RenderJsonPath(path);
 		error = $"query temporal parameter at '{renderedPath}.value' has an invalid or missing value for "
 			+ $"dataValueType {dataValueTypeCode}. Date, DateTime, and Time values must be JSON-encoded strings, "
-			+ "for example value text '2026-01-01T00:00:00.000Z' including the two single quote characters. "
+			+ "for example value text [double quote]2026-01-01T00:00:00.000Z[double quote]. "
 			+ "A plain ISO string is not accepted. "
 			+ "See the 'esq' and 'esq-filters-frontend' guidance.";
 		return false;
@@ -164,9 +171,13 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	private static string RenderJsonPath(
 		IReadOnlyList<(string? PropertyName, int? ArrayIndex)> segments) {
 		StringBuilder builder = new("$");
+		bool truncated = false;
 		foreach ((string? propertyName, int? arrayIndex) in segments) {
 			if (arrayIndex is not null) {
-				builder.Append('[').Append(arrayIndex.Value).Append(']');
+				if (!TryAppendPath(builder, $"[{arrayIndex.Value}]")) {
+					truncated = true;
+					break;
+				}
 				continue;
 			}
 			string name = propertyName ?? string.Empty;
@@ -174,12 +185,36 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 				&& (char.IsLetter(name[0]) || name[0] == '_')
 				&& name.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
 			if (isIdentifier) {
-				builder.Append('.').Append(name);
+				truncated = !TryAppendPath(builder, ".") || !TryAppendPath(builder, name);
+			} else if (TryAppendPath(builder, "[\"")) {
+				foreach (char character in name) {
+					string encodedCharacter = JsonEncodedText.Encode(character.ToString()).ToString();
+					if (!TryAppendPath(builder, encodedCharacter)) {
+						truncated = true;
+						break;
+					}
+				}
+				truncated = truncated || !TryAppendPath(builder, "\"]");
 			} else {
-				builder.Append('[').Append(JsonSerializer.Serialize(name)).Append(']');
+				truncated = true;
+			}
+			if (truncated) {
+				break;
 			}
 		}
-		return Truncate(builder.ToString());
+		return truncated ? builder.Append("...").ToString() : builder.ToString();
+	}
+
+	private static bool TryAppendPath(StringBuilder builder, string value) {
+		int remaining = MaxDiagnosticPathLength - 3 - builder.Length;
+		if (value.Length <= remaining) {
+			builder.Append(value);
+			return true;
+		}
+		if (remaining > 0 && value.All(character => char.IsLetterOrDigit(character) || character == '_')) {
+			builder.Append(value.AsSpan(0, remaining));
+		}
+		return false;
 	}
 
 	private static bool TryNormalizeQuery(JsonElement query, out JsonElement normalized, out string error) {
@@ -368,6 +403,7 @@ public sealed record ExecuteEsqArgs {
 	[JsonPropertyName("query")]
 	[Description(
 		"Raw ESQ SelectQuery object (the same shape stored in page bodies and accepted by the DataService). " +
+		"Maximum serialized size: 200000 UTF-8 bytes. " +
 		"Must include 'rootSchemaName' and usually 'columns' (with an 'items' map) and/or 'filters'. " +
 		"For a quick filter check, select a single COUNT(Id) aggregation column. See the 'esq' guidance for the envelope.")]
 	[Required]

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -25,7 +25,6 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	private const int MinTimeoutMs = 1_000;
 	private const int MaxTimeoutMs = 120_000;
 	private const int MaxDiagnosticPathLength = 500;
-	internal const int MaxQuerySizeBytes = 200_000;
 	internal const int MaxResponseSizeBytes = 200_000;
 	internal const string ResultTooLargeErrorClass = "result-too-large";
 
@@ -45,11 +44,6 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		try {
 			if (!TryNormalizeQuery(args.Query, out JsonElement query, out string queryError)) {
 				return ExecuteEsqResponse.Failure(queryError);
-			}
-			string queryJson = query.GetRawText();
-			if (Encoding.UTF8.GetByteCount(queryJson) > MaxQuerySizeBytes) {
-				return ExecuteEsqResponse.Failure(
-					$"query exceeds the {MaxQuerySizeBytes}-byte MCP safety limit; reduce selected columns or filters.");
 			}
 			if (!TryValidateTemporalParameterValues(query, [], out string temporalParameterError)) {
 				return ExecuteEsqResponse.Failure(temporalParameterError);
@@ -73,7 +67,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 			IServiceUrlBuilder urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
 
 			string url = urlBuilder.Build(ServiceUrlBuilder.KnownRoute.Select);
-			string responseJson = client.ExecutePostRequest(url, queryJson, timeout);
+			string responseJson = client.ExecutePostRequest(url, query.GetRawText(), timeout);
 			bool responseIsTooLarge = responseJson.Length > MaxResponseSizeBytes
 				|| Encoding.UTF8.GetByteCount(responseJson) > MaxResponseSizeBytes;
 			if (responseIsTooLarge) {
@@ -187,8 +181,8 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 			if (isIdentifier) {
 				truncated = !TryAppendPath(builder, ".") || !TryAppendPath(builder, name);
 			} else if (TryAppendPath(builder, "[\"")) {
-				foreach (char character in name) {
-					string encodedCharacter = JsonEncodedText.Encode(character.ToString()).ToString();
+				foreach (Rune rune in name.EnumerateRunes()) {
+					string encodedCharacter = JsonEncodedText.Encode(rune.ToString()).ToString();
 					if (!TryAppendPath(builder, encodedCharacter)) {
 						truncated = true;
 						break;
@@ -403,7 +397,6 @@ public sealed record ExecuteEsqArgs {
 	[JsonPropertyName("query")]
 	[Description(
 		"Raw ESQ SelectQuery object (the same shape stored in page bodies and accepted by the DataService). " +
-		"Maximum serialized size: 200000 UTF-8 bytes. " +
 		"Must include 'rootSchemaName' and usually 'columns' (with an 'items' map) and/or 'filters'. " +
 		"For a quick filter check, select a single COUNT(Id) aggregation column. See the 'esq' guidance for the envelope.")]
 	[Required]

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -180,15 +181,22 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 				&& name.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
 			if (isIdentifier) {
 				truncated = !TryAppendPath(builder, ".") || !TryAppendPath(builder, name);
-			} else if (TryAppendPath(builder, "[\"")) {
+			} else if (TryAppendPath(builder, "['")) {
 				foreach (Rune rune in name.EnumerateRunes()) {
-					string encodedCharacter = JsonEncodedText.Encode(rune.ToString()).ToString();
+					UnicodeCategory category = Rune.GetUnicodeCategory(rune);
+					bool requiresToken = category is UnicodeCategory.Control
+						or UnicodeCategory.Format
+						or UnicodeCategory.LineSeparator
+						or UnicodeCategory.ParagraphSeparator
+						or UnicodeCategory.SpaceSeparator
+						|| rune.Value is '\\' or '\'' or '"' or '/' or ':' or '=' or '<' or '>' or '|';
+					string encodedCharacter = requiresToken ? $"[U+{rune.Value:X4}]" : rune.ToString();
 					if (!TryAppendPath(builder, encodedCharacter)) {
 						truncated = true;
 						break;
 					}
 				}
-				truncated = truncated || !TryAppendPath(builder, "\"]");
+				truncated = truncated || !TryAppendPath(builder, "']");
 			} else {
 				truncated = true;
 			}

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -189,7 +189,7 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 						or UnicodeCategory.LineSeparator
 						or UnicodeCategory.ParagraphSeparator
 						or UnicodeCategory.SpaceSeparator
-						|| rune.Value is '\\' or '\'' or '"' or '/' or ':' or '=' or '<' or '>' or '|';
+						|| rune.Value is '\\' or '\'' or '"' or '[' or ']' or '/' or ':' or '=' or '<' or '>' or '|';
 					string encodedCharacter = requiresToken ? $"[U+{rune.Value:X4}]" : rune.ToString();
 					if (!TryAppendPath(builder, encodedCharacter)) {
 						truncated = true;

--- a/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteEsqTool.cs
@@ -24,7 +24,6 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 	private const int DefaultTimeoutMs = 30_000;
 	private const int MinTimeoutMs = 1_000;
 	private const int MaxTimeoutMs = 120_000;
-	private const int MaxDiagnosticPathLength = 500;
 	internal const int MaxResponseSizeBytes = 200_000;
 	internal const string ResultTooLargeErrorClass = "result-too-large";
 
@@ -139,21 +138,22 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		string renderedPath = RenderJsonPath(path);
 		error = $"query temporal parameter at '{renderedPath}.value' has an invalid or missing value for "
 			+ $"dataValueType {dataValueTypeCode}. Date, DateTime, and Time values must be JSON-encoded strings, "
-			+ "for example \"value\": \"\\\"2026-01-01T00:00:00.000Z\\\"\". A plain ISO string is not accepted. "
+			+ "for example value text '2026-01-01T00:00:00.000Z' including the two single quote characters. "
+			+ "A plain ISO string is not accepted. "
 			+ "See the 'esq' and 'esq-filters-frontend' guidance.";
 		return false;
 	}
 
 	private static bool IsJsonEncodedString(JsonElement value) {
 		if (value.ValueKind == JsonValueKind.String) {
-			string raw = value.GetString() ?? string.Empty;
-			if (raw.Length < 2
-				|| raw[0] is not ('"' or '\'')
-				|| raw[^1] != raw[0]) {
+			string encodedValue = (value.GetString() ?? string.Empty).Trim();
+			if (encodedValue.Length < 2
+				|| encodedValue[0] is not ('"' or '\'')
+				|| encodedValue[^1] != encodedValue[0]) {
 				return false;
 			}
 			try {
-				return Newtonsoft.Json.JsonConvert.DeserializeObject<string>(raw) is not null;
+				return Newtonsoft.Json.JsonConvert.DeserializeObject<string>(encodedValue) is not null;
 			} catch (Newtonsoft.Json.JsonException) {
 				return false;
 			}
@@ -166,60 +166,20 @@ public sealed class ExecuteEsqTool(IToolCommandResolver commandResolver) {
 		StringBuilder builder = new("$");
 		foreach ((string? propertyName, int? arrayIndex) in segments) {
 			if (arrayIndex is not null) {
-				if (!TryAppendBounded(builder, $"[{arrayIndex.Value}]")) {
-					break;
-				}
+				builder.Append('[').Append(arrayIndex.Value).Append(']');
 				continue;
 			}
-			if (!TryAppendPropertyName(builder, propertyName ?? string.Empty)) {
-				break;
+			string name = propertyName ?? string.Empty;
+			bool isIdentifier = name.Length > 0
+				&& (char.IsLetter(name[0]) || name[0] == '_')
+				&& name.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
+			if (isIdentifier) {
+				builder.Append('.').Append(name);
+			} else {
+				builder.Append('[').Append(JsonSerializer.Serialize(name)).Append(']');
 			}
 		}
-		return builder.ToString();
-	}
-
-	private static bool TryAppendPropertyName(StringBuilder builder, string propertyName) {
-		bool isIdentifier = propertyName.Length > 0
-			&& (char.IsLetter(propertyName[0]) || propertyName[0] == '_')
-			&& propertyName.Skip(1).All(character => char.IsLetterOrDigit(character) || character == '_');
-		if (isIdentifier) {
-			return TryAppendBounded(builder, ".") && TryAppendBounded(builder, propertyName);
-		}
-
-		if (!TryAppendBounded(builder, "['")) {
-			return false;
-		}
-		foreach (char character in propertyName) {
-			string escaped = character switch {
-				'\\' => "\\\\",
-				'\'' => "\\'",
-				'\n' => "\\n",
-				'\r' => "\\r",
-				'\t' => "\\t",
-				_ when char.IsControl(character) => $"\\u{(int)character:x4}",
-				_ => character.ToString()
-			};
-			if (!TryAppendBounded(builder, escaped)) {
-				return false;
-			}
-		}
-		return TryAppendBounded(builder, "']");
-	}
-
-	private static bool TryAppendBounded(StringBuilder builder, string value) {
-		int remaining = MaxDiagnosticPathLength - builder.Length;
-		if (value.Length <= remaining) {
-			builder.Append(value);
-			return true;
-		}
-		const string truncationMarker = "...";
-		if (remaining < truncationMarker.Length) {
-			builder.Length = MaxDiagnosticPathLength - truncationMarker.Length;
-		} else {
-			builder.Append(value, 0, remaining - truncationMarker.Length);
-		}
-		builder.Append(truncationMarker);
-		return false;
+		return Truncate(builder.ToString());
 	}
 
 	private static bool TryNormalizeQuery(JsonElement query, out JsonElement normalized, out string error) {

--- a/docs/knowledge/McpServer/execute-esq-temporal-parameters-require-json-encoded-values.md
+++ b/docs/knowledge/McpServer/execute-esq-temporal-parameters-require-json-encoded-values.md
@@ -1,0 +1,24 @@
+---
+description: execute-esq temporal parameter values for dataValueType 7 8 and 9 must be outer JSON strings containing an inner JSON-encoded date string; a plain ISO value reaches Creatio as null and produces an opaque ArgumentNullException
+applies-to:
+  - clio/Command/McpServer/Tools/ExecuteEsqTool.cs
+ticket: 1321
+date: 2026-09-02
+---
+
+**What is true** — the DataService SelectQuery contract does not accept a plain ISO string as the
+`value` of a DateTime (7), Date (8), or Time (9) parameter. The outer query JSON must carry a string
+whose content is another JSON string, for example `"value": "\"2026-01-01T00:00:00.000Z\""`.
+`ExecuteEsqTool` validates this recursively before resolving an environment and forwards a valid
+encoded value unchanged.
+
+**Why it is this way** — Creatio's SelectQuery parameter deserializer performs a second JSON decode
+for temporal parameter values. This was reproduced on Creatio 10.0.0.858 and is also the shape emitted
+by the Freedom UI filter designer and documented by the `esq-filters-frontend` guidance. Clio does not
+rewrite the value because choosing a timezone or changing Date versus DateTime intent belongs to the
+caller.
+
+**What breaks if you ignore it** — forwarding `"value": "2026-01-01T00:00:00.000Z"` reaches Creatio
+as a null temporal value and returns `ArgumentNullException: Value cannot be null. Parameter name:
+value`. The message falsely suggests that the caller omitted the field. Keep the preflight validation
+and its exact query path when changing `ExecuteEsqTool`; do not normalize temporal strings silently.

--- a/docs/knowledge/McpServer/execute-esq-temporal-parameters-require-json-encoded-values.md
+++ b/docs/knowledge/McpServer/execute-esq-temporal-parameters-require-json-encoded-values.md
@@ -10,7 +10,8 @@ date: 2026-09-02
 `value` of a DateTime (7), Date (8), or Time (9) parameter. The outer query JSON must carry a string
 whose content is another JSON string, for example `"value": "\"2026-01-01T00:00:00.000Z\""`.
 `ExecuteEsqTool` validates this recursively before resolving an environment and forwards a valid
-encoded value unchanged.
+encoded value unchanged. Creatio's Newtonsoft.Json parser also accepts the legacy single-quoted inner
+form; Clio preserves that compatibility, while the public guidance recommends standard double-quoted JSON.
 
 **Why it is this way** — Creatio's SelectQuery parameter deserializer performs a second JSON decode
 for temporal parameter values. This was reproduced on Creatio 10.0.0.858 and is also the shape emitted


### PR DESCRIPTION
## Outcome

`execute-esq` now stops malformed Date, DateTime, and Time parameters before environment resolution and returns a path-specific correction that survives the real MCP passthrough boundary.

## Changes

- Rejects missing, null, and plain temporal `parameter.value` inputs for `dataValueType` 7, 8, and 9.
- Preserves Creatio-compatible double-quoted, legacy single-quoted, and whitespace-surrounded encodings byte-for-byte.
- Reports the exact nested query path with escaped, bounded property names and a reusable accepted-value example.
- Adds unit and real stdio MCP E2E coverage plus the internal platform-serialization fact.
- Links the canonical guide repair in Advance-Technologies-Foundation/clio-knowledge#126.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "Category=Unit&Module=McpServer"` — 4,166 passed.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release -f net10.0 --no-build --filter "FullyQualifiedName~ExecuteEsqToolE2ETests"` — 5 passed.
- `git diff --check origin/master...HEAD` — clean.
- Comprehensive seven-lens agentic review completed; all High/Medium findings fixed and narrow rechecks closed on the exact final head.
- Claude independent review `rev_faf48da14c4d4621` found no blocking issue in the stable core implementation; all later review-only fixes received exact-head agentic review.

## Maintenance review

- Docs reviewed, no update required: `execute-esq` has no CLI verb/help surface.
- MCP reviewed and updated: tool contract, unit coverage, and mandatory stdio E2E coverage are aligned; prompts, resources, and shipped templates remain accurate.
- ClioRing compatibility reviewed, no Ring-consumed contract changed after inspecting `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`.
- KISS check: one preflight walk validates the raw query, then the existing request flow forwards the unchanged body; no server-side protocol or recovery state was added.
- Knowledge-base advisory check reports one unrelated pre-existing stale `ODataResponseError.cs` record; this diff introduces no stale knowledge record.

Refs #1321
Blocked by Advance-Technologies-Foundation/clio-knowledge#126