### PR TITLE
Keep installer unit tests off Windows feature inventory

### DIFF
--- a/clio.tests/Command/WindowsFeatureProviderIntegrationTests.cs
+++ b/clio.tests/Command/WindowsFeatureProviderIntegrationTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Clio.Command;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+[TestFixture]
+[Category("Integration")]
+[Platform(Include = "Win")]
+[Property("Module", "Command")]
+internal sealed class WindowsFeatureProviderIntegrationTests {
+	[Test]
+	[Description("Queries the real Windows optional-feature inventory through the operating-system provider.")]
+	public void GetActiveWindowsFeatures_ShouldReturnInstalledFeatures_OnWindows() {
+		// Arrange
+		ServiceCollection services = new();
+		services.AddSingleton<IWindowsFeatureProvider, WindowsFeatureProvider>();
+		using ServiceProvider serviceProvider = services.BuildServiceProvider();
+		IWindowsFeatureProvider sut = serviceProvider.GetRequiredService<IWindowsFeatureProvider>();
+
+		// Act
+		IEnumerable<string> features = sut.GetActiveWindowsFeatures();
+
+		// Assert
+		features.Should().NotBeEmpty(
+			because: "a Windows host exposes installed optional features through Win32_OptionalFeature");
+		features.Should().Contain(feature => !string.IsNullOrWhiteSpace(feature),
+			because: "the provider contract includes usable feature identifiers even when Windows omits a caption");
+	}
+}

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using Clio.Command;
 using Clio.Command.CreatioInstallCommand;
 using Clio.Common;
 using Clio.Common.IIS;
@@ -69,6 +70,9 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 		_tcpPortReservationReader = Substitute.For<ITcpPortReservationReader>();
 		_tcpPortReservationReader.GetReservedPorts(Arg.Any<int>(), Arg.Any<int>()).Returns([]);
 		containerBuilder.AddSingleton(_tcpPortReservationReader);
+		IWindowsFeatureManager windowsFeatureManager = Substitute.For<IWindowsFeatureManager>();
+		windowsFeatureManager.GetMissedComponents().Returns([]);
+		containerBuilder.AddSingleton(windowsFeatureManager);
 	}
 
 	protected override MockFileSystem CreateFs() {


### PR DESCRIPTION
## Summary

- substitute `IWindowsFeatureManager` in `CreatioInstallerServiceTests` so unit tests cannot execute the synchronous WMI inventory query
- exercise the existing `IWindowsFeatureProvider` once in a Windows-only integration test
- keep production deployment behavior and the MCP/CLI contract unchanged

## Performance evidence

The three affected tests changed locally from 0.282–0.764 seconds each (1.34 seconds total) to 0.017–0.309 seconds each (0.36 seconds total). More importantly, the hosted-only 19–30 second cold WMI query is no longer reachable from any of those unit tests.

The complete installer fixture runs 31 tests in 0.62–0.68 seconds locally.

## Validation

- `dotnet build clio.tests/clio.tests.csproj -c Release --no-restore`
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "TestCategory=Unit&Module=Core"` — 302 passed
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "FullyQualifiedName=Clio.Tests.Command.WindowsFeatureProviderIntegrationTests.GetActiveWindowsFeatures_ShouldReturnInstalledFeatures_OnWindows"` — 1 passed on Windows
- `dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter "FullyQualifiedName~Clio.Tests.TestSharding.TestShardingWorkflowTests"` — 6 passed
- comprehensive code-quality, performance/correctness, and security review — no findings

## Contract review

- docs reviewed, no update required: no `deploy-creatio` option or behavior changed
- MCP reviewed, no update required: no tool argument, execution, result, or progress contract changed
- ClioRing compatibility reviewed, no Ring-consumed contract changed