### PR TITLE
Address update-page quality findings

### DIFF
--- a/clio/Command/PageUpdateOptions.cs
+++ b/clio/Command/PageUpdateOptions.cs
@@ -131,6 +131,7 @@
 		private const string LocalizableStringsKey = "localizableStrings";
 		private const string ChecksumColumnName = "Checksum";
 		private const string ModifiedOnColumnName = "ModifiedOn";
+		private const string AppendMode = "append";
 
 		private readonly IApplicationClient _applicationClient;
 		private readonly IServiceUrlBuilder _serviceUrlBuilder;
@@ -191,31 +192,47 @@
 				if (!TryCheckForExternalModification(options, context, out response)) return false;
 				PageUpdateResponse validationError = ValidateInput(options, context.SchemaType, explicitResources);
 				if (validationError != null) { response = validationError; return false; }
-				if (options.DryRun) {
-					if (string.Equals(options.Mode, "append", StringComparison.OrdinalIgnoreCase)) {
-						if (!TryLoadSchemaForSave(options.SchemaName, context, out JObject currentSchema, out response)) return false;
-						if (!TryResolveBodyToWrite(currentSchema, options, out _, out response)) return false;
-					}
-					response = CreateSuccessResponse(options, dryRun: true, registeredKeys: null);
-					response.Warnings = BuildDryRunWidgetCaptionWarnings(options.Body, context.SchemaType, explicitResources);
-					return true;
-				}
-				if (!TryLoadSchemaForSave(options.SchemaName, context, out JObject schemaToSave, out response)) return false;
-				if (!TryResolveBodyToWrite(schemaToSave, options, out string bodyToWrite, out response)) return false;
-				IReadOnlyList<string> downgradeWarnings = PageInsertDowngradeDetector.Detect(schemaToSave["body"]?.ToString(), bodyToWrite);
-				List<string> registeredKeys = UpdateSchemaBody(schemaToSave, bodyToWrite, context.SchemaType, explicitResources, parsedOptionalProperties);
-				PageUpdateResponse captionError = ValidateInsertedWidgetCaptionsResolve(options, schemaToSave, bodyToWrite, context.SchemaType);
-				if (captionError != null) { response = captionError; return false; }
-				if (!TrySaveSchema(schemaToSave, out response)) return false;
-				response = CreateSuccessResponse(options, dryRun: false, registeredKeys);
-				response.Warnings = downgradeWarnings is { Count: > 0 } ? downgradeWarnings : null;
-				PopulatePostSaveChecksum(options, context, response);
-				AppendDesignerPresenceWarning(options, response);
-				return true;
+				return options.DryRun
+					? TryCompleteDryRun(options, context, explicitResources, out response)
+					: TrySaveValidatedPage(options, context, explicitResources, parsedOptionalProperties, out response);
 			} catch (Exception ex) {
 				response = new PageUpdateResponse { Success = false, Error = ex.Message };
 				return false;
 			}
+		}
+
+		private bool TryCompleteDryRun(
+			PageUpdateOptions options,
+			EditableSchemaContext context,
+			Dictionary<string, string> explicitResources,
+			out PageUpdateResponse response) {
+			if (string.Equals(options.Mode, AppendMode, StringComparison.OrdinalIgnoreCase)) {
+				if (!TryLoadSchemaForSave(options.SchemaName, context, out JObject currentSchema, out response)) return false;
+				if (!TryResolveBodyToWrite(currentSchema, options, out _, out response)) return false;
+			}
+			response = CreateSuccessResponse(options, dryRun: true, registeredKeys: null);
+			response.Warnings = BuildDryRunWidgetCaptionWarnings(options.Body, context.SchemaType, explicitResources);
+			return true;
+		}
+
+		private bool TrySaveValidatedPage(
+			PageUpdateOptions options,
+			EditableSchemaContext context,
+			Dictionary<string, string> explicitResources,
+			JArray parsedOptionalProperties,
+			out PageUpdateResponse response) {
+			if (!TryLoadSchemaForSave(options.SchemaName, context, out JObject schemaToSave, out response)) return false;
+			if (!TryResolveBodyToWrite(schemaToSave, options, out string bodyToWrite, out response)) return false;
+			IReadOnlyList<string> downgradeWarnings = PageInsertDowngradeDetector.Detect(schemaToSave["body"]?.ToString(), bodyToWrite);
+			List<string> registeredKeys = UpdateSchemaBody(schemaToSave, bodyToWrite, context.SchemaType, explicitResources, parsedOptionalProperties);
+			PageUpdateResponse captionError = ValidateInsertedWidgetCaptionsResolve(options, schemaToSave, bodyToWrite, context.SchemaType);
+			if (captionError != null) { response = captionError; return false; }
+			if (!TrySaveSchema(schemaToSave, out response)) return false;
+			response = CreateSuccessResponse(options, dryRun: false, registeredKeys);
+			response.Warnings = downgradeWarnings is { Count: > 0 } ? downgradeWarnings : null;
+			PopulatePostSaveChecksum(options, context, response);
+			AppendDesignerPresenceWarning(options, response);
+			return true;
 		}
 
 		/// <summary>
@@ -366,7 +383,7 @@
 		private static bool TryResolveBodyToWrite(JObject schemaToSave, PageUpdateOptions options, out string bodyToWrite, out PageUpdateResponse response) {
 			bodyToWrite = options.Body;
 			response = null;
-			if (string.Equals(options.Mode, "append", StringComparison.OrdinalIgnoreCase)) {
+			if (string.Equals(options.Mode, AppendMode, StringComparison.OrdinalIgnoreCase)) {
 				string currentBody = schemaToSave["body"]?.ToString();
 				if (!string.IsNullOrWhiteSpace(currentBody)) {
 					try {
@@ -387,7 +404,7 @@
 					}
 				}
 			}
-			if (!string.Equals(options.Mode, "append", StringComparison.OrdinalIgnoreCase) ||
+			if (!string.Equals(options.Mode, AppendMode, StringComparison.OrdinalIgnoreCase) ||
 				PageSchemaTypeExtensions.FromBody(bodyToWrite) == PageSchemaType.Mobile) {
 				return true;
 			}
@@ -918,7 +935,7 @@
 			// body is valid JavaScript, so it would save, after which PageSchemaSectionReader can no longer
 			// extract sections and append-merge is dead on that page. ResolveSyntaxFailure already treats
 			// markers as the "is this still a recognizable page" test for the same reason.
-			bool isAppendMode = string.Equals(options.Mode, "append", StringComparison.OrdinalIgnoreCase);
+			bool isAppendMode = string.Equals(options.Mode, AppendMode, StringComparison.OrdinalIgnoreCase);
 			if (!isAppendMode) {
 				SchemaValidationResult integrityResult = SchemaValidationService.ValidateMarkerIntegrity(options.Body);
 				if (!integrityResult.IsValid) {

--- a/clio/Command/SchemaValidationService.cs
+++ b/clio/Command/SchemaValidationService.cs
@@ -3596,7 +3596,7 @@ public static class SchemaValidationService
 					attributeBody.ValueKind != JsonValueKind.Object) {
 					continue;
 				}
-				string attributeName = path[1].GetString()!;
+				string attributeName = path[1].GetString();
 				switch (path.GetArrayLength()) {
 					case 2:
 						CollectMissingCustomValidatorReferences(


### PR DESCRIPTION
## Summary

- extract the already-validated dry-run and save terminal paths from `TryUpdatePage` to clear the new cognitive-complexity issue
- centralize the append mode literal
- remove a redundant null-forgiving operator after the existing string-kind guard

This is the quality-gate follow-up to #1357, which auto-merged before these Sonar findings were addressed. It does not change the validator behavior delivered there.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Debug --no-build --filter "Category=Unit&(Module=Command|Module=McpServer)"` — 8,120 passed, 13 skipped
- focused validator/dry-run regression set — 8 passed
- real MCP E2E `PageUpdateTool_Should_Persist_CustomValidator_Through_Append` against the exclusive `issue-1249` lab — 1 passed after the refactor
- comprehensive pre-PR intent, correctness, KISS, performance, quality, security, and testing reviews — clean
- `git diff --check` — clean

## Maintenance review

- docs reviewed, no update required: behavior and public contract are unchanged
- MCP reviewed, no update required: no MCP contract or execution semantics changed
- ClioRing compatibility reviewed, no Ring-consumed contract changed

## KISS check

The refactor names the two existing terminal branches and introduces no new state, protocol, or abstraction layer.