### PR TITLE
feat(mcp): convert legacy Mobile-wizard list settings in get-mobile-p…

### DIFF
--- a/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
@@ -10,6 +10,7 @@ using Allure.NUnit.Attributes;
 using Clio.Command;
 using Clio.Command.McpServer.Tools;
 using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
@@ -896,6 +897,100 @@ public sealed class MobilePageConversionGuideSandboxE2ETests : McpContractFixtur
 			}
 		}
 		return -1;
+	}
+
+	/// <summary>
+	/// OOTB legacy Mobile-wizard list settings schemas that ship with most Creatio products. The legacy sandbox test
+	/// tries them in order and IGNORES (never passes vacuously) when none exists on the environment.
+	/// </summary>
+	private static readonly string[] LegacyGridPageSettingsCandidates = [
+		"MobileActivityGridPageSettingsDefaultWorkplace",
+		"MobileContactGridPageSettingsDefaultWorkplace",
+		"MobileAccountGridPageSettingsDefaultWorkplace",
+		"MobileCaseGridPageSettingsDefaultWorkplace",
+		"MobileOrderGridPageSettingsDefaultWorkplace",
+		"MobileLeadGridPageSettingsDefaultWorkplace",
+		"MobileOpportunityGridPageSettingsDefaultWorkplace"
+	];
+
+	[Test]
+	[Description("Legacy source (ENG-95730): converts a real classic Mobile-wizard GridPageSettings schema through the real clio MCP server and verifies the legacy mechanism ran (sourceType legacy-mobile-grid-page, conversionMechanism legacy-mobile-settings-converter), the guide recommends BaseMobileListTemplate, carries exactly ONE merge onto ListItem with a string title, declares PDS_Id, exposes no raw body in legacySource.layers, and is idempotent across two calls. Ignores when no OOTB legacy settings schema exists on the environment; a runtime failure on an existing schema fails the test.")]
+	[AllureTag(ToolName)]
+	[AllureName("get-mobile-page-conversion-guide converts a legacy mobile wizard list settings schema")]
+	[AllureDescription("Tries the OOTB Mobile<Entity>GridPageSettingsDefaultWorkplace schemas against the sandbox; on the first one that exists asserts the legacy mechanism contract end to end, and calls the tool twice to prove the guide is deterministic.")]
+	public async Task MobilePageConversionGuideTool_Should_Convert_Legacy_GridPageSettings_Schema() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(5));
+		await RequireConverterFeatureOrIgnoreAsync(context);
+		string environmentName = await ResolveReachableEnvironmentAsync(settings);
+
+		// Act — the first existing legacy schema decides; a missing schema is a seed gap, any other failure a regression.
+		MobilePageConversionGuideResponse? response = null;
+		string convertedSchemaName = string.Empty;
+		List<string> missing = [];
+		foreach (string schemaName in LegacyGridPageSettingsCandidates) {
+			MobilePageConversionGuideResponse candidate = await ConvertAsync(context, schemaName, environmentName);
+			if (!candidate.Success && candidate.Error?.Contains("not found", StringComparison.OrdinalIgnoreCase) == true) {
+				missing.Add(schemaName);
+				continue;
+			}
+			response = candidate;
+			convertedSchemaName = schemaName;
+			break;
+		}
+		if (response is null) {
+			Assert.Ignore(
+				$"None of the OOTB legacy Mobile-wizard list settings schemas exist on environment '{environmentName}' "
+				+ $"({string.Join(", ", missing)}). Seed one with the classic Mobile application wizard to guard the legacy path.");
+		}
+
+		// Assert
+		response!.ConversionMechanism.Should().Be(LegacyMobileListAnalysisService.MechanismLegacySettingsConverter,
+			because: "a GridPageSettings schema must be routed to the legacy mechanism, and the result must say so");
+		response.SourceType.Should().Be(LegacyMobileListAnalysisService.SourceTypeLegacyGridPage,
+			because: "the detected source type is reported on the response");
+		response.Success.Should().BeTrue(
+			because: $"an existing legacy list settings schema '{convertedSchemaName}' must convert (a custom-viewConfig refusal would name it). Error: {response.Error}");
+		MobilePageConversionGuide guide = response.Guide!;
+		guide.RecommendedMobileTemplate.Should().Be(LegacyMobileListAnalysisService.RecommendedTemplate,
+			because: "every converted legacy list page inherits the shipped mobile list template");
+		guide.ElementMap.Should().HaveCount(2, because: "the legacy guide carries exactly the two merges the designer writes: FolderTreeActions and ListItem");
+		guide.ElementMap.Should().OnlyContain(e => e.Operation == "merge", because: "every target element is template-provided");
+		ElementMapEntry folder = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.FolderTreeActionsName);
+		folder.MobileValues!["rootSchemaName"]!.GetValue<string>().Should().Be(guide.LegacySource!.EntitySchemaName,
+			because: "folder filtering is bound to the entity the wizard page was bound to");
+		ElementMapEntry merge = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName);
+		merge.MobileValues!["title"]!.GetValueKind().Should().Be(JsonValueKind.String,
+			because: "a wizard list page always has a title column bound as a string attribute reference");
+		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().ContainsKey("PDS_Id").Should().BeTrue(
+			because: "PDS_Id is always declared so the row can open its record");
+		guide.LegacySource.Should().NotBeNull(because: "the legacy facts are the per-element report");
+		guide.LegacySource!.Layers.Should().NotBeEmpty(because: "at least one package layer contributed");
+		JsonSerializer.Serialize(guide.LegacySource.Layers).Should().NotContain("\"operation\"",
+			because: "no raw schema body may leak into the guide — layers carry package names and counts only");
+
+		MobilePageConversionGuideResponse second = await ConvertAsync(context, convertedSchemaName, environmentName);
+		second.Success.Should().BeTrue(because: "the second run must succeed exactly like the first");
+		JsonSerializer.Serialize(second.Guide!.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName).MobileValues).Should().Be(JsonSerializer.Serialize(merge.MobileValues),
+			because: "the conversion is deterministic — running twice yields the same row values");
+		JsonSerializer.Serialize(second.Guide.ViewModelConfigDiff).Should().Be(JsonSerializer.Serialize(guide.ViewModelConfigDiff),
+			because: "the conversion is deterministic — running twice yields the same attribute declaration");
+	}
+
+	private static async Task<MobilePageConversionGuideResponse> ConvertAsync(ArrangeContext context, string schemaName, string environmentName) {
+		CallToolResult callResult = await context.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = schemaName,
+					["environment-name"] = environmentName
+				}
+			},
+			context.CancellationTokenSource.Token);
+		callResult.IsError.Should().NotBeTrue(because: $"converting '{schemaName}' must return a structured envelope, not a transport-level error");
+		return EntitySchemaStructuredResultParser.Extract<MobilePageConversionGuideResponse>(callResult);
 	}
 
 	/// <summary>

--- a/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
@@ -954,14 +954,14 @@ public sealed class MobilePageConversionGuideSandboxE2ETests : McpContractFixtur
 		response.Success.Should().BeTrue(
 			because: $"an existing legacy list settings schema '{convertedSchemaName}' must convert (a custom-viewConfig refusal would name it). Error: {response.Error}");
 		MobilePageConversionGuide guide = response.Guide!;
-		guide.RecommendedMobileTemplate.Should().Be(LegacyMobileListAnalysisService.RecommendedTemplate,
+		guide.RecommendedMobileTemplate.Should().Be(LegacyMobileListAnalysisService.DefaultGridPageTemplate.TemplateName,
 			because: "every converted legacy list page inherits the shipped mobile list template");
 		guide.ElementMap.Should().HaveCount(2, because: "the legacy guide carries exactly the two merges the designer writes: FolderTreeActions and ListItem");
 		guide.ElementMap.Should().OnlyContain(e => e.Operation == "merge", because: "every target element is template-provided");
-		ElementMapEntry folder = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.FolderTreeActionsName);
+		ElementMapEntry folder = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.DefaultGridPageTemplate.FolderTreeActionsName);
 		folder.MobileValues!["rootSchemaName"]!.GetValue<string>().Should().Be(guide.LegacySource!.EntitySchemaName,
 			because: "folder filtering is bound to the entity the wizard page was bound to");
-		ElementMapEntry merge = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName);
+		ElementMapEntry merge = guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.DefaultGridPageTemplate.ListItemName);
 		merge.MobileValues!["title"]!.GetValueKind().Should().Be(JsonValueKind.String,
 			because: "a wizard list page always has a title column bound as a string attribute reference");
 		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().ContainsKey("PDS_Id").Should().BeTrue(
@@ -973,7 +973,7 @@ public sealed class MobilePageConversionGuideSandboxE2ETests : McpContractFixtur
 
 		MobilePageConversionGuideResponse second = await ConvertAsync(context, convertedSchemaName, environmentName);
 		second.Success.Should().BeTrue(because: "the second run must succeed exactly like the first");
-		JsonSerializer.Serialize(second.Guide!.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName).MobileValues).Should().Be(JsonSerializer.Serialize(merge.MobileValues),
+		JsonSerializer.Serialize(second.Guide!.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.DefaultGridPageTemplate.ListItemName).MobileValues).Should().Be(JsonSerializer.Serialize(merge.MobileValues),
 			because: "the conversion is deterministic — running twice yields the same row values");
 		JsonSerializer.Serialize(second.Guide.ViewModelConfigDiff).Should().Be(JsonSerializer.Serialize(guide.ViewModelConfigDiff),
 			because: "the conversion is deterministic — running twice yields the same attribute declaration");

--- a/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
@@ -970,6 +970,13 @@ public sealed class MobilePageConversionGuideSandboxE2ETests : McpContractFixtur
 		guide.LegacySource!.Layers.Should().NotBeEmpty(because: "at least one package layer contributed");
 		JsonSerializer.Serialize(guide.LegacySource.Layers).Should().NotContain("\"operation\"",
 			because: "no raw schema body may leak into the guide — layers carry package names and counts only");
+		// ENG-95733: the designer names come from a data table, and the table is only as good as the template it
+		// describes. Against a real stand the template IS readable, so neither the "unverified" fallback nor a
+		// missing-element warning may appear — this is what proves the probe ran and the shipped names are right.
+		guide.Constraints.Should().NotContain(c => c.Contains("UNVERIFIED"),
+			because: "the template probe must have read the shipped template on a real environment");
+		guide.Constraints.Should().NotContain(c => c.Contains("does not declare"),
+			because: "every designer name the shipped rules table declares must exist in the real template");
 
 		MobilePageConversionGuideResponse second = await ConvertAsync(context, convertedSchemaName, environmentName);
 		second.Success.Should().BeTrue(because: "the second run must succeed exactly like the first");

--- a/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
@@ -97,6 +97,10 @@ public sealed class MobilePageConversionGuideToolE2ETests : McpContractFixtureBa
 			because: "the mechanism label must be discoverable so a wrong dispatch is visible in the result");
 		contract.Description.Should().Contain("freedom-web",
 			because: "the Freedom UI web source type must still be advertised — no regression of the existing path");
+		contract.Description.Should().Contain("overrideOutcomes",
+			because: "a caller must know where the per-operation verdict of every embedded override is reported");
+		contract.Description.Should().Contain("NO fixed",
+			because: "elementMap grows by one entry per carried override, so a caller must not assume two merges");
 	}
 
 	// The freedom-page-web-to-mobile-conversion article itself is no longer Clio-owned: since

--- a/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideToolE2ETests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
@@ -64,6 +65,38 @@ public sealed class MobilePageConversionGuideToolE2ETests : McpContractFixtureBa
 		// Assert
 		toolNames.Should().Contain(ToolName,
 			because: "get-mobile-page-conversion-guide must be advertised so MCP callers can discover the conversion-guide tool");
+	}
+
+	[Test]
+	[Description("Advertises BOTH supported source types in the tool description — Freedom UI web and legacy Mobile-wizard list settings (ENG-95730) — so a caller discovers the legacy mechanism from the contract alone.")]
+	[AllureTag(ToolName)]
+	[AllureName("get-mobile-page-conversion-guide advertises the legacy mobile source type")]
+	[AllureDescription("Lists tools on the real clio MCP server and verifies the get-mobile-page-conversion-guide description names sourceType legacy-mobile-grid-page and the legacy-mobile-settings-converter mechanism next to freedom-web.")]
+	public async Task MobilePageConversionGuideTool_Should_Advertise_Legacy_Source_Type() {
+		// Arrange
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act — the tool is not resident in tools/list on the lazy surface, so its description comes from the
+		// get-tool-contract full contract (the same place an agent discovers it).
+		CallToolResult contractResult = await context.Session.CallToolAsync(
+			ToolContractGetTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["tool-names"] = new[] { ToolName }
+				}
+			},
+			context.CancellationTokenSource.Token);
+		ToolContractGetResponse contracts =
+			EntitySchemaStructuredResultParser.Extract<ToolContractGetResponse>(contractResult);
+		ToolContractDefinition contract = contracts.Tools!.Single(definition => definition.Name == ToolName);
+
+		// Assert
+		contract.Description.Should().Contain("legacy-mobile-grid-page",
+			because: "the contract must name the legacy Mobile-wizard list source type the tool now converts");
+		contract.Description.Should().Contain("legacy-mobile-settings-converter",
+			because: "the mechanism label must be discoverable so a wrong dispatch is visible in the result");
+		contract.Description.Should().Contain("freedom-web",
+			because: "the Freedom UI web source type must still be advertised — no regression of the existing path");
 	}
 
 	// The freedom-page-web-to-mobile-conversion article itself is no longer Clio-owned: since

--- a/clio.tests/Command/McpServer/Fixtures/LegacyMobile/MobileOrderGridPageSettingsDefaultWorkplace.json
+++ b/clio.tests/Command/McpServer/Fixtures/LegacyMobile/MobileOrderGridPageSettingsDefaultWorkplace.json
@@ -1,0 +1,57 @@
+[
+	{
+		"operation": "insert",
+		"name": "settings",
+		"values": {
+			"entitySchemaName": "Order",
+			"items": [],
+			"subtitleItems": [],
+			"groupItems": [],
+			"settingsType": "GridPage",
+			"operation": "insert",
+			"localizableStrings": {}
+		}
+	},
+	{
+		"operation": "insert",
+		"name": "cbe553ba-01d9-46ea-b240-ca53053ff011",
+		"values": {
+			"row": 0,
+			"content": "Number",
+			"columnName": "Number",
+			"dataValueType": 1,
+			"operation": "insert"
+		},
+		"parentName": "settings",
+		"propertyName": "items",
+		"index": 0
+	},
+	{
+		"operation": "insert",
+		"name": "feee752c-0f41-4a9a-ad81-2826e6da2885",
+		"values": {
+			"row": 0,
+			"content": "Account",
+			"columnName": "Account",
+			"dataValueType": 10,
+			"operation": "insert"
+		},
+		"parentName": "settings",
+		"propertyName": "subtitleItems",
+		"index": 0
+	},
+	{
+		"operation": "insert",
+		"name": "30c0c117-648a-48e4-96e9-a7bde3a279e5",
+		"values": {
+			"row": 0,
+			"content": "Payment amount",
+			"columnName": "PaymentAmount",
+			"dataValueType": 6,
+			"operation": "insert"
+		},
+		"parentName": "settings",
+		"propertyName": "groupItems",
+		"index": 0
+	}
+]

--- a/clio.tests/Command/McpServer/Fixtures/LegacyMobile/OrderMobileListPage.expected.json
+++ b/clio.tests/Command/McpServer/Fixtures/LegacyMobile/OrderMobileListPage.expected.json
@@ -1,0 +1,36 @@
+{
+	"listItemValues": {
+		"body": [
+			{ "value": "$PDS_Account" },
+			{ "value": "$PDS_PaymentAmount" }
+		],
+		"title": "$PDS_Number",
+		"icon": null
+	},
+	"viewModelConfigDiff": [
+		{
+			"operation": "merge",
+			"path": [ "attributes", "Items", "viewModelConfig", "attributes" ],
+			"values": {
+				"PDS_Account": { "modelConfig": { "path": "PDS.Account" } },
+				"PDS_PaymentAmount": { "modelConfig": { "path": "PDS.PaymentAmount" } },
+				"PDS_Number": { "modelConfig": { "path": "PDS.Number" } },
+				"PDS_Id": { "modelConfig": { "path": "PDS.Id" } }
+			}
+		}
+	],
+	"modelConfigDiff": [
+		{
+			"operation": "merge",
+			"path": [ "dataSources", "PDS", "config" ],
+			"values": {
+				"attributes": {
+					"Account": { "path": "Account" },
+					"PaymentAmount": { "path": "PaymentAmount" },
+					"Number": { "path": "Number" }
+				},
+				"entitySchemaName": "Order"
+			}
+		}
+	]
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Clio.Command;
+using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for the pure legacy Mobile-wizard LIST settings analysis (ENG-95730): the merged settings of a
+/// <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c> schema become ONE ListItem merge plus the two data-section
+/// diffs, in the same guide contract the Freedom UI web analysis returns.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class LegacyMobileListAnalysisServiceTests {
+
+	private const string SourceSchema = "MobileOrderGridPageSettingsDefaultWorkplace";
+	private const string Target = "UsrOrder_MobileListPage";
+
+	private static string FixturePath(string name) =>
+		Path.Combine(TestContext.CurrentContext.TestDirectory, "Command", "McpServer", "Fixtures", "LegacyMobile", name);
+
+	/// <summary>Merges one or more legacy diff arrays exactly like the reader does and wraps them as a successful read.</summary>
+	private static LegacyMobileSettingsReadResult Read(params string[] layerBodies) {
+		List<(JArray Operations, int SchemaVersion)> layers = layerBodies
+			.Select(body => (JArray.Parse(LegacyMobileSettingsReader.Unescape(body)), 1))
+			.ToList();
+		JArray merged = LegacyMobileSettingsReader.Merge(layers, () => new JsonDiffApplier());
+		JObject settings = merged.OfType<JObject>().Single(o => o.Value<string>("name") == "settings");
+		List<LegacyMobileSettingsLayer> layerInfos = layers
+			.Select((l, i) => new LegacyMobileSettingsLayer($"uid-{i}", SourceSchema, $"pkg-{i}", $"Package{i}", 1, l.Operations.Count))
+			.ToList();
+		return new LegacyMobileSettingsReadResult(true, null, SourceSchema, "uid-0", 0, layerInfos, settings,
+			LegacyBodyShape.OperationArray, []);
+	}
+
+	private static MobilePageConversionGuide Analyze(LegacyMobileSettingsReadResult read, SectionRegistrationInfo section = null) =>
+		LegacyMobileListAnalysisService.Analyze(
+			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, section);
+
+	private static string Settings(string entity, string items, string subtitles, string groups, string extraSettings = "") => $$"""
+		[
+		  { "operation": "insert", "name": "settings", "values": { "entitySchemaName": "{{entity}}", "items": [], "subtitleItems": [], "groupItems": [], "settingsType": "GridPage", "operation": "insert", "localizableStrings": {} {{extraSettings}} } }
+		  {{items}}{{subtitles}}{{groups}}
+		]
+		""";
+
+	private static string Column(string bucket, int row, string columnName, string caption, int dvt = 1, string extra = "") =>
+		$$""", { "operation": "insert", "name": "{{Guid.NewGuid()}}", "values": { "row": {{row}}, "content": "{{caption}}", "columnName": "{{columnName}}", "dataValueType": {{dvt}}, "operation": "insert" {{extra}} }, "parentName": "settings", "propertyName": "{{bucket}}", "index": {{row}} }""";
+
+	private static string Json(JsonNode node) => node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+
+	/// <summary>The ListItem merge of a legacy guide (the second of its two elementMap operations).</summary>
+	private static ElementMapEntry ListItem(MobilePageConversionGuide guide) =>
+		guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName);
+
+	[Test]
+	[Description("GOLDEN: the sample Order wizard settings produce exactly the expected ListItem merge values, viewModelConfigDiff and modelConfigDiff (title from items, body from subtitleItems then groupItems, PDS_Id appended, entitySchemaName Order).")]
+	public void Analyze_ShouldMatchExpectedFixture_WhenGivenSampleOrderSettings() {
+		// Arrange
+		string source = File.ReadAllText(FixturePath("MobileOrderGridPageSettingsDefaultWorkplace.json"));
+		JsonObject expected = JsonNode.Parse(File.ReadAllText(FixturePath("OrderMobileListPage.expected.json")))!.AsObject();
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.ElementMap.Should().HaveCount(2, because: "a legacy list page needs exactly the two merges the designer writes: FolderTreeActions and ListItem");
+		ElementMapEntry folder = guide.ElementMap[0];
+		folder.Operation.Should().Be("merge", because: "FolderTreeActions is template-provided and is never re-inserted");
+		folder.MobileName.Should().Be("FolderTreeActions", because: "folder filtering is bound on the template's element, first — as the designer orders it");
+		Json(folder.MobileValues).Should().Be("""{"sourceSchemaName":"FolderTree","rootSchemaName":"Order"}""",
+			because: "the designer-generated list page binds the folder tree with exactly these two values, rootSchemaName being the entity");
+		ElementMapEntry merge = guide.ElementMap[1];
+		merge.Operation.Should().Be("merge", because: "the ListItem is template-provided and is never re-inserted");
+		merge.MobileName.Should().Be("ListItem", because: "the merge targets the BaseMobileListTemplate row element by name");
+		merge.MobileType.Should().Be("crt.ListItem", because: "the caller learns the target type without a registry lookup");
+		Json(merge.MobileValues).Should().Be(Json(expected["listItemValues"]),
+			because: "the ListItem values must be byte-identical to the designer's own output: body rows in wizard order, title, icon null");
+		Json(guide.ViewModelConfigDiff).Should().Be(Json(expected["viewModelConfigDiff"]),
+			because: "the collection attributes are declared as one targeted merge under Items.viewModelConfig.attributes, PDS_Id last");
+		Json(guide.ModelConfigDiff).Should().Be(Json(expected["modelConfigDiff"]),
+			because: "the data source is bound to Order with one attribute per column as a targeted merge on dataSources.PDS.config");
+	}
+
+	[Test]
+	[Description("The legacy guide is LEAN and uses the shared contract: sourceType legacy-mobile-grid-page, BaseMobileListTemplate recommended, PDS data source, no component suggestions / contracts / container map, no web-only sections, and legacySource populated.")]
+	public void Analyze_ShouldFillSharedContractLeanly_WhenGivenSampleOrderSettings() {
+		// Arrange
+		string source = File.ReadAllText(FixturePath("MobileOrderGridPageSettingsDefaultWorkplace.json"));
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.SourceType.Should().Be(LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, because: "the guide names the detected source type");
+		guide.SourcePage.Should().Be(SourceSchema, because: "the guide names the source schema");
+		guide.RecommendedMobileTemplate.Should().Be("BaseMobileListTemplate", because: "every converted legacy list page inherits the shipped list template");
+		guide.SuggestedTargetSchemaName.Should().Be(Target, because: "the suggested target is passed through");
+		guide.DataSources.Should().Equal(new[] { "PDS" }, because: "the template's primary data source is the only one");
+		guide.SourceTemplate.Should().BeNull(because: "a legacy settings schema has no web template");
+		guide.SourceStructure.Should().BeEmpty(because: "the column facts live in legacySource, not in a web-style structure");
+		guide.ComponentSuggestions.Should().BeEmpty(because: "the target elements are known up front and all supported — nothing to choose");
+		guide.MobileContracts.Should().BeEmpty(because: "no registry lookup is needed for the template's own ListItem");
+		guide.ContainerMap.Should().BeEmpty(because: "there are no web containers to map");
+		guide.ModelConfig.Should().BeNull(because: "only the diffs are shipped for a legacy source");
+		guide.ViewModelConfig.Should().BeNull(because: "only the diffs are shipped for a legacy source");
+		guide.WebOnlySections.Should().BeNull(because: "a legacy settings body has no handlers/converters/validators");
+		guide.PageBusinessRules.Should().BeNull(because: "no page-level business rule probe runs for a legacy source");
+		guide.GuidanceArticle.Should().Be("freedom-page-web-to-mobile-conversion", because: "the same guidance article governs both source types");
+		guide.LegacySource.Should().NotBeNull(because: "the legacy facts are the per-element report for this source type");
+		guide.LegacySource.EntitySchemaName.Should().Be("Order", because: "the entity comes from settings.entitySchemaName");
+		guide.LegacySource.SettingsType.Should().Be("GridPage", because: "the wizard list settings type is echoed");
+		guide.LegacySource.Workplace.Should().Be("DefaultWorkplace", because: "the workplace suffix is parsed from the schema name");
+		guide.LegacySource.Classification.Should().Be("plain", because: "the sample carries no Freedom UI overrides");
+		guide.LegacySource.TitleColumn.ColumnName.Should().Be("Number", because: "the single items column is the title");
+		guide.LegacySource.TitleColumn.Target.Should().Be("ListItem.title", because: "the title column's target is named for the report");
+		guide.LegacySource.BodyColumns.Select(c => c.ColumnName).Should().Equal(new[] { "Account", "PaymentAmount" }, because: "subtitle columns come first, group columns second, each in row order");
+		guide.LegacySource.BodyColumns.Select(c => c.Bucket).Should().Equal(new[] { "subtitle", "group" }, because: "each body row records the wizard bucket it came from");
+		guide.LegacySource.Layers.Should().ContainSingle(l => l.OperationCount == 4, because: "one package layer with four operations contributed");
+		guide.LegacySource.Decisions.Should().BeEmpty(because: "the sample needs no user decision");
+		guide.Constraints.Should().Contain(c => c.Contains("exactly TWO operations"), because: "the caller must emit both merges and nothing else");
+		guide.Constraints.Should().Contain(c => c.Contains("left untouched"), because: "idempotence and non-mutation of the classic schema are promised");
+		guide.NextSteps.Should().Contain(s => s.Contains("create-page") && s.Contains("BaseMobileListTemplate") && s.Contains("entity-schema-name=Order"),
+			because: "the next steps carry the exact create-page invocation");
+		guide.NextSteps.Should().Contain(s => s.Contains("Gate M"), because: "nothing is written before the approval gate");
+	}
+
+	[Test]
+	[Description("A dotted column path binds as PDS_<A>_<B> with model path PDS.<A>_<B> and its data-source attribute carries the dotted path plus type ForwardReference; a lookup column binds directly.")]
+	public void Analyze_ShouldEmitForwardReference_WhenColumnPathIsDotted() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"),
+			Column("subtitleItems", 0, "Account.Type", "Account type", 10),
+			Column("groupItems", 0, "Owner", "Owner", 10));
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		JsonObject values = ListItem(guide).MobileValues.AsObject();
+		values["body"]!.AsArray().Select(r => r!["value"]!.GetValue<string>()).Should().Equal(new[] { "$PDS_Account_Type", "$PDS_Owner" }, because: "the dot becomes an underscore in the attribute name and a lookup binds directly");
+		JsonObject vmAttributes = guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject();
+		vmAttributes["PDS_Account_Type"]!["modelConfig"]!["path"]!.GetValue<string>().Should().Be("PDS.Account_Type",
+			because: "the collection attribute path uses the underscored attribute name under the PDS alias");
+		JsonObject dsAttributes = guide.ModelConfigDiff!.AsArray()[0]!["values"]!["attributes"]!.AsObject();
+		dsAttributes["Account_Type"]!["path"]!.GetValue<string>().Should().Be("Account.Type", because: "the data source attribute keeps the real dotted entity path");
+		dsAttributes["Account_Type"]!["type"]!.GetValue<string>().Should().Be("ForwardReference", because: "a related-column path must be declared as a ForwardReference for the mobile designer");
+		dsAttributes["Owner"]!.AsObject().ContainsKey("type").Should().BeFalse(because: "a direct column carries no ForwardReference type");
+		guide.LegacySource.BodyColumns[0].Attribute.Should().Be("PDS_Account_Type", because: "the report names the attribute the row binds to");
+	}
+
+	[Test]
+	[Description("Several subtitle and group columns keep wizard row order: all subtitle rows first (by row), then all group rows (by row), regardless of the order the operations appear in the body.")]
+	public void Analyze_ShouldKeepWizardRowOrder_WhenSeveralSubtitleAndGroupColumnsExist() {
+		// Arrange — group column listed BEFORE subtitle columns, and subtitle rows out of order.
+		string source = Settings("Contact",
+			Column("items", 0, "Name", "Name"),
+			Column("groupItems", 0, "Type", "Type") + Column("subtitleItems", 1, "Email", "Email") + Column("subtitleItems", 0, "Account", "Account"),
+			Column("groupItems", 1, "Owner", "Owner"));
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		ListItem(guide).MobileValues["body"]!.AsArray().Select(r => r!["value"]!.GetValue<string>())
+			.Should().Equal(new[] { "$PDS_Account", "$PDS_Email", "$PDS_Type", "$PDS_Owner" }, because: "subtitle rows by row then group rows by row is the order the wizard displayed them in");
+		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().Select(kv => kv.Key)
+			.Should().Equal(new[] { "PDS_Account", "PDS_Email", "PDS_Type", "PDS_Owner", "PDS_Name", "PDS_Id" }, because: "attributes are declared in body order, then the title, then PDS_Id — deterministic for byte-stable output");
+	}
+
+	[Test]
+	[Description("A column present in two wizard buckets is bound twice on the row but declared once as an attribute, with a note explaining the deduplication.")]
+	public void Analyze_ShouldDeclareAttributeOnce_WhenColumnAppearsInTwoBuckets() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"),
+			Column("subtitleItems", 0, "Account", "Account", 10),
+			Column("groupItems", 0, "Account", "Account", 10));
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().Count(kv => kv.Key == "PDS_Account").Should().Be(1,
+			because: "a JSON object cannot declare the same attribute twice");
+		ListItem(guide).MobileValues["body"]!.AsArray().Should().HaveCount(2, because: "both wizard rows are still rendered");
+		guide.LegacySource.Notes.Should().Contain(n => n.Contains("more than one wizard bucket"), because: "the deduplication is reported, not silent");
+	}
+
+	[Test]
+	[Description("When the wizard 'items' bucket is empty the ListItem merge carries no title key, a decision asks the user to choose one, and a constraint tells the caller how to add it.")]
+	public void Analyze_ShouldOmitTitleAndAskForDecision_WhenNoTitleColumnExists() {
+		// Arrange
+		string source = Settings("Order", string.Empty, Column("subtitleItems", 0, "Account", "Account", 10), string.Empty);
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		ListItem(guide).MobileValues.AsObject().ContainsKey("title").Should().BeFalse(because: "there is no column to bind the title to");
+		guide.LegacySource.TitleColumn.Should().BeNull(because: "the report shows no title column");
+		guide.LegacySource.Decisions.Should().Contain(d => d.Contains("No title column"), because: "the user must choose the title");
+		guide.Constraints.Should().Contain(c => c.Contains("No title column was found"), because: "the caller is told how to add the title after the decision");
+		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().Select(kv => kv.Key).Should().Equal(new[] { "PDS_Account", "PDS_Id" }, because: "only the body column and PDS_Id are declared");
+	}
+
+	[Test]
+	[Description("When the wizard 'items' bucket holds several columns the lowest row becomes the title and the others are moved to the front of the body, each reported as a decision (adapted, not silently lost).")]
+	public void Analyze_ShouldUseLowestRowAsTitle_WhenSeveralTitleColumnsExist() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 1, "Account", "Account", 10) + Column("items", 0, "Number", "Number"),
+			Column("subtitleItems", 0, "PaymentAmount", "Payment amount", 6),
+			string.Empty);
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		ListItem(guide).MobileValues["title"]!.GetValue<string>().Should().Be("$PDS_Number", because: "row 0 wins the title");
+		ListItem(guide).MobileValues["body"]!.AsArray().Select(r => r!["value"]!.GetValue<string>()).Should().Equal(new[] { "$PDS_Account", "$PDS_PaymentAmount" }, because: "the extra title column is prepended to the body so it is not lost");
+		guide.LegacySource.BodyColumns[0].Bucket.Should().Be("title", because: "the report shows where the moved column came from");
+		guide.LegacySource.Decisions.Should().Contain(d => d.Contains("more than one column") && d.Contains("Account"),
+			because: "the adaptation is a decision for the user");
+	}
+
+	[Test]
+	[Description("Wizard column properties without a counterpart on a ListItem row (view types such as phone/email/url, formats) are reported as dropped in the coverage table with the columns that carried them, added to decisions, and named in a constraint.")]
+	public void Analyze_ShouldReportDroppedColumnProperties_WhenWizardRecordedViewTypes() {
+		// Arrange
+		string source = Settings("Contact",
+			Column("items", 0, "Name", "Name"),
+			Column("subtitleItems", 0, "Phone", "Phone", 1, ", \"viewType\": \"phone\"") + Column("subtitleItems", 1, "Email", "Email", 1, ", \"viewType\": \"email\", \"displayFormat\": \"short\""),
+			string.Empty);
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		LegacyPropertyCoverageInfo viewType = guide.LegacySource.ColumnPropertyCoverage.Single(c => c.Property == "viewType");
+		viewType.Status.Should().Be("dropped", because: "a template ListItem body row carries only a value binding");
+		viewType.Columns.Should().Equal(new[] { "Phone", "Email" }, because: "the coverage row names the columns that carried the property");
+		guide.LegacySource.ColumnPropertyCoverage.Should().Contain(c => c.Property == "displayFormat" && c.Status == "dropped",
+			because: "every unknown column property is covered, not just the first");
+		guide.LegacySource.ColumnPropertyCoverage.Should().Contain(c => c.Property == "columnName" && c.Status == "transferred",
+			because: "the binding itself transfers");
+		guide.LegacySource.ColumnPropertyCoverage.Should().Contain(c => c.Property == "content" && c.Status == "informational",
+			because: "captions are not rendered on mobile list rows");
+		guide.LegacySource.Decisions.Should().Contain(d => d.Contains("'viewType'"), because: "dropped properties need a user decision");
+		guide.Constraints.Should().Contain(c => c.Contains("Dropped column properties") && c.Contains("viewType") && c.Contains("displayFormat"),
+			because: "the caller is told to present the dropped properties at the plan gate");
+	}
+
+	[Test]
+	[Description("The wizard's classic grid layout settings (gridType / rows / columns, present on every OOTB list settings schema) are informational — reported in notes, never as a user decision — while an unknown settings property still becomes a decision.")]
+	public void Analyze_ShouldTreatGridLayoutSettingsAsInformational_AndUnknownSettingsAsDecisions() {
+		// Arrange
+		string source = Settings("Activity",
+			Column("items", 0, "Title", "Title"), string.Empty, string.Empty,
+			", \"gridType\": \"listed\", \"rows\": 1, \"columns\": 1, \"mysteryFlag\": true");
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.LegacySource.Decisions.Should().NotContain(d => d.Contains("gridType") || d.Contains("'rows'") || d.Contains("'columns'"),
+			because: "classic grid geometry is not something the user can decide about on a mobile list row");
+		guide.LegacySource.Notes.Should().Contain(n => n.Contains("gridType 'listed'"), because: "the classic layout is still reported for transparency");
+		guide.LegacySource.Decisions.Should().ContainSingle(d => d.Contains("'mysteryFlag'"), because: "a genuinely unknown settings property needs a decision");
+	}
+
+	[Test]
+	[Description("Freedom UI override sections embedded in the settings are recognised and reported (classification freedom-ui-overrides, overrideSections with op counts, an ENG-95733 constraint) but the wizard buckets still convert and no override content leaks into the diffs.")]
+	public void Analyze_ShouldReportOverrides_WhenSettingsCarryFreedomUiSections() {
+		// Arrange — the wizard stores override sections as JSON-encoded strings.
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"), string.Empty, string.Empty,
+			", \"viewConfigDiff\": \"[{\\\"operation\\\":\\\"merge\\\",\\\"name\\\":\\\"X\\\",\\\"values\\\":{}}]\", \"modelConfigDiff\": []");
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.LegacySource.Classification.Should().Be("freedom-ui-overrides", because: "override sections were present");
+		guide.LegacySource.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 1 && s.Ticket == "ENG-95733",
+			because: "a string-encoded section is parsed to count its operations");
+		guide.LegacySource.OverrideSections.Should().NotContain(s => s.Section == "modelConfigDiff",
+			because: "an EMPTY placeholder section carries nothing to convert and must not be reported as a dropped override");
+		guide.LegacySource.Notes.Should().Contain(n => n.Contains("'modelConfigDiff'") && n.Contains("empty"),
+			because: "the empty placeholder is still mentioned for transparency");
+		guide.Constraints.Should().Contain(c => c.Contains("RECOGNISED but NOT converted") && c.Contains("ENG-95733"),
+			because: "the caller must tell the user the overrides were not carried");
+		guide.ModelConfigDiff!.AsArray().Should().HaveCount(1, because: "the override modelConfigDiff is not merged into the guide's diff");
+		ListItem(guide).MobileValues["title"]!.GetValue<string>().Should().Be("$PDS_Number", because: "the wizard buckets still convert");
+	}
+
+	[Test]
+	[Description("Two package layers merge ROOT -> HEAD: the head layer's insert at index 0 lands first, its remove takes a subtitle column away, and its merge changes a caption — and every layer appears in legacySource.layers without a body.")]
+	public void Analyze_ShouldReflectMergedLayers_WhenSettingsSpanTwoPackages() {
+		// Arrange
+		string subtitleName = Guid.NewGuid().ToString();
+		string root = $$"""
+			[
+			  { "operation": "insert", "name": "settings", "values": { "entitySchemaName": "Order", "items": [], "subtitleItems": [], "groupItems": [], "settingsType": "GridPage", "operation": "insert", "localizableStrings": {} } },
+			  { "operation": "insert", "name": "t1", "values": { "row": 0, "content": "Number", "columnName": "Number", "dataValueType": 1, "operation": "insert" }, "parentName": "settings", "propertyName": "items", "index": 0 },
+			  { "operation": "insert", "name": "{{subtitleName}}", "values": { "row": 0, "content": "Account", "columnName": "Account", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "subtitleItems", "index": 0 },
+			  { "operation": "insert", "name": "g1", "values": { "row": 1, "content": "Owner", "columnName": "Owner", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "groupItems", "index": 0 }
+			]
+			""";
+		string head = $$"""
+			[
+			  { "operation": "remove", "name": "{{subtitleName}}" },
+			  { "operation": "insert", "name": "g0", "values": { "row": 0, "content": "Status", "columnName": "Status", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "groupItems", "index": 0 },
+			  { "operation": "merge", "name": "t1", "values": { "content": "Order number" } }
+			]
+			""";
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(root, head));
+
+		// Assert
+		ListItem(guide).MobileValues["body"]!.AsArray().Select(r => r!["value"]!.GetValue<string>()).Should().Equal(new[] { "$PDS_Status", "$PDS_Owner" }, because: "the head layer removed Account and inserted Status at row 0 before Owner");
+		guide.LegacySource.TitleColumn.Caption.Should().Be("Order number", because: "the head layer's merge changed the title caption");
+		guide.LegacySource.Layers.Should().HaveCount(2, because: "both package layers contributed");
+		guide.LegacySource.Layers.Select(l => l.OperationCount).Should().Equal(new[] { 4, 3 }, because: "layers are reported ROOT -> HEAD with their operation counts");
+		guide.LegacySource.Layers.Select(l => l.PackageName).Should().Equal(new[] { "Package0", "Package1" }, because: "the contributing packages are named for the plan");
+	}
+
+	[Test]
+	[Description("A wizard column literally named Id does not declare PDS_Id twice or move it: PDS_Id stays the LAST attribute and the row still binds $PDS_Id.")]
+	public void Analyze_ShouldKeepPdsIdLast_WhenAColumnIsNamedId() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"),
+			Column("subtitleItems", 0, "Id", "Id", 0),
+			string.Empty);
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.ViewModelConfigDiff!.AsArray()[0]!["values"]!.AsObject().Select(kv => kv.Key).Should().Equal(new[] { "PDS_Number", "PDS_Id" },
+			because: "PDS_Id is declared once, last, by the converter itself");
+		ListItem(guide).MobileValues["body"]!.AsArray()[0]!["value"]!.GetValue<string>().Should().Be("$PDS_Id",
+			because: "the row still binds the column the wizard asked for");
+	}
+
+	[Test]
+	[Description("RECORDED DIVERGENCE from the mobile runtime converter: subtitle columns land in ListItem.body (as the Mobile designer generates), never in the template's 'subtitles' slot, and no search-column list is emitted (the template searches $Items through crt.OpenSearchListRequest); both are stated in legacySource.notes.")]
+	public void Analyze_ShouldPutSubtitlesInBodyAndEmitNoSearchColumns_AsRecordedDivergences() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"),
+			Column("subtitleItems", 0, "Account", "Account", 10),
+			string.Empty);
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		JsonObject values = ListItem(guide).MobileValues.AsObject();
+		values.ContainsKey("subtitles").Should().BeFalse(because: "the designer's own list page puts every extra column in body");
+		values["body"]!.AsArray().Select(r => r!["value"]!.GetValue<string>()).Should().Equal(new[] { "$PDS_Account" }, because: "the subtitle column is a body row");
+		Json(guide.ViewModelConfigDiff).Should().NotContain("search", because: "no per-page search-column configuration exists in the BaseMobileListTemplate vocabulary");
+		guide.LegacySource.Notes.Should().Contain(n => n.Contains("ListItem.subtitles"), because: "the subtitle divergence is written down for the user");
+		guide.LegacySource.Notes.Should().Contain(n => n.Contains("crt.OpenSearchListRequest"), because: "the search divergence is written down for the user");
+	}
+
+	[Test]
+	[Description("Running the analysis twice on the same input yields byte-identical diffs and ListItem values (idempotent, deterministic key order).")]
+	public void Analyze_ShouldBeDeterministic_WhenRunTwice() {
+		// Arrange
+		string source = File.ReadAllText(FixturePath("MobileOrderGridPageSettingsDefaultWorkplace.json"));
+
+		// Act
+		MobilePageConversionGuide first = Analyze(Read(source));
+		MobilePageConversionGuide second = Analyze(Read(source));
+
+		// Assert
+		Json(second.ElementMap[0].MobileValues).Should().Be(Json(first.ElementMap[0].MobileValues), because: "the row values must not depend on run order");
+		Json(second.ViewModelConfigDiff).Should().Be(Json(first.ViewModelConfigDiff), because: "the attribute declaration must be stable");
+		Json(second.ModelConfigDiff).Should().Be(Json(first.ModelConfigDiff), because: "the data source declaration must be stable");
+	}
+
+	[Test]
+	[Description("The provided section registration is passed through onto the guide so the caller can drive Gate S from one place.")]
+	public void Analyze_ShouldCarrySectionRegistration_WhenProvided() {
+		// Arrange
+		string source = File.ReadAllText(FixturePath("MobileOrderGridPageSettingsDefaultWorkplace.json"));
+		var section = new SectionRegistrationInfo { SourcePageIsSection = true, SectionCode = "Order", ProbeOk = true };
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source), section);
+
+		// Assert
+		guide.SectionRegistration.Should().BeSameAs(section, because: "the probe result is surfaced verbatim");
+	}
+
+	[TestCase("Order", "Usr", ExpectedResult = "UsrOrder_MobileListPage")]
+	[TestCase("UsrMK_Test", "Usr", ExpectedResult = "UsrMK_Test_MobileListPage")]
+	[TestCase("Order", "", ExpectedResult = "Order_MobileListPage")]
+	[TestCase("Order", null, ExpectedResult = "Order_MobileListPage")]
+	[TestCase("Contact", "Glb", ExpectedResult = "GlbContact_MobileListPage")]
+	[Description("The default target name is <Prefix><Entity>_MobileListPage, without doubling a prefix the entity already carries, and without a prefix when the environment declares none.")]
+	public string DeriveTargetSchemaName_ShouldPrefixOnce(string entity, string prefix) =>
+		LegacyMobileListAnalysisService.DeriveTargetSchemaName(entity, prefix);
+
+	[TestCase("MobileOrderGridPageSettingsDefaultWorkplace", "Order", "DefaultWorkplace", false)]
+	[TestCase("MobileCaseGridPageSettings", "Case", null, false)]
+	[TestCase("MobileActivityRecordPageSettingsDefaultWorkplace", "Activity", "DefaultWorkplace", true)]
+	[Description("The schema name pattern Mobile<Entity>(Grid|Record)PageSettings<Workplace> yields entity, optional workplace and the page kind.")]
+	public void TryParseSchemaName_ShouldExtractParts(string name, string entity, string workplace, bool isRecord) {
+		// Act
+		LegacyMobileListAnalysisService.LegacySchemaNameParts parts = LegacyMobileListAnalysisService.TryParseSchemaName(name);
+
+		// Assert
+		parts.Should().NotBeNull(because: "the name follows the wizard pattern");
+		parts.Entity.Should().Be(entity, because: "the entity sits between the Mobile prefix and the settings kind");
+		parts.Workplace.Should().Be(workplace, because: "the workplace is the optional suffix");
+		parts.IsRecordPage.Should().Be(isRecord, because: "the kind distinguishes list from record settings");
+	}
+
+	[Test]
+	[Description("A name that does not follow the wizard pattern yields null instead of a guess.")]
+	public void TryParseSchemaName_ShouldReturnNull_WhenNameDoesNotMatch() {
+		LegacyMobileListAnalysisService.TryParseSchemaName("UsrOrder_ListPage").Should().BeNull(because: "a Freedom UI page name is not a wizard settings name");
+	}
+
+	[Test]
+	[Description("The analysis refuses a failed read instead of producing an empty guide.")]
+	public void Analyze_ShouldThrow_WhenReadFailed() {
+		// Arrange
+		LegacyMobileSettingsReadResult failed = LegacyMobileSettingsReadResult.Fail(SourceSchema, "boom");
+		var classification = new LegacySettingsClassification(LegacySettingsKind.Plain, [], []);
+
+		// Act
+		Action act = () => LegacyMobileListAnalysisService.Analyze(failed, classification, SourceSchema, Target, null);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(because: "a guide must never be built from nothing");
+	}
+
+	[Test]
+	[Description("Settings without entitySchemaName cannot bind a mobile page and are rejected with a clear message.")]
+	public void Parse_ShouldThrow_WhenEntitySchemaNameIsMissing() {
+		// Arrange
+		JObject settings = JObject.Parse("""{ "name": "settings", "settingsType": "GridPage", "items": [] }""");
+
+		// Act
+		Action act = () => LegacyGridPageSettingsParser.Parse(settings);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>().WithMessage("*entitySchemaName*", because: "the missing binding is named");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
@@ -558,6 +558,34 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 	}
 
 	[Test]
+	[Description("The two merges the converter always writes address TEMPLATE elements, so a template that does not declare them is called out — and an unreadable template says the names are unverified rather than pretending they were checked.")]
+	public void Analyze_ShouldStateWhetherTheTemplateElementsWereVerified() {
+		// Arrange
+		LegacyMobileSettingsReadResult read = Read(Settings("Order", Column("items", 0, "Number", "Number"), "", ""));
+
+		// Act
+		MobilePageConversionGuide unverified = LegacyMobileListAnalysisService.Analyze(
+			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, null,
+			Template, RuntimeNames);
+		MobilePageConversionGuide missing = LegacyMobileListAnalysisService.Analyze(
+			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, null,
+			Template, RuntimeNames, null, new HashSet<string>(["Scaffold", "List"]));
+		MobilePageConversionGuide verified = LegacyMobileListAnalysisService.Analyze(
+			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, null,
+			Template, RuntimeNames, null, new HashSet<string>(["ListItem", "FolderTreeActions"]));
+
+		// Assert
+		unverified.Constraints.Should().Contain(c => c.Contains("UNVERIFIED"),
+			because: "an unreadable template must not be reported as if the names had been checked");
+		missing.Constraints.Should().Contain(c => c.Contains("does not declare 'ListItem'"),
+			because: "a template without the row element makes the whole conversion author nothing");
+		missing.Constraints.Should().Contain(c => c.Contains("does not declare 'FolderTreeActions'"),
+			because: "both of the converter's own targets are checked, not just the first");
+		verified.Constraints.Should().NotContain(c => c.Contains("UNVERIFIED") || c.Contains("does not declare"),
+			because: "a template that carries both targets produces no warning at all");
+	}
+
+	[Test]
 	[Description("The shipped conversion rules file carries a mobileLegacyTemplates.gridPage group, and it agrees with the bundled defaults so the two cannot drift apart silently.")]
 	public void ShippedRules_ShouldCarryGridPageTemplate_MatchingTheBundledDefaults() {
 		// Arrange

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisServiceTests.cs
@@ -43,9 +43,18 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 			LegacyBodyShape.OperationArray, []);
 	}
 
-	private static MobilePageConversionGuide Analyze(LegacyMobileSettingsReadResult read, SectionRegistrationInfo section = null) =>
+	/// <summary>The bundled target-template configuration the analyzer falls back to when the rules file has none.</summary>
+	private static readonly MobileLegacyTemplateRule Template = LegacyMobileListAnalysisService.DefaultGridPageTemplate;
+
+	/// <summary>The shipped runtime-name table, so the tests exercise the same data the tool loads.</summary>
+	private static readonly MobileLegacyRuntimeNameSet RuntimeNames =
+		WebToMobilePageConversionRulesCatalog.LoadBundled().MobileLegacyRuntimeNames?.GridPage;
+
+	private static MobilePageConversionGuide Analyze(LegacyMobileSettingsReadResult read, SectionRegistrationInfo section = null,
+		MobileLegacyTemplateRule template = null) =>
 		LegacyMobileListAnalysisService.Analyze(
-			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, section);
+			read, LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings), SourceSchema, Target, section,
+			template ?? Template, RuntimeNames);
 
 	private static string Settings(string entity, string items, string subtitles, string groups, string extraSettings = "") => $$"""
 		[
@@ -61,7 +70,7 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 
 	/// <summary>The ListItem merge of a legacy guide (the second of its two elementMap operations).</summary>
 	private static ElementMapEntry ListItem(MobilePageConversionGuide guide) =>
-		guide.ElementMap.Single(e => e.MobileName == LegacyMobileListAnalysisService.ListItemName);
+		guide.ElementMap.Single(e => e.MobileName == Template.ListItemName);
 
 	[Test]
 	[Description("GOLDEN: the sample Order wizard settings produce exactly the expected ListItem merge values, viewModelConfigDiff and modelConfigDiff (title from items, body from subtitleItems then groupItems, PDS_Id appended, entitySchemaName Order).")]
@@ -128,11 +137,14 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 		guide.LegacySource.BodyColumns.Select(c => c.Bucket).Should().Equal(new[] { "subtitle", "group" }, because: "each body row records the wizard bucket it came from");
 		guide.LegacySource.Layers.Should().ContainSingle(l => l.OperationCount == 4, because: "one package layer with four operations contributed");
 		guide.LegacySource.Decisions.Should().BeEmpty(because: "the sample needs no user decision");
-		guide.Constraints.Should().Contain(c => c.Contains("exactly TWO operations"), because: "the caller must emit both merges and nothing else");
+		guide.Constraints.Should().Contain(c => c.Contains("starts with TWO merges"), because: "a source with no overrides yields exactly the two designer merges");
 		guide.Constraints.Should().Contain(c => c.Contains("left untouched"), because: "idempotence and non-mutation of the classic schema are promised");
-		guide.NextSteps.Should().Contain(s => s.Contains("create-page") && s.Contains("BaseMobileListTemplate") && s.Contains("entity-schema-name=Order"),
+		guide.NextSteps.Should().BeEmpty(
+			because: "the legacy guide states rules in constraints; the conversion FLOW is the skill's, not the guide's");
+		guide.Constraints.Should().Contain(c => c.Contains("BaseMobileListTemplate"),
 			because: "the next steps carry the exact create-page invocation");
-		guide.NextSteps.Should().Contain(s => s.Contains("Gate M"), because: "nothing is written before the approval gate");
+		guide.Constraints.Should().Contain(c => c.Contains("left untouched") && c.Contains("idempotent"),
+			because: "the guide states what it does NOT do to the source; the approval gate itself belongs to the skill");
 	}
 
 	[Test]
@@ -293,15 +305,17 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 
 		// Assert
 		guide.LegacySource.Classification.Should().Be("freedom-ui-overrides", because: "override sections were present");
-		guide.LegacySource.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 1 && s.Ticket == "ENG-95733",
-			because: "a string-encoded section is parsed to count its operations");
+		guide.LegacySource.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 1 && s.Supported && s.Ticket == null,
+			because: "a string-encoded section is parsed, and this format is processed operation by operation rather than deferred to a ticket");
 		guide.LegacySource.OverrideSections.Should().NotContain(s => s.Section == "modelConfigDiff",
 			because: "an EMPTY placeholder section carries nothing to convert and must not be reported as a dropped override");
 		guide.LegacySource.Notes.Should().Contain(n => n.Contains("'modelConfigDiff'") && n.Contains("empty"),
 			because: "the empty placeholder is still mentioned for transparency");
-		guide.Constraints.Should().Contain(c => c.Contains("RECOGNISED but NOT converted") && c.Contains("ENG-95733"),
-			because: "the caller must tell the user the overrides were not carried");
-		guide.ModelConfigDiff!.AsArray().Should().HaveCount(1, because: "the override modelConfigDiff is not merged into the guide's diff");
+		guide.Constraints.Should().Contain(c => c.Contains("re-pointed individually") && c.Contains("overrideOutcomes"),
+			because: "the caller must present the per-operation outcome of every override");
+		guide.LegacySource.OverrideOutcomes.Should().ContainSingle(o => o.Target == "X" && o.Lane == LegacyOverrideLanes.Reported,
+			because: "'X' is not a name the runtime would generate for this source, so it is reported instead of guessed at");
+		guide.ModelConfigDiff!.AsArray().Should().HaveCount(1, because: "an empty override section contributes no operation");
 		ListItem(guide).MobileValues["title"]!.GetValue<string>().Should().Be("$PDS_Number", because: "the wizard buckets still convert");
 	}
 
@@ -445,7 +459,7 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 		var classification = new LegacySettingsClassification(LegacySettingsKind.Plain, [], []);
 
 		// Act
-		Action act = () => LegacyMobileListAnalysisService.Analyze(failed, classification, SourceSchema, Target, null);
+		Action act = () => LegacyMobileListAnalysisService.Analyze(failed, classification, SourceSchema, Target, null, Template);
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(because: "a guide must never be built from nothing");
@@ -462,5 +476,185 @@ public sealed class LegacyMobileListAnalysisServiceTests {
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>().WithMessage("*entitySchemaName*", because: "the missing binding is named");
+	}
+
+	[Test]
+	[Description("END TO END over the real shipped override `remove ViewConfig properties:[floatAction]`: the guide gains a third elementMap entry removing the template's CreateRecordButton, the outcome is recorded as a target delta, and the wizard buckets convert unchanged alongside it.")]
+	public void Analyze_ShouldCarryAShippedOverride_IntoTheElementMap() {
+		// Arrange
+		string source = Settings("Order",
+			Column("items", 0, "Number", "Number"), string.Empty, Column("groupItems", 0, "Account", "Account"),
+			", \"viewConfigDiff\": \"[{\\\"operation\\\":\\\"remove\\\",\\\"name\\\":\\\"ViewConfig\\\",\\\"properties\\\":[\\\"floatAction\\\"]}]\"");
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.ElementMap.Should().HaveCount(3, because: "the two designer merges are joined by the override's own operation");
+		ElementMapEntry carried = guide.ElementMap[2];
+		carried.Operation.Should().Be("remove", because: "the override switches the floating action off");
+		carried.MobileName.Should().Be("CreateRecordButton", because: "that is what the shipped template calls the floating action");
+		carried.MobileValues.Should().BeNull(because: "a removal carries no values");
+		carried.Reason.Should().Contain("viewConfigDiff[0]", because: "the reason points back at the exact source operation");
+		guide.LegacySource.OverrideOutcomes.Should().ContainSingle(o => o.Lane == LegacyOverrideLanes.TargetDelta,
+			because: "the operation was carried onto the converted page rather than reported");
+		ListItem(guide).MobileValues["title"]!.GetValue<string>().Should().Be("$PDS_Number",
+			because: "the wizard buckets convert exactly as they do without an override");
+		Json(ListItem(guide).MobileValues["body"]).Should().Be("""[{"value":"$PDS_Account"}]""",
+			because: "a chrome-level override must not disturb the converted columns");
+	}
+
+	[Test]
+	[Description("END TO END over the two shipped OOTB overrides (row icon + default sort): the icon lands on the elementMap's ListItem entry with its binding re-derived, the column it needs is declared in BOTH data sections before PDS_Id, and the sort default becomes a targeted merge on the Items sortingConfig path.")]
+	public void Analyze_ShouldCarryIconAndSort_IntoTheElementMapAndBothDiffs() {
+		// Arrange — the shape MobileFUIContactGridPageSettingsDefaultWorkplace ships.
+		string source = Settings("Contact",
+			Column("items", 0, "Name", "Name"), string.Empty, string.Empty,
+			", \"viewConfigDiff\": \"[{\\\"operation\\\":\\\"merge\\\",\\\"name\\\":\\\"Contact_ListItem\\\",\\\"values\\\":{\\\"icon\\\":\\\"$Photo\\\"}}]\""
+			+ ", \"viewModelConfigDiff\": \"[{\\\"operation\\\":\\\"insert\\\",\\\"name\\\":\\\"Attribute_Items_SortingConfig\\\",\\\"parentName\\\":\\\"Attribute_Items_ModelConfig\\\",\\\"propertyName\\\":\\\"sortingConfig\\\",\\\"values\\\":{\\\"default\\\":[{\\\"columnName\\\":\\\"Name\\\",\\\"direction\\\":\\\"asc\\\"}]}}]\"");
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert — the icon is folded into the converter's own ListItem merge, not added as a rival entry.
+		guide.ElementMap.Should().HaveCount(2, because: "the override refines the row the converter already writes");
+		ListItem(guide).MobileValues["icon"]!.GetValue<string>().Should().Be("$PDS_Photo",
+			because: "$Photo would resolve to nothing; the converted page declares PDS_Photo");
+
+		// …and everything the carried binding needs is declared, with PDS_Id still last.
+		JsonObject attributes = guide.ViewModelConfigDiff![0]!["values"]!.AsObject();
+		attributes.Select(pair => pair.Key).Should().Equal(["PDS_Name", "PDS_Photo", "PDS_Id"],
+			because: "the icon column is declared like a wizard column, and PDS_Id stays the last attribute");
+		guide.ModelConfigDiff![0]!["values"]!["attributes"]!["Photo"]!["path"]!.GetValue<string>().Should().Be("Photo",
+			because: "the data source must load the column the icon binds to");
+
+		// …and the sort default is a targeted merge on the path the shipped designer page really carries.
+		Json(guide.ViewModelConfigDiff!.AsArray()[1]).Should().Be(
+			"""{"operation":"merge","path":["attributes","Items","modelConfig","sortingConfig"],"values":{"default":[{"columnName":"Name","direction":"asc"}]}}""",
+			because: "the template already supplies attributeName on that node, so only 'default' is set");
+		guide.LegacySource.OverrideOutcomes.Should().OnlyContain(o => o.Lane == LegacyOverrideLanes.TargetDelta,
+			because: "both shipped overrides are carried, neither is reported");
+	}
+
+	[Test]
+	[Description("Warnings about embedded overrides reach guide.constraints — the block a caller cannot skip — and nowhere else: an override whose outcome differs from what it asked for must not be discoverable only by reading a report section.")]
+	public void Analyze_ShouldSurfaceOverrideWarnings_InTheConstraints() {
+		// Arrange — the shipped Contact move plus an operation whose target this source never generates.
+		string source = Settings("Contact",
+			Column("items", 0, "Name", "Name"), string.Empty, Column("groupItems", 0, "Account", "Account"),
+			", \"viewConfigDiff\": \"[{\\\"operation\\\":\\\"remove\\\",\\\"name\\\":\\\"Contact_ListItem_Body_Account\\\"},{\\\"operation\\\":\\\"insert\\\",\\\"name\\\":\\\"Contact_ListItem_Subtitle_Account\\\",\\\"parentName\\\":\\\"Contact_ListItem\\\",\\\"propertyName\\\":\\\"subtitles\\\",\\\"index\\\":0,\\\"values\\\":{\\\"value\\\":\\\"$Account\\\"}}]\""
+			+ ", \"viewModelConfigDiff\": \"[{\\\"operation\\\":\\\"remove\\\",\\\"name\\\":\\\"GlbContactStatusActiveFilter\\\"}]\"");
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(Read(source));
+
+		// Assert
+		guide.Constraints.Should().Contain(c => c.Contains("moves column 'Account'") && c.Contains("nothing was changed"),
+			because: "a move between row slots is a no-op on the converted page and the caller must be told");
+		guide.Constraints.Should().Contain(c => c.Contains("GlbContactStatusActiveFilter") && c.Contains("SKIPPED"),
+			because: "an operation whose target this source never generates is skipped, and the caller must be told");
+		ListItem(guide).MobileValues["body"]!.AsArray().Should().ContainSingle(
+			because: "the column survives the attempted move exactly where it was");
+	}
+
+	[Test]
+	[Description("The shipped conversion rules file carries a mobileLegacyTemplates.gridPage group, and it agrees with the bundled defaults so the two cannot drift apart silently.")]
+	public void ShippedRules_ShouldCarryGridPageTemplate_MatchingTheBundledDefaults() {
+		// Arrange
+		// The rules file ships as an embedded resource, so the bundled loader is what the tool actually reads.
+		WebToMobilePageConversionRules rules = WebToMobilePageConversionRulesCatalog.LoadBundled();
+
+		// Act
+		MobileLegacyTemplateRule resolved = LegacyMobileListAnalysisService.ResolveGridPageTemplate(rules);
+
+		// Assert
+		rules!.MobileLegacyTemplates?.GridPage.Should().NotBeNull(
+			because: "the legacy branch picks its target template from the rules file, not from a constant");
+		resolved.TemplateName.Should().Be(Template.TemplateName, because: "the shipped group and the bundled fallback must agree");
+		resolved.ListItemName.Should().Be(Template.ListItemName, because: "the shipped group and the bundled fallback must agree");
+		resolved.ListName.Should().Be(Template.ListName, because: "the shipped group and the bundled fallback must agree");
+		resolved.ListContainerName.Should().Be(Template.ListContainerName, because: "the shipped group and the bundled fallback must agree");
+		resolved.FolderTreeActionsName.Should().Be(Template.FolderTreeActionsName, because: "the shipped group and the bundled fallback must agree");
+		resolved.FolderSourceSchemaName.Should().Be(Template.FolderSourceSchemaName, because: "the shipped group and the bundled fallback must agree");
+		resolved.ItemsAttributeName.Should().Be(Template.ItemsAttributeName, because: "the shipped group and the bundled fallback must agree");
+	}
+
+	[Test]
+	[Description("The shipped grid-page group names the BaseMobileListTemplate elements exactly as the live template declares them (verified against DevMK) — CreateRecordButton in particular, because the runtime carries the floating action as a ViewConfig PROPERTY while the designer carries it as a NAMED element, so an invented name would add a second button instead of removing one.")]
+	public void ShippedRules_ShouldNameTheTemplateElements_AsTheLiveTemplateDeclaresThem() {
+		// Arrange
+		MobileLegacyTemplateRule resolved =
+			LegacyMobileListAnalysisService.ResolveGridPageTemplate(WebToMobilePageConversionRulesCatalog.LoadBundled());
+
+		// Act
+		(string Actual, string Expected)[] pairs = [
+			(resolved.TemplateName, "BaseMobileListTemplate"),
+			(resolved.ScaffoldName, "Scaffold"),
+			(resolved.MainContainerName, "MainContainer"),
+			(resolved.HeaderContainerName, "HeaderContainer"),
+			(resolved.SearchButtonName, "SearchButton"),
+			(resolved.FilterGroupButtonName, "FilterGroupButton"),
+			(resolved.SortButtonName, "SortButton"),
+			(resolved.FolderTreeActionsName, "FolderTreeActions"),
+			(resolved.QuickFilterGroupName, "QuickFilterGroup"),
+			(resolved.ListContainerName, "ListContainer"),
+			(resolved.ListName, "List"),
+			(resolved.ListItemName, "ListItem"),
+			(resolved.CreateRecordButtonName, "CreateRecordButton")
+		];
+
+		// Assert
+		pairs.Should().OnlyContain(p => p.Actual == p.Expected,
+			because: "these are the twelve elements BaseMobileListTemplate declares; see the knowledge record base-mobile-list-template-element-inventory");
+	}
+
+	[Test]
+	[Description("Rules without the mobileLegacyTemplates group degrade to the bundled defaults instead of failing, so an older CDN-served rules file keeps the legacy branch working.")]
+	public void ResolveGridPageTemplate_ShouldFallBackToDefaults_WhenRulesCarryNoGroup() {
+		// Arrange
+		var empty = new WebToMobilePageConversionRules();
+
+		// Act
+		MobileLegacyTemplateRule fromEmpty = LegacyMobileListAnalysisService.ResolveGridPageTemplate(empty);
+		MobileLegacyTemplateRule fromNull = LegacyMobileListAnalysisService.ResolveGridPageTemplate(null);
+
+		// Assert
+		fromEmpty.Should().BeSameAs(LegacyMobileListAnalysisService.DefaultGridPageTemplate,
+			because: "a rules file that predates the group must not break the legacy branch");
+		fromNull.Should().BeSameAs(LegacyMobileListAnalysisService.DefaultGridPageTemplate,
+			because: "an unreachable rules file must not break the legacy branch either");
+	}
+
+	[Test]
+	[Description("The target template and its element names come from the rules data, not from constants: a different mobileLegacyTemplates.gridPage group changes the recommended template, both elementMap targets and the next steps.")]
+	public void Analyze_ShouldTakeTargetTemplateFromRules_WhenGroupOverridesTheDefaults() {
+		// Arrange
+		LegacyMobileSettingsReadResult read = Read(Settings("Order", Column("items", 0, "Number", "Number"), "", ""));
+		var custom = new MobileLegacyTemplateRule {
+			TemplateName = "UsrCustomMobileListTemplate",
+			ListName = "UsrList",
+			ListContainerName = "UsrListContainer",
+			ListItemName = "UsrRow",
+			ListItemType = "crt.ListItem",
+			FolderTreeActionsName = "UsrFolders",
+			FolderTreeActionsType = "crt.FolderTreeActions",
+			FolderSourceSchemaName = "UsrFolderTree",
+			ItemsAttributeName = "Records"
+		};
+
+		// Act
+		MobilePageConversionGuide guide = Analyze(read, template: custom);
+
+		// Assert
+		guide.RecommendedMobileTemplate.Should().Be("UsrCustomMobileListTemplate",
+			because: "the recommended template is read from the rules group, not hardcoded");
+		guide.ElementMap.Select(e => e.MobileName).Should().Equal(["UsrFolders", "UsrRow"],
+			because: "both merge targets are the template element names the rules group declares, in the designer's order");
+		guide.ElementMap[0].MobileValues!["sourceSchemaName"]!.GetValue<string>().Should().Be("UsrFolderTree",
+			because: "the folder schema binding comes from the rules group too");
+		Json(guide.ViewModelConfigDiff![0]!["path"]!).Should().Contain("Records",
+			because: "the collection attribute the list is bound to is named by the rules group");
+		guide.Constraints.Should().Contain(c => c.Contains("UsrCustomMobileListTemplate"),
+			because: "the constraints must name the template the rules group selected");
 	}
 }

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifierTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifierTests.cs
@@ -1,0 +1,87 @@
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for <see cref="LegacyMobileSettingsClassifier"/>: the merged legacy settings are classified
+/// STRUCTURALLY (property presence on the settings node), never by string-sniffing a body.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class LegacyMobileSettingsClassifierTests {
+
+	private static JObject Settings(string extra = "") =>
+		JObject.Parse($$"""{ "name": "settings", "entitySchemaName": "Order", "settingsType": "GridPage", "items": [], "subtitleItems": [], "groupItems": [] {{extra}} }""");
+
+	[Test]
+	[Description("Wizard-only settings classify as plain with no override sections.")]
+	public void Classify_ShouldReturnPlain_WhenOnlyWizardBucketsExist() {
+		// Act
+		LegacySettingsClassification result = LegacyMobileSettingsClassifier.Classify(Settings());
+
+		// Assert
+		result.Kind.Should().Be(LegacySettingsKind.Plain, because: "nothing beyond the wizard buckets is present");
+		result.Label.Should().Be("plain", because: "the caller-facing label mirrors the kind");
+		result.OverrideSections.Should().BeEmpty(because: "there are no override sections");
+	}
+
+	[Test]
+	[Description("Override sections stored as JSON-encoded STRINGS (the wizard's storage format) are recognised and their operations counted after parsing; an array section is counted directly; diffV2 is recognised too.")]
+	public void Classify_ShouldReturnOverrides_WhenSectionsArePresentAsStringsOrArrays() {
+		// Arrange
+		JObject settings = Settings(
+			", \"viewConfigDiff\": \"[{\\\"operation\\\":\\\"merge\\\",\\\"name\\\":\\\"A\\\",\\\"values\\\":{}},{\\\"operation\\\":\\\"remove\\\",\\\"name\\\":\\\"B\\\"}]\"" +
+			", \"viewModelConfigDiff\": [ { \"operation\": \"merge\", \"path\": [], \"values\": {} } ]" +
+			", \"diffV2\": \"not json\"");
+
+		// Act
+		LegacySettingsClassification result = LegacyMobileSettingsClassifier.Classify(settings);
+
+		// Assert
+		result.Kind.Should().Be(LegacySettingsKind.FreedomUiOverrides, because: "override sections are present");
+		result.Label.Should().Be("freedom-ui-overrides", because: "the caller-facing label mirrors the kind");
+		result.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 2 && s.Ticket == "ENG-95733",
+			because: "a string-encoded section is parsed before counting");
+		result.OverrideSections.Should().Contain(s => s.Section == "viewModelConfigDiff" && s.OperationCount == 1,
+			because: "an array section is counted directly");
+		result.OverrideSections.Should().Contain(s => s.Section == "diffV2" && s.OperationCount == -1,
+			because: "a section that cannot be parsed is still reported, with an unknown count");
+		result.Notes.Should().Contain(n => n.Contains("diffV2"), because: "the uncountable section is explained");
+	}
+
+	[TestCase("viewConfig")]
+	[TestCase("modelViewConfig")]
+	[Description("A hand-authored viewConfig / modelViewConfig classifies as custom-viewconfig (refused), and wins even when override sections are also present.")]
+	public void Classify_ShouldReturnCustomViewConfig_WhenHandAuthoredConfigExists(string key) {
+		// Arrange
+		JObject settings = Settings($", \"{key}\": {{ \"items\": [] }}, \"viewConfigDiff\": [ {{ \"operation\": \"merge\", \"name\": \"X\", \"values\": {{}} }} ]");
+
+		// Act
+		LegacySettingsClassification result = LegacyMobileSettingsClassifier.Classify(settings);
+
+		// Assert
+		result.Kind.Should().Be(LegacySettingsKind.CustomViewConfig, because: "a custom config cannot be converted or even opened by the classic designer");
+		result.Label.Should().Be("custom-viewconfig", because: "the caller-facing label mirrors the kind");
+		result.OverrideSections.Should().ContainSingle(s => s.Section == "viewConfigDiff", because: "the override sections are still reported");
+		result.Notes.Should().Contain(n => n.Contains(key), because: "the refusal reason names the offending property");
+	}
+
+	[Test]
+	[Description("Null, blank-string and EMPTY sections ([] or \"[]\") do not count as overrides, so a placeholder does not misclassify plain settings or tell the user something was dropped.")]
+	public void Classify_ShouldIgnoreNullBlankOrEmptySections() {
+		// Arrange
+		JObject settings = Settings(", \"viewConfigDiff\": null, \"modelConfigDiff\": \"  \", \"viewModelConfigDiff\": [], \"diffV2\": \"[]\", \"viewConfig\": null");
+
+		// Act
+		LegacySettingsClassification result = LegacyMobileSettingsClassifier.Classify(settings);
+
+		// Assert
+		result.Kind.Should().Be(LegacySettingsKind.Plain, because: "absent-by-value and empty sections are not overrides");
+		result.OverrideSections.Should().BeEmpty(because: "nothing was left unconverted");
+		result.Notes.Should().Contain(n => n.Contains("'viewModelConfigDiff'") && n.Contains("empty"), because: "an empty placeholder is still mentioned");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifierTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifierTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
@@ -44,13 +45,40 @@ public sealed class LegacyMobileSettingsClassifierTests {
 		// Assert
 		result.Kind.Should().Be(LegacySettingsKind.FreedomUiOverrides, because: "override sections are present");
 		result.Label.Should().Be("freedom-ui-overrides", because: "the caller-facing label mirrors the kind");
-		result.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 2 && s.Ticket == "ENG-95733",
-			because: "a string-encoded section is parsed before counting");
+		result.OverrideSections.Should().Contain(s => s.Section == "viewConfigDiff" && s.OperationCount == 2 && s.Supported,
+			because: "a string-encoded section is parsed before counting, and this format is processed");
 		result.OverrideSections.Should().Contain(s => s.Section == "viewModelConfigDiff" && s.OperationCount == 1,
 			because: "an array section is counted directly");
 		result.OverrideSections.Should().Contain(s => s.Section == "diffV2" && s.OperationCount == -1,
 			because: "a section that cannot be parsed is still reported, with an unknown count");
 		result.Notes.Should().Contain(n => n.Contains("diffV2"), because: "the uncountable section is explained");
+	}
+
+	[Test]
+	[Description("The three *ConfigDiff sections and diffV2 get DIFFERENT verdicts: the former are processed operation by operation, diffV2 is permanently unsupported and carries a reason instead — collapsing the two would tell the user to wait for something that is not coming.")]
+	public void Classify_ShouldSeparateProcessedSectionsFromPermanentlyUnsupportedOnes() {
+		// Arrange
+		JObject settings = Settings(
+			", \"viewConfigDiff\": [ { \"operation\": \"remove\", \"name\": \"ViewConfig\", \"properties\": [\"floatAction\"] } ]" +
+			", \"diffV2\": [ { \"operation\": \"insert\", \"name\": \"Root\", \"values\": {} } ]");
+
+		// Act
+		LegacySettingsClassification result = LegacyMobileSettingsClassifier.Classify(settings);
+
+		// Assert
+		LegacyOverrideSection pending = result.OverrideSections.Single(s => s.Section == "viewConfigDiff");
+		LegacyOverrideSection refused = result.OverrideSections.Single(s => s.Section == "diffV2");
+		pending.Supported.Should().BeTrue(because: "this override format is processed operation by operation");
+		pending.Ticket.Should().BeNull(
+			because: "the format is carried across here, so naming a story would tell the user to wait for work that is already done");
+		pending.Reason.Should().BeNull(because: "there is no permanent reason it cannot be carried");
+		pending.Operations.Should().NotBeNull(because: "the parsed operations are retained for the rebase step");
+		pending.Operations!.Count.Should().Be(1, because: "the retained payload is the section's own operations");
+		refused.Ticket.Should().BeNull(because: "no story will carry diffV2 across; a ticket would promise otherwise");
+		refused.Reason.Should().NotBeNullOrWhiteSpace(because: "an unsupported verdict must say why");
+		refused.Reason.Should().Contain("verbatim",
+			because: "the reason is that the mobile runtime passes diffV2 through rather than translating it");
+		refused.Operations.Should().BeNull(because: "operations are only retained for sections that will be processed");
 	}
 
 	[TestCase("viewConfig")]

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReaderTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReaderTests.cs
@@ -250,6 +250,43 @@ public sealed class LegacyMobileSettingsReaderTests {
 	}
 
 	[Test]
+	[Description("A stored body carrying JavaScript comments still parses: real partner schemas annotate operations (\"// Migration Id\") and comment whole operations out, and two of the shipped Vetoquinol grid schemas would otherwise fail to read.")]
+	public void Read_ShouldTolerateJavaScriptComments_InAStoredBody() {
+		// Arrange
+		string body = RootBody.Replace("\"columnName\": \"Number\"", "\"columnName\": \"Number\" // Migration Id\n")
+			+ "\n// { \"operation\": \"remove\", \"name\": \"disabled-op\" }";
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> { Layer(RootUId, "CrtBase", body) });
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: $"comments are annotations, not content: {result.Error}");
+		result.EffectiveSettings["items"]![0]!["columnName"]!.ToString().Should().Be("Number",
+			because: "the commented operation is ignored and the real one survives intact");
+	}
+
+	[Test]
+	[Description("An EMPTY layer body is skipped instead of failing the read: one shipped Vetoquinol grid schema file is zero bytes, and a package that contributes nothing must not sink the layers that do.")]
+	public void Read_ShouldSkipAnEmptyLayer_AndStillMergeTheRest() {
+		// Arrange
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(RootUId, "CrtBase", RootBody),
+			Layer("empty-uid", "UsrEmpty", string.Empty)
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: $"an empty layer contributes nothing but breaks nothing: {result.Error}");
+		result.EffectiveSettings["entitySchemaName"]!.ToString().Should().Be("Case",
+			because: "the contributing layer is still merged");
+	}
+
+	[Test]
 	[Description("Unescape resolves \\$ to $, trims whitespace and drops a single trailing semicolon; an empty body yields an empty string.")]
 	public void Unescape_ShouldNormalizeBodyText() {
 		LegacyMobileSettingsReader.Unescape("  [\"\\$a\"] ;  ").Should().Be("[\"$a\"]", because: "escape, whitespace and terminator are normalized");

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReaderTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReaderTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Clio.Command;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using Clio.Common;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for <see cref="LegacyMobileSettingsReader"/>: the effective classic Mobile-wizard settings are the
+/// ordered application (ROOT -> HEAD) of EVERY package layer's diff array — a schema such as
+/// <c>MobileCaseGridPageSettingsDefaultWorkplace</c> may live in several packages, and missing one layer silently
+/// changes the converted page. Raw bodies never leave the reader.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class LegacyMobileSettingsReaderTests {
+
+	private const string SchemaName = "MobileCaseGridPageSettingsDefaultWorkplace";
+	private const string RootUId = "11111111-1111-1111-1111-111111111111";
+	private const string MiddleUId = "22222222-2222-2222-2222-222222222222";
+	private const string HeadUId = "33333333-3333-3333-3333-333333333333";
+	private const string DesignPackageUId = "99999999-9999-9999-9999-999999999999";
+
+	private const string RootBody = """
+		[
+		  { "operation": "insert", "name": "settings", "values": { "entitySchemaName": "Case", "items": [], "subtitleItems": [], "groupItems": [], "settingsType": "GridPage", "operation": "insert", "localizableStrings": {} } },
+		  { "operation": "insert", "name": "title", "values": { "row": 0, "content": "Number", "columnName": "Number", "dataValueType": 1, "operation": "insert" }, "parentName": "settings", "propertyName": "items", "index": 0 },
+		  { "operation": "insert", "name": "sub-account", "values": { "row": 0, "content": "Account", "columnName": "Account", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "subtitleItems", "index": 0 }
+		]
+		""";
+
+	private const string MiddleBody = """
+		[
+		  { "operation": "remove", "name": "sub-account" },
+		  { "operation": "insert", "name": "grp-status", "values": { "row": 0, "content": "Status", "columnName": "Status", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "groupItems", "index": 0 }
+		]
+		""";
+
+	private const string HeadBody = """
+		[
+		  { "operation": "merge", "name": "title", "values": { "content": "Case number" } },
+		  { "operation": "insert", "name": "grp-owner", "values": { "row": 1, "content": "Owner", "columnName": "Owner", "dataValueType": 10, "operation": "insert" }, "parentName": "settings", "propertyName": "groupItems", "index": 1 }
+		]
+		""";
+
+	private IApplicationClient _client;
+	private IServiceUrlBuilder _urlBuilder;
+	private IPageDesignerHierarchyClient _hierarchy;
+
+	[SetUp]
+	public void SetUp() {
+		_client = Substitute.For<IApplicationClient>();
+		_urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		_urlBuilder.Build(Arg.Any<string>()).Returns(ci => ci.Arg<string>());
+		_hierarchy = Substitute.For<IPageDesignerHierarchyClient>();
+		_hierarchy.GetDesignPackageUId(Arg.Any<string>()).Returns(DesignPackageUId);
+	}
+
+	private LegacyMobileSettingsReader Reader() =>
+		new(_client, _urlBuilder, _hierarchy, () => new JsonDiffApplier());
+
+	/// <summary>Answers the SysSchema SelectQuery: the single-row lookup and the all-packages cross-check.</summary>
+	private void ArrangeSysSchema(string uid, string packageUId, params string[] allPackages) {
+		_client.ExecutePostRequest(Arg.Is<string>(u => u.Contains("SelectQuery")), Arg.Any<string>())
+			.Returns(ci => {
+				string body = ci.ArgAt<string>(1);
+				JObject query = JObject.Parse(body);
+				int rowCount = query["rowCount"]?.Value<int>() ?? 1;
+				var rows = new JArray();
+				if (rowCount == 1) {
+					rows.Add(new JObject { ["UId"] = uid, ["PackageUId"] = packageUId, ["PackageName"] = allPackages.Length > 0 ? allPackages[^1] : "Custom" });
+				} else {
+					foreach (string package in allPackages) {
+						rows.Add(new JObject { ["PackageName"] = package });
+					}
+				}
+				return new JObject { ["success"] = true, ["rows"] = rows }.ToString();
+			});
+	}
+
+	private static PageDesignerHierarchySchema Layer(string uid, string package, string body, int schemaType = 0) =>
+		new() { UId = uid, Name = SchemaName, PackageUId = package + "-uid", PackageName = package, SchemaVersion = 1, Body = body, SchemaType = schemaType };
+
+	[Test]
+	[Description("Three package layers are applied ROOT -> HEAD: the middle layer removes a subtitle column and inserts a group column, the head layer merges the title caption and appends a group column — and the merged settings reflect all of it, with every layer reported without its body.")]
+	public void Read_ShouldMergeAllPackageLayersInHierarchyOrder_WhenSchemaSpansThreePackages() {
+		// Arrange — the hierarchy service returns HEAD -> ROOT.
+		ArrangeSysSchema(HeadUId, "Custom-uid", "CrtBase", "Product", "Custom");
+		_hierarchy.GetParentSchemas(HeadUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(HeadUId, "Custom", HeadBody), Layer(MiddleUId, "Product", MiddleBody), Layer(RootUId, "CrtBase", RootBody)
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: $"three well-formed layers merge cleanly: {result.Error}");
+		result.Layers.Select(l => l.PackageName).Should().Equal(new[] { "CrtBase", "Product", "Custom" }, because: "layers are reported ROOT -> HEAD in package-hierarchy order");
+		result.Layers.Select(l => l.OperationCount).Should().Equal(new[] { 3, 2, 2 }, because: "each layer reports how many operations it contributed");
+		JObject settings = result.EffectiveSettings;
+		settings["subtitleItems"]!.Should().BeEmpty(because: "the middle layer removed the only subtitle column");
+		settings["groupItems"]!.Select(g => g["columnName"]!.ToString()).Should().Equal(new[] { "Status", "Owner" }, because: "middle inserted Status at 0, head appended Owner at 1");
+		settings["items"]![0]!["content"]!.ToString().Should().Be("Case number", because: "the head layer's merge changed the title caption");
+		result.Notes.Should().BeEmpty(because: "every SysSchema package is present in the hierarchy");
+		result.HeadSchemaType.Should().Be(0, because: "the head layer's raw ClientUnitSchemaType is surfaced for the caller's detection report");
+	}
+
+	[Test]
+	[Description("When the requested schema row resolves to a LOWER package, the reader re-queries the hierarchy from the ROOT schema so the upper replacing layers appear — otherwise a package layer would be silently dropped.")]
+	public void Read_ShouldRequeryFromRoot_WhenRequestedRowIsNotTheHead() {
+		// Arrange — the first read (from the requested uid) returns only root+itself; the root re-query returns all.
+		ArrangeSysSchema(MiddleUId, "Product-uid", "CrtBase", "Product", "Custom");
+		_hierarchy.GetParentSchemas(MiddleUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(MiddleUId, "Product", MiddleBody), Layer(RootUId, "CrtBase", RootBody)
+		});
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(HeadUId, "Custom", HeadBody), Layer(MiddleUId, "Product", MiddleBody), Layer(RootUId, "CrtBase", RootBody)
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: result.Error);
+		result.Layers.Should().HaveCount(3, because: "the root re-query surfaced the Custom layer the first read did not return");
+		result.EffectiveSettings["items"]![0]!["content"]!.ToString().Should().Be("Case number", because: "the head layer's merge was applied");
+	}
+
+	[Test]
+	[Description("A package that stores the schema but is absent from the resolved hierarchy is reported in Notes (never silent), while the layers that were found still merge.")]
+	public void Read_ShouldNoteMissingPackage_WhenSysSchemaHasALayerTheHierarchyDidNotReturn() {
+		// Arrange
+		ArrangeSysSchema(HeadUId, "Custom-uid", "CrtBase", "Product", "Custom", "UsrSecondCustom");
+		_hierarchy.GetParentSchemas(HeadUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(HeadUId, "Custom", HeadBody), Layer(MiddleUId, "Product", MiddleBody), Layer(RootUId, "CrtBase", RootBody)
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: "the found layers still merge");
+		result.Notes.Should().ContainSingle(n => n.Contains("UsrSecondCustom") && n.Contains("NOT part of the resolved hierarchy"),
+			because: "an unresolved package layer would silently change the page, so it is surfaced");
+	}
+
+	[Test]
+	[Description("Escaped \\$ sequences in a stored body are resolved before JSON parsing, and a trailing semicolon is tolerated.")]
+	public void Read_ShouldUnescapeDollar_BeforeParsing() {
+		// Arrange
+		string body = RootBody.Replace("\"content\": \"Number\"", "\"content\": \"\\$Number\"") + ";";
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> { Layer(RootUId, "CrtBase", body) });
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeTrue(because: $"the escape is normalized before parsing: {result.Error}");
+		result.EffectiveSettings["items"]![0]!["content"]!.ToString().Should().Be("$Number", because: "\\$ becomes $");
+	}
+
+	[Test]
+	[Description("A Freedom UI JSON object body stored under a legacy settings name is detected as the ENG-95733 override case and reported as a clean failure naming the package, not a crash.")]
+	public void Read_ShouldFailWithFreedomUiShape_WhenBodyIsAJsonObject() {
+		// Arrange
+		ArrangeSysSchema(HeadUId, "Custom-uid", "CrtBase", "Custom");
+		_hierarchy.GetParentSchemas(HeadUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(HeadUId, "Custom", "{ \"viewConfigDiff\": [] }"), Layer(RootUId, "CrtBase", RootBody)
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeFalse(because: "a Freedom UI body is not a wizard settings array");
+		result.BodyShape.Should().Be(LegacyBodyShape.FreedomUiJsonObject, because: "the shape is classified for the caller");
+		result.Error.Should().Contain("Custom").And.Contain("ENG-95733", because: "the failure names the package and the owning story");
+	}
+
+	[Test]
+	[Description("A body that is neither an operation array nor a JSON object fails cleanly with the package name and the parse error.")]
+	public void Read_ShouldFailUnparseable_WhenBodyIsNotJson() {
+		// Arrange
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> { Layer(RootUId, "CrtBase", "define(\"x\", [], function() {})") });
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeFalse(because: "an AMD module is not a settings array");
+		result.BodyShape.Should().Be(LegacyBodyShape.Unparseable, because: "the shape is classified for the caller");
+		result.Error.Should().Contain("not a JSON operation array", because: "the failure explains what was expected");
+	}
+
+	[Test]
+	[Description("When no layer contains a 'settings' root the reader fails with a message naming the missing node.")]
+	public void Read_ShouldFail_WhenNoSettingsRootExists() {
+		// Arrange
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(RootUId, DesignPackageUId).Returns(new List<PageDesignerHierarchySchema> {
+			Layer(RootUId, "CrtBase", """[ { "operation": "insert", "name": "other", "values": { "a": 1 } } ]""")
+		});
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeFalse(because: "there is nothing to convert without the settings root");
+		result.Error.Should().Contain("'settings' root node", because: "the failure names the missing node");
+	}
+
+	[Test]
+	[Description("A hierarchy service failure surfaces as a clean failure result (with the recovery hint), never as an exception.")]
+	public void Read_ShouldFail_WhenHierarchyServiceThrows() {
+		// Arrange
+		ArrangeSysSchema(RootUId, "CrtBase-uid", "CrtBase");
+		_hierarchy.GetParentSchemas(Arg.Any<string>(), Arg.Any<string>()).Returns(_ => throw new InvalidOperationException("designer down"));
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read(SchemaName);
+
+		// Assert
+		result.Success.Should().BeFalse(because: "the hierarchy could not be loaded");
+		result.Error.Should().Contain("designer down", because: "the underlying error is preserved for the operator");
+	}
+
+	[Test]
+	[Description("An unknown schema name fails with the lookup error instead of reading a hierarchy.")]
+	public void Read_ShouldFail_WhenSchemaRowIsMissing() {
+		// Arrange
+		_client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>())
+			.Returns(new JObject { ["success"] = true, ["rows"] = new JArray() }.ToString());
+
+		// Act
+		LegacyMobileSettingsReadResult result = Reader().Read("MobileNopeGridPageSettings");
+
+		// Assert
+		result.Success.Should().BeFalse(because: "no SysSchema row exists");
+		result.Error.Should().Contain("not found", because: "the lookup error is surfaced");
+		_hierarchy.DidNotReceive().GetParentSchemas(Arg.Any<string>(), Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Unescape resolves \\$ to $, trims whitespace and drops a single trailing semicolon; an empty body yields an empty string.")]
+	public void Unescape_ShouldNormalizeBodyText() {
+		LegacyMobileSettingsReader.Unescape("  [\"\\$a\"] ;  ").Should().Be("[\"$a\"]", because: "escape, whitespace and terminator are normalized");
+		LegacyMobileSettingsReader.Unescape(null).Should().BeEmpty(because: "a null body has nothing to normalize");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaserTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaserTests.cs
@@ -1,0 +1,362 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for the override REBASE (ENG-95733). Every case is taken from an override actually shipped in a
+/// partner package (<c>C:\builds\vetoquinol\Pkg</c>), because the point of the story is that real customisations
+/// survive conversion — or are reported honestly when they cannot.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class LegacyOverrideRebaserTests {
+
+	private static readonly MobileLegacyTemplateRule Template =
+		LegacyMobileListAnalysisService.ResolveGridPageTemplate(WebToMobilePageConversionRulesCatalog.LoadBundled());
+
+	private static readonly MobileLegacyRuntimeNameSet NameSet =
+		WebToMobilePageConversionRulesCatalog.LoadBundled().MobileLegacyRuntimeNames?.GridPage;
+
+	private static LegacyGridPageSettings Parse(string entity, string items = "", string subtitles = "", string groups = "") =>
+		LegacyGridPageSettingsParser.Parse(JObject.Parse($$"""
+			{
+			  "name": "settings", "settingsType": "GridPage", "entitySchemaName": "{{entity}}",
+			  "items": [{{items}}], "subtitleItems": [{{subtitles}}], "groupItems": [{{groups}}]
+			}
+			"""));
+
+	private static string Column(string columnName, int row = 0) => Caption(columnName, columnName, row);
+
+	/// <summary>A wizard column whose caption differs from its name, so caption propagation is observable.</summary>
+	private static string Caption(string columnName, string caption, int row = 0) =>
+		$$"""{ "name": "id-{{columnName}}", "row": {{row}}, "content": "{{caption}}", "columnName": "{{columnName}}", "dataValueType": 1 }""";
+
+	private static LegacyOverrideSection Section(string name, string operationsJson) {
+		JArray ops = JArray.Parse(operationsJson);
+		return new LegacyOverrideSection(name, ops.Count, LegacyMobileSettingsClassifier.OverridesTicket, true, null, ops);
+	}
+
+	private static LegacyOverrideRebaseResult Rebase(LegacyGridPageSettings settings, params LegacyOverrideSection[] sections) =>
+		LegacyOverrideRebaser.Rebase(settings, sections,
+			LegacyRuntimeNameOracle.Build(settings, NameSet), Template, NameSet);
+
+	private static string Json(JsonNode node) => node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+
+	[Test]
+	[Description("REAL: `remove ViewConfig properties:[floatAction]` (3 of the 4 shipped grid overrides) becomes a removal of the template's CreateRecordButton — the runtime keeps the floating action as a property of its screen root, the designer as a named element.")]
+	public void Rebase_ShouldTurnAFloatActionPropertyRemoval_IntoRemovingTheTemplatesCreateRecordButton() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("GlbTerritoryManagerRel", items: Column("GlbManager"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"remove","name":"ViewConfig","properties":["floatAction"]}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ViewConfigOperations.Should().ContainSingle(because: "one property removal becomes one element removal");
+		Json(result.ViewConfigOperations[0]).Should().Be("""{"operation":"remove","name":"CreateRecordButton"}""",
+			because: "CreateRecordButton is what BaseMobileListTemplate calls the floating action");
+		result.Outcomes.Should().ContainSingle(o => o.Lane == LegacyOverrideLanes.TargetDelta,
+			because: "the removal exists only in the target dialect, so it is a target delta");
+		result.Settings.Items.Should().HaveCount(1, because: "the wizard buckets are untouched by a chrome removal");
+	}
+
+	[Test]
+	[Description("REAL: the shipped Contact override moves column Account from the row body into the subtitle slot. A converted row has ONE slot and already shows the column, so nothing changes — the removal is NOT applied on its own — and a warning says so.")]
+	public void Rebase_ShouldChangeNothingButWarn_WhenAnOverrideMovesAColumnBetweenRowSlots() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"), groups: Column("Account"));
+		LegacyOverrideSection section = Section("viewConfigDiff", """
+			[{"operation":"remove","name":"Contact_ListItem_Body_Account"},
+			 {"operation":"insert","name":"Contact_ListItem_Subtitle_Account","values":{"value":"$Account","label":{"visible":true}},"parentName":"Contact_ListItem","propertyName":"subtitles","index":0}]
+			""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.Settings.GroupItems.Should().ContainSingle(c => c.ColumnName == "Account",
+			because: "the column stays exactly where it is: applying only the removal would delete it instead of moving it");
+		result.Settings.SubtitleItems.Should().BeEmpty(because: "no second copy of the column is added");
+		result.ViewConfigOperations.Should().BeEmpty(because: "the move needs no operation on the converted page");
+		result.Warnings.Should().ContainSingle(w => w.Contains("moves column 'Account'") && w.Contains("nothing was changed"),
+			because: "the user must learn the move was a no-op rather than assume the slot was honoured");
+		result.Outcomes.Should().HaveCount(2, because: "both halves of the pair are accounted for");
+	}
+
+	[Test]
+	[Description("A lone insert into the subtitle slot ADDS the column to the list row as an ordinary column — its value is shown — with a warning that the separate subtitle placement is not reproduced.")]
+	public void Rebase_ShouldAddTheColumn_WhenAnOverrideInsertsOneIntoTheSubtitleSlot() {
+		// Arrange — the source does not carry Account at all.
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"insert","name":"Contact_ListItem_Subtitle_Account","values":{"value":"$Account","label":{"visible":true}},"parentName":"Contact_ListItem","propertyName":"subtitles","index":0}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.Settings.SubtitleItems.Should().ContainSingle(c => c.ColumnName == "Account",
+			because: "the column the override asked for is added to the wizard model, so the analyzer renders it");
+		result.Outcomes.Single().Lane.Should().Be(LegacyOverrideLanes.SourceEdit,
+			because: "the addition is expressed in the wizard model, not as a target operation");
+		result.Warnings.Should().ContainSingle(w => w.Contains("added to the row body"),
+			because: "the value is shown but the separate subtitle placement is not reproduced");
+	}
+
+	[Test]
+	[Description("A subtitle insert for a column the page already shows changes nothing and does not duplicate it; the warning says the column is already there.")]
+	public void Rebase_ShouldNotDuplicateAColumn_WhenTheSubtitleInsertTargetsOneAlreadyShown() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"), groups: Column("Account"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"insert","name":"Contact_ListItem_Subtitle_Account","values":{"value":"$Account"},"parentName":"Contact_ListItem","propertyName":"subtitles","index":0}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.Settings.SubtitleItems.Should().BeEmpty(because: "the column is already shown, so adding it again would duplicate it");
+		result.Settings.GroupItems.Should().ContainSingle(c => c.ColumnName == "Account", because: "it stays where it was");
+		result.Warnings.Should().ContainSingle(w => w.Contains("already shows that column"),
+			because: "the user learns the override needed no action");
+	}
+
+	[Test]
+	[Description("A lone removal of a wizard column is said in the wizard's own language — the column leaves its bucket and the analyzer re-derives the page, so bindings are recomputed rather than copied from the override.")]
+	public void Rebase_ShouldDropTheColumnFromItsBucket_WhenAColumnElementIsRemovedOnItsOwn() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact",
+			items: Column("Name"), groups: Column("Account") + ", " + Column("Job", 1));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"remove","name":"Contact_ListItem_Body_Account"}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.Settings.GroupItems.Select(c => c.ColumnName).Should().Equal(["Job"],
+			because: "the removed column leaves the bucket and the rest keep their order");
+		result.Outcomes.Should().ContainSingle(o => o.Lane == LegacyOverrideLanes.SourceEdit,
+			because: "a column removal is expressible in the wizard model itself");
+		result.ViewConfigOperations.Should().BeEmpty(because: "a source edit adds no operation to the page");
+	}
+
+	[Test]
+	[Description("REAL: `merge Attribute_Items_ModelConfig` (a cache sync rule) is re-pointed onto the converted page's attributes/Items/modelConfig path, because the target dialect addresses the data sections by path rather than by name.")]
+	public void Rebase_ShouldRepointAnItemsModelConfigMerge_OntoTheTargetPath() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("GlbTerritoryManagerRel", items: Column("GlbManager"));
+		LegacyOverrideSection section = Section("viewModelConfigDiff", """
+			[{"operation":"merge","name":"Attribute_Items_ModelConfig","values":{"cacheConfig":{"syncRuleName":"GlbTerritoryManagerRelStandardDetail"}}}]
+			""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ViewModelConfigOperations.Should().ContainSingle(because: "the merge has an addressable counterpart");
+		Json(result.ViewModelConfigOperations[0]).Should().Be(
+			"""{"operation":"merge","path":["attributes","Items","modelConfig"],"values":{"cacheConfig":{"syncRuleName":"GlbTerritoryManagerRelStandardDetail"}}}""",
+			because: "the runtime name maps to a path and the values are carried through unchanged");
+		result.Outcomes.Should().ContainSingle(o => o.Lane == LegacyOverrideLanes.TargetDelta,
+			because: "the operation lands on the converted page, not on the wizard source");
+	}
+
+	[Test]
+	[Description("REAL: `remove GlbContactStatusActiveFilter` targets an attribute this source never generates, so it is reported with an explanation instead of being applied to something that merely looks similar.")]
+	public void Rebase_ShouldReportAnOperation_WhoseTargetThisSourceNeverGenerates() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"));
+		LegacyOverrideSection section = Section("viewModelConfigDiff",
+			"""[{"operation":"remove","name":"GlbContactStatusActiveFilter"}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ViewModelConfigOperations.Should().BeEmpty(because: "an unknown target is never guessed at");
+		LegacyOverrideOutcome outcome = result.Outcomes.Single();
+		outcome.Lane.Should().Be(LegacyOverrideLanes.Reported, because: "the operation could not be carried");
+		outcome.Reason.Should().Contain("GlbContactStatusActiveFilter", because: "the report names the target");
+		outcome.Reason.Should().Contain("hand-written", because: "the report explains where such a target comes from");
+	}
+
+	[Test]
+	[Description("A merge on the list row WINS over the converted values, key by key: it is the later and more specific customisation of the same element, so a key the converter also writes is taken from the override.")]
+	public void Rebase_ShouldLetAnOverrideWin_OnEveryKeyItNamesOnTheListRow() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"merge","name":"Contact_ListItem","values":{"showEmptyValues":false,"title":"$JobTitle"}}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		Json(result.ElementValueOverrides["ListItem"]).Should().Be("""{"showEmptyValues":false,"title":"$PDS_JobTitle"}""",
+			because: "every key the override names is carried, and a row binding is re-derived into the PDS_ convention");
+		result.RequiredColumns.Should().Equal(["JobTitle"],
+			because: "the overriding title binds a column the wizard buckets did not declare");
+		result.Outcomes.Single().Lane.Should().Be(LegacyOverrideLanes.TargetDelta,
+			because: "the override reaches the converted page instead of being reported");
+	}
+
+	[Test]
+	[Description("REAL: the default-sort override shipped in MobileCaseGridPageSettingsPortal / MobileFUIAccountGridPageSettingsDefaultWorkplace arrives as an INSERT into Attribute_Items_ModelConfig.sortingConfig, and is re-pointed onto attributes/Items/modelConfig/sortingConfig — the path the shipped designer page really carries, where the template already supplies attributeName.")]
+	public void Rebase_ShouldCarryTheDefaultSort_FromAnInsertIntoTheSortingConfig() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"));
+		LegacyOverrideSection section = Section("viewModelConfigDiff", """
+			[{"operation":"insert","name":"Attribute_Items_SortingConfig","parentName":"Attribute_Items_ModelConfig","propertyName":"sortingConfig","values":{"default":[{"columnName":"RegisteredOn","direction":"desc"}]}}]
+			""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ViewModelConfigOperations.Should().ContainSingle(because: "the sort default has an addressable counterpart");
+		Json(result.ViewModelConfigOperations[0]).Should().Be(
+			"""{"operation":"merge","path":["attributes","Items","modelConfig","sortingConfig"],"values":{"default":[{"columnName":"RegisteredOn","direction":"desc"}]}}""",
+			because: "only 'default' is set; the template already provides attributeName on that node");
+		result.Outcomes.Single().Lane.Should().Be(LegacyOverrideLanes.TargetDelta,
+			because: "an insert that SETS content is re-pointed just like a merge");
+	}
+
+	[Test]
+	[Description("REAL: the row-icon override shipped in MobileFUIContactGridPageSettingsDefaultWorkplace wins over the converted value, its binding is re-derived into the converted page's PDS_ convention, and the column it references is requested for both data sections so the binding is not dead.")]
+	public void Rebase_ShouldCarryTheRowIcon_AndRequestTheColumnItsBindingNeeds() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"merge","name":"Contact_ListItem","values":{"icon":"$Photo"}}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ElementValueOverrides.Should().ContainKey("ListItem", because: "the row is the template element the override targets");
+		Json(result.ElementValueOverrides["ListItem"]).Should().Be("""{"icon":"$PDS_Photo"}""",
+			because: "$Photo would resolve to nothing on the converted page, which declares PDS_Photo");
+		result.RequiredColumns.Should().Equal(["Photo"],
+			because: "the icon column is not a wizard column, so it must still be declared like one");
+		result.Outcomes.Single().Lane.Should().Be(LegacyOverrideLanes.TargetDelta,
+			because: "the icon is carried onto the converted page");
+	}
+
+	[Test]
+	[Description("REAL: `merge Case_ListItem_Body_Symptoms {label:{visible:false}}` cannot be honoured — a converted row shows a label for every body column and offers no per-column switch — so it is reported and the report says the label stays visible rather than implying the column was lost.")]
+	public void Rebase_ShouldReportThatALabelCouldNotBeHidden() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"), groups: Column("Symptoms"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"merge","name":"Case_ListItem_Body_Symptoms","values":{"label":{"visible":false}}}]""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		LegacyOverrideOutcome outcome = result.Outcomes.Single();
+		outcome.Lane.Should().Be(LegacyOverrideLanes.Reported, because: "the target row has no per-column label switch");
+		outcome.Reason.Should().Contain("stays visible",
+			because: "the user must learn the label is still shown, not that the column disappeared");
+		result.Warnings.Should().ContainSingle(w => w.Contains("does not support controlling a list-row label"),
+			because: "the warning reaches guide.constraints, which the caller cannot skip");
+		result.Settings.GroupItems.Should().ContainSingle(c => c.ColumnName == "Symptoms",
+			because: "an unhonoured label setting must not cost the column itself");
+	}
+
+	[Test]
+	[Description("REAL: the shipped Case override offers a column in the sort tool. The runtime inserts it into ListSortToolItem.sortOptions; the designer carries the same thing as a SortButton.sortItems entry shaped { attributeName, caption } with the RAW column name — the shape a designer-authored page really uses.")]
+	public void Rebase_ShouldCarryASortOption_IntoSortButtonSortItems() {
+		// Arrange — Symptoms IS a page column (so its caption is known); RegisteredOn is not.
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"), groups: Caption("Symptoms", "Description"));
+		LegacyOverrideSection section = Section("viewConfigDiff", """
+			[{"operation":"insert","name":"Case_SortOptions_RegisteredOn","propertyName":"sortOptions","parentName":"Case_ListScreen_Tools_ListSortToolItem","values":{"property":"RegisteredOn"}},
+			 {"operation":"insert","name":"Case_SortOptions_Symptoms","propertyName":"sortOptions","parentName":"Case_ListScreen_Tools_ListSortToolItem","values":{"property":"Symptoms"}}]
+			""");
+
+		// Act
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		Json(result.ElementValueOverrides["SortButton"]).Should().Be(
+			"""{"sortItems":[{"attributeName":"RegisteredOn"},{"attributeName":"Symptoms","caption":"Description"}]}""",
+			because: "both options accumulate into ONE merge, attributeName is the raw column name — no PDS_ prefix — and an unresolved caption is OMITTED rather than filled with the machine name");
+		result.Outcomes.Should().OnlyContain(o => o.Lane == LegacyOverrideLanes.TargetDelta,
+			because: "both are carried onto the converted page");
+		result.RequiredColumns.Should().Contain("RegisteredOn",
+			because: "a column offered for sorting must be declared in the data sections or the sort cannot load it");
+		result.Warnings.Should().ContainSingle(w => w.Contains("RegisteredOn") && w.Contains("no caption could be resolved"),
+			because: "only the column with no resolvable caption needs a warning");
+	}
+
+	[Test]
+	[Description("When the page does not carry the sorted column, its caption is taken from the OBJECT — the real display label — and no warning is needed.")]
+	public void Rebase_ShouldTakeASortCaptionFromTheObject_WhenThePageDoesNotCarryTheColumn() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"insert","name":"Case_SortOptions_RegisteredOn","propertyName":"sortOptions","parentName":"Case_ListScreen_Tools_ListSortToolItem","values":{"property":"RegisteredOn"}}]""");
+		var captions = new Dictionary<string, string> { ["RegisteredOn"] = "Registered on" };
+
+		// Act
+		LegacyOverrideRebaseResult result = LegacyOverrideRebaser.Rebase(settings, [section],
+			LegacyRuntimeNameOracle.Build(settings, NameSet), Template, NameSet, captions);
+
+		// Assert
+		Json(result.ElementValueOverrides["SortButton"]).Should().Be(
+			"""{"sortItems":[{"attributeName":"RegisteredOn","caption":"Registered on"}]}""",
+			because: "the object's own column caption is the real display label for the sort menu");
+		result.Warnings.Should().BeEmpty(because: "nothing had to be guessed at, so there is nothing to warn about");
+	}
+
+	[Test]
+	[Description("With no supported sections nothing is rebased and the wizard settings come back untouched, so a plain source is unaffected by the override pass existing.")]
+	public void Rebase_ShouldBeANoOp_WhenThereAreNoSupportedSections() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"), groups: Column("Account"));
+		var unsupported = new LegacyOverrideSection("diffV2", 1, null, false, "not supported");
+
+		// Act
+		LegacyOverrideRebaseResult empty = Rebase(settings);
+		LegacyOverrideRebaseResult refused = Rebase(settings, unsupported);
+
+		// Assert
+		empty.Settings.Should().BeSameAs(settings, because: "nothing was edited");
+		empty.Outcomes.Should().BeEmpty(because: "there was nothing to report on");
+		refused.ViewConfigOperations.Should().BeEmpty(because: "an unsupported section is never processed");
+		refused.Outcomes.Should().BeEmpty(because: "the classifier already reported it; the rebaser does not double-report");
+	}
+
+	[Test]
+	[Description("Rebasing the same source and overrides twice produces the same edits, target operations and outcomes, so re-running the conversion is safe.")]
+	public void Rebase_ShouldBeDeterministic_AcrossRepeatedRuns() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"), groups: Column("Account"));
+		string ops = """
+			[{"operation":"remove","name":"ViewConfig","properties":["floatAction"]},
+			 {"operation":"remove","name":"Contact_ListItem_Body_Account"}]
+			""";
+
+		// Act
+		LegacyOverrideRebaseResult first = Rebase(settings, Section("viewConfigDiff", ops));
+		LegacyOverrideRebaseResult second = Rebase(settings, Section("viewConfigDiff", ops));
+
+		// Assert
+		first.ViewConfigOperations.Select(Json).Should().Equal(second.ViewConfigOperations.Select(Json),
+			because: "the same source and overrides must produce the same page");
+		first.Outcomes.Should().Equal(second.Outcomes, because: "the report must be reproducible too");
+		first.Settings.GroupItems.Should().BeEmpty(because: "the column removal applied on both runs alike");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaserTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaserTests.cs
@@ -322,6 +322,61 @@ public sealed class LegacyOverrideRebaserTests {
 	}
 
 	[Test]
+	[Description("A designer target the TARGET TEMPLATE does not declare is reported, not authored: a merge onto a name the template does not carry writes nothing and no metadata validation catches it.")]
+	public void Rebase_ShouldReportADesignerTarget_TheTemplateDoesNotDeclare() {
+		// Arrange — a template whose element inventory lacks the floating action.
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"remove","name":"ViewConfig","properties":["floatAction"]}]""");
+		var withoutFloatAction = new HashSet<string>(["Scaffold", "List", "ListItem", "FolderTreeActions"]);
+
+		// Act
+		LegacyOverrideRebaseResult result = LegacyOverrideRebaser.Rebase(settings, [section],
+			LegacyRuntimeNameOracle.Build(settings, NameSet), Template, NameSet, null, withoutFloatAction);
+
+		// Assert
+		result.ViewConfigOperations.Should().BeEmpty(because: "authoring a removal of a name the template lacks does nothing");
+		result.Outcomes.Single().Lane.Should().Be(LegacyOverrideLanes.Reported, because: "the target does not exist");
+		result.Warnings.Should().ContainSingle(w => w.Contains("does not declare an element named 'CreateRecordButton'"),
+			because: "the report must name the element the template is missing");
+	}
+
+	[Test]
+	[Description("When the template DOES declare the target the operation is carried exactly as before, so the verification only ever removes wrong output — it never blocks correct output.")]
+	public void Rebase_ShouldCarryTheOperation_WhenTheTemplateDeclaresTheTarget() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"remove","name":"ViewConfig","properties":["floatAction"]}]""");
+		var withFloatAction = new HashSet<string>(["Scaffold", "ListItem", "FolderTreeActions", "CreateRecordButton"]);
+
+		// Act
+		LegacyOverrideRebaseResult result = LegacyOverrideRebaser.Rebase(settings, [section],
+			LegacyRuntimeNameOracle.Build(settings, NameSet), Template, NameSet, null, withFloatAction);
+
+		// Assert
+		Json(result.ViewConfigOperations.Single()).Should().Be("""{"operation":"remove","name":"CreateRecordButton"}""",
+			because: "a verified target behaves exactly as it did before the check existed");
+		result.Warnings.Should().BeEmpty(because: "nothing was wrong, so nothing is warned about");
+	}
+
+	[Test]
+	[Description("With no template inventory (the stand could not be read) the names go UNVERIFIED and operations are still carried — an unreadable template must not silently strip a customisation.")]
+	public void Rebase_ShouldStillCarryOperations_WhenTheTemplateCouldNotBeRead() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Case", items: Column("Number"));
+		LegacyOverrideSection section = Section("viewConfigDiff",
+			"""[{"operation":"remove","name":"ViewConfig","properties":["floatAction"]}]""");
+
+		// Act — templateElements omitted, exactly as when the probe fails.
+		LegacyOverrideRebaseResult result = Rebase(settings, section);
+
+		// Assert
+		result.ViewConfigOperations.Should().ContainSingle(
+			because: "an unreadable template degrades to trusting the table, it does not drop the override");
+	}
+
+	[Test]
 	[Description("With no supported sections nothing is rebased and the wizard settings come back untouched, so a plain source is unaffected by the override pass existing.")]
 	public void Rebase_ShouldBeANoOp_WhenThereAreNoSupportedSections() {
 		// Arrange

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyRuntimeNameOracleTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyRuntimeNameOracleTests.cs
@@ -1,0 +1,227 @@
+using System.Linq;
+using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for the runtime NAME ORACLE (ENG-95733). The expectations are taken from the mobile runtime's own
+/// converter — <c>GridPageConverter.java</c> / <c>BaseScreenConverter.java</c> — which is the reference for the
+/// dialect embedded <c>viewConfigDiff</c> operations are written against:
+/// <list type="bullet">
+///   <item>names are joined with <c>_</c> (<c>concatProperties</c>), except the row name which is
+///   <c>&lt;Entity&gt;_List</c> + <c>Item</c> with NO separator;</item>
+///   <item>the <c>subtitleItems</c> bucket produces <c>&lt;Entity&gt;_ListItem_Subtitle_&lt;Column&gt;</c> in the
+///   <c>subtitles</c> slot, the <c>groupItems</c> bucket produces <c>&lt;Entity&gt;_ListItem_Body_&lt;Column&gt;</c>
+///   in the <c>body</c> slot, and the <c>items</c> (title) bucket produces NO element of its own;</item>
+///   <item>a dotted column keeps its dots in the NAME (the binding is what replaces them with <c>_</c>).</item>
+/// </list>
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class LegacyRuntimeNameOracleTests {
+
+	/// <summary>The shipped runtime-name table — the same data the tool reads at run time.</summary>
+	private static readonly MobileLegacyRuntimeNameSet Shipped =
+		WebToMobilePageConversionRulesCatalog.LoadBundled().MobileLegacyRuntimeNames?.GridPage;
+
+	/// <summary>Builds a merged settings node the way the reader hands it over (wizard values hoisted onto the item).</summary>
+	private static LegacyGridPageSettings Parse(string entity, string items = "", string subtitles = "", string groups = "") =>
+		LegacyGridPageSettingsParser.Parse(JObject.Parse($$"""
+			{
+			  "name": "settings", "settingsType": "GridPage", "entitySchemaName": "{{entity}}",
+			  "items": [{{items}}], "subtitleItems": [{{subtitles}}], "groupItems": [{{groups}}]
+			}
+			"""));
+
+	private static string Column(string columnName, int row = 0) =>
+		$$"""{ "name": "id-{{columnName}}", "row": {{row}}, "content": "{{columnName}}", "columnName": "{{columnName}}", "dataValueType": 1 }""";
+
+	private static LegacyRuntimeNameInventory Build(LegacyGridPageSettings settings) =>
+		LegacyRuntimeNameOracle.Build(settings, Shipped);
+
+	[Test]
+	[Description("The shipped conversion rules carry a runtime-name table for GridPage; without it the override pass has no addressing space to work in.")]
+	public void ShippedRules_ShouldCarryRuntimeNameTable_ForGridPage() {
+		// Arrange & Act
+		MobileLegacyRuntimeNameSet table = Shipped;
+
+		// Assert
+		table.Should().NotBeNull(because: "embedded overrides are re-pointed through a data table, not through code");
+		table!.Anchors.Should().NotBeEmpty(because: "an empty table would silently switch the override pass off");
+		table.Anchors.Should().OnlyContain(a => !string.IsNullOrWhiteSpace(a.Role) && !string.IsNullOrWhiteSpace(a.Pattern),
+			because: "an anchor without a role or a pattern cannot resolve anything");
+	}
+
+	[Test]
+	[Description("The fixed scaffold names the runtime generates for any list source are all enumerated, spelled exactly as GridPageConverter builds them (note <Entity>_ListItem has no separator before 'Item').")]
+	public void Build_ShouldEnumerateTheFixedScaffold_AsTheRuntimeSpellsIt() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact");
+
+		// Act
+		LegacyRuntimeNameInventory inventory = Build(settings);
+
+		// Assert
+		inventory.Names.Should().Contain([
+			"ViewConfig", "Contact_List", "Contact_ListItem", "Contact_ListItem_Body_Column",
+			"Contact_Action_StartSearch_Button", "PDS_SearchFilter", "Contact_FloatActionButton",
+			"Contact_ListScreen_Tools_FilterGroupButton", "Contact_ListScreen_Tools_ListSortToolItem",
+			"Contact_ListScreen_Tools_ListFolderFilter", "QuickFilterGroup"
+		], because: "these are the viewConfig elements GridPageConverter emits for every list page");
+		inventory.Names.Should().Contain([
+			"Attribute_Items", "Attribute_Items_ModelConfig", "Attribute_Items_ViewModelConfig",
+			"Attribute_Items_ViewModelConfig_Attributes", "Attribute_ItemsSorting",
+			"ModelConfig", "DataSources", "PDS", "PDS_Config", "PDS_Attributes"
+		], because: "the data sections carry their own runtime names and overrides address those too");
+	}
+
+	[Test]
+	[Description("A subtitleItems column becomes <Entity>_ListItem_Subtitle_<Column> in the subtitles slot; a groupItems column becomes <Entity>_ListItem_Body_<Column> in the body slot; the title column produces no element of its own.")]
+	public void Build_ShouldMapEachWizardBucket_ToTheRuntimeElementItGenerates() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact",
+			items: Column("Name"), subtitles: Column("Job"), groups: Column("Account"));
+
+		// Act
+		LegacyRuntimeNameInventory inventory = Build(settings);
+		LegacyRuntimeAnchor subtitle = inventory.Resolve("Contact_ListItem_Subtitle_Job");
+		LegacyRuntimeAnchor body = inventory.Resolve("Contact_ListItem_Body_Account");
+
+		// Assert
+		subtitle.Should().NotBeNull(because: "a subtitleItems column is addressable by the name the runtime gave it");
+		subtitle!.Role.Should().Be(LegacyRuntimeRoles.SubtitleField, because: "the bucket decides the role");
+		subtitle.Bucket.Should().Be("subtitleItems", because: "the anchor carries the bucket the column came from");
+		subtitle.Slot.Should().Be("subtitles", because: "the runtime inserts it into the row's subtitles slot");
+		subtitle.ColumnPath.Should().Be("Job", because: "the column path is recovered from the name");
+		subtitle.FromInventory.Should().BeTrue(because: "the column really is in this source");
+
+		body!.Role.Should().Be(LegacyRuntimeRoles.BodyField, because: "groupItems render in the row body");
+		body.Bucket.Should().Be("groupItems", because: "the anchor carries the bucket the column came from");
+		body.Slot.Should().Be("body", because: "the runtime inserts it into the row's body slot");
+		body.ColumnPath.Should().Be("Account", because: "the column path is recovered from the name");
+
+		inventory.Names.Should().NotContain(n => n.Contains("_Name", System.StringComparison.Ordinal),
+			because: "the title column is merged onto the row as a 'title' value and gets no element name of its own");
+	}
+
+	[Test]
+	[Description("The literal body-column marker resolves as the marker, not as a body field for a column that happens to be called 'Column' — literal templates are matched before templates carrying {column}.")]
+	public void Resolve_ShouldPreferTheLiteralMarker_OverAColumnTemplateThatCouldAlsoMatch() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", groups: Column("Account"));
+
+		// Act
+		LegacyRuntimeAnchor marker = Build(settings).Resolve("Contact_ListItem_Body_Column");
+
+		// Assert
+		marker.Should().NotBeNull(because: "the runtime emits this marker when the last group column goes");
+		marker!.Role.Should().Be(LegacyRuntimeRoles.BodyColumnMarker,
+			because: "an exact template wins over a parameterised one that would read 'Column' as a column name");
+		marker.ColumnPath.Should().BeNull(because: "the marker is not column-bound");
+	}
+
+	[Test]
+	[Description("A dotted column path keeps its dots in the generated NAME (GridPageConverter only underscores the BINDING), so an override addressing a related column resolves back to the full path.")]
+	public void Resolve_ShouldKeepDots_InTheNameOfARelatedColumn() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", groups: Column("Account.CreatedBy.Name"));
+
+		// Act
+		LegacyRuntimeAnchor anchor = Build(settings).Resolve("Contact_ListItem_Body_Account.CreatedBy.Name");
+
+		// Assert
+		anchor.Should().NotBeNull(because: "the runtime writes the dotted path into the element name verbatim");
+		anchor!.ColumnPath.Should().Be("Account.CreatedBy.Name",
+			because: "the whole dotted path is the column, not just its last segment");
+		anchor.FromInventory.Should().BeTrue(because: "the column is present in this source's groupItems");
+	}
+
+	[Test]
+	[Description("A name that matches a template but names a column this source does not carry still resolves — with FromInventory false, so it can be reported as pointing at something the conversion did not produce instead of being applied.")]
+	public void Resolve_ShouldFlagAnchorsOutsideTheSource_RatherThanTreatingThemAsConversionInput() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", groups: Column("Account"));
+
+		// Act
+		LegacyRuntimeAnchor stranger = Build(settings).Resolve("Contact_ListItem_Body_SomethingElse");
+
+		// Assert
+		stranger.Should().NotBeNull(because: "the template explains what the name MEANS even when the column is absent");
+		stranger!.Role.Should().Be(LegacyRuntimeRoles.BodyField, because: "the meaning comes from the template");
+		stranger.ColumnPath.Should().Be("SomethingElse", because: "the column is parsed out of the name");
+		stranger.FromInventory.Should().BeFalse(
+			because: "this source produced no such element, and applying an override for it would be a guess");
+	}
+
+	[Test]
+	[Description("A name no template explains resolves to null, so the operation is reported rather than half-applied.")]
+	public void Resolve_ShouldReturnNull_WhenNoTemplateExplainsTheName() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", groups: Column("Account"));
+
+		// Act & Assert
+		Build(settings).Resolve("SomeHandWrittenElement").Should().BeNull(
+			because: "an unexplained target must never be guessed at");
+		Build(settings).Resolve("Account_ListItem").Should().BeNull(
+			because: "the entity prefix is part of the template — another entity's element is not ours");
+	}
+
+	[Test]
+	[Description("REAL CORPUS: the override shipped in GlbMobileFUIContactGridPageSettingsFieldForceWorkplace decodes into 'move column Account from groupItems into subtitleItems', which is a wizard-model edit rather than a JSON patch.")]
+	public void Resolve_ShouldDecodeARealShippedOverride_IntoWizardBucketMoves() {
+		// Arrange — the source carries Account as a group column, and the override re-points it into subtitles.
+		LegacyGridPageSettings settings = Parse("Contact", items: Column("Name"), groups: Column("Account"));
+		LegacyRuntimeNameInventory inventory = Build(settings);
+
+		// Act
+		LegacyRuntimeAnchor removed = inventory.Resolve("Contact_ListItem_Body_Account");
+		LegacyRuntimeAnchor inserted = inventory.Resolve("Contact_ListItem_Subtitle_Account");
+		LegacyRuntimeAnchor parent = inventory.Resolve("Contact_ListItem");
+		LegacyRuntimeAnchor root = inventory.Resolve("ViewConfig");
+
+		// Assert
+		removed!.Bucket.Should().Be("groupItems", because: "the removed element is the group-bucket rendering of Account");
+		removed.FromInventory.Should().BeTrue(because: "this conversion really did produce that element");
+		inserted!.Bucket.Should().Be("subtitleItems", because: "the inserted element is the subtitle-bucket rendering");
+		inserted.ColumnPath.Should().Be(removed.ColumnPath, because: "the pair is one column moving between buckets");
+		parent!.Role.Should().Be(LegacyRuntimeRoles.ListRow, because: "the operation's parentName is the row");
+		root!.Role.Should().Be(LegacyRuntimeRoles.ScreenRoot,
+			because: "the other shipped override removes ViewConfig.floatAction, so the root must resolve too");
+	}
+
+	[Test]
+	[Description("Without a runtime-name table the oracle yields an empty inventory that resolves nothing, so the override pass switches off by data rather than by code.")]
+	public void Build_ShouldYieldAnEmptyInventory_WhenTheTableIsAbsent() {
+		// Arrange
+		LegacyGridPageSettings settings = Parse("Contact", groups: Column("Account"));
+
+		// Act
+		LegacyRuntimeNameInventory fromNull = LegacyRuntimeNameOracle.Build(settings, null);
+		LegacyRuntimeNameInventory fromEmpty = LegacyRuntimeNameOracle.Build(settings, new MobileLegacyRuntimeNameSet());
+
+		// Assert
+		fromNull.IsEmpty.Should().BeTrue(because: "no table means no addressing space");
+		fromEmpty.IsEmpty.Should().BeTrue(because: "an empty anchor list is the same as no table");
+		fromNull.Resolve("Contact_ListItem").Should().BeNull(because: "nothing can be resolved without templates");
+	}
+
+	[Test]
+	[Description("The inventory is a deterministic function of the parsed source: the same settings produce the same names in the same order.")]
+	public void Build_ShouldBeDeterministic_ForTheSameSource() {
+		// Arrange
+		LegacyGridPageSettings first = Parse("Contact", items: Column("Name"), subtitles: Column("Job"), groups: Column("Account"));
+		LegacyGridPageSettings second = Parse("Contact", items: Column("Name"), subtitles: Column("Job"), groups: Column("Account"));
+
+		// Act
+		string[] a = [.. Build(first).Names];
+		string[] b = [.. Build(second).Names];
+
+		// Assert
+		a.Should().Equal(b, because: "re-running the conversion on the same source must produce the same result");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/MobilePageConversionGuideToolLegacyDetectionTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/Legacy/MobilePageConversionGuideToolLegacyDetectionTests.cs
@@ -1,0 +1,85 @@
+using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Unit tests for the legacy Mobile-wizard detection and gate on <see cref="MobilePageConversionGuideTool"/>
+/// (ENG-95730): a schema whose platform type is unknown and whose name carries GridPageSettings is routed to the
+/// legacy list mechanism; a RecordPageSettings schema is recognised and rejected with the owning story; the
+/// existing freedom-web / mobile / classic verdicts are unchanged.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "McpServer")]
+public sealed class MobilePageConversionGuideToolLegacyDetectionTests {
+
+	private static MobilePageConversionGuideArgs Args(string schemaName) =>
+		new(schemaName, TargetSchemaName: null, Version: null, EnvironmentName: null, Uri: null, Login: null, Password: null);
+
+	[TestCase("MobileOrderGridPageSettingsDefaultWorkplace", "unknown", ExpectedResult = LegacyMobileListAnalysisService.SourceTypeLegacyGridPage)]
+	[TestCase("mobilecasegridpagesettings", "UNKNOWN", ExpectedResult = LegacyMobileListAnalysisService.SourceTypeLegacyGridPage)]
+	[TestCase("MobileActivityRecordPageSettingsDefaultWorkplace", "unknown", ExpectedResult = LegacyMobileListAnalysisService.SourceTypeLegacyRecordPage)]
+	[TestCase("MobileOrderGridPageSettingsDefaultWorkplace", "web", ExpectedResult = null)]
+	[TestCase("MobileOrderGridPageSettingsDefaultWorkplace", "mobile", ExpectedResult = null)]
+	[TestCase("UsrOrder_ListPage", "unknown", ExpectedResult = null)]
+	[TestCase("UsrGridPageSettingsHelper", "unknown", ExpectedResult = null)]
+	[TestCase("", "unknown", ExpectedResult = null)]
+	[TestCase(null, "unknown", ExpectedResult = null)]
+	[Description("Legacy detection refines only an 'unknown' platform label and only for the wizard name pattern Mobile<Entity>(Grid|Record)PageSettings<Workplace> (case-insensitive); a web/mobile label, an unrelated name, or a name that merely contains the words stays as detected (null).")]
+	public string DetectLegacySourceType_ShouldRefineUnknownLabelByName(string schemaName, string label) =>
+		MobilePageConversionGuideTool.DetectLegacySourceType(schemaName, label);
+
+	[Test]
+	[Description("A legacy list settings source passes the gate (null rejection) so the legacy mechanism may run.")]
+	public void RejectUnsupportedSourceType_ShouldReturnNull_ForLegacyGridPage() {
+		// Act
+		MobilePageConversionGuideResponse rejection = MobilePageConversionGuideTool.RejectUnsupportedSourceType(
+			Args("MobileOrderGridPageSettingsDefaultWorkplace"), LegacyMobileListAnalysisService.SourceTypeLegacyGridPage);
+
+		// Assert
+		rejection.Should().BeNull(because: "legacy wizard list settings are a supported source type");
+	}
+
+	[Test]
+	[Description("A legacy RECORD settings source is rejected with a structured failure naming ENG-95731 and the supported source types.")]
+	public void RejectUnsupportedSourceType_ShouldRejectLegacyRecordPage_WithOwningStory() {
+		// Act
+		MobilePageConversionGuideResponse rejection = MobilePageConversionGuideTool.RejectUnsupportedSourceType(
+			Args("MobileActivityRecordPageSettingsDefaultWorkplace"), LegacyMobileListAnalysisService.SourceTypeLegacyRecordPage);
+
+		// Assert
+		rejection.Should().NotBeNull(because: "record pages are a later story");
+		rejection!.Success.Should().BeFalse(because: "the gate short-circuits with a failure");
+		rejection.SourceType.Should().Be(LegacyMobileListAnalysisService.SourceTypeLegacyRecordPage, because: "the detected source type is echoed");
+		rejection.Error.Should().Contain("ENG-95731", because: "the caller learns which story owns record pages");
+		rejection.Error.Should().Contain(LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, because: "the supported list source is named");
+	}
+
+	[Test]
+	[Description("The generic not-supported verdict (e.g. Classic UI) now lists BOTH supported source types.")]
+	public void RejectUnsupportedSourceType_ShouldListBothSupportedTypes_ForClassicSource() {
+		// Act
+		MobilePageConversionGuideResponse rejection = MobilePageConversionGuideTool.RejectUnsupportedSourceType(Args("UsrLegacyPage"), "classic");
+
+		// Assert
+		rejection.Should().NotBeNull(because: "Classic UI is still unsupported");
+		rejection!.Error.Should().Contain("freedom-web").And.Contain("legacy-mobile-grid-page",
+			because: "the supported list must stay truthful after the legacy source was added");
+	}
+
+	[Test]
+	[Description("Detection and gate compose end to end: an unknown-typed GridPageSettings schema detects as legacy list and passes the gate.")]
+	public void DetectThenReject_ShouldAcceptLegacyGridPageSettings() {
+		// Act
+		string label = MobilePageConversionGuideTool.DetectSourceType("unknown");
+		string sourceType = MobilePageConversionGuideTool.DetectLegacySourceType("MobileOrderGridPageSettingsDefaultWorkplace", label) ?? label;
+		MobilePageConversionGuideResponse rejection = MobilePageConversionGuideTool.RejectUnsupportedSourceType(Args("MobileOrderGridPageSettingsDefaultWorkplace"), sourceType);
+
+		// Assert
+		sourceType.Should().Be(LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, because: "the unknown label is refined by the name");
+		rejection.Should().BeNull(because: "the refined source type is supported");
+	}
+}

--- a/clio.tests/Command/McpServer/Tools/MobilePageConverter/MobileSectionRegistrationProbeTests.cs
+++ b/clio.tests/Command/McpServer/Tools/MobilePageConverter/MobileSectionRegistrationProbeTests.cs
@@ -165,4 +165,138 @@ public sealed class MobileSectionRegistrationProbeTests {
 		client.DidNotReceive().ExecuteGetRequest(
 			Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
+
+	// ── ProbeByEntity (ENG-95730: legacy wizard settings are not SysModule pages; the section is found by entity) ──
+
+	private const string EntityUId = "88888888-8888-8888-8888-888888888888";
+	private const string ModuleEntityId = "99999999-9999-9999-9999-999999999999";
+
+	/// <summary>Resolver whose OData GETs (root entity schema lookup included) are answered by <paramref name="odataRoute"/>.</summary>
+	private static IToolCommandResolver EntityResolver(Func<string, string> odataRoute, string entityUId = EntityUId) {
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(ci => {
+				string url = ci.Arg<string>();
+				if (url.Contains("odata/SysSchema?")) {
+					url.Should().Contain("ExtendParent eq false",
+						because: "SysModuleEntity references the ROOT entity schema UId, so only the non-replacing row may be matched");
+					return entityUId is null ? Value("") : Value($"{{\"UId\":\"{entityUId}\"}}");
+				}
+				return odataRoute(url);
+			});
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		urlBuilder.Build(Arg.Any<string>()).Returns(ci => ci.Arg<string>());
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		return resolver;
+	}
+
+	private static string EntityRouteFor(string url, string sysModuleRows, string moduleEntityRows = null) {
+		if (url.Contains("odata/SysModuleEntity?")) {
+			return moduleEntityRows ?? Value($"{{\"Id\":\"{ModuleEntityId}\"}}");
+		}
+		return RouteFor(url, sysModuleRows);
+	}
+
+	[Test]
+	[Description("ProbeByEntity finds the section through SysModuleEntity -> SysModule for the entity, reports its registration facts and the mobile workplaces, and records the entity on the result.")]
+	public void ProbeByEntity_ShouldReportSection_WhenEntityHasOneModule() {
+		// Arrange
+		string moduleRow = Value($"{{\"Id\":\"{SysModuleId}\",\"Code\":\"Order\",\"Caption\":\"Orders\"}}");
+		IToolCommandResolver resolver = EntityResolver(url => EntityRouteFor(url, moduleRow));
+
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(resolver, "env", null, null, null, "Order");
+
+		// Assert
+		info.ProbeOk.Should().BeTrue(because: "every query answered");
+		info.SourcePageIsSection.Should().BeTrue(because: "a SysModule row exists for the entity");
+		info.SysModuleId.Should().Be(SysModuleId, because: "the odata-update target is surfaced");
+		info.SectionCode.Should().Be("Order", because: "the section code is surfaced");
+		info.EntitySchemaName.Should().Be("Order", because: "the entity the lookup ran for is recorded");
+		info.IsFormPage.Should().BeFalse(because: "a legacy list settings source is never a form page");
+		info.MobileSectionRegistered.Should().BeFalse(because: "MobileSectionSchemaUId is empty");
+		info.AvailableMobileWorkplaces.Should().ContainSingle(w => w.IsMobile, because: "the shared workplace tail runs for the entity probe too");
+		info.RegistrationActions.Should().Contain(a => a.Contains("MobileSectionSchemaUId"), because: "the caller is told how to register the mobile page");
+	}
+
+	[Test]
+	[Description("When the entity has several sections the first is probed and the note names all of them so the user decides which section receives the mobile page.")]
+	public void ProbeByEntity_ShouldNoteAllSections_WhenEntityHasSeveralModules() {
+		// Arrange
+		string moduleRows = Value(
+			$"{{\"Id\":\"{SysModuleId}\",\"Code\":\"Activity\",\"Caption\":\"Activities\"}}," +
+			$"{{\"Id\":\"{RegisteredMobilePageUId}\",\"Code\":\"Calendar\",\"Caption\":\"Calendar\"}}");
+		IToolCommandResolver resolver = EntityResolver(url => EntityRouteFor(url, moduleRows));
+
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(resolver, "env", null, null, null, "Activity");
+
+		// Assert
+		info.ProbeOk.Should().BeTrue(because: "the probe completed");
+		info.SysModuleId.Should().Be(SysModuleId, because: "the first section is reported");
+		info.Note.Should().Contain("2 sections").And.Contain("Calendar", because: "the alternatives are named for the user's decision");
+	}
+
+	[Test]
+	[Description("When no SysModuleEntity references the entity the probe reports that no section exists (probe still ok) with a register-manually action.")]
+	public void ProbeByEntity_ShouldReportNoSection_WhenEntityHasNoModule() {
+		// Arrange
+		IToolCommandResolver resolver = EntityResolver(url => EntityRouteFor(url, Value(""), moduleEntityRows: Value("")));
+
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(resolver, "env", null, null, null, "UsrThing");
+
+		// Assert
+		info.ProbeOk.Should().BeTrue(because: "the environment answered");
+		info.SourcePageIsSection.Should().BeFalse(because: "no section is registered for the entity");
+		info.Note.Should().Contain("No section", because: "the result explains what was (not) found");
+		info.RegistrationActions.Should().ContainSingle(a => a.Contains("register one manually"), because: "the caller learns the section must be created first");
+	}
+
+	[Test]
+	[Description("When no root entity schema of that name exists the probe degrades to probeOk=false naming the entity, and never throws.")]
+	public void ProbeByEntity_ShouldDegrade_WhenEntityIsUnknown() {
+		// Arrange
+		IToolCommandResolver resolver = EntityResolver(url => EntityRouteFor(url, Value("")), entityUId: null);
+
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(resolver, "env", null, null, null, "Nope");
+
+		// Assert
+		info.ProbeOk.Should().BeFalse(because: "the entity UId could not be resolved");
+		info.Note.Should().Contain("Nope", because: "the note names the entity");
+	}
+
+	[Test]
+	[Description("An entity name that is not a plain identifier is rejected before any OData request is issued, so it can never reach the string-literal filter.")]
+	public void ProbeByEntity_ShouldReturnNotProbed_WhenEntityNameIsNotAnIdentifier() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
+		urlBuilder.Build(Arg.Any<string>()).Returns(ci => ci.Arg<string>());
+		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
+		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
+		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(resolver, "env", null, null, null, "Order' or 1 eq 1");
+
+		// Assert
+		info.ProbeOk.Should().BeFalse(because: "a non-identifier is refused");
+		info.Note.Should().Contain("not a valid entity schema name", because: "the note explains the refusal");
+		client.DidNotReceive().ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("Without a resolver or an entity name the entity probe returns a non-throwing, not-probed result.")]
+	public void ProbeByEntity_ShouldReturnNotProbed_WhenInputsAreMissing() {
+		// Act
+		SectionRegistrationInfo info = MobileSectionRegistrationProbe.ProbeByEntity(null, "env", null, null, null, "Order");
+
+		// Assert
+		info.ProbeOk.Should().BeFalse(because: "nothing could be queried");
+		info.EntitySchemaName.Should().Be("Order", because: "the entity is still recorded");
+	}
 }

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -21,6 +21,7 @@ using Clio.Command.McpServer;
 using Clio.Command.McpServer.Knowledge;
 using Clio.Command.McpServer.Resources;
 using Clio.Command.McpServer.Tools.MobilePageConverter;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 using Clio.Command.PackageCommand;
 using Clio.Command.ProcessModel;
 using Clio.Command.RelatedPages;
@@ -620,6 +621,7 @@ public class BindingsModule {
 		services.AddTransient<ImportSchemaTool>();
 		services.AddTransient<PageSyncTool>();
 		services.AddTransient<MobilePageConversionGuideTool>();
+		services.AddTransient<ILegacyMobileSettingsReader, LegacyMobileSettingsReader>();
 		services.AddSingleton<IPageBodySamplingService, PageBodySamplingServiceImpl>();
 		services.AddTransient<GuidanceGetTool>();
 		services.AddTransient<KnowledgeManagementTools>();

--- a/clio/Command/McpServer/AGENTS.md
+++ b/clio/Command/McpServer/AGENTS.md
@@ -564,6 +564,14 @@ A binding already written as `$PDS_…` is left alone: the source column cannot 
 (`insert Attribute_Items_SortingConfig`) onto `attributes/Items/modelConfig/sortingConfig`. A `remove` or `set`
 there names runtime elements the converted page never declares, and is reported.
 
+**Every designer target is verified against the TEMPLATE, not trusted from the table.** The legacy branch reads
+the target template through the same `LoadMobileTemplateProbe` the web branch uses and checks each name it is about
+to author (`ListItem`, `FolderTreeActions`, and whatever an override retargets onto). A name the template does not
+declare is REPORTED, never authored — a merge onto a missing name writes nothing, `validate-page` cannot see it
+(`MobileDiffApplyValidator` applies `viewConfigDiff` against an empty base; see the ENG-95429 knowledge record), so
+it would be a silent no-op. An unreadable template degrades to authoring anyway plus an explicit `UNVERIFIED`
+constraint — a stand that is down must not quietly strip a customisation.
+
 **Warnings go to `guide.constraints` and NOWHERE else.** An override whose outcome on the converted page differs
 from what it asked for, or that was skipped, must not be discoverable only by reading a report section;
 `constraints` is the block a caller cannot skip. `legacySource.overrideOutcomes` still records the per-operation

--- a/clio/Command/McpServer/AGENTS.md
+++ b/clio/Command/McpServer/AGENTS.md
@@ -514,8 +514,79 @@ A legacy RECORD settings schema (`RecordPageSettings`, ENG-95731) and any other 
 `RejectUnsupportedSourceType`. The legacy guide is deliberately lean: the two `elementMap` merges the Mobile designer
 itself writes for a generated list page (`FolderTreeActions` bound to the entity, `ListItem` row), the two data-section
 diffs, and `guide.legacySource` (column mapping, contributing package layers, coverage table, decisions, recorded
-divergences from the mobile runtime converter). Embedded Freedom UI override sections are only classified and reported
-(ENG-95733). Both paths share the same response contract, feature flag, guidance article and skill.
+divergences from the mobile runtime converter). Both paths share the same response contract, feature flag, guidance
+article and skill.
+
+The target template and the names of the template-provided elements the converted page merges onto are DATA, not
+constants: `mobileLegacyTemplates.gridPage` in `Data/WebToMobilePageConversionRules.json`. Its sibling group
+`mobileLegacyRuntimeNames.gridPage` is the other half of the mapping — the names the MOBILE RUNTIME generates for the
+same wizard metadata (`<Entity>_ListItem`, `<Entity>_ListItem_Subtitle_<Column>`, `Attribute_Items_ModelConfig`, …),
+ported from the runtime's own `GridPageConverter`/`BaseScreenConverter`. Embedded override operations address the
+RUNTIME names; the designer understands only the template names, so carrying an override across means re-pointing it
+through those two tables. `Legacy/LegacyRuntimeNameOracle` builds the runtime name inventory for one parsed source and
+inverts a name back into its meaning (role, wizard bucket, slot, column). Both groups carry bundled defaults, so an
+older CDN-served rules file never breaks the legacy branch.
+
+Embedded override sections get two different verdicts, and they must stay apart: `viewConfigDiff` /
+`viewModelConfigDiff` / `modelConfigDiff` are CONVERTED operation by operation, while `diffV2` is reported with
+`supported: false` plus a reason and is never translated — the mobile runtime does not translate it either
+(`PageSettingsMetadataDiffV2Converter.addDiffV2` registers the inserted names and passes the array through verbatim),
+so there is no reference behaviour to port. A hand-authored `viewConfig` / `modelViewConfig` is refused outright.
+
+`Legacy/LegacyOverrideRebaser` resolves each operation into exactly one of three lanes, reported per operation in
+`guide.legacySource.overrideOutcomes`:
+
+| Lane | Meaning | Example |
+|---|---|---|
+| `source-edit` | expressible in the wizard model, so the SOURCE is edited and the pure analyzer re-derives the page — one emit path, bindings recomputed rather than copied | `remove <Entity>_ListItem_Body_<Column>` → drop the column from its bucket |
+| `target-delta` | expressible only in the target dialect, so it becomes an extra `elementMap` entry or path diff | `remove ViewConfig properties:["floatAction"]` → `remove CreateRecordButton` |
+| `reported` | everything else, with the reason | a target this source never generates |
+
+Four rules that are load-bearing and easy to undo by accident.
+
+**Operations are grouped by SUBJECT (the column they touch, else the element they address) and a group resolves
+entirely or not at all** — a move arrives as a remove + insert pair, and applying only the resolvable half would
+DELETE the column instead of moving it.
+
+**The override WINS on every key it names.** A merge on an element the converter also writes (the list row, the
+folder tree) is folded over the converted values rather than added as a rival entry with the same name; it is the
+later, more specific customisation of the same element.
+
+**A row binding is re-derived, never copied.** Inside the list row `$X` addresses a column of the record, and the
+converted page names those `PDS_<Column>` — a hand-written `{"icon": "$Photo"}` carried verbatim would resolve to
+nothing. The binding is rewritten and the column it references is declared in BOTH data sections exactly like a
+wizard column (before `PDS_Id`, which stays last), because a carried binding whose attribute is missing is dead.
+A binding already written as `$PDS_…` is left alone: the source column cannot be recovered from an underscored name.
+
+**Both `merge` and `insert` are re-pointed onto a data-section path**, because the runtime's
+`insert <X> into <parent>.<property>` and its `merge <X>` both say "this is what X holds", and X's own
+`designerPath` already encodes where that is — this is what carries the shipped default-sort override
+(`insert Attribute_Items_SortingConfig`) onto `attributes/Items/modelConfig/sortingConfig`. A `remove` or `set`
+there names runtime elements the converted page never declares, and is reported.
+
+**Warnings go to `guide.constraints` and NOWHERE else.** An override whose outcome on the converted page differs
+from what it asked for, or that was skipped, must not be discoverable only by reading a report section;
+`constraints` is the block a caller cannot skip. `legacySource.overrideOutcomes` still records the per-operation
+verdict, but it is the record, not the alert.
+
+Row-slot rules, all three warning-carrying (a converted row has ONE slot where the runtime has `subtitles` and
+`body`):
+
+| Source shape | Outcome |
+|---|---|
+| `insert <E>_ListItem_Subtitle_<C>`, column NOT on the page | the column is added to the wizard model, so the row shows it |
+| the same, column already on the page | nothing changes — never duplicated |
+| `remove <E>_ListItem_Body_<C>` + `insert <E>_ListItem_Subtitle_<C>` (a move) | nothing changes; the removal is deliberately NOT applied alone, or "move" becomes "delete" |
+| `merge <E>_ListItem_Body_<C> {label:…}` | reported: the designer does not support controlling a list-row label yet |
+
+`<E>_SortOptions_<C>` (the runtime's sort-tool option) becomes an entry of `SortButton.sortItems`, shaped
+`{attributeName, caption}` with the **raw** column name — no `PDS_` prefix, verified against a designer-authored
+page. Several such inserts accumulate into ONE merge: a resolution can declare that its array values append
+rather than replace, so the rule stays about operation semantics instead of hard-coding the property name. The
+caption comes from the wizard column when the page carries it, else the column name plus a warning.
+
+`elementMap` therefore no longer has a fixed length: it starts with the two designer merges and grows by one entry
+per carried view override. Callers must emit each entry with its own `operation`, not assume `merge`.
 
 ## Workspace-scoped tools
 

--- a/clio/Command/McpServer/AGENTS.md
+++ b/clio/Command/McpServer/AGENTS.md
@@ -500,6 +500,23 @@ When changing the catalog data source, refer to:
   creatio-ui team (URL pattern, JSON shape, GA-tag trigger, git push into
   `static-files-mcp`, `latest/ComponentRegistry.json` semver gate).
 
+## Mobile page conversion guide (`get-mobile-page-conversion-guide`)
+
+The tool (`Tools/MobilePageConverter/MobilePageConversionGuideTool.cs`, feature flag `mobile-page-converter`)
+dispatches on the detected source type and reports the mechanism it ran in `conversionMechanism`:
+
+| sourceType | Detection | Analysis | Mechanism label |
+|---|---|---|---|
+| `freedom-web` | schema-type `web` | `WebToMobileAnalysisService.Analyze` (elementMap built from the merged web bundle + rules) | `freedom-web-analysis` |
+| `legacy-mobile-grid-page` | schema-type `unknown` + name contains `GridPageSettings`, body confirmed `settingsType: GridPage` | `Legacy/LegacyMobileListAnalysisService.Analyze` over the package-merged settings read by `Legacy/LegacyMobileSettingsReader` | `legacy-mobile-settings-converter` |
+
+A legacy RECORD settings schema (`RecordPageSettings`, ENG-95731) and any other source are rejected in
+`RejectUnsupportedSourceType`. The legacy guide is deliberately lean: the two `elementMap` merges the Mobile designer
+itself writes for a generated list page (`FolderTreeActions` bound to the entity, `ListItem` row), the two data-section
+diffs, and `guide.legacySource` (column mapping, contributing package layers, coverage table, decisions, recorded
+divergences from the mobile runtime converter). Embedded Freedom UI override sections are only classified and reported
+(ENG-95733). Both paths share the same response contract, feature flag, guidance article and skill.
+
 ## Workspace-scoped tools
 
 For tools that operate on a local workspace:

--- a/clio/Command/McpServer/Data/WebToMobilePageConversionRules.json
+++ b/clio/Command/McpServer/Data/WebToMobilePageConversionRules.json
@@ -205,6 +205,66 @@
     }
   ],
   "nonConvertingScopeContainers": ["MainHeader"],
+  "mobileLegacyTemplates": {
+    "gridPage": {
+      "templateName": "BaseMobileListTemplate",
+      "listName": "List",
+      "listContainerName": "ListContainer",
+      "listItemName": "ListItem",
+      "listItemType": "crt.ListItem",
+      "folderTreeActionsName": "FolderTreeActions",
+      "folderTreeActionsType": "crt.FolderTreeActions",
+      "folderSourceSchemaName": "FolderTree",
+      "itemsAttributeName": "Items",
+      "scaffoldName": "Scaffold",
+      "mainContainerName": "MainContainer",
+      "headerContainerName": "HeaderContainer",
+      "searchButtonName": "SearchButton",
+      "filterGroupButtonName": "FilterGroupButton",
+      "sortButtonName": "SortButton",
+      "quickFilterGroupName": "QuickFilterGroup",
+      "createRecordButtonName": "CreateRecordButton",
+      "note": "Target of the legacy Mobile-wizard GridPageSettings converter. These are DESIGNER-dialect names taken from the shipped template; the mobile runtime's own converter generates a different set (<Entity>_ListItem, <Entity>_ListItem_Body_<Column>, …) which is what embedded viewConfigDiff operations address. Re-pointing those onto the names here is ENG-95733."
+    }
+  },
+  "mobileLegacyRuntimeNames": {
+    "gridPage": {
+      "note": "The element names the MOBILE RUNTIME generates when it converts a classic GridPageSettings on the device — the dialect embedded viewConfigDiff / viewModelConfigDiff / modelConfigDiff operations are written against. Ported from the runtime's own GridPageConverter/BaseScreenConverter (names are built by joining with '_'; the row name is <Entity>_List + 'Item' with NO separator). {entity} is settings.entitySchemaName, {column} is the wizard values.columnName verbatim (dots kept in the NAME; the binding replaces them with '_').",
+      "anchors": [
+        { "role": "screenRoot", "pattern": "ViewConfig", "designerName": "Scaffold", "propertyTargets": {"floatAction": "CreateRecordButton"} },
+        { "role": "list", "pattern": "{entity}_List", "designerName": "List" },
+        { "role": "listRow", "pattern": "{entity}_ListItem", "designerName": "ListItem" },
+        { "role": "bodyColumnMarker", "pattern": "{entity}_ListItem_Body_Column" },
+        { "role": "subtitleField", "pattern": "{entity}_ListItem_Subtitle_{column}", "bucket": "subtitleItems", "slot": "subtitles" },
+        { "role": "bodyField", "pattern": "{entity}_ListItem_Body_{column}", "bucket": "groupItems", "slot": "body" },
+        { "role": "sortOption", "pattern": "{entity}_SortOptions_{column}", "slot": "sortOptions", "designerName": "SortButton", "note": "One column offered in the sort tool. The runtime inserts it into ListSortToolItem.sortOptions as {property}; the designer carries the same thing as an entry of SortButton.sortItems, shaped {attributeName, caption} with the RAW column name (no PDS_ prefix)." },
+        { "role": "searchActionButton", "pattern": "{entity}_Action_StartSearch_Button", "designerName": "SearchButton" },
+        { "role": "searchFilter", "pattern": "PDS_SearchFilter" },
+        { "role": "searchExpression", "pattern": "PDS_SearchExpression_{column}" },
+        { "role": "addButton", "pattern": "{entity}_FloatActionButton", "designerName": "CreateRecordButton" },
+        { "role": "quickFilterButton", "pattern": "{entity}_ListScreen_Tools_FilterGroupButton", "designerName": "FilterGroupButton" },
+        { "role": "sortTool", "pattern": "{entity}_ListScreen_Tools_ListSortToolItem", "designerName": "SortButton" },
+        { "role": "folderFilter", "pattern": "{entity}_ListScreen_Tools_ListFolderFilter", "designerName": "FolderTreeActions" },
+        { "role": "folderFilterAttribute", "pattern": "{entity}_ListScreen_Tools_ListFolderFilter_active_folder_filter_data" },
+        { "role": "quickFilterGroup", "pattern": "QuickFilterGroup", "designerName": "QuickFilterGroup" },
+        { "role": "quickFilterAttribute", "pattern": "QuickFilterGroup_Filters" },
+        { "role": "viewModelConfigRoot", "pattern": "ViewModelConfig", "designerPath": [] },
+        { "role": "attributes", "pattern": "Attributes", "designerPath": ["attributes"] },
+        { "role": "itemsAttribute", "pattern": "Attribute_Items", "designerPath": ["attributes", "{items}"] },
+        { "role": "itemsModelConfig", "pattern": "Attribute_Items_ModelConfig", "designerPath": ["attributes", "{items}", "modelConfig"] },
+        { "role": "itemsCacheConfig", "pattern": "Attribute_Items_CacheConfig", "designerPath": ["attributes", "{items}", "modelConfig", "cacheConfig"] },
+        { "role": "itemsSortingConfig", "pattern": "Attribute_Items_SortingConfig", "designerPath": ["attributes", "{items}", "modelConfig", "sortingConfig"] },
+        { "role": "itemsViewModelConfig", "pattern": "Attribute_Items_ViewModelConfig", "designerPath": ["attributes", "{items}", "viewModelConfig"] },
+        { "role": "itemsViewModelAttributes", "pattern": "Attribute_Items_ViewModelConfig_Attributes", "designerPath": ["attributes", "{items}", "viewModelConfig", "attributes"] },
+        { "role": "sortingAttribute", "pattern": "Attribute_ItemsSorting", "designerPath": ["attributes", "ItemsSorting"] },
+        { "role": "modelConfigRoot", "pattern": "ModelConfig", "designerPath": [] },
+        { "role": "dataSources", "pattern": "DataSources", "designerPath": ["dataSources"] },
+        { "role": "primaryDataSource", "pattern": "PDS", "designerPath": ["dataSources", "{pds}"] },
+        { "role": "primaryDataSourceConfig", "pattern": "PDS_Config", "designerPath": ["dataSources", "{pds}", "config"] },
+        { "role": "primaryDataSourceAttributes", "pattern": "PDS_Attributes", "designerPath": ["dataSources", "{pds}", "config", "attributes"] }
+      ]
+    }
+  },
   "requests": [
     { "web": "crt.SaveRecordRequest", "mobile": "crt.SaveRecordRequest", "category": "DirectMapping" },
     { "web": "crt.CreateRecordRequest", "mobile": "crt.CreateRecordRequest", "category": "DirectMapping" },

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyGridPageSettingsParser.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyGridPageSettingsParser.cs
@@ -1,0 +1,160 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// One column the classic Mobile wizard placed on a list page: the entity column path (possibly dotted), its
+/// caption, its display row inside the bucket, the platform data-value type, and every other property the
+/// wizard recorded (view types, formats, …) which the converter reports rather than silently drops.
+/// </summary>
+public sealed record LegacyGridColumn(
+	string Name,
+	string ColumnName,
+	string Caption,
+	int Row,
+	int? DataValueType,
+	IReadOnlyDictionary<string, JToken> OtherProperties);
+
+/// <summary>
+/// The effective (package-hierarchy-merged) classic Mobile wizard list settings, parsed into the three wizard
+/// buckets. <see cref="Items"/> holds the title column (the wizard always writes exactly one; the parser keeps
+/// whatever it finds so the analysis can report deviations), <see cref="SubtitleItems"/> and
+/// <see cref="GroupItems"/> the body columns, each bucket ordered by the wizard <c>row</c>.
+/// </summary>
+public sealed record LegacyGridPageSettings(
+	string EntitySchemaName,
+	string SettingsType,
+	IReadOnlyList<LegacyGridColumn> Items,
+	IReadOnlyList<LegacyGridColumn> SubtitleItems,
+	IReadOnlyList<LegacyGridColumn> GroupItems,
+	IReadOnlyDictionary<string, JToken> OtherSettingsProperties,
+	string GridType = null);
+
+/// <summary>
+/// Pure parser of the merged <c>settings</c> node of a legacy <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>
+/// schema (ENG-95730). The node is the result of applying every package layer's diff array with the page
+/// diff applier: the wizard's <c>values</c> are hoisted onto the item, so columns arrive as plain objects
+/// inside the <c>items</c> / <c>subtitleItems</c> / <c>groupItems</c> arrays.
+/// </summary>
+public static class LegacyGridPageSettingsParser {
+
+	/// <summary>Name of the root node of a legacy settings diff array.</summary>
+	public const string SettingsNodeName = "settings";
+
+	/// <summary><c>settingsType</c> of a wizard LIST page.</summary>
+	public const string GridPageSettingsType = "GridPage";
+
+	/// <summary><c>settingsType</c> of a wizard RECORD page (ENG-95731, not converted here).</summary>
+	public const string RecordPageSettingsType = "RecordPage";
+
+	/// <summary>Wizard bucket holding the single title column.</summary>
+	public const string ItemsBucket = "items";
+
+	/// <summary>Wizard bucket holding the subtitle columns.</summary>
+	public const string SubtitleItemsBucket = "subtitleItems";
+
+	/// <summary>Wizard bucket holding the group columns.</summary>
+	public const string GroupItemsBucket = "groupItems";
+
+	private const string RowKey = "row";
+	private const string ContentKey = "content";
+	private const string ColumnNameKey = "columnName";
+	private const string DataValueTypeKey = "dataValueType";
+
+	/// <summary>Column keys the converter consumes; anything else is reported through the coverage table.</summary>
+	private static readonly HashSet<string> KnownColumnKeys = new(StringComparer.Ordinal) {
+		"name", "operation", RowKey, ContentKey, ColumnNameKey, DataValueTypeKey
+	};
+
+	/// <summary>
+	/// Settings keys the converter or the classifier consumes; anything else is surfaced as an unconverted settings
+	/// property. The override-section keys are listed here because the classifier owns their reporting.
+	/// </summary>
+	internal static readonly HashSet<string> KnownSettingsKeys = new(StringComparer.Ordinal) {
+		"name", "operation", "entitySchemaName", "settingsType", ItemsBucket, SubtitleItemsBucket, GroupItemsBucket,
+		"localizableStrings", "viewConfigDiff", "viewModelConfigDiff", "modelConfigDiff", "diffV2", "viewConfig",
+		"modelViewConfig", GridTypeKey, "rows", "columns"
+	};
+
+	/// <summary>
+	/// Classic grid layout settings the wizard writes on every list page (<c>gridType</c> listed/tiled and the
+	/// tiled <c>rows</c>/<c>columns</c> geometry). They describe the classic list only — a mobile ListItem row has
+	/// one layout — so they are reported as informational, never as a decision.
+	/// </summary>
+	private const string GridTypeKey = "gridType";
+
+	/// <summary>
+	/// Parses the merged settings node.
+	/// </summary>
+	/// <param name="settings">The merged <c>settings</c> item (values hoisted).</param>
+	/// <returns>The parsed wizard settings.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="settings"/> is null.</exception>
+	/// <exception cref="InvalidOperationException">The node declares no <c>entitySchemaName</c>.</exception>
+	public static LegacyGridPageSettings Parse(JObject settings) {
+		ArgumentNullException.ThrowIfNull(settings);
+		string entity = settings.Value<string>("entitySchemaName");
+		if (string.IsNullOrWhiteSpace(entity)) {
+			throw new InvalidOperationException(
+				"Legacy mobile settings do not declare 'entitySchemaName'; the mobile list page cannot be bound to an object.");
+		}
+		var other = new Dictionary<string, JToken>(StringComparer.Ordinal);
+		foreach (JProperty property in settings.Properties()) {
+			if (!KnownSettingsKeys.Contains(property.Name)) {
+				other[property.Name] = property.Value;
+			}
+		}
+		return new LegacyGridPageSettings(
+			entity.Trim(),
+			settings.Value<string>("settingsType"),
+			ParseBucket(settings, ItemsBucket),
+			ParseBucket(settings, SubtitleItemsBucket),
+			ParseBucket(settings, GroupItemsBucket),
+			other,
+			settings.Value<string>(GridTypeKey));
+	}
+
+	/// <summary>
+	/// Reads one wizard bucket. Columns are ordered by <c>row</c> (stable, so two columns sharing a row keep
+	/// their merged-array order); a column without <c>row</c> takes its array position.
+	/// </summary>
+	private static List<LegacyGridColumn> ParseBucket(JObject settings, string bucket) {
+		if (settings[bucket] is not JArray array) {
+			return [];
+		}
+		var columns = new List<LegacyGridColumn>(array.Count);
+		int position = 0;
+		foreach (JToken token in array) {
+			if (token is not JObject column) {
+				position++;
+				continue;
+			}
+			string columnName = column.Value<string>(ColumnNameKey);
+			if (string.IsNullOrWhiteSpace(columnName)) {
+				position++;
+				continue;
+			}
+			var extra = new Dictionary<string, JToken>(StringComparer.Ordinal);
+			foreach (JProperty property in column.Properties()) {
+				if (!KnownColumnKeys.Contains(property.Name)) {
+					extra[property.Name] = property.Value;
+				}
+			}
+			int row = column[RowKey]?.Type == JTokenType.Integer ? column.Value<int>(RowKey) : position;
+			int? dataValueType = column[DataValueTypeKey]?.Type == JTokenType.Integer
+				? column.Value<int>(DataValueTypeKey)
+				: null;
+			columns.Add(new LegacyGridColumn(
+				column.Value<string>("name"),
+				columnName.Trim(),
+				column.Value<string>(ContentKey),
+				row,
+				dataValueType,
+				extra));
+			position++;
+		}
+		return columns.OrderBy(c => c.Row).ToList();
+	}
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
@@ -1,0 +1,397 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+// LEGACY Mobile-wizard LIST settings -> Freedom UI MOBILE list page conversion ANALYSIS (advisory-only, ENG-95730).
+// Second source type of get-mobile-page-conversion-guide, beside the Freedom UI web analysis. Pure: no Creatio I/O.
+// Unlike a web page with dozens of components, the target elements are known up front and all of them are
+// supported, so the guide is deliberately LEAN: the two elementMap merges the designer itself writes for a generated
+// list page (FolderTreeActions bound to the entity, ListItem row), the two data-section diffs, and the column facts in
+// one place (legacySource).
+
+/// <summary>
+/// Deterministic analyzer for a classic Mobile-wizard list settings schema. Given the merged settings and their
+/// classification it returns the same <see cref="MobilePageConversionGuide"/> shape the Freedom UI web analysis
+/// returns, so the caller (skill) processes both source types through one contract.
+/// </summary>
+public static class LegacyMobileListAnalysisService {
+
+	/// <summary>Source type of a legacy Mobile-wizard LIST settings schema.</summary>
+	public const string SourceTypeLegacyGridPage = "legacy-mobile-grid-page";
+
+	/// <summary>Source type of a legacy Mobile-wizard RECORD settings schema (detected, not converted — ENG-95731).</summary>
+	public const string SourceTypeLegacyRecordPage = "legacy-mobile-record-page";
+
+	/// <summary>Mechanism label reported for a Freedom UI web source.</summary>
+	public const string MechanismFreedomWebAnalysis = "freedom-web-analysis";
+
+	/// <summary>Mechanism label reported for a legacy Mobile-wizard settings source.</summary>
+	public const string MechanismLegacySettingsConverter = "legacy-mobile-settings-converter";
+
+	/// <summary>The shipped mobile list template every converted legacy list page inherits.</summary>
+	public const string RecommendedTemplate = "BaseMobileListTemplate";
+
+	/// <summary>The template's row element the guide merges onto.</summary>
+	public const string ListItemName = "ListItem";
+
+	/// <summary>The template's folder-tree action element the guide binds to the entity (folder filtering).</summary>
+	public const string FolderTreeActionsName = "FolderTreeActions";
+
+	/// <summary>The folder schema name the shipped template and the designer both put on FolderTreeActions.</summary>
+	public const string FolderTreeSourceSchemaName = "FolderTree";
+
+	/// <summary>Default fallback when the environment's SchemaNamePrefix cannot be read.</summary>
+	public const string DefaultSchemaNamePrefix = "Usr";
+
+	private const string GuidanceArticleName = "freedom-page-web-to-mobile-conversion";
+	private const string PrimaryDataSourceAlias = "PDS";
+	private const string ItemsAttribute = "Items";
+	private const string ListItemType = "crt.ListItem";
+	private const string FolderTreeActionsType = "crt.FolderTreeActions";
+	private const string BucketTitle = "title";
+	private const string BucketSubtitle = "subtitle";
+	private const string BucketGroup = "group";
+
+	private static readonly Regex SchemaNamePattern = new(
+		"^Mobile(?<entity>.+?)(?<kind>GridPageSettings|RecordPageSettings)(?<workplace>.*)$",
+		RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+	/// <summary>Entity and workplace hints parsed from a legacy settings schema name.</summary>
+	public sealed record LegacySchemaNameParts(string Entity, string Workplace, bool IsRecordPage);
+
+	/// <summary>
+	/// Parses <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>; null when the name does not follow the pattern.
+	/// </summary>
+	public static LegacySchemaNameParts TryParseSchemaName(string schemaName) {
+		if (string.IsNullOrWhiteSpace(schemaName)) {
+			return null;
+		}
+		Match match = SchemaNamePattern.Match(schemaName.Trim());
+		if (!match.Success) {
+			return null;
+		}
+		string workplace = match.Groups["workplace"].Value;
+		return new LegacySchemaNameParts(
+			match.Groups["entity"].Value,
+			string.IsNullOrWhiteSpace(workplace) ? null : workplace,
+			match.Groups["kind"].Value.StartsWith("Record", StringComparison.OrdinalIgnoreCase));
+	}
+
+	/// <summary>
+	/// Default target mobile page name: <c>&lt;Prefix&gt;&lt;Entity&gt;_MobileListPage</c>, without doubling a prefix
+	/// the entity already carries (<c>UsrMK_Test</c> → <c>UsrMK_Test_MobileListPage</c>).
+	/// </summary>
+	public static string DeriveTargetSchemaName(string entitySchemaName, string schemaNamePrefix) {
+		string entity = (entitySchemaName ?? string.Empty).Trim();
+		string prefix = (schemaNamePrefix ?? string.Empty).Trim();
+		if (entity.Length == 0) {
+			return $"{prefix}Mobile_ListPage";
+		}
+		bool alreadyPrefixed = prefix.Length > 0 && entity.StartsWith(prefix, StringComparison.Ordinal);
+		return $"{(alreadyPrefixed ? string.Empty : prefix)}{entity}_MobileListPage";
+	}
+
+	/// <summary>The view-model attribute a wizard column binds to: <c>PDS_&lt;path with '.' → '_'&gt;</c>.</summary>
+	public static string AttributeName(string columnPath) =>
+		$"{PrimaryDataSourceAlias}_{columnPath.Replace('.', '_')}";
+
+	/// <summary>The attribute's model path: <c>PDS.&lt;path with '.' → '_'&gt;</c>.</summary>
+	public static string ModelPath(string columnPath) =>
+		$"{PrimaryDataSourceAlias}.{columnPath.Replace('.', '_')}";
+
+	/// <summary>
+	/// Builds the conversion guide for a legacy Mobile-wizard list settings source.
+	/// </summary>
+	/// <param name="read">The merged settings read (must be successful).</param>
+	/// <param name="classification">Static classification of the merged settings.</param>
+	/// <param name="sourcePage">The source schema name.</param>
+	/// <param name="suggestedTarget">The target mobile page name.</param>
+	/// <param name="sectionRegistration">Read-only section registration facts, or null when not probed.</param>
+	/// <returns>The advisory guide.</returns>
+	public static MobilePageConversionGuide Analyze(
+		LegacyMobileSettingsReadResult read,
+		LegacySettingsClassification classification,
+		string sourcePage,
+		string suggestedTarget,
+		SectionRegistrationInfo sectionRegistration) {
+		ArgumentNullException.ThrowIfNull(read);
+		ArgumentNullException.ThrowIfNull(classification);
+		if (!read.Success || read.EffectiveSettings is null) {
+			throw new InvalidOperationException("Analyze requires a successful legacy settings read.");
+		}
+		LegacyGridPageSettings settings = LegacyGridPageSettingsParser.Parse(read.EffectiveSettings);
+		var decisions = new List<string>();
+		var notes = new List<string>(read.Notes ?? []);
+		notes.AddRange(classification.Notes ?? []);
+
+		LegacySchemaNameParts nameParts = TryParseSchemaName(sourcePage);
+		if (nameParts is not null
+			&& !string.Equals(nameParts.Entity, settings.EntitySchemaName, StringComparison.OrdinalIgnoreCase)) {
+			notes.Add($"The schema name suggests entity '{nameParts.Entity}' but the settings bind '{settings.EntitySchemaName}'; the settings are authoritative.");
+		}
+
+		// Title: the wizard writes exactly one items column. Lowest row wins when several are present; the rest
+		// join the body (reported as adapted) rather than being silently lost.
+		LegacyGridColumn titleColumn = settings.Items.FirstOrDefault();
+		var bodySource = new List<(LegacyGridColumn Column, string Bucket)>();
+		foreach (LegacyGridColumn extra in settings.Items.Skip(1)) {
+			bodySource.Add((extra, BucketTitle));
+			decisions.Add($"Wizard 'items' bucket holds more than one column; '{extra.ColumnName}' was moved into ListItem.body (the title shows '{titleColumn.ColumnName}'). Confirm or pick another title.");
+		}
+		bodySource.AddRange(settings.SubtitleItems.Select(c => (c, BucketSubtitle)));
+		bodySource.AddRange(settings.GroupItems.Select(c => (c, BucketGroup)));
+		if (titleColumn is null) {
+			decisions.Add("No title column ('items' bucket) was found in the wizard settings — choose the column that becomes ListItem.title.");
+		}
+
+		// Attributes in emission order: body columns, then the title, then PDS_Id (always). Duplicates once.
+		var attributeOrder = new List<string>();
+		var attributeColumn = new Dictionary<string, string>(StringComparer.Ordinal);
+		var bodyMappings = new List<LegacyColumnMappingInfo>();
+		var bodyRows = new JsonArray();
+		int bodyIndex = 0;
+		foreach ((LegacyGridColumn column, string bucket) in bodySource) {
+			string attribute = AttributeName(column.ColumnName);
+			bodyRows.Add(new JsonObject { ["value"] = $"${attribute}" });
+			bodyMappings.Add(Mapping(column, bucket, attribute, $"{ListItemName}.body[{bodyIndex}]"));
+			Register(attributeOrder, attributeColumn, attribute, column.ColumnName, notes);
+			bodyIndex++;
+		}
+		LegacyColumnMappingInfo titleMapping = null;
+		if (titleColumn is not null) {
+			string attribute = AttributeName(titleColumn.ColumnName);
+			titleMapping = Mapping(titleColumn, BucketTitle, attribute, $"{ListItemName}.title");
+			Register(attributeOrder, attributeColumn, attribute, titleColumn.ColumnName, notes);
+		}
+
+		// The template's ListItem merge (key order mirrors the designer's own output: body, title, icon).
+		var mobileValues = new JsonObject { ["body"] = bodyRows };
+		if (titleMapping is not null) {
+			mobileValues["title"] = $"${titleMapping.Attribute}";
+		}
+		mobileValues["icon"] = null;
+
+		var viewModelAttributes = new JsonObject();
+		var dataSourceAttributes = new JsonObject();
+		foreach (string attribute in attributeOrder) {
+			viewModelAttributes[attribute] = new JsonObject {
+				["modelConfig"] = new JsonObject { ["path"] = ModelPath(attributeColumn[attribute]) }
+			};
+			string columnPath = attributeColumn[attribute];
+			var dataSourceAttribute = new JsonObject { ["path"] = columnPath };
+			if (columnPath.Contains('.')) {
+				dataSourceAttribute["type"] = "ForwardReference";
+			}
+			dataSourceAttributes[columnPath.Replace('.', '_')] = dataSourceAttribute;
+		}
+		viewModelAttributes[AttributeName("Id")] = new JsonObject {
+			["modelConfig"] = new JsonObject { ["path"] = ModelPath("Id") }
+		};
+
+		var viewModelConfigDiff = new JsonArray {
+			new JsonObject {
+				["operation"] = "merge",
+				["path"] = new JsonArray("attributes", ItemsAttribute, "viewModelConfig", "attributes"),
+				["values"] = viewModelAttributes
+			}
+		};
+		var modelConfigDiff = new JsonArray {
+			new JsonObject {
+				["operation"] = "merge",
+				["path"] = new JsonArray("dataSources", PrimaryDataSourceAlias, "config"),
+				["values"] = new JsonObject {
+					["attributes"] = dataSourceAttributes,
+					["entitySchemaName"] = settings.EntitySchemaName
+				}
+			}
+		};
+
+		// Recorded divergences from the mobile runtime's own converter (see the knowledge record
+		// legacy-list-conversion-divergences-from-the-mobile-runtime): the target is the designer's vocabulary.
+		notes.Add("Subtitle columns land in ListItem.body (together with group columns), not in ListItem.subtitles — this is what the Mobile Freedom UI designer itself generates for a list page; the runtime converter's separate subtitle slot is not reproduced.");
+		notes.Add("Search: BaseMobileListTemplate opens search through crt.OpenSearchListRequest over $Items; this vocabulary has no per-page search-column list, the runtime searches the bound Items attributes (the converted columns), so no searchFilter columns are emitted.");
+		List<LegacyPropertyCoverageInfo> coverage = BuildCoverage(settings, decisions);
+		if (!string.IsNullOrWhiteSpace(settings.GridType)) {
+			notes.Add($"Classic grid layout settings (gridType '{settings.GridType}', rows, columns) describe the classic list only and have no mobile counterpart; the mobile ListItem row has one layout.");
+		}
+		foreach (KeyValuePair<string, Newtonsoft.Json.Linq.JToken> extra in settings.OtherSettingsProperties) {
+			decisions.Add($"Settings property '{extra.Key}' has no counterpart on the mobile list page and was dropped.");
+		}
+
+		IReadOnlyList<string> dropped = coverage.Where(c => c.Status == "dropped").Select(c => c.Property).ToList();
+		var legacySource = new LegacyMobileSourceInfo {
+			SettingsType = settings.SettingsType,
+			EntitySchemaName = settings.EntitySchemaName,
+			Workplace = nameParts?.Workplace,
+			Classification = classification.Label,
+			OverrideSections = classification.OverrideSections.Count > 0
+				? classification.OverrideSections.Select(s => new LegacyOverrideSectionInfo {
+					Section = s.Section, OperationCount = s.OperationCount, Ticket = s.Ticket
+				}).ToList()
+				: null,
+			Layers = read.Layers.Select(l => new LegacyMobileSettingsLayerInfo {
+				SchemaName = l.SchemaName, PackageName = l.PackageName, OperationCount = l.OperationCount
+			}).ToList(),
+			TitleColumn = titleMapping,
+			BodyColumns = bodyMappings,
+			ColumnPropertyCoverage = coverage,
+			Decisions = decisions,
+			Notes = notes.Count > 0 ? notes : null
+		};
+
+		string elementReason = titleMapping is null
+			? $"Legacy wizard list settings for '{settings.EntitySchemaName}': {bodyMappings.Count} body row(s) from subtitleItems/groupItems merge onto the template's ListItem; no title column was defined."
+			: $"Legacy wizard list settings for '{settings.EntitySchemaName}': the items column '{titleMapping.ColumnName}' becomes ListItem.title and {bodyMappings.Count} subtitle/group column(s) become ListItem.body rows, in wizard row order — merged onto the template-provided ListItem (do not insert a duplicate).";
+
+		return new MobilePageConversionGuide {
+			SourcePage = sourcePage,
+			SourceType = SourceTypeLegacyGridPage,
+			SourceTemplate = null,
+			SourceStructure = [],
+			DataSources = [PrimaryDataSourceAlias],
+			ModelConfigDiff = modelConfigDiff,
+			ViewModelConfigDiff = viewModelConfigDiff,
+			RecommendedMobileTemplate = RecommendedTemplate,
+			TemplateNote = "Shipped mobile list template: Scaffold + header (search, sort, folder tree, QuickFilterGroup) + ListContainer with crt.List bound to $Items and a ListItem row. The converter MERGES onto the template's ListItem — it never re-declares any of these elements.",
+			ContainerMap = [],
+			ComponentSuggestions = [],
+			ElementMap = [
+				// Same two merges the Mobile Freedom UI designer writes for a generated list page, in its order:
+				// the folder tree bound to the entity (folder filtering keeps working), then the row.
+				new ElementMapEntry {
+					WebName = LegacyGridPageSettingsParser.SettingsNodeName,
+					WebType = "GridPageSettings",
+					Operation = "merge",
+					MobileName = FolderTreeActionsName,
+					MobileType = FolderTreeActionsType,
+					MobileValues = new JsonObject {
+						["sourceSchemaName"] = FolderTreeSourceSchemaName,
+						["rootSchemaName"] = settings.EntitySchemaName
+					},
+					Reason = $"Folder filtering: the template-provided FolderTreeActions is bound to entity '{settings.EntitySchemaName}' (rootSchemaName) exactly as the Mobile designer does for a generated list page — merge by name, do not insert a duplicate."
+				},
+				new ElementMapEntry {
+					WebName = LegacyGridPageSettingsParser.SettingsNodeName,
+					WebType = "GridPageSettings",
+					Operation = "merge",
+					MobileName = ListItemName,
+					MobileType = ListItemType,
+					MobileValues = mobileValues,
+					Reason = elementReason
+				}
+			],
+			MobileContracts = [],
+			SectionRegistration = sectionRegistration,
+			LegacySource = legacySource,
+			Constraints = BuildConstraints(sourcePage, classification, dropped, titleMapping is null, notes),
+			NextSteps = BuildNextSteps(suggestedTarget, settings.EntitySchemaName),
+			GuidanceArticle = GuidanceArticleName,
+			SuggestedTargetSchemaName = suggestedTarget
+		};
+	}
+
+	private static LegacyColumnMappingInfo Mapping(LegacyGridColumn column, string bucket, string attribute, string target) =>
+		new() {
+			Bucket = bucket,
+			Row = column.Row,
+			ColumnName = column.ColumnName,
+			Caption = column.Caption,
+			DataValueType = column.DataValueType,
+			Attribute = attribute,
+			ModelPath = ModelPath(column.ColumnName),
+			Target = target
+		};
+
+	private static void Register(List<string> order, Dictionary<string, string> byAttribute, string attribute, string columnPath, List<string> notes) {
+		if (string.Equals(attribute, AttributeName("Id"), StringComparison.Ordinal)) {
+			// PDS_Id is always declared LAST by the converter (the row's record key); a wizard column literally
+			// named Id must not declare it a second time or move it.
+			return;
+		}
+		if (byAttribute.ContainsKey(attribute)) {
+			notes.Add($"Column '{columnPath}' appears in more than one wizard bucket; its attribute '{attribute}' is declared once.");
+			return;
+		}
+		byAttribute[attribute] = columnPath;
+		order.Add(attribute);
+	}
+
+	/// <summary>
+	/// Coverage table over every wizard column property: <c>row</c> and <c>columnName</c> transfer (order and
+	/// binding), <c>content</c> and <c>dataValueType</c> are informational (a mobile list row shows the bound
+	/// value; its caption and type come from the entity), and anything else the wizard recorded (view types such as
+	/// phone/email/url/map/preview, formats) has no counterpart on a template ListItem row and is dropped — each
+	/// such property adds a decision for the user.
+	/// </summary>
+	private static List<LegacyPropertyCoverageInfo> BuildCoverage(LegacyGridPageSettings settings, List<string> decisions) {
+		List<LegacyGridColumn> all = settings.Items.Concat(settings.SubtitleItems).Concat(settings.GroupItems).ToList();
+		List<string> allNames = all.Select(c => c.ColumnName).ToList();
+		var coverage = new List<LegacyPropertyCoverageInfo> {
+			new() { Property = "columnName", Status = "transferred", Note = "Bound as $PDS_<column> on the ListItem row; a dotted path becomes a ForwardReference attribute.", Columns = allNames },
+			new() { Property = "row", Status = "transferred", Note = "Wizard row order is kept: title first, then subtitle rows, then group rows.", Columns = allNames },
+			new() { Property = "content", Status = "informational", Note = "Column caption. A mobile list row shows values only; captions are not rendered on ListItem rows.", Columns = all.Where(c => !string.IsNullOrWhiteSpace(c.Caption)).Select(c => c.ColumnName).ToList() },
+			new() { Property = "dataValueType", Status = "informational", Note = "The mobile runtime formats the value from the entity column type; lookups display their primary display value.", Columns = all.Where(c => c.DataValueType is not null).Select(c => c.ColumnName).ToList() }
+		};
+		var extras = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+		foreach (LegacyGridColumn column in all) {
+			foreach (string key in column.OtherProperties.Keys) {
+				if (!extras.TryGetValue(key, out List<string> columns)) {
+					columns = [];
+					extras[key] = columns;
+				}
+				columns.Add(column.ColumnName);
+			}
+		}
+		foreach (KeyValuePair<string, List<string>> extra in extras) {
+			coverage.Add(new LegacyPropertyCoverageInfo {
+				Property = extra.Key,
+				Status = "dropped",
+				Note = "A BaseMobileListTemplate ListItem body row carries only a value binding; this wizard column property has no counterpart and was not transferred.",
+				Columns = extra.Value
+			});
+			decisions.Add($"Column property '{extra.Key}' (on {string.Join(", ", extra.Value)}) is not supported on a mobile ListItem row and was dropped — confirm with the user or configure an alternative manually.");
+		}
+		return coverage;
+	}
+
+	private static List<string> BuildConstraints(
+		string sourcePage, LegacySettingsClassification classification, IReadOnlyList<string> droppedProperties,
+		bool titleMissing, IReadOnlyList<string> notes) {
+		var constraints = new List<string> {
+			"Mobile body is plain JSON with only viewConfigDiff / viewModelConfigDiff / modelConfigDiff — no AMD, no markers, no define() wrapper.",
+			"The mobile template (BaseMobileListTemplate) already provides the Scaffold root, the header (search, sort, folder tree, QuickFilterGroup), the crt.List bound to $Items and its ListItem row — do NOT add a second Scaffold, List, ListItem or QuickFilterGroup. The page only MERGES onto the template's ListItem.",
+			"elementMap carries exactly TWO operations, both merges onto template-provided elements, in order: 'FolderTreeActions' (sourceSchemaName + rootSchemaName, so folder filtering resolves the entity) and 'ListItem' (title / body / icon). Emit each VERBATIM as { \"operation\": \"merge\", \"name\": <mobileName>, \"values\": <mobileValues> } — do not rename attributes (PDS_<Column>), reorder or drop body rows, add properties, or move subtitle columns into a 'subtitles' slot.",
+			"Paste the provided viewModelConfigDiff and modelConfigDiff VERBATIM as the page's viewModelConfigDiff / modelConfigDiff. Keep PDS_Id and every attribute path exactly as provided (a dotted column carries type ForwardReference); do NOT collapse them into a root merge, hand-build the data-source section, or copy it from another mobile body.",
+			"Source is a legacy Mobile-wizard LIST settings schema (settingsType GridPage). Only the wizard buckets were converted: items -> ListItem.title, subtitleItems then groupItems (row order) -> ListItem.body. Read guide.legacySource for the column mapping, the contributing package layers and the columnPropertyCoverage table, and present them at the plan gate."
+		};
+		if (classification.Kind == LegacySettingsKind.FreedomUiOverrides) {
+			string sections = string.Join(", ", classification.OverrideSections.Select(s => s.Section));
+			constraints.Add($"The settings schema ALSO carries Freedom UI override sections ({sections}) — they were RECOGNISED but NOT converted ({LegacyMobileSettingsClassifier.OverridesTicket}). Tell the user; do not merge them by hand.");
+		}
+		if (droppedProperties.Count > 0) {
+			constraints.Add($"Dropped column properties need a user decision before you build: {string.Join(", ", droppedProperties)}. Present them at the plan gate (Gate M); never invent a mobile equivalent.");
+		}
+		if (titleMissing) {
+			constraints.Add("No title column was found in the wizard settings: ask the user which column becomes ListItem.title, then add \"title\": \"$PDS_<Column>\" to the ListItem merge and the matching PDS_<Column> attribute to both diffs.");
+		}
+		foreach (string note in notes.Where(n => n.Contains("NOT part of the resolved hierarchy", StringComparison.Ordinal))) {
+			constraints.Add(note);
+		}
+		constraints.Add($"The classic settings schema '{sourcePage}' is left untouched — nothing is written to it — and re-running this tool yields the same guide (idempotent).");
+		return constraints;
+	}
+
+	private static List<string> BuildNextSteps(string suggestedTarget, string entitySchemaName) => [
+		$"Read get-guidance with name \"{GuidanceArticleName}\".",
+		"Present the plan from guide.legacySource: which page will be created, the title column and body rows that transfer, what was adapted, the dropped column properties and why, the open decisions, and the packages that contributed. Wait for explicit approval (Gate M) — nothing is written before it.",
+		$"Create the target mobile page with create-page: schema-name={suggestedTarget}, template={RecommendedTemplate}, entity-schema-name={entitySchemaName}, in the user's target package.",
+		"Build the body: viewConfigDiff = [ the elementMap merges in order — 'FolderTreeActions' then 'ListItem' — each with its mobileValues verbatim ]; viewModelConfigDiff and modelConfigDiff = the provided diffs pasted verbatim.",
+		"Validate the body with validate-page; resolve findings only by asking the user — never by silently editing the pasted values.",
+		"Persist with update-page (mode replace), then read the page back with get-page and confirm ListItem.title / body and the PDS_* attributes match guide.legacySource before reporting success.",
+		"Register the section for mobile per guide.sectionRegistration after approval (Gate S), then open the result in Freedom UI Mobile Designer for final review."
+	];
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
@@ -120,6 +120,10 @@ public static class LegacyMobileListAnalysisService {
 	/// Entity column name → caption, read best-effort from the object. Used only where an override references a
 	/// column the wizard never placed, so a carried sort option can show a real label instead of a machine name.
 	/// </param>
+	/// <param name="templateElements">
+	/// Every element the target template declares, read from the stand. Designer targets are verified against it,
+	/// so a name that does not exist is reported instead of authored. Null means the template could not be read.
+	/// </param>
 	/// <param name="runtimeNames">
 	/// The runtime-name table used to re-point embedded overrides (ENG-95733); null switches the override pass off
 	/// and every embedded operation is reported instead.
@@ -133,7 +137,8 @@ public static class LegacyMobileListAnalysisService {
 		SectionRegistrationInfo sectionRegistration,
 		MobileLegacyTemplateRule template,
 		MobileLegacyRuntimeNameSet runtimeNames = null,
-		IReadOnlyDictionary<string, string> columnCaptions = null) {
+		IReadOnlyDictionary<string, string> columnCaptions = null,
+		IReadOnlySet<string> templateElements = null) {
 		ArgumentNullException.ThrowIfNull(read);
 		ArgumentNullException.ThrowIfNull(classification);
 		if (!read.Success || read.EffectiveSettings is null) {
@@ -145,7 +150,8 @@ public static class LegacyMobileListAnalysisService {
 		// Embedded overrides are re-pointed BEFORE conversion, so anything expressible in the wizard's own language
 		// flows through the single emit path below and the page stays a pure function of one model.
 		LegacyOverrideRebaseResult rebase = LegacyOverrideRebaser.Rebase(parsed, classification.OverrideSections,
-			LegacyRuntimeNameOracle.Build(parsed, runtimeNames), template, runtimeNames, columnCaptions);
+			LegacyRuntimeNameOracle.Build(parsed, runtimeNames), template, runtimeNames, columnCaptions,
+			templateElements);
 		LegacyGridPageSettings settings = rebase.Settings;
 		var decisions = new List<string>();
 		var notes = new List<string>(read.Notes ?? []);
@@ -312,7 +318,8 @@ public static class LegacyMobileListAnalysisService {
 			MobileContracts = [],
 			SectionRegistration = sectionRegistration,
 			LegacySource = legacySource,
-			Constraints = BuildConstraints(sourcePage, classification, dropped, titleMapping is null, notes, template, rebase),
+			Constraints = BuildConstraints(sourcePage, classification, dropped, titleMapping is null, notes, template,
+				rebase, templateElements),
 			GuidanceArticle = GuidanceArticleName,
 			SuggestedTargetSchemaName = suggestedTarget
 		};
@@ -465,7 +472,7 @@ public static class LegacyMobileListAnalysisService {
 	private static List<string> BuildConstraints(
 		string sourcePage, LegacySettingsClassification classification, IReadOnlyList<string> droppedProperties,
 		bool titleMissing, IReadOnlyList<string> notes, MobileLegacyTemplateRule template,
-		LegacyOverrideRebaseResult rebase) {
+		LegacyOverrideRebaseResult rebase, IReadOnlySet<string> templateElements) {
 		var constraints = new List<string> {
 			"Mobile body is plain JSON with only viewConfigDiff / viewModelConfigDiff / modelConfigDiff — no AMD, no markers, no define() wrapper.",
 			$"The mobile template ({template.TemplateName}) already provides the Scaffold root, the header (search, sort, folder tree, QuickFilterGroup), the '{template.ListName}' bound to ${template.ItemsAttributeName} inside '{template.ListContainerName}', and its '{template.ListItemName}' row — do NOT add a second Scaffold, {template.ListName}, {template.ListItemName} or QuickFilterGroup. The page only MERGES onto the template's {template.ListItemName}.",
@@ -498,6 +505,16 @@ public static class LegacyMobileListAnalysisService {
 		// skip, and an override whose outcome differs from what it asked for must not be discoverable only by
 		// reading a report section.
 		constraints.AddRange(rebase.Warnings);
+		// The two merges the converter always writes address TEMPLATE elements. If the template does not declare
+		// them the page authors nothing and no validation catches it, so the mismatch is stated up front.
+		if (templateElements is null) {
+			constraints.Add($"The target template '{template.TemplateName}' could not be read, so the element names in elementMap are UNVERIFIED. Confirm the page renders before reporting success.");
+		} else {
+			foreach (string required in new[] { template.FolderTreeActionsName, template.ListItemName }
+				.Where(name => !templateElements.Contains(name))) {
+				constraints.Add($"The target template '{template.TemplateName}' does not declare '{required}', which this conversion merges onto. The merge would author nothing — check the template before writing the page.");
+			}
+		}
 		foreach (string note in notes.Where(n => n.Contains("NOT part of the resolved hierarchy", StringComparison.Ordinal))) {
 			constraints.Add(note);
 		}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
@@ -32,26 +32,27 @@ public static class LegacyMobileListAnalysisService {
 	/// <summary>Mechanism label reported for a legacy Mobile-wizard settings source.</summary>
 	public const string MechanismLegacySettingsConverter = "legacy-mobile-settings-converter";
 
-	/// <summary>The shipped mobile list template every converted legacy list page inherits.</summary>
-	public const string RecommendedTemplate = "BaseMobileListTemplate";
-
-	/// <summary>The template's row element the guide merges onto.</summary>
-	public const string ListItemName = "ListItem";
-
-	/// <summary>The template's folder-tree action element the guide binds to the entity (folder filtering).</summary>
-	public const string FolderTreeActionsName = "FolderTreeActions";
-
-	/// <summary>The folder schema name the shipped template and the designer both put on FolderTreeActions.</summary>
-	public const string FolderTreeSourceSchemaName = "FolderTree";
-
 	/// <summary>Default fallback when the environment's SchemaNamePrefix cannot be read.</summary>
 	public const string DefaultSchemaNamePrefix = "Usr";
 
+	/// <summary>
+	/// Bundled fallback used when the rules file carries no <c>mobileLegacyTemplates.gridPage</c> group. The rules
+	/// file is CDN-fetchable, so the file most likely to lack the group is an OLD one; degrading to the bundled
+	/// defaults keeps the legacy branch behaving exactly as it did before the group existed.
+	/// </summary>
+	public static readonly MobileLegacyTemplateRule DefaultGridPageTemplate = new();
+
+	/// <summary>
+	/// Resolves the shipped mobile list template and the names of the template-provided elements a converted
+	/// legacy list page merges onto, from the conversion rules; never null.
+	/// </summary>
+	/// <param name="rules">The loaded conversion rules, or null when they could not be fetched.</param>
+	/// <returns>The grid-page template configuration, or <see cref="DefaultGridPageTemplate"/>.</returns>
+	public static MobileLegacyTemplateRule ResolveGridPageTemplate(WebToMobilePageConversionRules rules) =>
+		rules?.MobileLegacyTemplates?.GridPage ?? DefaultGridPageTemplate;
+
 	private const string GuidanceArticleName = "freedom-page-web-to-mobile-conversion";
 	private const string PrimaryDataSourceAlias = "PDS";
-	private const string ItemsAttribute = "Items";
-	private const string ListItemType = "crt.ListItem";
-	private const string FolderTreeActionsType = "crt.FolderTreeActions";
 	private const string BucketTitle = "title";
 	private const string BucketSubtitle = "subtitle";
 	private const string BucketGroup = "group";
@@ -111,19 +112,41 @@ public static class LegacyMobileListAnalysisService {
 	/// <param name="sourcePage">The source schema name.</param>
 	/// <param name="suggestedTarget">The target mobile page name.</param>
 	/// <param name="sectionRegistration">Read-only section registration facts, or null when not probed.</param>
+	/// <param name="template">
+	/// Target template configuration from the conversion rules (<see cref="ResolveGridPageTemplate"/>); null
+	/// degrades to <see cref="DefaultGridPageTemplate"/>.
+	/// </param>
+	/// <param name="columnCaptions">
+	/// Entity column name → caption, read best-effort from the object. Used only where an override references a
+	/// column the wizard never placed, so a carried sort option can show a real label instead of a machine name.
+	/// </param>
+	/// <param name="runtimeNames">
+	/// The runtime-name table used to re-point embedded overrides (ENG-95733); null switches the override pass off
+	/// and every embedded operation is reported instead.
+	/// </param>
 	/// <returns>The advisory guide.</returns>
 	public static MobilePageConversionGuide Analyze(
 		LegacyMobileSettingsReadResult read,
 		LegacySettingsClassification classification,
 		string sourcePage,
 		string suggestedTarget,
-		SectionRegistrationInfo sectionRegistration) {
+		SectionRegistrationInfo sectionRegistration,
+		MobileLegacyTemplateRule template,
+		MobileLegacyRuntimeNameSet runtimeNames = null,
+		IReadOnlyDictionary<string, string> columnCaptions = null) {
 		ArgumentNullException.ThrowIfNull(read);
 		ArgumentNullException.ThrowIfNull(classification);
 		if (!read.Success || read.EffectiveSettings is null) {
 			throw new InvalidOperationException("Analyze requires a successful legacy settings read.");
 		}
-		LegacyGridPageSettings settings = LegacyGridPageSettingsParser.Parse(read.EffectiveSettings);
+		template ??= DefaultGridPageTemplate;
+		LegacyGridPageSettings parsed = LegacyGridPageSettingsParser.Parse(read.EffectiveSettings);
+
+		// Embedded overrides are re-pointed BEFORE conversion, so anything expressible in the wizard's own language
+		// flows through the single emit path below and the page stays a pure function of one model.
+		LegacyOverrideRebaseResult rebase = LegacyOverrideRebaser.Rebase(parsed, classification.OverrideSections,
+			LegacyRuntimeNameOracle.Build(parsed, runtimeNames), template, runtimeNames, columnCaptions);
+		LegacyGridPageSettings settings = rebase.Settings;
 		var decisions = new List<string>();
 		var notes = new List<string>(read.Notes ?? []);
 		notes.AddRange(classification.Notes ?? []);
@@ -157,15 +180,20 @@ public static class LegacyMobileListAnalysisService {
 		foreach ((LegacyGridColumn column, string bucket) in bodySource) {
 			string attribute = AttributeName(column.ColumnName);
 			bodyRows.Add(new JsonObject { ["value"] = $"${attribute}" });
-			bodyMappings.Add(Mapping(column, bucket, attribute, $"{ListItemName}.body[{bodyIndex}]"));
+			bodyMappings.Add(Mapping(column, bucket, attribute, $"{template.ListItemName}.body[{bodyIndex}]"));
 			Register(attributeOrder, attributeColumn, attribute, column.ColumnName, notes);
 			bodyIndex++;
 		}
 		LegacyColumnMappingInfo titleMapping = null;
 		if (titleColumn is not null) {
 			string attribute = AttributeName(titleColumn.ColumnName);
-			titleMapping = Mapping(titleColumn, BucketTitle, attribute, $"{ListItemName}.title");
+			titleMapping = Mapping(titleColumn, BucketTitle, attribute, $"{template.ListItemName}.title");
 			Register(attributeOrder, attributeColumn, attribute, titleColumn.ColumnName, notes);
+		}
+		// A carried override can bind a column the wizard never placed (a row icon, for example). Its attribute is
+		// declared exactly like a wizard column — before PDS_Id, which stays last — or the binding would be dead.
+		foreach (string column in rebase.RequiredColumns) {
+			Register(attributeOrder, attributeColumn, AttributeName(column), column, notes);
 		}
 
 		// The template's ListItem merge (key order mirrors the designer's own output: body, title, icon).
@@ -174,6 +202,12 @@ public static class LegacyMobileListAnalysisService {
 			mobileValues["title"] = $"${titleMapping.Attribute}";
 		}
 		mobileValues["icon"] = null;
+		// The override wins on every key it names: it is the later, more specific customisation of the same row.
+		if (rebase.ElementValueOverrides.TryGetValue(template.ListItemName, out JsonObject rowOverrides)) {
+			foreach (KeyValuePair<string, JsonNode> pair in rowOverrides) {
+				mobileValues[pair.Key] = pair.Value?.DeepClone();
+			}
+		}
 
 		var viewModelAttributes = new JsonObject();
 		var dataSourceAttributes = new JsonObject();
@@ -195,7 +229,7 @@ public static class LegacyMobileListAnalysisService {
 		var viewModelConfigDiff = new JsonArray {
 			new JsonObject {
 				["operation"] = "merge",
-				["path"] = new JsonArray("attributes", ItemsAttribute, "viewModelConfig", "attributes"),
+				["path"] = new JsonArray("attributes", template.ItemsAttributeName, "viewModelConfig", "attributes"),
 				["values"] = viewModelAttributes
 			}
 		};
@@ -209,12 +243,20 @@ public static class LegacyMobileListAnalysisService {
 				}
 			}
 		};
+		// Rebased overrides land AFTER the converted sections, so an override refines what the wizard produced
+		// rather than being overwritten by it.
+		foreach (JsonObject operation in rebase.ViewModelConfigOperations) {
+			viewModelConfigDiff.Add(operation.DeepClone());
+		}
+		foreach (JsonObject operation in rebase.ModelConfigOperations) {
+			modelConfigDiff.Add(operation.DeepClone());
+		}
 
 		// Recorded divergences from the mobile runtime's own converter (see the knowledge record
 		// legacy-list-conversion-divergences-from-the-mobile-runtime): the target is the designer's vocabulary.
 		notes.Add("Subtitle columns land in ListItem.body (together with group columns), not in ListItem.subtitles — this is what the Mobile Freedom UI designer itself generates for a list page; the runtime converter's separate subtitle slot is not reproduced.");
-		notes.Add("Search: BaseMobileListTemplate opens search through crt.OpenSearchListRequest over $Items; this vocabulary has no per-page search-column list, the runtime searches the bound Items attributes (the converted columns), so no searchFilter columns are emitted.");
-		List<LegacyPropertyCoverageInfo> coverage = BuildCoverage(settings, decisions);
+		notes.Add($"Search: {template.TemplateName} opens search through crt.OpenSearchListRequest over ${template.ItemsAttributeName}; this vocabulary has no per-page search-column list, the runtime searches the bound {template.ItemsAttributeName} attributes (the converted columns), so no searchFilter columns are emitted.");
+		List<LegacyPropertyCoverageInfo> coverage = BuildCoverage(settings, decisions, template);
 		if (!string.IsNullOrWhiteSpace(settings.GridType)) {
 			notes.Add($"Classic grid layout settings (gridType '{settings.GridType}', rows, columns) describe the classic list only and have no mobile counterpart; the mobile ListItem row has one layout.");
 		}
@@ -230,7 +272,8 @@ public static class LegacyMobileListAnalysisService {
 			Classification = classification.Label,
 			OverrideSections = classification.OverrideSections.Count > 0
 				? classification.OverrideSections.Select(s => new LegacyOverrideSectionInfo {
-					Section = s.Section, OperationCount = s.OperationCount, Ticket = s.Ticket
+					Section = s.Section, OperationCount = s.OperationCount, Ticket = s.Ticket,
+					Supported = s.Supported, Reason = s.Reason
 				}).ToList()
 				: null,
 			Layers = read.Layers.Select(l => new LegacyMobileSettingsLayerInfo {
@@ -239,6 +282,12 @@ public static class LegacyMobileListAnalysisService {
 			TitleColumn = titleMapping,
 			BodyColumns = bodyMappings,
 			ColumnPropertyCoverage = coverage,
+			OverrideOutcomes = rebase.Outcomes.Count > 0
+				? rebase.Outcomes.Select(o => new LegacyOverrideOutcomeInfo {
+					Section = o.Section, Index = o.Index, Operation = o.Operation, Target = o.Target,
+					Lane = o.Lane, Effect = o.Effect, Reason = o.Reason
+				}).ToList()
+				: null,
 			Decisions = decisions,
 			Notes = notes.Count > 0 ? notes : null
 		};
@@ -255,40 +304,15 @@ public static class LegacyMobileListAnalysisService {
 			DataSources = [PrimaryDataSourceAlias],
 			ModelConfigDiff = modelConfigDiff,
 			ViewModelConfigDiff = viewModelConfigDiff,
-			RecommendedMobileTemplate = RecommendedTemplate,
-			TemplateNote = "Shipped mobile list template: Scaffold + header (search, sort, folder tree, QuickFilterGroup) + ListContainer with crt.List bound to $Items and a ListItem row. The converter MERGES onto the template's ListItem — it never re-declares any of these elements.",
+			RecommendedMobileTemplate = template.TemplateName,
+			TemplateNote = $"Shipped mobile list template '{template.TemplateName}': Scaffold + header (search, sort, folder tree, QuickFilterGroup) + '{template.ListContainerName}' with '{template.ListName}' bound to ${template.ItemsAttributeName} and a '{template.ListItemName}' row. The converter MERGES onto the template's {template.ListItemName} — it never re-declares any of these elements.",
 			ContainerMap = [],
 			ComponentSuggestions = [],
-			ElementMap = [
-				// Same two merges the Mobile Freedom UI designer writes for a generated list page, in its order:
-				// the folder tree bound to the entity (folder filtering keeps working), then the row.
-				new ElementMapEntry {
-					WebName = LegacyGridPageSettingsParser.SettingsNodeName,
-					WebType = "GridPageSettings",
-					Operation = "merge",
-					MobileName = FolderTreeActionsName,
-					MobileType = FolderTreeActionsType,
-					MobileValues = new JsonObject {
-						["sourceSchemaName"] = FolderTreeSourceSchemaName,
-						["rootSchemaName"] = settings.EntitySchemaName
-					},
-					Reason = $"Folder filtering: the template-provided FolderTreeActions is bound to entity '{settings.EntitySchemaName}' (rootSchemaName) exactly as the Mobile designer does for a generated list page — merge by name, do not insert a duplicate."
-				},
-				new ElementMapEntry {
-					WebName = LegacyGridPageSettingsParser.SettingsNodeName,
-					WebType = "GridPageSettings",
-					Operation = "merge",
-					MobileName = ListItemName,
-					MobileType = ListItemType,
-					MobileValues = mobileValues,
-					Reason = elementReason
-				}
-			],
+			ElementMap = BuildElementMap(settings, template, mobileValues, elementReason, rebase),
 			MobileContracts = [],
 			SectionRegistration = sectionRegistration,
 			LegacySource = legacySource,
-			Constraints = BuildConstraints(sourcePage, classification, dropped, titleMapping is null, notes),
-			NextSteps = BuildNextSteps(suggestedTarget, settings.EntitySchemaName),
+			Constraints = BuildConstraints(sourcePage, classification, dropped, titleMapping is null, notes, template, rebase),
 			GuidanceArticle = GuidanceArticleName,
 			SuggestedTargetSchemaName = suggestedTarget
 		};
@@ -327,13 +351,13 @@ public static class LegacyMobileListAnalysisService {
 	/// phone/email/url/map/preview, formats) has no counterpart on a template ListItem row and is dropped — each
 	/// such property adds a decision for the user.
 	/// </summary>
-	private static List<LegacyPropertyCoverageInfo> BuildCoverage(LegacyGridPageSettings settings, List<string> decisions) {
+	private static List<LegacyPropertyCoverageInfo> BuildCoverage(LegacyGridPageSettings settings, List<string> decisions, MobileLegacyTemplateRule template) {
 		List<LegacyGridColumn> all = settings.Items.Concat(settings.SubtitleItems).Concat(settings.GroupItems).ToList();
 		List<string> allNames = all.Select(c => c.ColumnName).ToList();
 		var coverage = new List<LegacyPropertyCoverageInfo> {
 			new() { Property = "columnName", Status = "transferred", Note = "Bound as $PDS_<column> on the ListItem row; a dotted path becomes a ForwardReference attribute.", Columns = allNames },
 			new() { Property = "row", Status = "transferred", Note = "Wizard row order is kept: title first, then subtitle rows, then group rows.", Columns = allNames },
-			new() { Property = "content", Status = "informational", Note = "Column caption. A mobile list row shows values only; captions are not rendered on ListItem rows.", Columns = all.Where(c => !string.IsNullOrWhiteSpace(c.Caption)).Select(c => c.ColumnName).ToList() },
+			new() { Property = "content", Status = "informational", Note = "Column caption. A converted list row shows the column's LABEL from the object, not this wizard caption, and the label cannot be switched off per column.", Columns = all.Where(c => !string.IsNullOrWhiteSpace(c.Caption)).Select(c => c.ColumnName).ToList() },
 			new() { Property = "dataValueType", Status = "informational", Note = "The mobile runtime formats the value from the entity column type; lookups display their primary display value.", Columns = all.Where(c => c.DataValueType is not null).Select(c => c.ColumnName).ToList() }
 		};
 		var extras = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
@@ -350,27 +374,119 @@ public static class LegacyMobileListAnalysisService {
 			coverage.Add(new LegacyPropertyCoverageInfo {
 				Property = extra.Key,
 				Status = "dropped",
-				Note = "A BaseMobileListTemplate ListItem body row carries only a value binding; this wizard column property has no counterpart and was not transferred.",
+				Note = $"A {template.TemplateName} {template.ListItemName} body row carries only a value binding; this wizard column property has no counterpart and was not transferred.",
 				Columns = extra.Value
 			});
-			decisions.Add($"Column property '{extra.Key}' (on {string.Join(", ", extra.Value)}) is not supported on a mobile ListItem row and was dropped — confirm with the user or configure an alternative manually.");
+			decisions.Add($"Column property '{extra.Key}' (on {string.Join(", ", extra.Value)}) is not supported on a mobile {template.ListItemName} row and was dropped — confirm with the user or configure an alternative manually.");
 		}
 		return coverage;
 	}
 
+	/// <summary>
+	/// The page's element map: the two merges the Mobile Freedom UI designer writes for a generated list page,
+	/// followed by whatever an embedded override contributed that only the target dialect can express (ENG-95733).
+	/// Built rather than literal, because the number of operations now depends on the source.
+	/// </summary>
+	private static List<ElementMapEntry> BuildElementMap(
+		LegacyGridPageSettings settings, MobileLegacyTemplateRule template, JsonObject mobileValues,
+		string elementReason, LegacyOverrideRebaseResult rebase) {
+		var map = new List<ElementMapEntry> {
+			// The folder tree bound to the entity (folder filtering keeps working), then the row.
+			new() {
+				WebName = LegacyGridPageSettingsParser.SettingsNodeName,
+				WebType = "GridPageSettings",
+				Operation = "merge",
+				MobileName = template.FolderTreeActionsName,
+				MobileType = template.FolderTreeActionsType,
+				MobileValues = Fold(new JsonObject {
+					["sourceSchemaName"] = template.FolderSourceSchemaName,
+					["rootSchemaName"] = settings.EntitySchemaName
+				}, rebase, template.FolderTreeActionsName),
+				Reason = $"Folder filtering: the template-provided {template.FolderTreeActionsName} is bound to entity '{settings.EntitySchemaName}' (rootSchemaName) exactly as the Mobile designer does for a generated list page — merge by name, do not insert a duplicate."
+			},
+			new() {
+				WebName = LegacyGridPageSettingsParser.SettingsNodeName,
+				WebType = "GridPageSettings",
+				Operation = "merge",
+				MobileName = template.ListItemName,
+				MobileType = template.ListItemType,
+				MobileValues = mobileValues,
+				Reason = elementReason
+			}
+		};
+		// A template element the converter does not otherwise write, carrying override values, becomes its own merge.
+		foreach (KeyValuePair<string, JsonObject> pair in rebase.ElementValueOverrides) {
+			if (string.Equals(pair.Key, template.ListItemName, StringComparison.Ordinal)
+				|| string.Equals(pair.Key, template.FolderTreeActionsName, StringComparison.Ordinal)) {
+				continue;
+			}
+			LegacyOverrideOutcome source = rebase.Outcomes.FirstOrDefault(
+				o => o.Effect is not null && o.Effect.Contains($"'{pair.Key}'", StringComparison.Ordinal));
+			map.Add(new ElementMapEntry {
+				WebName = source?.Target ?? LegacyGridPageSettingsParser.SettingsNodeName,
+				WebType = "GridPageSettings",
+				Operation = "merge",
+				MobileName = pair.Key,
+				MobileValues = pair.Value,
+				Reason = source is null
+					? $"Carried over from an embedded Freedom UI override in the source settings."
+					: $"Embedded Freedom UI override ({source.Section}[{source.Index}] {source.Operation} '{source.Target}'): {source.Effect}"
+			});
+		}
+		foreach (JsonObject operation in rebase.ViewConfigOperations) {
+			string name = operation["name"]?.GetValue<string>();
+			LegacyOverrideOutcome outcome = rebase.Outcomes.FirstOrDefault(
+				o => o.Lane == LegacyOverrideLanes.TargetDelta && o.Effect is not null && o.Effect.Contains($"'{name}'", StringComparison.Ordinal));
+			map.Add(new ElementMapEntry {
+				WebName = outcome?.Target ?? LegacyGridPageSettingsParser.SettingsNodeName,
+				WebType = "GridPageSettings",
+				Operation = operation["operation"]?.GetValue<string>() ?? "remove",
+				MobileName = name,
+				MobileValues = operation["values"]?.DeepClone() as JsonObject,
+				Reason = outcome?.Effect is null
+					? $"Carried over from an embedded Freedom UI override in the source settings."
+					: $"Embedded Freedom UI override ({outcome.Section}[{outcome.Index}] {outcome.Operation} '{outcome.Target}'): {outcome.Effect}"
+			});
+		}
+		return map;
+	}
+
+	/// <summary>Folds an element's override values over the converter's own; the override wins on every key it names.</summary>
+	private static JsonObject Fold(JsonObject own, LegacyOverrideRebaseResult rebase, string elementName) {
+		if (!rebase.ElementValueOverrides.TryGetValue(elementName, out JsonObject overrides)) {
+			return own;
+		}
+		foreach (KeyValuePair<string, JsonNode> pair in overrides) {
+			own[pair.Key] = pair.Value?.DeepClone();
+		}
+		return own;
+	}
+
 	private static List<string> BuildConstraints(
 		string sourcePage, LegacySettingsClassification classification, IReadOnlyList<string> droppedProperties,
-		bool titleMissing, IReadOnlyList<string> notes) {
+		bool titleMissing, IReadOnlyList<string> notes, MobileLegacyTemplateRule template,
+		LegacyOverrideRebaseResult rebase) {
 		var constraints = new List<string> {
 			"Mobile body is plain JSON with only viewConfigDiff / viewModelConfigDiff / modelConfigDiff — no AMD, no markers, no define() wrapper.",
-			"The mobile template (BaseMobileListTemplate) already provides the Scaffold root, the header (search, sort, folder tree, QuickFilterGroup), the crt.List bound to $Items and its ListItem row — do NOT add a second Scaffold, List, ListItem or QuickFilterGroup. The page only MERGES onto the template's ListItem.",
-			"elementMap carries exactly TWO operations, both merges onto template-provided elements, in order: 'FolderTreeActions' (sourceSchemaName + rootSchemaName, so folder filtering resolves the entity) and 'ListItem' (title / body / icon). Emit each VERBATIM as { \"operation\": \"merge\", \"name\": <mobileName>, \"values\": <mobileValues> } — do not rename attributes (PDS_<Column>), reorder or drop body rows, add properties, or move subtitle columns into a 'subtitles' slot.",
+			$"The mobile template ({template.TemplateName}) already provides the Scaffold root, the header (search, sort, folder tree, QuickFilterGroup), the '{template.ListName}' bound to ${template.ItemsAttributeName} inside '{template.ListContainerName}', and its '{template.ListItemName}' row — do NOT add a second Scaffold, {template.ListName}, {template.ListItemName} or QuickFilterGroup. The page only MERGES onto the template's {template.ListItemName}.",
+			$"elementMap starts with TWO merges onto template-provided elements, in order: '{template.FolderTreeActionsName}' (sourceSchemaName + rootSchemaName, so folder filtering resolves the entity) and '{template.ListItemName}' (title / body / icon). Any FURTHER entry comes from an embedded Freedom UI override and carries its own operation. Emit every entry VERBATIM as {{ \"operation\": <operation>, \"name\": <mobileName>, \"values\": <mobileValues> }} in the given order, omitting \"values\" when the entry has none — do not rename attributes (PDS_<Column>), reorder or drop body rows, add properties, or move subtitle columns into a 'subtitles' slot.",
 			"Paste the provided viewModelConfigDiff and modelConfigDiff VERBATIM as the page's viewModelConfigDiff / modelConfigDiff. Keep PDS_Id and every attribute path exactly as provided (a dotted column carries type ForwardReference); do NOT collapse them into a root merge, hand-build the data-source section, or copy it from another mobile body.",
 			"Source is a legacy Mobile-wizard LIST settings schema (settingsType GridPage). Only the wizard buckets were converted: items -> ListItem.title, subtitleItems then groupItems (row order) -> ListItem.body. Read guide.legacySource for the column mapping, the contributing package layers and the columnPropertyCoverage table, and present them at the plan gate."
 		};
 		if (classification.Kind == LegacySettingsKind.FreedomUiOverrides) {
-			string sections = string.Join(", ", classification.OverrideSections.Select(s => s.Section));
-			constraints.Add($"The settings schema ALSO carries Freedom UI override sections ({sections}) — they were RECOGNISED but NOT converted ({LegacyMobileSettingsClassifier.OverridesTicket}). Tell the user; do not merge them by hand.");
+			// Two different verdicts, kept apart on purpose: a section this converter processes operation by
+			// operation, versus one it will never process. Collapsing them would tell the user to wait for
+			// something that is not coming.
+			List<LegacyOverrideSection> processed = classification.OverrideSections.Where(s => s.Supported).ToList();
+			List<LegacyOverrideSection> refused = classification.OverrideSections.Where(s => !s.Supported).ToList();
+			if (processed.Count > 0) {
+				int carried = rebase.Outcomes.Count(o => o.Lane != LegacyOverrideLanes.Reported);
+				int reported = rebase.Outcomes.Count - carried;
+				constraints.Add($"The settings schema ALSO carries Freedom UI override sections ({string.Join(", ", processed.Select(s => s.Section))}). Each operation was re-pointed individually: {carried} carried over, {reported} could not be. Read guide.legacySource.overrideOutcomes and present EVERY reported one at the plan gate — each names its source operation and the reason. Never carry a reported operation by hand — each was held back for the reason it states, and a partial re-application is worse than none.");
+			}
+			foreach (LegacyOverrideSection section in refused) {
+				constraints.Add($"Override section '{section.Section}' ({section.OperationCount} operation(s)) is NOT supported by this converter and was not carried over. {section.Reason} Tell the user; never translate it by hand into the converted page.");
+			}
 		}
 		if (droppedProperties.Count > 0) {
 			constraints.Add($"Dropped column properties need a user decision before you build: {string.Join(", ", droppedProperties)}. Present them at the plan gate (Gate M); never invent a mobile equivalent.");
@@ -378,6 +494,10 @@ public static class LegacyMobileListAnalysisService {
 		if (titleMissing) {
 			constraints.Add("No title column was found in the wizard settings: ask the user which column becomes ListItem.title, then add \"title\": \"$PDS_<Column>\" to the ListItem merge and the matching PDS_<Column> attribute to both diffs.");
 		}
+		// Warnings about embedded overrides live HERE and nowhere else: constraints is the block the caller cannot
+		// skip, and an override whose outcome differs from what it asked for must not be discoverable only by
+		// reading a report section.
+		constraints.AddRange(rebase.Warnings);
 		foreach (string note in notes.Where(n => n.Contains("NOT part of the resolved hierarchy", StringComparison.Ordinal))) {
 			constraints.Add(note);
 		}
@@ -385,13 +505,4 @@ public static class LegacyMobileListAnalysisService {
 		return constraints;
 	}
 
-	private static List<string> BuildNextSteps(string suggestedTarget, string entitySchemaName) => [
-		$"Read get-guidance with name \"{GuidanceArticleName}\".",
-		"Present the plan from guide.legacySource: which page will be created, the title column and body rows that transfer, what was adapted, the dropped column properties and why, the open decisions, and the packages that contributed. Wait for explicit approval (Gate M) — nothing is written before it.",
-		$"Create the target mobile page with create-page: schema-name={suggestedTarget}, template={RecommendedTemplate}, entity-schema-name={entitySchemaName}, in the user's target package.",
-		"Build the body: viewConfigDiff = [ the elementMap merges in order — 'FolderTreeActions' then 'ListItem' — each with its mobileValues verbatim ]; viewModelConfigDiff and modelConfigDiff = the provided diffs pasted verbatim.",
-		"Validate the body with validate-page; resolve findings only by asking the user — never by silently editing the pasted values.",
-		"Persist with update-page (mode replace), then read the page back with get-page and confirm ListItem.title / body and the PDS_* attributes match guide.legacySource before reporting success.",
-		"Register the section for mobile per guide.sectionRegistration after approval (Gate S), then open the result in Freedom UI Mobile Designer for final review."
-	];
 }

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifier.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifier.cs
@@ -16,8 +16,25 @@ public enum LegacySettingsKind {
 	CustomViewConfig
 }
 
-/// <summary>A Freedom UI override section found inside legacy settings.</summary>
-public sealed record LegacyOverrideSection(string Section, int OperationCount, string Ticket);
+/// <summary>
+/// A Freedom UI override section found inside legacy settings, with the operations it carries.
+/// </summary>
+/// <param name="Section">The settings key the section came from.</param>
+/// <param name="OperationCount">Operation count, or -1 when the section could not be parsed as an array.</param>
+/// <param name="Ticket">The story that owns converting the section, when one does; null once it is converted here.</param>
+/// <param name="Supported">Whether the converter processes this section at all.</param>
+/// <param name="Reason">Why the section is not processed; null when it is.</param>
+/// <param name="Operations">
+/// The parsed operations, retained so the rebaser does not have to parse the section a second time. Null when
+/// the section is unsupported or could not be parsed — never an empty array standing in for "unknown".
+/// </param>
+public sealed record LegacyOverrideSection(
+	string Section,
+	int OperationCount,
+	string Ticket,
+	bool Supported = false,
+	string Reason = null,
+	JArray Operations = null);
 
 /// <summary>Static classification of a merged legacy settings node.</summary>
 public sealed record LegacySettingsClassification(
@@ -42,8 +59,21 @@ public static class LegacyMobileSettingsClassifier {
 	/// <summary>The story that owns converting embedded Freedom UI overrides.</summary>
 	public const string OverridesTicket = "ENG-95733";
 
+	/// <summary>Why <c>diffV2</c> is reported rather than translated.</summary>
+	internal const string DiffV2UnsupportedReason =
+		"diffV2 is the previous-generation override format. The mobile runtime does not translate it either — its "
+		+ "converter registers the inserted names and passes the array through verbatim — so there is no reference "
+		+ "behaviour to port, and a translation would be guesswork. Re-author these operations as viewConfigDiff / "
+		+ "viewModelConfigDiff / modelConfigDiff on the source schema, or apply them by hand after conversion.";
+
 	private static readonly string[] CustomViewConfigKeys = ["viewConfig", "modelViewConfig"];
-	private static readonly string[] OverrideSectionKeys = ["viewConfigDiff", "viewModelConfigDiff", "modelConfigDiff", "diffV2"];
+
+	/// <summary>Override sections this converter processes (ENG-95733), in the order the runtime reads them.</summary>
+	private static readonly string[] SupportedSectionKeys = ["viewConfigDiff", "viewModelConfigDiff", "modelConfigDiff"];
+
+	/// <summary>Override sections recognised but deliberately NOT processed, each with the reason it is not.</summary>
+	private static readonly Dictionary<string, string> UnsupportedSectionKeys =
+		new(StringComparer.Ordinal) { ["diffV2"] = DiffV2UnsupportedReason };
 
 	/// <summary>
 	/// Classifies the merged settings node.
@@ -54,18 +84,36 @@ public static class LegacyMobileSettingsClassifier {
 		ArgumentNullException.ThrowIfNull(settings);
 		var notes = new List<string>();
 		var sections = new List<LegacyOverrideSection>();
-		foreach (string key in OverrideSectionKeys) {
+		foreach (string key in SupportedSectionKeys) {
 			if (!IsPresent(settings[key])) {
 				continue;
 			}
-			int count = CountOperations(settings[key], key, notes);
+			JArray operations = ReadOperations(settings[key], key, notes);
+			int count = operations?.Count ?? -1;
 			if (count == 0) {
 				// An empty placeholder ("[]" or []) carries nothing to convert — reporting it as a dropped override
 				// would tell the user something was lost when nothing was.
 				notes.Add($"Override section '{key}' is present but empty; nothing was left unconverted.");
 				continue;
 			}
-			sections.Add(new LegacyOverrideSection(key, count, OverridesTicket));
+			// These sections ARE carried across (ENG-95733), operation by operation, so no ticket is reported for
+			// them; what could not be re-pointed comes back per operation in the rebase outcomes. The parsed
+			// operations are retained so the rebaser reads exactly what was classified here.
+			sections.Add(count < 0
+				? new LegacyOverrideSection(key, -1, null, false,
+					$"Section '{key}' could not be parsed as a JSON operation array, so none of it can be re-pointed safely.")
+				: new LegacyOverrideSection(key, count, null, true, null, operations));
+		}
+		foreach (KeyValuePair<string, string> unsupported in UnsupportedSectionKeys) {
+			if (!IsPresent(settings[unsupported.Key])) {
+				continue;
+			}
+			int count = ReadOperations(settings[unsupported.Key], unsupported.Key, notes)?.Count ?? -1;
+			if (count == 0) {
+				notes.Add($"Override section '{unsupported.Key}' is present but empty; nothing was left unconverted.");
+				continue;
+			}
+			sections.Add(new LegacyOverrideSection(unsupported.Key, count, null, false, unsupported.Value));
 		}
 		foreach (string key in CustomViewConfigKeys) {
 			if (IsPresent(settings[key])) {
@@ -83,24 +131,29 @@ public static class LegacyMobileSettingsClassifier {
 		&& !(token.Type == JTokenType.String && string.IsNullOrWhiteSpace(token.Value<string>()));
 
 	/// <summary>
-	/// Counts a section's operations. The classic wizard stores override sections as JSON-ENCODED STRINGS (the
-	/// mobile runtime parses <c>values.getString(prop)</c>), so a string is parsed before counting; an already
-	/// materialized array is counted directly; anything else cannot be counted (-1) and is noted.
+	/// Reads a section's operations. The classic wizard stores override sections as JSON-ENCODED STRINGS (the
+	/// mobile runtime parses <c>values.getString(prop)</c>), so a string is parsed first; an already materialized
+	/// array is taken as is; anything else yields null and is noted. The parsed array is retained rather than
+	/// counted and thrown away, so the rebaser reads the same operations the classification reported on.
 	/// </summary>
-	private static int CountOperations(JToken token, string key, List<string> notes) {
+	private static JArray ReadOperations(JToken token, string key, List<string> notes) {
 		switch (token) {
 			case JArray array:
-				return array.Count;
+				return array;
 			case JValue { Type: JTokenType.String } value:
 				try {
-					return JToken.Parse(value.Value<string>()) is JArray parsed ? parsed.Count : -1;
+					if (JToken.Parse(value.Value<string>()) is JArray parsed) {
+						return parsed;
+					}
+					notes.Add($"Override section '{key}' is a string that parses as JSON but not as an operation array; its operations could not be read.");
+					return null;
 				} catch (Exception) {
 					notes.Add($"Override section '{key}' is a string that does not parse as a JSON array; its operations could not be counted.");
-					return -1;
+					return null;
 				}
 			default:
 				notes.Add($"Override section '{key}' is a {token.Type}; its operations could not be counted.");
-				return -1;
+				return null;
 		}
 	}
 }

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifier.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifier.cs
@@ -1,0 +1,106 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+/// <summary>What kind of legacy settings source the merged body is.</summary>
+public enum LegacySettingsKind {
+	/// <summary>Only what the classic wizard itself writes (the three column buckets).</summary>
+	Plain,
+
+	/// <summary>Also carries NON-EMPTY Freedom UI override sections (viewConfigDiff / viewModelConfigDiff / modelConfigDiff / diffV2) — recognised, not converted (ENG-95733). An empty placeholder section does not count.</summary>
+	FreedomUiOverrides,
+
+	/// <summary>Carries a hand-authored <c>viewConfig</c> / <c>modelViewConfig</c> — refused: even the classic designer cannot open it.</summary>
+	CustomViewConfig
+}
+
+/// <summary>A Freedom UI override section found inside legacy settings.</summary>
+public sealed record LegacyOverrideSection(string Section, int OperationCount, string Ticket);
+
+/// <summary>Static classification of a merged legacy settings node.</summary>
+public sealed record LegacySettingsClassification(
+	LegacySettingsKind Kind,
+	IReadOnlyList<LegacyOverrideSection> OverrideSections,
+	IReadOnlyList<string> Notes) {
+
+	/// <summary>Caller-facing label: <c>plain</c> | <c>freedom-ui-overrides</c> | <c>custom-viewconfig</c>.</summary>
+	public string Label => Kind switch {
+		LegacySettingsKind.Plain => "plain",
+		LegacySettingsKind.FreedomUiOverrides => "freedom-ui-overrides",
+		_ => "custom-viewconfig"
+	};
+}
+
+/// <summary>
+/// Decides, statically from the merged settings node (never by string-sniffing a body), whether a legacy source
+/// is plain wizard output, carries Freedom UI overrides, or carries a custom viewConfig (ENG-95730).
+/// </summary>
+public static class LegacyMobileSettingsClassifier {
+
+	/// <summary>The story that owns converting embedded Freedom UI overrides.</summary>
+	public const string OverridesTicket = "ENG-95733";
+
+	private static readonly string[] CustomViewConfigKeys = ["viewConfig", "modelViewConfig"];
+	private static readonly string[] OverrideSectionKeys = ["viewConfigDiff", "viewModelConfigDiff", "modelConfigDiff", "diffV2"];
+
+	/// <summary>
+	/// Classifies the merged settings node.
+	/// </summary>
+	/// <param name="settings">The merged <c>settings</c> item.</param>
+	/// <returns>The classification; a custom viewConfig wins over override sections.</returns>
+	public static LegacySettingsClassification Classify(JObject settings) {
+		ArgumentNullException.ThrowIfNull(settings);
+		var notes = new List<string>();
+		var sections = new List<LegacyOverrideSection>();
+		foreach (string key in OverrideSectionKeys) {
+			if (!IsPresent(settings[key])) {
+				continue;
+			}
+			int count = CountOperations(settings[key], key, notes);
+			if (count == 0) {
+				// An empty placeholder ("[]" or []) carries nothing to convert — reporting it as a dropped override
+				// would tell the user something was lost when nothing was.
+				notes.Add($"Override section '{key}' is present but empty; nothing was left unconverted.");
+				continue;
+			}
+			sections.Add(new LegacyOverrideSection(key, count, OverridesTicket));
+		}
+		foreach (string key in CustomViewConfigKeys) {
+			if (IsPresent(settings[key])) {
+				notes.Add($"Settings carry a hand-authored '{key}' — the classic designer cannot open such a page either.");
+				return new LegacySettingsClassification(LegacySettingsKind.CustomViewConfig, sections, notes);
+			}
+		}
+		return new LegacySettingsClassification(
+			sections.Count > 0 ? LegacySettingsKind.FreedomUiOverrides : LegacySettingsKind.Plain, sections, notes);
+	}
+
+	private static bool IsPresent(JToken token) =>
+		token is not null
+		&& token.Type is not (JTokenType.Null or JTokenType.Undefined)
+		&& !(token.Type == JTokenType.String && string.IsNullOrWhiteSpace(token.Value<string>()));
+
+	/// <summary>
+	/// Counts a section's operations. The classic wizard stores override sections as JSON-ENCODED STRINGS (the
+	/// mobile runtime parses <c>values.getString(prop)</c>), so a string is parsed before counting; an already
+	/// materialized array is counted directly; anything else cannot be counted (-1) and is noted.
+	/// </summary>
+	private static int CountOperations(JToken token, string key, List<string> notes) {
+		switch (token) {
+			case JArray array:
+				return array.Count;
+			case JValue { Type: JTokenType.String } value:
+				try {
+					return JToken.Parse(value.Value<string>()) is JArray parsed ? parsed.Count : -1;
+				} catch (Exception) {
+					notes.Add($"Override section '{key}' is a string that does not parse as a JSON array; its operations could not be counted.");
+					return -1;
+				}
+			default:
+				notes.Add($"Override section '{key}' is a {token.Type}; its operations could not be counted.");
+				return -1;
+		}
+	}
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReader.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReader.cs
@@ -1,0 +1,270 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Clio.Common;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Reads the EFFECTIVE classic Mobile-wizard settings of a legacy <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>
+/// schema from a Creatio environment (ENG-95730). The schema may live in several packages as replacing schemas;
+/// every package layer contributes its own diff array, and only their ordered application (ROOT → HEAD, in
+/// package-hierarchy order) is the effective settings. Raw bodies never leave the reader: the result carries the
+/// merged <c>settings</c> node and per-layer facts (package, operation count) only.
+/// </summary>
+public interface ILegacyMobileSettingsReader {
+	/// <summary>
+	/// Reads and merges every package layer of the named legacy settings schema.
+	/// </summary>
+	/// <param name="schemaName">The legacy settings schema name.</param>
+	/// <returns>The merged settings or a failure with an actionable error; never throws for a server-side problem.</returns>
+	LegacyMobileSettingsReadResult Read(string schemaName);
+}
+
+/// <summary>What shape the stored body had.</summary>
+public enum LegacyBodyShape {
+	/// <summary>A JSON operation array (the classic wizard format).</summary>
+	OperationArray,
+
+	/// <summary>A JSON object — a Freedom UI mobile body stored under a legacy schema name (ENG-95733 case).</summary>
+	FreedomUiJsonObject,
+
+	/// <summary>No layer carried a body.</summary>
+	Empty,
+
+	/// <summary>A body that parsed as neither.</summary>
+	Unparseable
+}
+
+/// <summary>One package layer of the legacy settings hierarchy. Carries no body.</summary>
+public sealed record LegacyMobileSettingsLayer(
+	string SchemaUId,
+	string SchemaName,
+	string PackageUId,
+	string PackageName,
+	int SchemaVersion,
+	int OperationCount);
+
+/// <summary>Result of <see cref="ILegacyMobileSettingsReader.Read"/>.</summary>
+public sealed record LegacyMobileSettingsReadResult(
+	bool Success,
+	string Error,
+	string SchemaName,
+	string SchemaUId,
+	int? HeadSchemaType,
+	IReadOnlyList<LegacyMobileSettingsLayer> Layers,
+	JObject EffectiveSettings,
+	LegacyBodyShape BodyShape,
+	IReadOnlyList<string> Notes) {
+
+	/// <summary>Builds a failure result.</summary>
+	public static LegacyMobileSettingsReadResult Fail(string schemaName, string error,
+		LegacyBodyShape shape = LegacyBodyShape.Unparseable, IReadOnlyList<LegacyMobileSettingsLayer> layers = null) =>
+		new(false, error, schemaName, null, null, layers ?? [], null, shape, []);
+}
+
+/// <summary>
+/// Default <see cref="ILegacyMobileSettingsReader"/>: SysSchema row → designer hierarchy (re-queried from the ROOT
+/// schema so every replacing layer appears) → per-layer unescape + parse → <see cref="IJsonDiffApplier.ApplyDiff"/>
+/// ROOT → HEAD → the merged <c>settings</c> node. Cross-checks the hierarchy against every SysSchema row of that
+/// name so a package the designer service did not return is reported instead of silently missing.
+/// </summary>
+internal sealed class LegacyMobileSettingsReader : ILegacyMobileSettingsReader {
+
+	private readonly IApplicationClient _applicationClient;
+	private readonly IServiceUrlBuilder _serviceUrlBuilder;
+	private readonly IPageDesignerHierarchyClient _hierarchyClient;
+	private readonly Func<IJsonDiffApplier> _applierFactory;
+
+	public LegacyMobileSettingsReader(
+		IApplicationClient applicationClient,
+		IServiceUrlBuilder serviceUrlBuilder,
+		IPageDesignerHierarchyClient hierarchyClient,
+		Func<IJsonDiffApplier> applierFactory) {
+		_applicationClient = applicationClient;
+		_serviceUrlBuilder = serviceUrlBuilder;
+		_hierarchyClient = hierarchyClient;
+		_applierFactory = applierFactory;
+	}
+
+	/// <inheritdoc />
+	public LegacyMobileSettingsReadResult Read(string schemaName) {
+		if (string.IsNullOrWhiteSpace(schemaName)) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName, "schemaName is required");
+		}
+		(JToken row, string error) = PageSchemaMetadataHelper.QuerySysSchemaRow(
+			_applicationClient, _serviceUrlBuilder, schemaName,
+			("UId", "UId"), ("PackageUId", "SysPackage.UId"), ("PackageName", "SysPackage.Name"));
+		if (row is null) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName, error ?? $"Schema '{schemaName}' not found");
+		}
+		string schemaUId = row["UId"]?.ToString();
+		string packageUId = row["PackageUId"]?.ToString();
+		if (string.IsNullOrWhiteSpace(schemaUId) || string.IsNullOrWhiteSpace(packageUId)) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName,
+				$"Schema '{schemaName}' metadata is missing package or schema identifiers");
+		}
+
+		string designPackageUId = ResolveDesignPackageUId(schemaUId, packageUId);
+		IReadOnlyList<PageDesignerHierarchySchema> hierarchy;
+		try {
+			hierarchy = _hierarchyClient.GetParentSchemas(schemaUId, designPackageUId);
+		} catch (Exception ex) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName,
+				PageHierarchyRecoveryHint.Append($"Failed to load hierarchy for '{schemaName}': {ex.Message}"));
+		}
+		if (hierarchy.Count == 0) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName, $"Schema '{schemaName}' hierarchy is empty");
+		}
+		// Re-query from the ROOT layer: when the requested row resolves to a lower package, the upper replacing
+		// layers only appear when the hierarchy is read from the root (same rule as PageGetCommand.ResolveHierarchy).
+		string rootSchemaUId = FindRootSchemaUId(hierarchy, schemaName) ?? schemaUId;
+		if (!string.Equals(rootSchemaUId, schemaUId, StringComparison.OrdinalIgnoreCase)) {
+			try {
+				IReadOnlyList<PageDesignerHierarchySchema> full = _hierarchyClient.GetParentSchemas(rootSchemaUId, designPackageUId);
+				if (full.Count > 0) {
+					hierarchy = full;
+				}
+			} catch (Exception) {
+				// Best-effort: keep the hierarchy already read; the package cross-check below reports any gap.
+			}
+		}
+
+		// Only the layers that carry THIS schema name are settings layers (the designer service may also return
+		// unrelated parents for a schema that extends another one).
+		List<PageDesignerHierarchySchema> ordered = hierarchy
+			.Where(s => string.Equals(s.Name, schemaName, StringComparison.OrdinalIgnoreCase))
+			.Reverse()
+			.ToList();
+		if (ordered.Count == 0) {
+			ordered = hierarchy.Reverse().ToList();
+		}
+		var notes = new List<string>();
+		notes.AddRange(CrossCheckPackages(schemaName, ordered));
+
+		var layerOps = new List<(JArray Operations, int SchemaVersion)>();
+		var layers = new List<LegacyMobileSettingsLayer>();
+		foreach (PageDesignerHierarchySchema layer in ordered) {
+			JArray operations = new();
+			if (!string.IsNullOrWhiteSpace(layer.Body)) {
+				string text = Unescape(layer.Body);
+				if (text.StartsWith('{')) {
+					return LegacyMobileSettingsReadResult.Fail(schemaName,
+						$"Schema '{schemaName}' (package '{layer.PackageName}') stores a Freedom UI JSON body under a legacy settings schema name; that is the {LegacyMobileSettingsClassifier.OverridesTicket} override case and is not converted here.",
+						LegacyBodyShape.FreedomUiJsonObject, layers);
+				}
+				try {
+					operations = JArray.Parse(text);
+				} catch (Exception ex) {
+					return LegacyMobileSettingsReadResult.Fail(schemaName,
+						$"Schema '{schemaName}' (package '{layer.PackageName}') body is not a JSON operation array: {ex.Message}",
+						LegacyBodyShape.Unparseable, layers);
+				}
+			}
+			layerOps.Add((operations, layer.SchemaVersion));
+			layers.Add(new LegacyMobileSettingsLayer(layer.UId, layer.Name, layer.PackageUId, layer.PackageName, layer.SchemaVersion, operations.Count));
+		}
+		if (layers.TrueForAll(l => l.OperationCount == 0)) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName,
+				$"Schema '{schemaName}' carries no settings operations in any package layer.", LegacyBodyShape.Empty, layers);
+		}
+
+		JArray merged;
+		try {
+			merged = Merge(layerOps, _applierFactory);
+		} catch (Exception ex) when (ex is JsonDiffApplierException or InvalidCastException or FormatException or ArgumentException) {
+			// A malformed layer (a non-numeric index, an object where a name should be) surfaces from the applier as
+			// a cast/format error, not only as JsonDiffApplierException; all of them are "this package's body is
+			// broken", so keep the layer diagnostics instead of letting a bare exception escape.
+			return LegacyMobileSettingsReadResult.Fail(schemaName,
+				$"Applying the package layers of '{schemaName}' failed ({string.Join(" -> ", layers.Select(l => l.PackageName ?? l.SchemaUId))}): {ex.Message}",
+				LegacyBodyShape.OperationArray, layers);
+		}
+		JObject settings = merged.OfType<JObject>().FirstOrDefault(item =>
+			string.Equals(item.Value<string>("name"), LegacyGridPageSettingsParser.SettingsNodeName, StringComparison.Ordinal));
+		if (settings is null) {
+			return LegacyMobileSettingsReadResult.Fail(schemaName,
+				$"Schema '{schemaName}' does not contain a '{LegacyGridPageSettingsParser.SettingsNodeName}' root node after merging its package layers.",
+				LegacyBodyShape.OperationArray, layers);
+		}
+		return new LegacyMobileSettingsReadResult(
+			true, null, schemaName, schemaUId, hierarchy[0].SchemaType, layers, settings,
+			LegacyBodyShape.OperationArray, notes);
+	}
+
+	/// <summary>
+	/// Applies every layer's operations in the given (ROOT → HEAD) order onto an empty tree with the page diff
+	/// applier — the same applier and options page-bundle resolution uses. Pure; exposed for tests.
+	/// </summary>
+	internal static JArray Merge(IReadOnlyList<(JArray Operations, int SchemaVersion)> layers, Func<IJsonDiffApplier> applierFactory) {
+		ArgumentNullException.ThrowIfNull(layers);
+		ArgumentNullException.ThrowIfNull(applierFactory);
+		JToken result = applierFactory().ApplyDiff(
+			new JArray(),
+			layers.Select(l => l.Operations).ToList(),
+			layers.Select(l => new JsonApplierOperationsOptions { ApplyMoveIfIndirectParentMoved = l.SchemaVersion >= 1 }).ToList());
+		return result as JArray ?? new JArray();
+	}
+
+	/// <summary>
+	/// Normalizes a stored legacy body before JSON parsing: resolves escaped <c>\$</c> sequences (an invalid JSON
+	/// escape the wizard may leave in bodies), trims, and drops a trailing statement terminator.
+	/// </summary>
+	internal static string Unescape(string body) {
+		if (string.IsNullOrWhiteSpace(body)) {
+			return string.Empty;
+		}
+		string text = body.Replace("\\$", "$").Trim();
+		if (text.EndsWith(';')) {
+			text = text[..^1].TrimEnd();
+		}
+		return text;
+	}
+
+	private string ResolveDesignPackageUId(string schemaUId, string fallbackPackageUId) {
+		string designPackageUId;
+		try {
+			designPackageUId = _hierarchyClient.GetDesignPackageUId(schemaUId);
+		} catch (Exception) {
+			designPackageUId = null;
+		}
+		return string.IsNullOrWhiteSpace(designPackageUId) ? fallbackPackageUId : designPackageUId;
+	}
+
+	// Mirrors PageGetCommand.FindRootSchemaUId: the LAST hierarchy entry carrying the schema name is the root layer.
+	private static string FindRootSchemaUId(IReadOnlyList<PageDesignerHierarchySchema> hierarchy, string schemaName) {
+		for (int i = hierarchy.Count - 1; i >= 0; i--) {
+			if (string.Equals(hierarchy[i].Name, schemaName, StringComparison.OrdinalIgnoreCase)) {
+				return hierarchy[i].UId;
+			}
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Compares the packages that carry a SysSchema row of this name against the layers the hierarchy service
+	/// returned; a package present in SysSchema but absent from the hierarchy is reported (never silent).
+	/// </summary>
+	private IEnumerable<string> CrossCheckPackages(string schemaName, IReadOnlyList<PageDesignerHierarchySchema> layers) {
+		(JArray rows, string error) = PageSchemaMetadataHelper.QuerySysSchemaRowsByName(
+			_applicationClient, _serviceUrlBuilder, schemaName, ("PackageName", "SysPackage.Name"), ("PackageUId", "SysPackage.UId"));
+		if (rows is null) {
+			yield return $"The package cross-check for '{schemaName}' could not run ({error ?? "query failed"}); the resolved hierarchy was not verified against SysSchema.";
+			yield break;
+		}
+		var knownNames = new HashSet<string>(layers.Select(l => l.PackageName).Where(n => !string.IsNullOrWhiteSpace(n)), StringComparer.OrdinalIgnoreCase);
+		var knownUIds = new HashSet<string>(layers.Select(l => l.PackageUId).Where(u => !string.IsNullOrWhiteSpace(u)), StringComparer.OrdinalIgnoreCase);
+		var reported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (JToken row in rows) {
+			string package = row["PackageName"]?.ToString();
+			string packageUId = row["PackageUId"]?.ToString();
+			bool known = (!string.IsNullOrWhiteSpace(package) && knownNames.Contains(package))
+				|| (!string.IsNullOrWhiteSpace(packageUId) && knownUIds.Contains(packageUId));
+			string label = string.IsNullOrWhiteSpace(package) ? packageUId : package;
+			if (!known && !string.IsNullOrWhiteSpace(label) && reported.Add(label)) {
+				yield return $"Package '{label}' carries a '{schemaName}' schema that was NOT part of the resolved hierarchy — the effective settings may be incomplete; verify the page in the classic Mobile application wizard.";
+			}
+		}
+	}
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSourceModels.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSourceModels.cs
@@ -37,6 +37,15 @@ public sealed class LegacyMobileSourceInfo {
 	public IReadOnlyList<LegacyOverrideSectionInfo> OverrideSections { get; init; }
 
 	/// <summary>
+	/// What happened to EVERY operation inside those sections, one entry each, in source order (ENG-95733). An
+	/// operation is either carried across (as a wizard-source edit or as an extra operation on the converted page)
+	/// or reported with the reason it could not be — never partially applied.
+	/// </summary>
+	[JsonPropertyName("overrideOutcomes")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IReadOnlyList<LegacyOverrideOutcomeInfo> OverrideOutcomes { get; init; }
+
+	/// <summary>
 	/// Every schema layer that contributed to the effective settings, ROOT → HEAD in package-hierarchy order.
 	/// Package names and operation counts only — no bodies.
 	/// </summary>
@@ -92,9 +101,59 @@ public sealed class LegacyOverrideSectionInfo {
 	[JsonPropertyName("operationCount")]
 	public int OperationCount { get; init; }
 
-	/// <summary>The story that owns converting this section.</summary>
+	/// <summary>
+	/// Whether the converter processes this section at all. The three <c>*ConfigDiff</c> sections are converted
+	/// (ENG-95733); <c>diffV2</c> is not — the mobile runtime passes it through verbatim rather than translating
+	/// it, so there is no reference behaviour to port, and it does not occur in the shipped corpus.
+	/// </summary>
+	[JsonPropertyName("supported")]
+	public bool Supported { get; init; }
+
+	/// <summary>Why the section is not processed; null when it is.</summary>
+	[JsonPropertyName("reason")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string Reason { get; init; }
+
+	/// <summary>The story that owns converting this section, when one does; null once it is converted here.</summary>
 	[JsonPropertyName("ticket")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string Ticket { get; init; }
+}
+
+/// <summary>What happened to one embedded override operation.</summary>
+public sealed class LegacyOverrideOutcomeInfo {
+	/// <summary>The settings key the operation came from.</summary>
+	[JsonPropertyName("section")]
+	public string Section { get; init; }
+
+	/// <summary>Its position inside that section, so the user can find it in the source schema.</summary>
+	[JsonPropertyName("index")]
+	public int Index { get; init; }
+
+	/// <summary>The diff operation (<c>merge</c> / <c>remove</c> / <c>insert</c> / …).</summary>
+	[JsonPropertyName("operation")]
+	public string Operation { get; init; }
+
+	/// <summary>The runtime-generated name the operation addressed.</summary>
+	[JsonPropertyName("target")]
+	public string Target { get; init; }
+
+	/// <summary>
+	/// <c>source-edit</c> (expressed as a change to the wizard source), <c>target-delta</c> (an extra operation on
+	/// the converted page), or <c>reported</c> (not carried over).
+	/// </summary>
+	[JsonPropertyName("lane")]
+	public string Lane { get; init; }
+
+	/// <summary>What it did on the converted page; absent when it was only reported.</summary>
+	[JsonPropertyName("effect")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string Effect { get; init; }
+
+	/// <summary>Why it could not be carried; absent when it was.</summary>
+	[JsonPropertyName("reason")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string Reason { get; init; }
 }
 
 /// <summary>How one wizard column maps onto the mobile list row.</summary>

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSourceModels.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSourceModels.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+/// <summary>
+/// Facts about a LEGACY mobile wizard settings source (a <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>
+/// schema) surfaced on the conversion guide (ENG-95730). Carries everything the plan and the final report need —
+/// which packages contributed, how each wizard column maps onto the mobile list row, which column properties were
+/// transferred / dropped, and the open decisions — WITHOUT any raw schema body (bodies never enter an agent's context).
+/// </summary>
+public sealed class LegacyMobileSourceInfo {
+	/// <summary>The wizard <c>settingsType</c> of the merged settings node (today always <c>GridPage</c>).</summary>
+	[JsonPropertyName("settingsType")]
+	public string SettingsType { get; init; }
+
+	/// <summary>The entity the wizard page was bound to (<c>settings.entitySchemaName</c>) — the mobile page binds to the same object.</summary>
+	[JsonPropertyName("entitySchemaName")]
+	public string EntitySchemaName { get; init; }
+
+	/// <summary>Workplace suffix parsed from the schema name (e.g. <c>DefaultWorkplace</c>); null when the name carries none.</summary>
+	[JsonPropertyName("workplace")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string Workplace { get; init; }
+
+	/// <summary>
+	/// Static classification of the merged settings: <c>plain</c> (wizard buckets only),
+	/// <c>freedom-ui-overrides</c> (also carries viewConfigDiff / viewModelConfigDiff / modelConfigDiff / diffV2 —
+	/// recognised, NOT converted, ENG-95733), or <c>custom-viewconfig</c> (refused before conversion).
+	/// </summary>
+	[JsonPropertyName("classification")]
+	public string Classification { get; init; }
+
+	/// <summary>Freedom UI override sections found in the settings and left untouched (ENG-95733).</summary>
+	[JsonPropertyName("overrideSections")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IReadOnlyList<LegacyOverrideSectionInfo> OverrideSections { get; init; }
+
+	/// <summary>
+	/// Every schema layer that contributed to the effective settings, ROOT → HEAD in package-hierarchy order.
+	/// Package names and operation counts only — no bodies.
+	/// </summary>
+	[JsonPropertyName("layers")]
+	public IReadOnlyList<LegacyMobileSettingsLayerInfo> Layers { get; init; } = [];
+
+	/// <summary>The wizard <c>items</c> column that becomes <c>ListItem.title</c>; null when the wizard defined none.</summary>
+	[JsonPropertyName("titleColumn")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public LegacyColumnMappingInfo TitleColumn { get; init; }
+
+	/// <summary>The <c>subtitleItems</c> then <c>groupItems</c> columns, in the order they become <c>ListItem.body</c> rows.</summary>
+	[JsonPropertyName("bodyColumns")]
+	public IReadOnlyList<LegacyColumnMappingInfo> BodyColumns { get; init; } = [];
+
+	/// <summary>Coverage table: for every wizard column property, whether it was transferred, is informational, or was dropped and why.</summary>
+	[JsonPropertyName("columnPropertyCoverage")]
+	public IReadOnlyList<LegacyPropertyCoverageInfo> ColumnPropertyCoverage { get; init; } = [];
+
+	/// <summary>Open decisions the user must take before the page is written (e.g. no title column, dropped view types).</summary>
+	[JsonPropertyName("decisions")]
+	public IReadOnlyList<string> Decisions { get; init; } = [];
+
+	/// <summary>Advisory notes about the source (e.g. a package layer the hierarchy service did not return).</summary>
+	[JsonPropertyName("notes")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public IReadOnlyList<string> Notes { get; init; }
+}
+
+/// <summary>One schema layer of a legacy settings hierarchy (a package's replacing schema). No body.</summary>
+public sealed class LegacyMobileSettingsLayerInfo {
+	/// <summary>The settings schema name of this layer (the same name in every package).</summary>
+	[JsonPropertyName("schemaName")]
+	public string SchemaName { get; init; }
+
+	/// <summary>The package that carries this layer.</summary>
+	[JsonPropertyName("packageName")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string PackageName { get; init; }
+
+	/// <summary>Number of diff operations this layer contributed (0 for a body-less replacing schema).</summary>
+	[JsonPropertyName("operationCount")]
+	public int OperationCount { get; init; }
+}
+
+/// <summary>A Freedom UI override section embedded in legacy settings (recognised, not converted).</summary>
+public sealed class LegacyOverrideSectionInfo {
+	/// <summary><c>viewConfigDiff</c> | <c>viewModelConfigDiff</c> | <c>modelConfigDiff</c> | <c>diffV2</c>.</summary>
+	[JsonPropertyName("section")]
+	public string Section { get; init; }
+
+	/// <summary>Operation count when the section parsed as an array; -1 when it could not be counted.</summary>
+	[JsonPropertyName("operationCount")]
+	public int OperationCount { get; init; }
+
+	/// <summary>The story that owns converting this section.</summary>
+	[JsonPropertyName("ticket")]
+	public string Ticket { get; init; }
+}
+
+/// <summary>How one wizard column maps onto the mobile list row.</summary>
+public sealed class LegacyColumnMappingInfo {
+	/// <summary><c>title</c> | <c>subtitle</c> | <c>group</c> — the wizard bucket the column came from.</summary>
+	[JsonPropertyName("bucket")]
+	public string Bucket { get; init; }
+
+	/// <summary>The wizard <c>row</c> (display order inside its bucket).</summary>
+	[JsonPropertyName("row")]
+	public int Row { get; init; }
+
+	/// <summary>The wizard <c>columnName</c> — an entity column path, possibly dotted (e.g. <c>Account.Type</c>).</summary>
+	[JsonPropertyName("columnName")]
+	public string ColumnName { get; init; }
+
+	/// <summary>The wizard caption (<c>content</c>). Informational: mobile list rows show values, not captions.</summary>
+	[JsonPropertyName("caption")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string Caption { get; init; }
+
+	/// <summary>The platform data-value type the wizard recorded for the column (informational).</summary>
+	[JsonPropertyName("dataValueType")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public int? DataValueType { get; init; }
+
+	/// <summary>The view-model attribute the row binds to (<c>PDS_&lt;path with '.' → '_'&gt;</c>).</summary>
+	[JsonPropertyName("attribute")]
+	public string Attribute { get; init; }
+
+	/// <summary>The attribute's <c>modelConfig.path</c> (<c>PDS.&lt;same&gt;</c>).</summary>
+	[JsonPropertyName("modelPath")]
+	public string ModelPath { get; init; }
+
+	/// <summary>Where the column lands on the mobile row: <c>ListItem.title</c> or <c>ListItem.body[i]</c>.</summary>
+	[JsonPropertyName("target")]
+	public string Target { get; init; }
+}
+
+/// <summary>Coverage of one wizard column property across the converted columns.</summary>
+public sealed class LegacyPropertyCoverageInfo {
+	/// <summary>The wizard column property (e.g. <c>columnName</c>, <c>content</c>, a view type).</summary>
+	[JsonPropertyName("property")]
+	public string Property { get; init; }
+
+	/// <summary><c>transferred</c> | <c>informational</c> | <c>dropped</c>.</summary>
+	[JsonPropertyName("status")]
+	public string Status { get; init; }
+
+	/// <summary>What happened to the property and why.</summary>
+	[JsonPropertyName("note")]
+	public string Note { get; init; }
+
+	/// <summary>Columns that carried the property.</summary>
+	[JsonPropertyName("columns")]
+	public IReadOnlyList<string> Columns { get; init; } = [];
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaser.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaser.cs
@@ -108,6 +108,12 @@ public static class LegacyOverrideRebaser {
 	/// <param name="inventory">The runtime name inventory for this source.</param>
 	/// <param name="template">The target template's element names.</param>
 	/// <param name="nameSet">The runtime-name table, which also carries the designer targets.</param>
+	/// <param name="columnCaptions">Entity column name → caption, for a carried option that needs a real label.</param>
+	/// <param name="templateElements">
+	/// Every element the TARGET TEMPLATE declares, read from the stand. An operation whose designer target is not
+	/// among them is reported instead of authored — a merge onto a name the template does not carry silently
+	/// authors nothing. Null means the template could not be read, and the names go unverified.
+	/// </param>
 	/// <returns>The rebase result; never null. With no usable table nothing is carried and everything is reported.</returns>
 	public static LegacyOverrideRebaseResult Rebase(
 		LegacyGridPageSettings settings,
@@ -115,7 +121,8 @@ public static class LegacyOverrideRebaser {
 		LegacyRuntimeNameInventory inventory,
 		MobileLegacyTemplateRule template,
 		MobileLegacyRuntimeNameSet nameSet,
-		IReadOnlyDictionary<string, string> columnCaptions = null) {
+		IReadOnlyDictionary<string, string> columnCaptions = null,
+		IReadOnlySet<string> templateElements = null) {
 		ArgumentNullException.ThrowIfNull(settings);
 		template ??= LegacyMobileListAnalysisService.DefaultGridPageTemplate;
 		var outcomes = new List<LegacyOverrideOutcome>();
@@ -140,7 +147,7 @@ public static class LegacyOverrideRebaser {
 			List<Operation> operations = Read(section);
 			if (string.Equals(section.Section, ViewConfigSection, StringComparison.Ordinal)) {
 				current = RebaseViewConfig(current, operations, inventory, byRole, viewOps, elementValues,
-					requiredColumns, warnings, outcomes, columnCaptions);
+					requiredColumns, warnings, outcomes, columnCaptions, templateElements);
 				continue;
 			}
 			List<JsonObject> target = string.Equals(section.Section, ModelConfigSection, StringComparison.Ordinal)
@@ -166,11 +173,12 @@ public static class LegacyOverrideRebaser {
 		List<string> requiredColumns,
 		List<string> warnings,
 		List<LegacyOverrideOutcome> outcomes,
-		IReadOnlyDictionary<string, string> columnCaptions) {
+		IReadOnlyDictionary<string, string> columnCaptions,
+		IReadOnlySet<string> templateElements) {
 		var resolutions = new List<(Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution)>();
 		foreach (Operation op in operations) {
 			LegacyRuntimeAnchor anchor = inventory?.Resolve(op.Name);
-			resolutions.Add((op, anchor, ResolveView(op, anchor, byRole, settings, columnCaptions)));
+			resolutions.Add((op, anchor, ResolveView(op, anchor, byRole, settings, columnCaptions, templateElements)));
 		}
 
 		// Subject = the column an operation touches, else the runtime element it addresses. A move arrives as a
@@ -284,7 +292,8 @@ public static class LegacyOverrideRebaser {
 	/// <summary>Decides what one view operation becomes, without applying anything.</summary>
 	private static Resolution ResolveView(
 		Operation op, LegacyRuntimeAnchor anchor, Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole,
-		LegacyGridPageSettings settings, IReadOnlyDictionary<string, string> columnCaptions) {
+		LegacyGridPageSettings settings, IReadOnlyDictionary<string, string> columnCaptions,
+		IReadOnlySet<string> templateElements) {
 		if (anchor is null) {
 			return Resolution.No(
 				$"No runtime element named '{op.Name}' is generated for this source, so there is nothing to re-point it onto. It most likely came from another schema in the hierarchy or was hand-written.");
@@ -292,6 +301,14 @@ public static class LegacyOverrideRebaser {
 		MobileLegacyRuntimeAnchorRule rule = Rule(byRole, anchor.Role);
 		bool isRemove = string.Equals(op.Kind, "remove", StringComparison.OrdinalIgnoreCase);
 		bool isMerge = string.Equals(op.Kind, "merge", StringComparison.OrdinalIgnoreCase);
+
+		// The designer target must EXIST in the template we are converting onto. A merge onto a name the template
+		// does not carry authors nothing at all, and no metadata validation catches it, so an unknown target is a
+		// report rather than an operation. Unverified (null) means the template could not be read; the guide says so.
+		foreach (string missing in DesignerTargets(rule, op).Where(t => templateElements?.Contains(t) == false)) {
+			return Resolution.No(
+				$"The target template does not declare an element named '{missing}'. Re-pointing '{op.Name}' onto it would author nothing, so the operation was not carried.");
+		}
 
 		// A property removal on an element the designer models as a separate element (the floating action).
 		if (isRemove && op.Properties.Count > 0) {
@@ -379,6 +396,23 @@ public static class LegacyOverrideRebaser {
 		}
 		return Resolution.No(
 			$"Only a removal or a property merge can be re-pointed onto the converted page's view; '{op.Kind}' on '{op.Name}' carries runtime-dialect content that the target template does not declare.");
+	}
+
+	/// <summary>Every designer element a rule could retarget an operation onto, so each can be verified.</summary>
+	private static IEnumerable<string> DesignerTargets(MobileLegacyRuntimeAnchorRule rule, Operation op) {
+		if (rule is null) {
+			yield break;
+		}
+		if (!string.IsNullOrWhiteSpace(rule.DesignerName)) {
+			yield return rule.DesignerName;
+		}
+		foreach (string property in op.Properties) {
+			if (rule.PropertyTargets is not null
+				&& rule.PropertyTargets.TryGetValue(property, out string target)
+				&& !string.IsNullOrWhiteSpace(target)) {
+				yield return target;
+			}
+		}
 	}
 
 	/// <summary>The wizard column with that path, from any bucket; null when the page does not carry it.</summary>

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaser.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyOverrideRebaser.cs
@@ -1,0 +1,569 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Newtonsoft.Json.Linq;
+
+// REBASE of embedded Freedom UI overrides onto the converted page (ENG-95733).
+//
+// An override in a classic settings schema addresses the names the mobile RUNTIME generates. This step turns each
+// operation into one of exactly three outcomes, and never anything in between:
+//
+//   source-edit   the operation says something the wizard model itself can say (drop a column), so the SOURCE is
+//                 edited and the existing pure analyzer re-derives the page from it. One emit path, so determinism
+//                 and the golden fixture survive, and bindings are re-derived instead of copied.
+//   target-delta  the operation says something only the target dialect can say (remove the floating action, set a
+//                 cache rule), so it becomes an extra designer-dialect operation.
+//   reported      everything else. Never guessed at, never half-applied.
+//
+// The all-or-nothing rule is structural, not a discipline: operations are grouped by SUBJECT (the column they
+// touch, or the element they target) and a group resolves entirely or not at all. This is what stops the shipped
+// "move Account from body to subtitles" pair from degrading into "delete Account", which is worse than doing
+// nothing.
+
+/// <summary>The outcome kinds an override operation can resolve into.</summary>
+public static class LegacyOverrideLanes {
+	/// <summary>Expressed as an edit to the wizard source; the analyzer re-derives the page from it.</summary>
+	public const string SourceEdit = "source-edit";
+
+	/// <summary>Expressed as an extra designer-dialect operation on the converted page.</summary>
+	public const string TargetDelta = "target-delta";
+
+	/// <summary>Not carried over; reported with a reason.</summary>
+	public const string Reported = "reported";
+}
+
+/// <summary>What happened to one override operation.</summary>
+/// <param name="Section">The settings key the operation came from.</param>
+/// <param name="Index">Its position in that section, so the user can find it in the source.</param>
+/// <param name="Operation">The diff operation (<c>merge</c> / <c>remove</c> / <c>insert</c> / …).</param>
+/// <param name="Target">The runtime name the operation addressed.</param>
+/// <param name="Lane">One of <see cref="LegacyOverrideLanes"/>.</param>
+/// <param name="Effect">What it did on the converted page; null when it was only reported.</param>
+/// <param name="Reason">Why it could not be carried; null when it was.</param>
+public sealed record LegacyOverrideOutcome(
+	string Section,
+	int Index,
+	string Operation,
+	string Target,
+	string Lane,
+	string Effect,
+	string Reason);
+
+/// <summary>The result of rebasing every embedded override of one source.</summary>
+/// <param name="Settings">The wizard settings after the source-edit lane; the analyzer converts THESE.</param>
+/// <param name="ViewConfigOperations">Extra designer-dialect view operations to append to the page body.</param>
+/// <param name="ViewModelConfigOperations">Extra path-addressed view-model operations.</param>
+/// <param name="ModelConfigOperations">Extra path-addressed model operations.</param>
+/// <param name="ElementValueOverrides">
+/// Designer element name → property values an override sets on it. The override WINS on every key it names: the
+/// converter folds these over its own values for an element it writes itself, and emits them as an extra merge
+/// for a template element it does not otherwise touch.
+/// </param>
+/// <param name="RequiredColumns">
+/// Column paths an override's bindings reference that the wizard buckets never declared. They are declared in
+/// both data sections exactly like a wizard column, otherwise the carried binding would be dead.
+/// </param>
+/// <param name="Warnings">
+/// Plain-language warnings about override operations whose outcome on the converted page differs from what the
+/// override asked for, or that were skipped. They are surfaced through the guide's <c>constraints</c>, which the
+/// caller cannot skip.
+/// </param>
+/// <param name="Outcomes">One entry per override operation, in source order.</param>
+public sealed record LegacyOverrideRebaseResult(
+	LegacyGridPageSettings Settings,
+	IReadOnlyList<JsonObject> ViewConfigOperations,
+	IReadOnlyList<JsonObject> ViewModelConfigOperations,
+	IReadOnlyList<JsonObject> ModelConfigOperations,
+	IReadOnlyDictionary<string, JsonObject> ElementValueOverrides,
+	IReadOnlyList<string> RequiredColumns,
+	IReadOnlyList<string> Warnings,
+	IReadOnlyList<LegacyOverrideOutcome> Outcomes);
+
+/// <summary>
+/// Re-points embedded Freedom UI override operations from the mobile runtime's generated names onto the converted
+/// page, using the runtime-name table (<see cref="LegacyRuntimeNameOracle"/>) and the target template's own
+/// element names.
+/// </summary>
+public static class LegacyOverrideRebaser {
+
+	private const string ViewConfigSection = "viewConfigDiff";
+	private const string ModelConfigSection = "modelConfigDiff";
+	private const string ItemsPlaceholder = "{items}";
+	private const string PrimaryDataSourcePlaceholder = "{pds}";
+	private const string PrimaryDataSourceAlias = "PDS";
+	private const string BindingPrefix = "$";
+	private const string AttributePrefix = "PDS_";
+
+	/// <summary>Operation kinds, in the order the mobile runtime's applier processes them.</summary>
+	private static readonly string[] RuntimeOperationOrder = ["merge", "remove", "move", "insert", "set"];
+
+	/// <summary>
+	/// Rebases every supported override section of one source.
+	/// </summary>
+	/// <param name="settings">The parsed wizard settings.</param>
+	/// <param name="sections">The classified override sections; only supported ones carrying operations are used.</param>
+	/// <param name="inventory">The runtime name inventory for this source.</param>
+	/// <param name="template">The target template's element names.</param>
+	/// <param name="nameSet">The runtime-name table, which also carries the designer targets.</param>
+	/// <returns>The rebase result; never null. With no usable table nothing is carried and everything is reported.</returns>
+	public static LegacyOverrideRebaseResult Rebase(
+		LegacyGridPageSettings settings,
+		IReadOnlyList<LegacyOverrideSection> sections,
+		LegacyRuntimeNameInventory inventory,
+		MobileLegacyTemplateRule template,
+		MobileLegacyRuntimeNameSet nameSet,
+		IReadOnlyDictionary<string, string> columnCaptions = null) {
+		ArgumentNullException.ThrowIfNull(settings);
+		template ??= LegacyMobileListAnalysisService.DefaultGridPageTemplate;
+		var outcomes = new List<LegacyOverrideOutcome>();
+		var viewOps = new List<JsonObject>();
+		var viewModelOps = new List<JsonObject>();
+		var modelOps = new List<JsonObject>();
+		var elementValues = new Dictionary<string, JsonObject>(StringComparer.Ordinal);
+		var requiredColumns = new List<string>();
+		var warnings = new List<string>();
+		LegacyGridPageSettings current = settings;
+
+		IReadOnlyList<LegacyOverrideSection> usable = (sections ?? [])
+			.Where(s => s is { Supported: true, Operations: not null })
+			.ToList();
+		if (usable.Count == 0) {
+			return new LegacyOverrideRebaseResult(current, viewOps, viewModelOps, modelOps, elementValues,
+				requiredColumns, warnings, outcomes);
+		}
+		Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole = BuildRoleIndex(nameSet);
+
+		foreach (LegacyOverrideSection section in usable) {
+			List<Operation> operations = Read(section);
+			if (string.Equals(section.Section, ViewConfigSection, StringComparison.Ordinal)) {
+				current = RebaseViewConfig(current, operations, inventory, byRole, viewOps, elementValues,
+					requiredColumns, warnings, outcomes, columnCaptions);
+				continue;
+			}
+			List<JsonObject> target = string.Equals(section.Section, ModelConfigSection, StringComparison.Ordinal)
+				? modelOps
+				: viewModelOps;
+			RebasePathSection(operations, inventory, byRole, template, target, warnings, outcomes);
+		}
+		return new LegacyOverrideRebaseResult(current, viewOps, viewModelOps, modelOps, elementValues,
+			requiredColumns, warnings, outcomes);
+	}
+
+	/// <summary>
+	/// The view lane. Operations are grouped by the column they touch (or by the element they address), and a group
+	/// is carried across only when EVERY operation in it resolves — a half-applied group is worse than none.
+	/// </summary>
+	private static LegacyGridPageSettings RebaseViewConfig(
+		LegacyGridPageSettings settings,
+		List<Operation> operations,
+		LegacyRuntimeNameInventory inventory,
+		Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole,
+		List<JsonObject> viewOps,
+		Dictionary<string, JsonObject> elementValues,
+		List<string> requiredColumns,
+		List<string> warnings,
+		List<LegacyOverrideOutcome> outcomes,
+		IReadOnlyDictionary<string, string> columnCaptions) {
+		var resolutions = new List<(Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution)>();
+		foreach (Operation op in operations) {
+			LegacyRuntimeAnchor anchor = inventory?.Resolve(op.Name);
+			resolutions.Add((op, anchor, ResolveView(op, anchor, byRole, settings, columnCaptions)));
+		}
+
+		// Subject = the column an operation touches, else the runtime element it addresses. A move arrives as a
+		// remove plus an insert of the SAME column, so grouping by column is what keeps the pair together.
+		foreach (IGrouping<string, (Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution)> group in
+			resolutions.GroupBy(r => r.Anchor?.ColumnPath ?? r.Op.Name ?? $"#{r.Op.Index}", StringComparer.Ordinal)) {
+			List<(Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution)> members = [.. group];
+
+			// An attempted MOVE of one column between the runtime's two row slots. A converted row has a single
+			// body slot and already shows the column there, so the pair is a no-op — and the removal must NOT be
+			// applied on its own, or "move" would silently become "delete".
+			if (IsSlotMove(members)) {
+				foreach ((Operation op, LegacyRuntimeAnchor _, Resolution _) in members) {
+					outcomes.Add(new LegacyOverrideOutcome(ViewConfigSection, op.Index, op.Kind, op.Name,
+						LegacyOverrideLanes.Reported, null,
+						$"Part of a move of column '{group.Key}' between the row's subtitle and body slots; a converted row has one slot, so nothing needed to change."));
+				}
+				warnings.Add($"Embedded override ({ViewConfigSection}[{string.Join(", ", members.Select(m => m.Op.Index))}]) moves column '{group.Key}' between the list row's subtitle and body slots. A converted list row has ONE slot and already shows the column there, so nothing was changed and the column is intact.");
+				continue;
+			}
+
+			(Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution) blocked =
+				members.FirstOrDefault(m => !m.Resolution.Resolved);
+			if (blocked.Op is not null) {
+				string shared = members.Count > 1
+					? $" It is one of {members.Count} operations on '{group.Key}', so none of them was applied — half of a move would delete the column instead of moving it."
+					: string.Empty;
+				foreach ((Operation op, LegacyRuntimeAnchor _, Resolution resolution) in members) {
+					string reason = (op.Index == blocked.Op.Index ? resolution.Reason : blocked.Resolution.Reason) + shared;
+					outcomes.Add(Report(ViewConfigSection, op, reason));
+					warnings.Add($"Embedded override ({ViewConfigSection}[{op.Index}] {op.Kind} '{op.Name}') was NOT carried over. {reason}");
+				}
+				continue;
+			}
+			foreach ((Operation op, LegacyRuntimeAnchor anchor, Resolution resolution) in
+				members.OrderBy(m => OperationRank(m.Op.Kind))) {
+				if (resolution.DropColumnFrom is not null) {
+					settings = DropColumn(settings, resolution.DropColumnFrom, anchor.ColumnPath);
+				}
+				if (resolution.AddColumnTo is not null) {
+					settings = AddColumn(settings, resolution.AddColumnTo, resolution.AddedColumn);
+				}
+				viewOps.AddRange(resolution.TargetOperations);
+				if (resolution.ElementName is not null) {
+					Fold(elementValues, resolution.ElementName, resolution.ElementValues, resolution.AppendArrays);
+				}
+				foreach (string column in resolution.RequiredColumns) {
+					if (!requiredColumns.Contains(column, StringComparer.Ordinal)) {
+						requiredColumns.Add(column);
+					}
+				}
+				if (resolution.Warning is not null) {
+					warnings.Add(resolution.Warning);
+				}
+				bool editedSource = resolution.DropColumnFrom is not null || resolution.AddColumnTo is not null;
+				bool touchedTarget = resolution.TargetOperations.Count > 0 || resolution.ElementName is not null;
+				outcomes.Add(new LegacyOverrideOutcome(ViewConfigSection, op.Index, op.Kind, op.Name,
+					editedSource ? LegacyOverrideLanes.SourceEdit
+						: touchedTarget ? LegacyOverrideLanes.TargetDelta : LegacyOverrideLanes.Reported,
+					resolution.Effect, null));
+			}
+		}
+		return settings;
+	}
+
+	/// <summary>
+	/// The data lanes. The target dialect addresses the view-model and model sections by PATH, so an operation is
+	/// re-pointed when the element it names carries a designer path. Both <c>merge</c> and <c>insert</c> qualify:
+	/// the runtime's <c>insert X into parent.property</c> and its <c>merge X</c> both mean "this is what X holds",
+	/// and X's own designer path already encodes where that is.
+	/// </summary>
+	private static void RebasePathSection(
+		List<Operation> operations,
+		LegacyRuntimeNameInventory inventory,
+		Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole,
+		MobileLegacyTemplateRule template,
+		List<JsonObject> target,
+		List<string> warnings,
+		List<LegacyOverrideOutcome> outcomes) {
+		foreach (Operation op in operations.OrderBy(o => OperationRank(o.Kind))) {
+			LegacyRuntimeAnchor anchor = inventory?.Resolve(op.Name);
+			MobileLegacyRuntimeAnchorRule rule = anchor is null ? null : Rule(byRole, anchor.Role);
+			if (anchor is null || rule?.DesignerPath is null) {
+				string reason = anchor is null
+					? $"No runtime element named '{op.Name}' is generated for this source, so there is nothing to re-point it onto. It most likely came from another schema in the hierarchy or was hand-written."
+					: $"The runtime element '{op.Name}' has no addressable counterpart in the converted page's data sections.";
+				outcomes.Add(Report(op.Section, op, reason));
+				warnings.Add($"Embedded override ({op.Section}[{op.Index}] {op.Kind} '{op.Name}') was SKIPPED. {reason}");
+				continue;
+			}
+			bool carries = string.Equals(op.Kind, "merge", StringComparison.OrdinalIgnoreCase)
+				|| string.Equals(op.Kind, "insert", StringComparison.OrdinalIgnoreCase);
+			if (!carries || op.Values is null) {
+				string reason = $"Only an operation that SETS content ('merge' or 'insert') can be re-pointed onto a data-section path; '{op.Kind}' addresses runtime elements that the converted page does not declare.";
+				outcomes.Add(Report(op.Section, op, reason));
+				warnings.Add($"Embedded override ({op.Section}[{op.Index}] {op.Kind} '{op.Name}') was SKIPPED. {reason}");
+				continue;
+			}
+			string[] segments = [.. rule.DesignerPath.Select(segment => ResolveSegment(segment, template))];
+			target.Add(new JsonObject {
+				["operation"] = "merge",
+				["path"] = new JsonArray([.. segments.Select(segment => (JsonNode)JsonValue.Create(segment))]),
+				["values"] = ToJsonNode(op.Values)
+			});
+			outcomes.Add(new LegacyOverrideOutcome(op.Section, op.Index, op.Kind, op.Name,
+				LegacyOverrideLanes.TargetDelta,
+				$"Re-pointed onto the converted page's {string.Join("/", segments)} path.", null));
+		}
+	}
+
+	/// <summary>Decides what one view operation becomes, without applying anything.</summary>
+	private static Resolution ResolveView(
+		Operation op, LegacyRuntimeAnchor anchor, Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole,
+		LegacyGridPageSettings settings, IReadOnlyDictionary<string, string> columnCaptions) {
+		if (anchor is null) {
+			return Resolution.No(
+				$"No runtime element named '{op.Name}' is generated for this source, so there is nothing to re-point it onto. It most likely came from another schema in the hierarchy or was hand-written.");
+		}
+		MobileLegacyRuntimeAnchorRule rule = Rule(byRole, anchor.Role);
+		bool isRemove = string.Equals(op.Kind, "remove", StringComparison.OrdinalIgnoreCase);
+		bool isMerge = string.Equals(op.Kind, "merge", StringComparison.OrdinalIgnoreCase);
+
+		// A property removal on an element the designer models as a separate element (the floating action).
+		if (isRemove && op.Properties.Count > 0) {
+			IReadOnlyDictionary<string, string> targets = rule?.PropertyTargets;
+			List<string> unmapped = [.. op.Properties.Where(p => targets is null || !targets.ContainsKey(p))];
+			return unmapped.Count > 0
+				? Resolution.No($"Property '{unmapped[0]}' of the runtime element '{op.Name}' has no counterpart on the converted page.")
+				: Resolution.Target(
+					[.. op.Properties.Select(p => Remove(targets[p]))],
+					$"Removed the template element(s) {string.Join(", ", op.Properties.Select(p => $"'{targets[p]}'"))}, which is how the converted page carries what the runtime kept as a property of '{op.Name}'.");
+		}
+		if (isRemove && anchor.ColumnPath is not null) {
+			// A column the wizard itself placed: say it in the wizard's own language and let the analyzer re-derive.
+			return anchor.FromInventory
+				? Resolution.Source(anchor.Bucket, $"Dropped column '{anchor.ColumnPath}' from the wizard '{anchor.Bucket}' bucket.")
+				: Resolution.No($"The override removes column '{anchor.ColumnPath}', which this source's '{anchor.Bucket}' bucket does not contain.");
+		}
+		if (isRemove && rule?.DesignerName is not null) {
+			return Resolution.Target([Remove(rule.DesignerName)], $"Removed the template element '{rule.DesignerName}'.");
+		}
+		if (isRemove) {
+			return Resolution.No($"The runtime element '{op.Name}' has no counterpart on the converted page, so removing it cannot be expressed.");
+		}
+		if (isMerge && anchor.ColumnPath is not null) {
+			// A per-column row property. The converted row carries only the column's value binding, so the label
+			// switch — the one shape that occurs in shipped packages — cannot be honoured.
+			return Resolution.No(op.Values?["label"] is not null
+				? $"The override hides the label of column '{anchor.ColumnPath}'. The Mobile Freedom UI designer does not support controlling a list-row label yet — every body column shows its label — so the label could NOT be hidden and it stays visible on the converted page."
+				: $"The override sets properties on the runtime's rendering of column '{anchor.ColumnPath}'; the converted row carries only that column's value binding, so they have no counterpart.");
+		}
+		if (isMerge && rule?.DesignerName is not null && op.Values is not null) {
+			// The override WINS on every key it names. On the list row a binding addresses a column of the record,
+			// so it is re-derived into the converted page's own attribute convention and the attribute is declared;
+			// anywhere else the values are carried through untouched.
+			bool isRow = string.Equals(anchor.Role, LegacyRuntimeRoles.ListRow, StringComparison.Ordinal);
+			var columns = new List<string>();
+			JsonNode values = ToJsonNode(op.Values);
+			if (isRow) {
+				values = RewriteBindings(values, columns);
+			}
+			JsonObject folded = values.AsObject();
+			string extra = columns.Count > 0
+				? $" Its binding(s) reference {string.Join(", ", columns.Select(c => $"'{c}'"))}, which the wizard buckets did not declare, so the attribute(s) were added to both data sections."
+				: string.Empty;
+			return Resolution.Element(rule.DesignerName, folded, columns,
+				$"Set {string.Join(", ", folded.Select(pair => $"'{pair.Key}'"))} on the template element '{rule.DesignerName}'; the override wins over the converted value.{extra}");
+		}
+		if (string.Equals(anchor.Role, LegacyRuntimeRoles.SortOption, StringComparison.Ordinal)
+			&& anchor.ColumnPath is not null && rule?.DesignerName is not null) {
+			// One column offered in the sort tool. The runtime inserts it into the sort item's sortOptions as
+			// { property }; the designer carries the same thing as an entry of SortButton.sortItems, shaped
+			// { attributeName, caption } with the RAW column name. Several such inserts accumulate into one merge.
+			LegacyGridColumn onPage = Column(settings, anchor.ColumnPath);
+			string caption = onPage?.Caption;
+			if (string.IsNullOrWhiteSpace(caption)) {
+				columnCaptions?.TryGetValue(anchor.ColumnPath, out caption);
+			}
+			var entry = new JsonObject { ["attributeName"] = anchor.ColumnPath };
+			if (!string.IsNullOrWhiteSpace(caption)) {
+				// A caption is a display label. Falling back to the column name would put a machine name in front
+				// of the user, so an unresolved caption is left out and reported instead of being invented.
+				entry["caption"] = caption;
+			}
+			return Resolution.ElementEntry(rule.DesignerName, new JsonObject { ["sortItems"] = new JsonArray(entry) },
+				[anchor.ColumnPath],
+				$"Offered column '{anchor.ColumnPath}' in the sort tool of '{rule.DesignerName}'.",
+				string.IsNullOrWhiteSpace(caption)
+					? $"Embedded override ({op.Section}[{op.Index}] {op.Kind} '{op.Name}') offers column '{anchor.ColumnPath}' in the sort tool of '{rule.DesignerName}', but no caption could be resolved for it — the column is neither one of the page's own columns nor readable from the object. The sort option is emitted WITHOUT a caption: give it one before the page is written."
+					: null);
+		}
+		if (anchor.ColumnPath is not null) {
+			// The override adds a column to one of the runtime's row slots. A converted row has a single body slot,
+			// so the column is added to the wizard model as an ordinary column — the value is shown, the separate
+			// slot is not reproduced — and only when the page does not already carry it.
+			if (Carries(settings, anchor.ColumnPath)) {
+				return Resolution.Unchanged(
+					$"Column '{anchor.ColumnPath}' is already shown in the list row, so nothing was changed.",
+					$"Embedded override ({op.Section}[{op.Index}] {op.Kind} '{op.Name}') places column '{anchor.ColumnPath}' in the list row's '{anchor.Slot}' slot. The converted row already shows that column in its single body slot, so nothing was changed.");
+			}
+			var added = new LegacyGridColumn(op.Name, anchor.ColumnPath, null, op.Index, null,
+				new Dictionary<string, JToken>());
+			return Resolution.Add(LegacyGridPageSettingsParser.SubtitleItemsBucket, added,
+				$"Added column '{anchor.ColumnPath}' to the list row.",
+				$"Embedded override ({op.Section}[{op.Index}] {op.Kind} '{op.Name}') places column '{anchor.ColumnPath}' in the list row's '{anchor.Slot}' slot. A converted list row has ONE slot, so the column was added to the row body instead: its value is shown, but the separate '{anchor.Slot}' placement is not reproduced.");
+		}
+		return Resolution.No(
+			$"Only a removal or a property merge can be re-pointed onto the converted page's view; '{op.Kind}' on '{op.Name}' carries runtime-dialect content that the target template does not declare.");
+	}
+
+	/// <summary>The wizard column with that path, from any bucket; null when the page does not carry it.</summary>
+	private static LegacyGridColumn Column(LegacyGridPageSettings settings, string columnPath) =>
+		settings.Items.Concat(settings.SubtitleItems).Concat(settings.GroupItems)
+			.FirstOrDefault(c => string.Equals(c.ColumnName, columnPath, StringComparison.Ordinal));
+
+	/// <summary>Whether any wizard bucket already carries the column, in which case an add would duplicate it.</summary>
+	private static bool Carries(LegacyGridPageSettings settings, string columnPath) =>
+		Column(settings, columnPath) is not null;
+
+	/// <summary>
+	/// Whether a group is an attempted move of ONE column between the runtime's row slots — a removal from one slot
+	/// paired with an insertion into the other. Both collapse to the converted row's single body slot.
+	/// </summary>
+	private static bool IsSlotMove(
+		List<(Operation Op, LegacyRuntimeAnchor Anchor, Resolution Resolution)> members) =>
+		members.Count > 1
+		&& members.All(m => m.Anchor?.ColumnPath is not null)
+		&& members.Any(m => string.Equals(m.Op.Kind, "remove", StringComparison.OrdinalIgnoreCase))
+		&& members.Any(m => string.Equals(m.Op.Kind, "insert", StringComparison.OrdinalIgnoreCase));
+
+	/// <summary>Appends a column the override asked for to a wizard bucket, keeping the bucket ordered by row.</summary>
+	private static LegacyGridPageSettings AddColumn(
+		LegacyGridPageSettings settings, string bucket, LegacyGridColumn column) =>
+		bucket switch {
+			LegacyGridPageSettingsParser.ItemsBucket => settings with { Items = [.. settings.Items, column] },
+			LegacyGridPageSettingsParser.SubtitleItemsBucket => settings with { SubtitleItems = [.. settings.SubtitleItems, column] },
+			LegacyGridPageSettingsParser.GroupItemsBucket => settings with { GroupItems = [.. settings.GroupItems, column] },
+			_ => settings
+		};
+
+	/// <summary>
+	/// Rewrites row-level bindings into the converted page's attribute convention and records the columns they
+	/// reference. A hand-written override commonly writes <c>$Photo</c> where the converted page declares
+	/// <c>$PDS_Photo</c>; carrying it verbatim would leave a binding that resolves to nothing.
+	/// </summary>
+	private static JsonNode RewriteBindings(JsonNode node, List<string> columns) {
+		switch (node) {
+			case JsonObject source: {
+				var rewritten = new JsonObject();
+				foreach (KeyValuePair<string, JsonNode> pair in source) {
+					rewritten[pair.Key] = RewriteBindings(pair.Value, columns);
+				}
+				return rewritten;
+			}
+			case JsonArray source:
+				return new JsonArray([.. source.Select(item => RewriteBindings(item, columns))]);
+			case JsonValue value when value.TryGetValue(out string text)
+				&& text.StartsWith(BindingPrefix, StringComparison.Ordinal): {
+				string name = text[BindingPrefix.Length..];
+				if (name.Length == 0 || name.StartsWith(AttributePrefix, StringComparison.Ordinal)) {
+					// Already in the converted page's convention; the source column cannot be recovered from an
+					// underscored name, so the binding is left exactly as authored.
+					return JsonValue.Create(text);
+				}
+				if (!columns.Contains(name, StringComparer.Ordinal)) {
+					columns.Add(name);
+				}
+				return JsonValue.Create(BindingPrefix + LegacyMobileListAnalysisService.AttributeName(name));
+			}
+			default:
+				return node?.DeepClone();
+		}
+	}
+
+	/// <summary>Folds one element's override values over anything already recorded for it; the later key wins.</summary>
+	private static void Fold(
+		Dictionary<string, JsonObject> elementValues, string name, JsonObject values, bool appendArrays = false) {
+		if (!elementValues.TryGetValue(name, out JsonObject existing)) {
+			elementValues[name] = values;
+			return;
+		}
+		foreach (KeyValuePair<string, JsonNode> pair in values) {
+			if (appendArrays && existing[pair.Key] is JsonArray target && pair.Value is JsonArray addition) {
+				foreach (JsonNode item in addition) {
+					target.Add(item?.DeepClone());
+				}
+				continue;
+			}
+			existing[pair.Key] = pair.Value?.DeepClone();
+		}
+	}
+
+	private static LegacyGridPageSettings DropColumn(LegacyGridPageSettings settings, string bucket, string columnPath) {
+		bool Keep(LegacyGridColumn c) => !string.Equals(c.ColumnName, columnPath, StringComparison.Ordinal);
+		return bucket switch {
+			LegacyGridPageSettingsParser.ItemsBucket => settings with { Items = [.. settings.Items.Where(Keep)] },
+			LegacyGridPageSettingsParser.SubtitleItemsBucket => settings with { SubtitleItems = [.. settings.SubtitleItems.Where(Keep)] },
+			LegacyGridPageSettingsParser.GroupItemsBucket => settings with { GroupItems = [.. settings.GroupItems.Where(Keep)] },
+			_ => settings
+		};
+	}
+
+	private static JsonObject Remove(string name) => new() { ["operation"] = "remove", ["name"] = name };
+
+	private static LegacyOverrideOutcome Report(string section, Operation op, string reason) =>
+		new(section, op.Index, op.Kind, op.Name, LegacyOverrideLanes.Reported, null, reason);
+
+	/// <summary>Mirrors the mobile applier's grouping so two operations on one target compose as they do at runtime.</summary>
+	private static int OperationRank(string kind) {
+		int index = Array.FindIndex(RuntimeOperationOrder, o => string.Equals(o, kind, StringComparison.OrdinalIgnoreCase));
+		return index < 0 ? RuntimeOperationOrder.Length : index;
+	}
+
+	private static string ResolveSegment(string segment, MobileLegacyTemplateRule template) => segment switch {
+		ItemsPlaceholder => template.ItemsAttributeName,
+		PrimaryDataSourcePlaceholder => PrimaryDataSourceAlias,
+		_ => segment
+	};
+
+	private static MobileLegacyRuntimeAnchorRule Rule(Dictionary<string, MobileLegacyRuntimeAnchorRule> byRole, string role) =>
+		role is not null && byRole.TryGetValue(role, out MobileLegacyRuntimeAnchorRule rule) ? rule : null;
+
+	private static Dictionary<string, MobileLegacyRuntimeAnchorRule> BuildRoleIndex(MobileLegacyRuntimeNameSet nameSet) {
+		var byRole = new Dictionary<string, MobileLegacyRuntimeAnchorRule>(StringComparer.Ordinal);
+		foreach (MobileLegacyRuntimeAnchorRule rule in nameSet?.Anchors ?? []) {
+			if (!string.IsNullOrWhiteSpace(rule?.Role)) {
+				byRole.TryAdd(rule.Role, rule);
+			}
+		}
+		return byRole;
+	}
+
+	/// <summary>Reads a section's operations into a shape the lanes can reason about, preserving source order.</summary>
+	private static List<Operation> Read(LegacyOverrideSection section) {
+		var operations = new List<Operation>();
+		for (int i = 0; i < section.Operations.Count; i++) {
+			if (section.Operations[i] is not JObject item) {
+				continue;
+			}
+			operations.Add(new Operation(
+				section.Section,
+				i,
+				item.Value<string>("operation") ?? string.Empty,
+				item.Value<string>("name"),
+				item["values"] as JObject,
+				[.. (item["properties"] as JArray ?? []).Select(p => p.ToString())]));
+		}
+		return operations;
+	}
+
+	private static JsonNode ToJsonNode(JObject values) => JsonNode.Parse(values.ToString(Newtonsoft.Json.Formatting.None));
+
+	/// <summary>One override operation, flattened.</summary>
+	private sealed record Operation(
+		string Section, int Index, string Kind, string Name, JObject Values, IReadOnlyList<string> Properties);
+
+	/// <summary>What an operation resolves to, before anything is applied.</summary>
+	private sealed record Resolution(
+		bool Resolved, string DropColumnFrom, string AddColumnTo, LegacyGridColumn AddedColumn,
+		IReadOnlyList<JsonObject> TargetOperations,
+		string ElementName, JsonObject ElementValues, IReadOnlyList<string> RequiredColumns,
+		string Effect, string Reason, string Warning) {
+
+		/// <summary>Whether an array value adds to what is already recorded instead of replacing it.</summary>
+		public bool AppendArrays { get; init; }
+
+		public static Resolution No(string reason) =>
+			new(false, null, null, null, [], null, null, [], null, reason, null);
+
+		public static Resolution Source(string bucket, string effect) =>
+			new(true, bucket, null, null, [], null, null, [], effect, null, null);
+
+		/// <summary>The column the override asked for is added to the wizard model, with a warning about the slot.</summary>
+		public static Resolution Add(string bucket, LegacyGridColumn column, string effect, string warning) =>
+			new(true, null, bucket, column, [], null, null, [], effect, null, warning);
+
+		/// <summary>The operation is understood and needs no change: the converted page already has that outcome.</summary>
+		public static Resolution Unchanged(string effect, string warning) =>
+			new(true, null, null, null, [], null, null, [], effect, null, warning);
+
+		public static Resolution Target(IReadOnlyList<JsonObject> operations, string effect) =>
+			new(true, null, null, null, operations, null, null, [], effect, null, null);
+
+		public static Resolution Element(string name, JsonObject values, IReadOnlyList<string> columns, string effect) =>
+			new(true, null, null, null, [], name, values, columns, effect, null, null);
+
+		/// <summary>
+		/// One entry the override ADDS to a collection property of a template element. Several such operations
+		/// accumulate into one merge, so their arrays are appended rather than replacing one another.
+		/// </summary>
+		public static Resolution ElementEntry(
+			string name, JsonObject values, IReadOnlyList<string> columns, string effect, string warning) =>
+			new(true, null, null, null, [], name, values, columns, effect, null, warning) { AppendArrays = true };
+	}
+}
+

--- a/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyRuntimeNameOracle.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyRuntimeNameOracle.cs
@@ -1,0 +1,200 @@
+namespace Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+// NAME ORACLE for embedded Freedom UI overrides in classic Mobile-wizard settings (ENG-95733).
+//
+// A classic settings schema can carry viewConfigDiff / viewModelConfigDiff / modelConfigDiff. Those operations
+// address elements by the names the MOBILE RUNTIME generates when it converts the same wizard metadata on the
+// device — a dialect that exists only at runtime. The Mobile Freedom UI designer works with the shipped
+// template's names instead. Re-pointing an override therefore starts by answering one question: "what would
+// the runtime have called this, and what did it MEAN?".
+//
+// This type answers exactly that and nothing more. It does not reproduce the runtime's JSON; it reproduces the
+// runtime's NAME INVENTORY for one parsed source, and inverts a name back into the meaning behind it. The
+// templates themselves are data (mobileLegacyRuntimeNames in the conversion rules), so a new runtime element is
+// added to a table rather than to a branch.
+
+/// <summary>
+/// Roles the runtime-name table can assign. Only the roles the converter actually acts on are named here; a role
+/// the data declares but this list does not know is carried through as an unrecognised anchor and REPORTED — never
+/// guessed at.
+/// </summary>
+public static class LegacyRuntimeRoles {
+	/// <summary>The screen root (<c>ViewConfig</c>) — carries title, actions, floatAction and header.</summary>
+	public const string ScreenRoot = "screenRoot";
+
+	/// <summary>The list component.</summary>
+	public const string List = "list";
+
+	/// <summary>The list row the wizard columns are rendered by.</summary>
+	public const string ListRow = "listRow";
+
+	/// <summary>A column from the wizard <c>subtitleItems</c> bucket, rendered in the row's <c>subtitles</c> slot.</summary>
+	public const string SubtitleField = "subtitleField";
+
+	/// <summary>A column from the wizard <c>groupItems</c> bucket, rendered in the row's <c>body</c> slot.</summary>
+	public const string BodyField = "bodyField";
+
+	/// <summary>The vestigial body-column marker the runtime removes when the last group column goes.</summary>
+	public const string BodyColumnMarker = "bodyColumnMarker";
+
+	/// <summary>The floating "add record" button.</summary>
+	public const string AddButton = "addButton";
+
+	/// <summary>One search column of the search filter (entity-schema derived, not enumerable from the settings).</summary>
+	public const string SearchExpression = "searchExpression";
+
+	/// <summary>One column offered in the sort tool's option list.</summary>
+	public const string SortOption = "sortOption";
+}
+
+/// <summary>
+/// One runtime-generated name together with the meaning behind it.
+/// </summary>
+/// <param name="RuntimeName">The name as the runtime would have generated it.</param>
+/// <param name="Role">The role from the runtime-name table (see <see cref="LegacyRuntimeRoles"/>).</param>
+/// <param name="Bucket">Wizard bucket the column came from, when the role is column-bound.</param>
+/// <param name="Slot">Runtime slot the element sits in (<c>subtitles</c> / <c>body</c>), when it has one.</param>
+/// <param name="ColumnPath">The wizard column path, when the role is column-bound.</param>
+/// <param name="FromInventory">
+/// True when the name was ENUMERATED from this source's own columns — the strongest possible evidence that the
+/// override refers to something this conversion actually produced. False when the name only matched a template:
+/// the meaning is known, but it points at something this source does not contain, which is a reportable fact
+/// rather than a conversion input.
+/// </param>
+public sealed record LegacyRuntimeAnchor(
+	string RuntimeName,
+	string Role,
+	string Bucket,
+	string Slot,
+	string ColumnPath,
+	bool FromInventory);
+
+/// <summary>
+/// The runtime name inventory for one parsed source, plus reverse lookup for names outside it.
+/// </summary>
+public sealed class LegacyRuntimeNameInventory {
+
+	private readonly Dictionary<string, LegacyRuntimeAnchor> _byName;
+	private readonly IReadOnlyList<(Regex Pattern, MobileLegacyRuntimeAnchorRule Rule)> _patterns;
+
+	internal LegacyRuntimeNameInventory(
+		Dictionary<string, LegacyRuntimeAnchor> byName,
+		IReadOnlyList<(Regex Pattern, MobileLegacyRuntimeAnchorRule Rule)> patterns) {
+		_byName = byName;
+		_patterns = patterns;
+	}
+
+	/// <summary>Every name the runtime would have generated for this source, in table order.</summary>
+	public IReadOnlyCollection<string> Names => _byName.Keys;
+
+	/// <summary>Whether the table carried any usable template at all (an empty table disables the override pass).</summary>
+	public bool IsEmpty => _byName.Count == 0 && _patterns.Count == 0;
+
+	/// <summary>
+	/// Resolves a name an override operation addresses back into its meaning.
+	/// </summary>
+	/// <param name="runtimeName">The <c>name</c> an override operation targets.</param>
+	/// <returns>The anchor, or null when no template in the table explains the name.</returns>
+	public LegacyRuntimeAnchor Resolve(string runtimeName) {
+		if (string.IsNullOrWhiteSpace(runtimeName)) {
+			return null;
+		}
+		if (_byName.TryGetValue(runtimeName, out LegacyRuntimeAnchor known)) {
+			return known;
+		}
+		foreach ((Regex pattern, MobileLegacyRuntimeAnchorRule rule) in _patterns) {
+			Match match = pattern.Match(runtimeName);
+			if (!match.Success) {
+				continue;
+			}
+			Group column = match.Groups["column"];
+			return new LegacyRuntimeAnchor(runtimeName, rule.Role, rule.Bucket, rule.Slot,
+				column.Success ? column.Value : null, false);
+		}
+		return null;
+	}
+}
+
+/// <summary>
+/// Reproduces the element names the mobile runtime would have generated for a parsed classic list source, and
+/// inverts them back into the meaning an embedded override was written against.
+/// </summary>
+public static class LegacyRuntimeNameOracle {
+
+	private const string EntityPlaceholder = "{entity}";
+	private const string ColumnPlaceholder = "{column}";
+	private const string BucketItems = "items";
+	private const string BucketSubtitleItems = "subtitleItems";
+	private const string BucketGroupItems = "groupItems";
+
+	/// <summary>An inventory built from no table at all — the override pass is then off and every section is reported.</summary>
+	public static readonly LegacyRuntimeNameInventory Empty = new([], []);
+
+	/// <summary>
+	/// Builds the runtime name inventory for one parsed source.
+	/// </summary>
+	/// <param name="settings">The parsed classic list settings.</param>
+	/// <param name="nameSet">The runtime-name table from the conversion rules; null or empty yields <see cref="Empty"/>.</param>
+	/// <returns>The inventory; never null.</returns>
+	/// <remarks>
+	/// Templates carrying no placeholder are matched BEFORE templates carrying <c>{column}</c>, so the literal
+	/// body-column marker is never read as a column that happens to be named "Column".
+	/// </remarks>
+	public static LegacyRuntimeNameInventory Build(LegacyGridPageSettings settings, MobileLegacyRuntimeNameSet nameSet) {
+		ArgumentNullException.ThrowIfNull(settings);
+		IReadOnlyList<MobileLegacyRuntimeAnchorRule> anchors = nameSet?.Anchors;
+		if (anchors is null || anchors.Count == 0) {
+			return Empty;
+		}
+		string entity = settings.EntitySchemaName ?? string.Empty;
+		var byName = new Dictionary<string, LegacyRuntimeAnchor>(StringComparer.Ordinal);
+		var literals = new List<(Regex, MobileLegacyRuntimeAnchorRule)>();
+		var parameterised = new List<(Regex, MobileLegacyRuntimeAnchorRule)>();
+
+		foreach (MobileLegacyRuntimeAnchorRule rule in anchors) {
+			if (string.IsNullOrWhiteSpace(rule?.Pattern) || string.IsNullOrWhiteSpace(rule.Role)) {
+				continue;
+			}
+			string resolved = rule.Pattern.Replace(EntityPlaceholder, entity, StringComparison.Ordinal);
+			bool hasColumn = resolved.Contains(ColumnPlaceholder, StringComparison.Ordinal);
+			(hasColumn ? parameterised : literals).Add((BuildPattern(resolved, hasColumn), rule));
+			if (!hasColumn) {
+				// A fixed element: it exists for every source, so it enumerates as itself.
+				byName.TryAdd(resolved, new LegacyRuntimeAnchor(resolved, rule.Role, null, rule.Slot, null, true));
+				continue;
+			}
+			foreach (LegacyGridColumn column in ColumnsOf(settings, rule.Bucket)) {
+				string name = resolved.Replace(ColumnPlaceholder, column.ColumnName, StringComparison.Ordinal);
+				byName.TryAdd(name,
+					new LegacyRuntimeAnchor(name, rule.Role, rule.Bucket, rule.Slot, column.ColumnName, true));
+			}
+		}
+		// Literals first so an exact marker always wins over a column template that could also match it.
+		return new LegacyRuntimeNameInventory(byName, [.. literals, .. parameterised]);
+	}
+
+	/// <summary>Columns of the named wizard bucket; empty when the rule names no bucket or an unknown one.</summary>
+	private static IReadOnlyList<LegacyGridColumn> ColumnsOf(LegacyGridPageSettings settings, string bucket) => bucket switch {
+		BucketItems => settings.Items,
+		BucketSubtitleItems => settings.SubtitleItems,
+		BucketGroupItems => settings.GroupItems,
+		_ => []
+	};
+
+	/// <summary>
+	/// Compiles one resolved template into an anchored matcher. Everything around <c>{column}</c> is literal, so
+	/// a name is only ever read as a column when the rest of it matches the template exactly.
+	/// </summary>
+	private static Regex BuildPattern(string resolved, bool hasColumn) {
+		string expression = hasColumn
+			? string.Join("(?<column>.+)",
+				resolved.Split(ColumnPlaceholder, StringSplitOptions.None).Select(Regex.Escape))
+			: Regex.Escape(resolved);
+		return new Regex($"^{expression}$", RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+	}
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideModels.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideModels.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 
 // Advisory contract for the `get-mobile-page-conversion-guide` MCP tool (ENG-89620).
 // The tool is REPORT-ONLY: it never builds a mobile page body and never writes to Creatio.
@@ -352,7 +353,7 @@ public sealed class MobilePageConversionGuide {
 	[JsonPropertyName("sourcePage")]
 	public string SourcePage { get; init; }
 
-	/// <summary>Detected source page type, e.g. <c>freedom-web</c> (future: other source types).</summary>
+	/// <summary>Detected source page type: <c>freedom-web</c> or <c>legacy-mobile-grid-page</c>.</summary>
 	[JsonPropertyName("sourceType")]
 	public string SourceType { get; init; }
 
@@ -576,6 +577,18 @@ public sealed class MobilePageConversionGuide {
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public IReadOnlyDictionary<string, string> ResourceStrings { get; init; }
 
+	// ── Legacy mobile wizard source (ENG-95730) ────────────────────────
+	/// <summary>
+	/// Present ONLY when <see cref="SourceType"/> is <c>legacy-mobile-grid-page</c>: the facts about the classic
+	/// Mobile-wizard settings schema the guide was built from — contributing package layers, the title/body column
+	/// mapping, the column-property coverage table and the open decisions. This is the per-element report for a
+	/// legacy source; <see cref="ElementMap"/> then carries exactly two <c>merge</c> operations onto the template's
+	/// <c>FolderTreeActions</c> and <c>ListItem</c>. Null for a Freedom UI web source.
+	/// </summary>
+	[JsonPropertyName("legacySource")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public LegacyMobileSourceInfo LegacySource { get; init; }
+
 	// ── Guidance ──────────────────────────────────────────────────────
 	[JsonPropertyName("constraints")]
 	public IReadOnlyList<string> Constraints { get; init; } = [];
@@ -606,6 +619,16 @@ public sealed class MobilePageConversionGuideResponse {
 	[JsonPropertyName("sourceType")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	public string SourceType { get; init; }
+
+	/// <summary>
+	/// Which conversion mechanism produced the result — <c>freedom-web-analysis</c> for a Freedom UI web source,
+	/// <c>legacy-mobile-settings-converter</c> for a classic Mobile-wizard settings source — so a wrong dispatch is
+	/// visible rather than silent. Set on success and on a legacy classification refusal; null when the source
+	/// could not be read or was rejected before any mechanism ran.
+	/// </summary>
+	[JsonPropertyName("conversionMechanism")]
+	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	public string ConversionMechanism { get; init; }
 
 	[JsonPropertyName("guide")]
 	[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
+using Clio.Common;
+
+namespace Clio.Command.McpServer.Tools.MobilePageConverter;
+
+/// <summary>
+/// Legacy branch of <c>get-mobile-page-conversion-guide</c> (ENG-95730): a classic Mobile-wizard LIST settings
+/// schema (<c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>) is read across every package layer, classified,
+/// and analysed into the same guide contract the Freedom UI web branch returns. Advisory-only: nothing is written.
+/// </summary>
+public sealed partial class MobilePageConversionGuideTool {
+
+	/// <summary>
+	/// Builds the guide for a legacy Mobile-wizard list settings source. Reads the effective (package-merged)
+	/// settings through <see cref="ILegacyMobileSettingsReader"/>, confirms the body really is a GridPage settings
+	/// array, refuses a custom viewConfig, and otherwise returns the analysis with the mechanism recorded.
+	/// </summary>
+	private MobilePageConversionGuideResponse BuildLegacyGridPageGuide(
+		MobilePageConversionGuideArgs args,
+		PageGetOptions getOptions,
+		string sourceType,
+		string version,
+		string resolvedFrom,
+		PlatformVersionResolution versionResolution) {
+		const string mechanism = LegacyMobileListAnalysisService.MechanismLegacySettingsConverter;
+
+		LegacyMobileSettingsReadResult read;
+		try {
+			ILegacyMobileSettingsReader reader = _commandResolver.Resolve<ILegacyMobileSettingsReader>(getOptions);
+			lock (McpToolExecutionLock.GetLock(McpToolExecutionLock.SharedFallbackKey)) {
+				try {
+					read = reader.Read(args.SchemaName);
+				} finally {
+					_logger.ClearMessages();
+				}
+			}
+		} catch (Exception ex) {
+			return FailLegacy(args, sourceType, mechanism, $"Failed to read legacy mobile settings '{args.SchemaName}': {ex.Message}");
+		}
+		if (read is null || !read.Success) {
+			return FailLegacy(args, sourceType, mechanism,
+				$"Could not read legacy mobile settings '{args.SchemaName}': {read?.Error ?? "unknown error"}");
+		}
+
+		// Body confirmation: the name said "GridPageSettings", the merged body must agree. Anything else is NOT
+		// converted — the generic not-supported verdict applies, with the label the platform actually gave.
+		// Scalars are read as JValue so a hand-edited object in their place fails cleanly, never with a cast error.
+		string settingsType = ScalarString(read.EffectiveSettings, "settingsType");
+		if (!string.Equals(settingsType, LegacyGridPageSettingsParser.GridPageSettingsType, StringComparison.OrdinalIgnoreCase)) {
+			return FailLegacy(args, "unknown", mechanism,
+				$"Schema '{args.SchemaName}' is named like a legacy Mobile-wizard list settings schema, but its merged body declares settingsType '{settingsType ?? "(none)"}' instead of '{LegacyGridPageSettingsParser.GridPageSettingsType}'. Nothing was converted.");
+		}
+
+		LegacySettingsClassification classification;
+		try {
+			classification = LegacyMobileSettingsClassifier.Classify(read.EffectiveSettings);
+		} catch (Exception ex) {
+			return FailLegacy(args, sourceType, mechanism, $"Failed to classify legacy mobile settings '{args.SchemaName}': {ex.Message}");
+		}
+		if (classification.Kind == LegacySettingsKind.CustomViewConfig) {
+			return FailLegacy(args, sourceType, mechanism,
+				$"Source schema '{args.SchemaName}' carries a custom viewConfig in its legacy mobile settings. It cannot be converted automatically — even the classic Mobile application wizard cannot open such a page. Rebuild the mobile list page by hand from {LegacyMobileListAnalysisService.RecommendedTemplate} (create-page) or remove the custom viewConfig from the settings schema first.");
+		}
+
+		string entitySchemaName = ScalarString(read.EffectiveSettings, "entitySchemaName")?.Trim();
+		if (string.IsNullOrWhiteSpace(entitySchemaName)) {
+			return FailLegacy(args, sourceType, mechanism,
+				$"Legacy mobile settings '{args.SchemaName}' do not declare 'entitySchemaName'; the mobile list page cannot be bound to an object. Nothing was converted.");
+		}
+		string targetName = string.IsNullOrWhiteSpace(args.TargetSchemaName)
+			? LegacyMobileListAnalysisService.DeriveTargetSchemaName(entitySchemaName, ReadSchemaNamePrefix(getOptions))
+			: args.TargetSchemaName.Trim();
+
+		// Read-only probe: the legacy settings schema is not itself a SysModule page, so the section is found by
+		// the entity the wizard page was bound to. Best-effort — never blocks the guide.
+		SectionRegistrationInfo sectionRegistration = MobileSectionRegistrationProbe.ProbeByEntity(
+			_commandResolver, args.EnvironmentName, args.Uri, args.Login, args.Password, entitySchemaName);
+
+		MobilePageConversionGuide guide;
+		try {
+			guide = LegacyMobileListAnalysisService.Analyze(read, classification, args.SchemaName, targetName, sectionRegistration);
+		} catch (Exception ex) {
+			return FailLegacy(args, sourceType, mechanism, $"Failed to analyze legacy mobile settings '{args.SchemaName}': {ex.Message}");
+		}
+
+		return new MobilePageConversionGuideResponse {
+			Success = true,
+			SourceSchemaName = args.SchemaName,
+			SourceType = sourceType,
+			ConversionMechanism = mechanism,
+			Guide = guide,
+			ResolvedTargetVersion = version,
+			ResolvedFrom = resolvedFrom,
+			VersionWarning = ComponentInfoResolution.GetVersionWarning(resolvedFrom),
+			RequiresVersionConfirmation = ComponentInfoResolution.RequiresVersionConfirmation(resolvedFrom),
+			ResolvedFromReason = ComponentInfoResolution.GetFallbackReason(resolvedFrom, versionResolution.Reason)
+		};
+	}
+
+	/// <summary>
+	/// Best-effort read of the environment's <c>SchemaNamePrefix</c> system setting for the default target name.
+	/// A blank setting AND an unreadable setting both degrade to
+	/// <see cref="LegacyMobileListAnalysisService.DefaultSchemaNamePrefix"/>, so two environments with the same
+	/// settings never produce different default names depending on whether the read succeeded (an explicit
+	/// <c>target-schema-name</c> always wins anyway).
+	/// </summary>
+	private string ReadSchemaNamePrefix(PageGetOptions getOptions) {
+		try {
+			ISysSettingsManager sysSettingsManager = _commandResolver.Resolve<ISysSettingsManager>(getOptions);
+			string prefix = SysSettingCodes.ReadSchemaNamePrefix(sysSettingsManager);
+			return string.IsNullOrWhiteSpace(prefix) ? LegacyMobileListAnalysisService.DefaultSchemaNamePrefix : prefix;
+		} catch (Exception) {
+			return LegacyMobileListAnalysisService.DefaultSchemaNamePrefix;
+		} finally {
+			_logger.ClearMessages();
+		}
+	}
+
+	/// <summary>
+	/// Resolves the version tier for the response contract WITHOUT loading any component registry (the legacy
+	/// guide needs none) and without letting a version-probe failure escape: any failure degrades to the
+	/// <c>latest-fallback</c> tier the caller already knows how to confirm.
+	/// </summary>
+	private async Task<(string Version, string ResolvedFrom, PlatformVersionResolution Resolution)> ResolveVersionTierBestEffortAsync(
+		MobilePageConversionGuideArgs args, CancellationToken cancellationToken) {
+		PlatformVersionResolution resolution;
+		try {
+			resolution = await ResolveVersionAsync(args, cancellationToken).ConfigureAwait(false);
+		} catch (Exception) {
+			resolution = ComponentInfoResolution.CreateNoActiveEnvironmentFallback();
+		} finally {
+			_logger.ClearMessages();
+		}
+		string resolvedFrom = ComponentInfoResolution.MapResolvedFrom(resolution.Source, resolution.ResolvedVersion, resolution.ResolvedVersion);
+		return (resolution.ResolvedVersion, resolvedFrom, resolution);
+	}
+
+	/// <summary>Reads a top-level scalar as text; an object/array/null in its place yields null instead of a cast error.</summary>
+	private static string ScalarString(Newtonsoft.Json.Linq.JObject settings, string key) =>
+		settings?[key] is Newtonsoft.Json.Linq.JValue { Type: not (Newtonsoft.Json.Linq.JTokenType.Null or Newtonsoft.Json.Linq.JTokenType.Undefined) } value
+			? value.ToString()
+			: null;
+
+	private static MobilePageConversionGuideResponse FailLegacy(
+		MobilePageConversionGuideArgs args, string sourceType, string mechanism, string error) =>
+		new() {
+			Success = false,
+			SourceSchemaName = args?.SchemaName,
+			SourceType = sourceType,
+			ConversionMechanism = mechanism,
+			Error = error
+		};
+}

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using Clio.Command.EntitySchemaDesigner;
 using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 using Clio.Common;
 
@@ -18,14 +20,33 @@ public sealed partial class MobilePageConversionGuideTool {
 	/// settings through <see cref="ILegacyMobileSettingsReader"/>, confirms the body really is a GridPage settings
 	/// array, refuses a custom viewConfig, and otherwise returns the analysis with the mechanism recorded.
 	/// </summary>
-	private MobilePageConversionGuideResponse BuildLegacyGridPageGuide(
+	private async Task<MobilePageConversionGuideResponse> BuildLegacyGridPageGuide(
 		MobilePageConversionGuideArgs args,
 		PageGetOptions getOptions,
 		string sourceType,
 		string version,
 		string resolvedFrom,
-		PlatformVersionResolution versionResolution) {
+		PlatformVersionResolution versionResolution,
+		CancellationToken cancellationToken) {
 		const string mechanism = LegacyMobileListAnalysisService.MechanismLegacySettingsConverter;
+
+		// The target template and the names of the template-provided elements the converted page merges onto are
+		// DATA, not constants (ENG-95733) — so the runtime-name → designer-name correspondence an embedded override
+		// is re-pointed through stays a table. The rules file is CDN-fetchable, so a fetch failure degrades to the
+		// bundled defaults rather than sinking an otherwise deterministic conversion.
+		MobileLegacyTemplateRule template;
+		MobileLegacyRuntimeNameSet runtimeNames;
+		try {
+			WebToMobilePageConversionRules rules =
+				await _rulesCatalog.GetRulesAsync(version, cancellationToken).ConfigureAwait(false);
+			template = LegacyMobileListAnalysisService.ResolveGridPageTemplate(rules);
+			runtimeNames = rules?.MobileLegacyRuntimeNames?.GridPage;
+		} catch (Exception) {
+			template = LegacyMobileListAnalysisService.DefaultGridPageTemplate;
+			runtimeNames = null;
+		} finally {
+			_logger.ClearMessages();
+		}
 
 		LegacyMobileSettingsReadResult read;
 		try {
@@ -62,7 +83,7 @@ public sealed partial class MobilePageConversionGuideTool {
 		}
 		if (classification.Kind == LegacySettingsKind.CustomViewConfig) {
 			return FailLegacy(args, sourceType, mechanism,
-				$"Source schema '{args.SchemaName}' carries a custom viewConfig in its legacy mobile settings. It cannot be converted automatically — even the classic Mobile application wizard cannot open such a page. Rebuild the mobile list page by hand from {LegacyMobileListAnalysisService.RecommendedTemplate} (create-page) or remove the custom viewConfig from the settings schema first.");
+				$"Source schema '{args.SchemaName}' carries a custom viewConfig in its legacy mobile settings. It cannot be converted automatically — even the classic Mobile application wizard cannot open such a page. Rebuild the mobile list page by hand from {template.TemplateName} (create-page) or remove the custom viewConfig from the settings schema first.");
 		}
 
 		string entitySchemaName = ScalarString(read.EffectiveSettings, "entitySchemaName")?.Trim();
@@ -81,7 +102,8 @@ public sealed partial class MobilePageConversionGuideTool {
 
 		MobilePageConversionGuide guide;
 		try {
-			guide = LegacyMobileListAnalysisService.Analyze(read, classification, args.SchemaName, targetName, sectionRegistration);
+			guide = LegacyMobileListAnalysisService.Analyze(read, classification, args.SchemaName, targetName,
+				sectionRegistration, template, runtimeNames, ReadColumnCaptions(getOptions, entitySchemaName));
 		} catch (Exception ex) {
 			return FailLegacy(args, sourceType, mechanism, $"Failed to analyze legacy mobile settings '{args.SchemaName}': {ex.Message}");
 		}
@@ -98,6 +120,39 @@ public sealed partial class MobilePageConversionGuideTool {
 			RequiresVersionConfirmation = ComponentInfoResolution.RequiresVersionConfirmation(resolvedFrom),
 			ResolvedFromReason = ComponentInfoResolution.GetFallbackReason(resolvedFrom, versionResolution.Reason)
 		};
+	}
+
+	/// <summary>
+	/// Best-effort read of the object's column captions, so an override that references a column the wizard never
+	/// placed (a sort option, for example) can carry a real label instead of a machine name. Never blocks the
+	/// guide: an unreadable schema simply yields no captions and the affected operation reports that.
+	/// </summary>
+	/// <param name="getOptions">Connection options for the current call.</param>
+	/// <param name="entitySchemaName">The object the converted page binds to.</param>
+	/// <returns>Column name → caption; empty when the schema could not be read.</returns>
+	private IReadOnlyDictionary<string, string> ReadColumnCaptions(PageGetOptions getOptions, string entitySchemaName) {
+		var captions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		try {
+			GetEntitySchemaPropertiesOptions options = new() {
+				SchemaName = entitySchemaName,
+				Environment = getOptions.Environment,
+				Uri = getOptions.Uri,
+				Login = getOptions.Login,
+				Password = getOptions.Password
+			};
+			IRemoteEntitySchemaColumnManager manager = _commandResolver.Resolve<IRemoteEntitySchemaColumnManager>(getOptions);
+			EntitySchemaPropertiesInfo properties = manager.GetSchemaProperties(options);
+			foreach (EntitySchemaPropertyColumnInfo column in properties?.Columns ?? []) {
+				if (!string.IsNullOrWhiteSpace(column.Name) && !string.IsNullOrWhiteSpace(column.Title)) {
+					captions[column.Name] = column.Title;
+				}
+			}
+		} catch (Exception) {
+			// An object we cannot read is not a conversion failure — the caption is simply reported as unresolved.
+		} finally {
+			_logger.ClearMessages();
+		}
+		return captions;
 	}
 
 	/// <summary>

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.Legacy.cs
@@ -95,6 +95,11 @@ public sealed partial class MobilePageConversionGuideTool {
 			? LegacyMobileListAnalysisService.DeriveTargetSchemaName(entitySchemaName, ReadSchemaNamePrefix(getOptions))
 			: args.TargetSchemaName.Trim();
 
+		// The designer names this conversion merges onto come from a data table; the table is only as good as the
+		// template it describes. Reading the template turns a stale or mistyped name into an explicit constraint
+		// instead of a merge that authors nothing. Best-effort, exactly as the Freedom UI web branch does it.
+		IReadOnlySet<string> templateElements = ReadTemplateElements(template.TemplateName, args);
+
 		// Read-only probe: the legacy settings schema is not itself a SysModule page, so the section is found by
 		// the entity the wizard page was bound to. Best-effort — never blocks the guide.
 		SectionRegistrationInfo sectionRegistration = MobileSectionRegistrationProbe.ProbeByEntity(
@@ -103,7 +108,8 @@ public sealed partial class MobilePageConversionGuideTool {
 		MobilePageConversionGuide guide;
 		try {
 			guide = LegacyMobileListAnalysisService.Analyze(read, classification, args.SchemaName, targetName,
-				sectionRegistration, template, runtimeNames, ReadColumnCaptions(getOptions, entitySchemaName));
+				sectionRegistration, template, runtimeNames, ReadColumnCaptions(getOptions, entitySchemaName),
+				templateElements);
 		} catch (Exception ex) {
 			return FailLegacy(args, sourceType, mechanism, $"Failed to analyze legacy mobile settings '{args.SchemaName}': {ex.Message}");
 		}
@@ -120,6 +126,21 @@ public sealed partial class MobilePageConversionGuideTool {
 			RequiresVersionConfirmation = ComponentInfoResolution.RequiresVersionConfirmation(resolvedFrom),
 			ResolvedFromReason = ComponentInfoResolution.GetFallbackReason(resolvedFrom, versionResolution.Reason)
 		};
+	}
+
+	/// <summary>
+	/// Every element the target template declares, read from the stand through the same probe the Freedom UI web
+	/// branch uses. Null when the template could not be read — the caller then reports the names as unverified
+	/// rather than silently trusting the table.
+	/// </summary>
+	/// <param name="templateSchemaName">The mobile template the converted page inherits.</param>
+	/// <param name="args">The current call's connection arguments.</param>
+	/// <returns>The template's element names, or null when it could not be read.</returns>
+	private IReadOnlySet<string> ReadTemplateElements(string templateSchemaName, MobilePageConversionGuideArgs args) {
+		MobileTemplateProbe probe = LoadMobileTemplateProbe(templateSchemaName, args);
+		return probe.Unavailable || probe.TypesByName is not { Count: > 0 }
+			? null
+			: new HashSet<string>(probe.TypesByName.Keys, StringComparer.OrdinalIgnoreCase);
 	}
 
 	/// <summary>

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Clio.Command.McpServer.Tools.MobilePageConverter.Legacy;
 using Clio.Common;
 using Clio.UserEnvironment;
 using ModelContextProtocol.Server;
@@ -23,14 +24,18 @@ namespace Clio.Command.McpServer.Tools.MobilePageConverter;
 /// comparison, and inline mobile component contracts). It builds NO page body and writes NOTHING to
 /// Creatio or disk — the caller (LLM) builds the mobile page body itself using create-page +
 /// update-page + validate-page.
-/// Supported source type today: Freedom UI web (<c>freedom-web</c>). Other source types (e.g. Classic
-/// UI) are detected and reported as not yet supported.
+/// Supported source types: Freedom UI web (<c>freedom-web</c>, analysed by
+/// <see cref="WebToMobileAnalysisService"/>) and legacy classic Mobile-wizard LIST settings
+/// (<c>legacy-mobile-grid-page</c>, schemas named <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c>,
+/// analysed by <see cref="LegacyMobileListAnalysisService"/> — ENG-95730). The tool dispatches on the detected
+/// source type and reports the mechanism it ran; a legacy RECORD settings schema (ENG-95731) and any other source
+/// type (e.g. Classic UI) are detected and reported as not yet supported.
 /// </summary>
 [McpServerToolType]
 [FeatureToggle("mobile-page-converter")]
 [SuppressMessage("Major Code Smell", "S1168:Empty arrays and collections should be returned instead of null", Justification = "The best-effort probe helpers return null to signal 'not read' (distinct from 'read, empty'); the caller treats null as skip.")]
 [SuppressMessage("Minor Code Smell", "S3267:Loops should be simplified with LINQ", Justification = "Explicit loops that build registry maps with side effects read more clearly than a LINQ rewrite here.")]
-public sealed class MobilePageConversionGuideTool {
+public sealed partial class MobilePageConversionGuideTool {
 	private readonly IToolCommandResolver _commandResolver;
 	private readonly ILogger _logger;
 	private readonly IMobileComponentInfoCatalog _mobileCatalog;
@@ -60,9 +65,14 @@ public sealed class MobilePageConversionGuideTool {
 
 	[McpServerTool(Name = ToolName, ReadOnly = true, Destructive = false, Idempotent = true, OpenWorld = false)]
 	[Description(
-		"Detect a page's source type and return an advisory mobile-conversion GUIDE. Supported source type today: "
-		+ "Freedom UI WEB (sourceType \"freedom-web\"); any other source type is detected and reported as not yet "
-		+ "supported. ADVISORY-ONLY: this tool builds NO page body and writes NOTHING to Creatio or disk — YOU build "
+		"Detect a page's source type and return an advisory mobile-conversion GUIDE. Supported source types: "
+		+ "Freedom UI WEB (sourceType \"freedom-web\", conversionMechanism freedom-web-analysis) and LEGACY classic "
+		+ "Mobile-wizard LIST settings (sourceType \"legacy-mobile-grid-page\", schemas named "
+		+ "Mobile<Entity>GridPageSettings<Workplace>, conversionMechanism legacy-mobile-settings-converter: the guide "
+		+ "carries the two elementMap merges onto the BaseMobileListTemplate FolderTreeActions and ListItem plus the data-section diffs, and "
+		+ "guide.legacySource reports the column mapping, contributing packages and dropped properties). A legacy "
+		+ "RECORD settings schema and any other source type are detected and reported as not yet supported. "
+		+ "ADVISORY-ONLY: this tool builds NO page body and writes NOTHING to Creatio or disk — YOU build "
 		+ "the mobile body from the guide, persist it with create-page (mobile template) + update-page, then "
 		+ "validate-page. The guide is self-describing: its own `constraints` and ordered `nextSteps` carry the rules "
 		+ "for applying THIS conversion, composed from what the converter actually did. "
@@ -100,10 +110,13 @@ public sealed class MobilePageConversionGuideTool {
 				"If the page is a Classic UI page, migrate it to a Freedom UI web page first.");
 		}
 
-		// Detect the source page type and gate on it. Only Freedom UI web is supported today; a
-		// non-Freedom-web source (e.g. Classic UI) or an already-mobile page short-circuits with a
-		// failure and never starts conversion (hard acceptance criterion).
+		// Detect the source page type and gate on it. Freedom UI web and legacy Mobile-wizard LIST settings are
+		// supported; any other source (Classic UI, a legacy RECORD settings schema) or an already-mobile page
+		// short-circuits with a failure and never starts conversion (hard acceptance criterion). A legacy schema
+		// reads as schema-type "unknown" (its ClientUnitSchemaType is neither 9 nor 10), so the name-based legacy
+		// detection refines that label; the body is confirmed by the legacy reader before anything converts.
 		string sourceType = DetectSourceType(pageResponse.Page?.SchemaType);
+		sourceType = DetectLegacySourceType(args.SchemaName, sourceType) ?? sourceType;
 		MobilePageConversionGuideResponse sourceTypeRejection = RejectUnsupportedSourceType(args, sourceType);
 		if (sourceTypeRejection is not null) {
 			return sourceTypeRejection;
@@ -118,6 +131,15 @@ public sealed class MobilePageConversionGuideTool {
 			&& !PlatformVersionResolver.TryNormaliseToThreePartSemver(args.Version, out _)) {
 			return Fail(args, sourceType,
 				$"'version' value '{args.Version}' is not a valid platform version. Use a 3-part semver, for example '8.3.3', or 'latest'.");
+		}
+
+		if (string.Equals(sourceType, LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, StringComparison.Ordinal)) {
+			// Legacy branch (ENG-95730): the target elements are known up front (BaseMobileListTemplate + its
+			// ListItem), so no registries / rules / template probes are needed. Only the version tier the response
+			// contract already carries is resolved — best-effort, so a CDN or cache miss never throws out of the tool.
+			(string legacyVersion, string legacyResolvedFrom, PlatformVersionResolution legacyResolution) =
+				await ResolveVersionTierBestEffortAsync(args, cancellationToken).ConfigureAwait(false);
+			return BuildLegacyGridPageGuide(args, getOptions, sourceType, legacyVersion, legacyResolvedFrom, legacyResolution);
 		}
 
 		// Resolve the component-registry version against the TARGET environment (mirrors get-component-info):
@@ -192,7 +214,7 @@ public sealed class MobilePageConversionGuideTool {
 
 		// Read-only probe: is this page a section, and what would registering it for mobile take?
 		// Best-effort — never blocks the guide if the environment can't be queried.
-		bool isFormPage = IsFormPage(args.SchemaName, pageResponse.Page?.ParentSchemaName);
+		bool isFormPage = IsFormPage(args.SchemaName, effectiveTemplate);
 		SectionRegistrationInfo sectionRegistration = MobileSectionRegistrationProbe.Probe(
 			_commandResolver, args.EnvironmentName, args.Uri, args.Login, args.Password,
 			pageResponse.Page?.SchemaUId, isFormPage);
@@ -234,6 +256,7 @@ public sealed class MobilePageConversionGuideTool {
 			Success = true,
 			SourceSchemaName = args.SchemaName,
 			SourceType = sourceType,
+			ConversionMechanism = LegacyMobileListAnalysisService.MechanismFreedomWebAnalysis,
 			Guide = guide,
 			ResolvedTargetVersion = version,
 			ResolvedFrom = resolvedFrom,
@@ -602,9 +625,9 @@ public sealed class MobilePageConversionGuideTool {
 
 	/// <summary>
 	/// Gates a detected source type against what the converter supports today. Returns a failure
-	/// response to short-circuit with — an already-mobile page, or a not-yet-supported source such as
-	/// Classic UI — or <c>null</c> when the source is a supported Freedom UI web page and conversion may
-	/// proceed. Extracted as an internal static gate so the safety-critical "never convert an
+	/// response to short-circuit with — an already-mobile page, a legacy RECORD settings schema, or a
+	/// not-yet-supported source such as Classic UI — or <c>null</c> when the source is a supported Freedom UI
+	/// web page or a legacy Mobile-wizard LIST settings schema and conversion may proceed. Extracted as an internal static gate so the safety-critical "never convert an
 	/// unsupported source" rule is unit-testable without a live page read.
 	/// </summary>
 	internal static MobilePageConversionGuideResponse RejectUnsupportedSourceType(
@@ -612,14 +635,44 @@ public sealed class MobilePageConversionGuideTool {
 		if (string.Equals(sourceType, "mobile", StringComparison.OrdinalIgnoreCase)) {
 			return Fail(args, sourceType, $"Source page '{args?.SchemaName}' is already a mobile page. Nothing to convert.");
 		}
+		if (string.Equals(sourceType, LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, StringComparison.OrdinalIgnoreCase)) {
+			return null;
+		}
+		if (string.Equals(sourceType, LegacyMobileListAnalysisService.SourceTypeLegacyRecordPage, StringComparison.OrdinalIgnoreCase)) {
+			return Fail(args, sourceType,
+				$"Source page '{args?.SchemaName}' is a legacy Mobile-wizard RECORD page settings schema, which is not yet supported by " +
+				"get-mobile-page-conversion-guide (ENG-95731). " +
+				$"Supported today: '{WebToMobileAnalysisService.SourceTypeFreedomWeb}', '{LegacyMobileListAnalysisService.SourceTypeLegacyGridPage}'.");
+		}
 		if (!string.Equals(sourceType, WebToMobileAnalysisService.SourceTypeFreedomWeb, StringComparison.OrdinalIgnoreCase)) {
 			return Fail(args, sourceType,
 				$"Source page '{args?.SchemaName}' has source type '{sourceType}', which is not yet supported by get-mobile-page-conversion-guide " +
-				$"(supported today: '{WebToMobileAnalysisService.SourceTypeFreedomWeb}'). " +
+				$"(supported today: '{WebToMobileAnalysisService.SourceTypeFreedomWeb}', '{LegacyMobileListAnalysisService.SourceTypeLegacyGridPage}'). " +
 				"A Classic UI page must first be converted to a Freedom UI web page (use the dedicated classic-web -> freedom-web converter), " +
 				"then run get-mobile-page-conversion-guide.");
 		}
 		return null;
+	}
+
+	/// <summary>
+	/// Refines the platform schema-type label with the legacy Mobile-wizard detection: a schema whose type is
+	/// neither web nor mobile (<c>unknown</c>) and whose name follows the wizard pattern
+	/// <c>Mobile&lt;Entity&gt;GridPageSettings&lt;Workplace&gt;</c> / <c>Mobile&lt;Entity&gt;RecordPageSettings&lt;Workplace&gt;</c>
+	/// is a classic wizard LIST / RECORD settings schema. Returns <c>null</c> when the
+	/// label should stay as detected. The body is confirmed later by the legacy reader (settingsType GridPage).
+	/// </summary>
+	internal static string DetectLegacySourceType(string schemaName, string sourceTypeLabel) {
+		if (string.IsNullOrWhiteSpace(schemaName)
+			|| !string.Equals(sourceTypeLabel, "unknown", StringComparison.OrdinalIgnoreCase)) {
+			return null;
+		}
+		LegacyMobileListAnalysisService.LegacySchemaNameParts parts = LegacyMobileListAnalysisService.TryParseSchemaName(schemaName);
+		if (parts is null) {
+			return null;
+		}
+		return parts.IsRecordPage
+			? LegacyMobileListAnalysisService.SourceTypeLegacyRecordPage
+			: LegacyMobileListAnalysisService.SourceTypeLegacyGridPage;
 	}
 }
 
@@ -628,12 +681,12 @@ public sealed class MobilePageConversionGuideTool {
 /// </summary>
 public sealed record MobilePageConversionGuideArgs(
 	[property: JsonPropertyName("schema-name")]
-	[property: Description("Source page schema name, e.g. 'UsrMyApp_FormPage'. Today only Freedom UI web pages are supported.")]
+	[property: Description("Source page schema name: a Freedom UI web page (e.g. 'UsrMyApp_FormPage') or a legacy classic Mobile-wizard list settings schema (e.g. 'MobileOrderGridPageSettingsDefaultWorkplace').")]
 	[property: Required]
 	string SchemaName,
 
 	[property: JsonPropertyName("target-schema-name")]
-	[property: Description("Optional suggested target mobile page schema name. Defaults to the source name with a mobile suffix (e.g. UsrMyApp_FormPage -> UsrMyApp_MobileFormPage).")]
+	[property: Description("Optional suggested target mobile page schema name. Defaults to the source name with a mobile suffix (e.g. UsrMyApp_FormPage -> UsrMyApp_MobileFormPage); for a legacy settings schema to <SchemaNamePrefix><Entity>_MobileListPage.")]
 	string TargetSchemaName,
 
 	[property: JsonPropertyName("version")]

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
@@ -70,7 +70,12 @@ public sealed partial class MobilePageConversionGuideTool {
 		+ "Mobile-wizard LIST settings (sourceType \"legacy-mobile-grid-page\", schemas named "
 		+ "Mobile<Entity>GridPageSettings<Workplace>, conversionMechanism legacy-mobile-settings-converter: the guide "
 		+ "carries the two elementMap merges onto the BaseMobileListTemplate FolderTreeActions and ListItem plus the data-section diffs, and "
-		+ "guide.legacySource reports the column mapping, contributing packages and dropped properties). A legacy "
+		+ "guide.legacySource reports the column mapping, contributing packages and dropped properties). Freedom UI "
+		+ "overrides embedded in legacy settings (viewConfigDiff / viewModelConfigDiff / modelConfigDiff) are "
+		+ "re-pointed from the mobile runtime's generated names onto the converted page, one operation at a time, and "
+		+ "guide.legacySource.overrideOutcomes states per operation whether it was carried over or why it could not "
+		+ "be; diffV2 and a hand-authored viewConfig are NOT converted and say so. elementMap therefore has NO fixed "
+		+ "length: emit every entry with ITS OWN operation, in order. A legacy "
 		+ "RECORD settings schema and any other source type are detected and reported as not yet supported. "
 		+ "ADVISORY-ONLY: this tool builds NO page body and writes NOTHING to Creatio or disk — YOU build "
 		+ "the mobile body from the guide, persist it with create-page (mobile template) + update-page, then "
@@ -134,12 +139,14 @@ public sealed partial class MobilePageConversionGuideTool {
 		}
 
 		if (string.Equals(sourceType, LegacyMobileListAnalysisService.SourceTypeLegacyGridPage, StringComparison.Ordinal)) {
-			// Legacy branch (ENG-95730): the target elements are known up front (BaseMobileListTemplate + its
-			// ListItem), so no registries / rules / template probes are needed. Only the version tier the response
+			// Legacy branch (ENG-95730): no component registries and no template probe are needed — the target
+			// elements are known up front. The conversion RULES are still loaded, because the target template and
+			// its element names live there rather than in constants (ENG-95733). Only the version tier the response
 			// contract already carries is resolved — best-effort, so a CDN or cache miss never throws out of the tool.
 			(string legacyVersion, string legacyResolvedFrom, PlatformVersionResolution legacyResolution) =
 				await ResolveVersionTierBestEffortAsync(args, cancellationToken).ConfigureAwait(false);
-			return BuildLegacyGridPageGuide(args, getOptions, sourceType, legacyVersion, legacyResolvedFrom, legacyResolution);
+			return await BuildLegacyGridPageGuide(args, getOptions, sourceType, legacyVersion, legacyResolvedFrom,
+				legacyResolution, cancellationToken).ConfigureAwait(false);
 		}
 
 		// Resolve the component-registry version against the TARGET environment (mirrors get-component-info):

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobileSectionRegistrationProbe.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobileSectionRegistrationProbe.cs
@@ -73,56 +73,7 @@ public static class MobileSectionRegistrationProbe {
 				};
 			}
 
-			JsonElement module = modules[0];
-			string sysModuleId = Str(module, "Id");
-			string mobileUId = Str(module, "MobileSectionSchemaUId");
-			bool mobileRegistered = !string.IsNullOrWhiteSpace(mobileUId)
-				&& !string.Equals(mobileUId, EmptyGuid, StringComparison.OrdinalIgnoreCase);
-
-			// 2. Which workplaces is this section already in?
-			var currentWorkplaceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-			foreach (JsonElement link in Query(client, urlBuilder,
-				"SysModuleInWorkplace",
-				$"$select=SysWorkplaceId&$filter=SysModuleId eq {sysModuleId}")) {
-				string wpId = Str(link, "SysWorkplaceId");
-				if (!string.IsNullOrWhiteSpace(wpId)) {
-					currentWorkplaceIds.Add(wpId);
-				}
-			}
-
-			// 3. Resolve the Mobile client type and list workplaces.
-			string mobileClientTypeId = ResolveMobileClientTypeId(client, urlBuilder);
-			var current = new List<WorkplaceInfo>();
-			var availableMobile = new List<WorkplaceInfo>();
-			foreach (JsonElement wp in Query(client, urlBuilder,
-				"SysWorkplace", "$select=Id,Name,SysApplicationClientTypeId&$top=100")) {
-				string id = Str(wp, "Id");
-				string clientTypeId = Str(wp, "SysApplicationClientTypeId");
-				bool isMobile = mobileClientTypeId is not null
-					&& string.Equals(clientTypeId, mobileClientTypeId, StringComparison.OrdinalIgnoreCase);
-				bool contains = currentWorkplaceIds.Contains(id);
-				var info = new WorkplaceInfo { Id = id, Name = Str(wp, "Name"), IsMobile = isMobile, ContainsSection = contains };
-				if (contains) {
-					current.Add(info);
-				}
-				if (isMobile) {
-					availableMobile.Add(info);
-				}
-			}
-
-			return new SectionRegistrationInfo {
-				SourcePageIsSection = true,
-				SysModuleId = sysModuleId,
-				SectionCode = Str(module, "Code"),
-				SectionCaption = Str(module, "Caption"),
-				MobileSectionSchemaUId = mobileRegistered ? mobileUId : null,
-				MobileSectionRegistered = mobileRegistered,
-				IsFormPage = isFormPage,
-				CurrentWorkplaces = current,
-				AvailableMobileWorkplaces = availableMobile,
-				ProbeOk = true,
-				RegistrationActions = BuildActions(sysModuleId, Str(module, "Code"), mobileRegistered, availableMobile, isFormPage)
-			};
+			return ProbeModule(client, urlBuilder, modules[0], isFormPage, entitySchemaName: null, note: null);
 		} catch (Exception ex) {
 			return new SectionRegistrationInfo {
 				IsFormPage = isFormPage,
@@ -131,6 +82,166 @@ public static class MobileSectionRegistrationProbe {
 				RegistrationActions = [ManualEditPageActionOrSkip(isFormPage)]
 			};
 		}
+	}
+
+	/// <summary>
+	/// Probes section / workplace registration for the ENTITY a page is bound to (ENG-95730): a legacy
+	/// Mobile-wizard settings schema is not itself a SysModule page, so the section is found through
+	/// <c>SysModuleEntity.SysEntitySchemaUId</c> → <c>SysModule.SysModuleEntityId</c>. Read-only, never throws;
+	/// when the entity has several sections the first is probed and the rest are named in the note so the user
+	/// decides.
+	/// </summary>
+	public static SectionRegistrationInfo ProbeByEntity(
+		IToolCommandResolver commandResolver,
+		string environment, string uri, string login, string password,
+		string entitySchemaName) {
+		if (commandResolver is null || string.IsNullOrWhiteSpace(entitySchemaName)) {
+			return new SectionRegistrationInfo {
+				IsFormPage = false,
+				EntitySchemaName = entitySchemaName,
+				ProbeOk = false,
+				Note = "Section registration was not probed (missing environment client or entity schema name).",
+				RegistrationActions = [ManualEditPageActionOrSkip(false)]
+			};
+		}
+		try {
+			var options = new EnvironmentOptions {
+				Environment = environment, Uri = uri, Login = login, Password = password
+			};
+			IApplicationClient client = commandResolver.Resolve<IApplicationClient>(options);
+			IServiceUrlBuilder urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
+
+			// The entity name is interpolated into an OData string literal: accept identifiers only, so a stray
+			// quote can never reach the filter. A malformed name degrades to "not probed".
+			if (!PageSchemaMetadataHelper.IsValidSchemaName(entitySchemaName)) {
+				return new SectionRegistrationInfo {
+					IsFormPage = false,
+					EntitySchemaName = entitySchemaName,
+					ProbeOk = false,
+					Note = $"Section registration was not probed: '{entitySchemaName}' is not a valid entity schema name.",
+					RegistrationActions = [ManualEditPageActionOrSkip(false)]
+				};
+			}
+			// SysModuleEntity references the entity's ROOT schema UId. An entity replaced in many packages has one
+			// SysSchema row per package with a DIFFERENT UId each, so the lookup must pick the root row
+			// (ExtendParent = false) — a Name-only first-row lookup returns an arbitrary replacing layer.
+			var entityGuids = new List<Guid>();
+			foreach (JsonElement schema in Query(client, urlBuilder,
+				"SysSchema",
+				$"$select=UId&$filter=Name eq '{entitySchemaName}' and ManagerName eq 'EntitySchemaManager' and ExtendParent eq false")) {
+				if (Guid.TryParse(Str(schema, "UId"), out Guid uid)) {
+					entityGuids.Add(uid);
+				}
+			}
+			if (entityGuids.Count == 0) {
+				return new SectionRegistrationInfo {
+					IsFormPage = false,
+					EntitySchemaName = entitySchemaName,
+					ProbeOk = false,
+					Note = $"Section registration was not probed: no root entity schema named '{entitySchemaName}' was found.",
+					RegistrationActions = [ManualEditPageActionOrSkip(false)]
+				};
+			}
+			var moduleEntities = new List<JsonElement>();
+			foreach (Guid entityGuid in entityGuids) {
+				moduleEntities.AddRange(Query(client, urlBuilder,
+					"SysModuleEntity", $"$select=Id&$filter=SysEntitySchemaUId eq {entityGuid}"));
+			}
+			var modules = new List<JsonElement>();
+			foreach (JsonElement moduleEntity in moduleEntities) {
+				string moduleEntityId = Str(moduleEntity, "Id");
+				if (!Guid.TryParse(moduleEntityId, out Guid moduleEntityGuid)) {
+					continue;
+				}
+				modules.AddRange(Query(client, urlBuilder,
+					"SysModule",
+					"$select=Id,Code,Caption,SectionSchemaUId,SysPageSchemaUId,MobileSectionSchemaUId&$filter=" +
+					$"SysModuleEntity/Id eq {moduleEntityGuid}"));
+			}
+			if (modules.Count == 0) {
+				return new SectionRegistrationInfo {
+					SourcePageIsSection = false,
+					IsFormPage = false,
+					EntitySchemaName = entitySchemaName,
+					ProbeOk = true,
+					Note = $"No section (SysModule) is registered for entity '{entitySchemaName}'.",
+					RegistrationActions = [
+						$"No section exists for '{entitySchemaName}' — register one manually (or with create-app-section) before adding the mobile list page to a mobile workplace."
+					]
+				};
+			}
+			string note = modules.Count > 1
+				? $"Entity '{entitySchemaName}' has {modules.Count} sections ({string.Join(", ", modules.Select(m => Str(m, "Code")).Where(c => !string.IsNullOrWhiteSpace(c)))}); the first one is reported — the user decides which section receives the mobile list page."
+				: null;
+			return ProbeModule(client, urlBuilder, modules[0], isFormPage: false, entitySchemaName, note);
+		} catch (Exception ex) {
+			return new SectionRegistrationInfo {
+				IsFormPage = false,
+				EntitySchemaName = entitySchemaName,
+				ProbeOk = false,
+				Note = $"Could not query the environment for section registration ({ex.Message}). Verify section / workplace registration manually.",
+				RegistrationActions = [ManualEditPageActionOrSkip(false)]
+			};
+		}
+	}
+
+	/// <summary>Shared tail of both probes: workplace membership, the Mobile client type and the registration actions for one SysModule row.</summary>
+	private static SectionRegistrationInfo ProbeModule(
+		IApplicationClient client, IServiceUrlBuilder urlBuilder, JsonElement module, bool isFormPage,
+		string entitySchemaName, string note) {
+		string sysModuleId = Str(module, "Id");
+		string mobileUId = Str(module, "MobileSectionSchemaUId");
+		bool mobileRegistered = !string.IsNullOrWhiteSpace(mobileUId)
+			&& !string.Equals(mobileUId, EmptyGuid, StringComparison.OrdinalIgnoreCase);
+
+		// 2. Which workplaces is this section already in? A lookup is filtered through its NAVIGATION path
+		//    (SysModule/Id): the Id-suffixed column works in $select but "Column by path SysModuleId not found"
+		//    in $filter, which Query() would swallow as an empty result — silently reporting no workplaces.
+		var currentWorkplaceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (JsonElement link in Query(client, urlBuilder,
+			"SysModuleInWorkplace",
+			$"$select=SysWorkplaceId&$filter=SysModule/Id eq {sysModuleId}")) {
+			string wpId = Str(link, "SysWorkplaceId");
+			if (!string.IsNullOrWhiteSpace(wpId)) {
+				currentWorkplaceIds.Add(wpId);
+			}
+		}
+
+		// 3. Resolve the Mobile client type and list workplaces.
+		string mobileClientTypeId = ResolveMobileClientTypeId(client, urlBuilder);
+		var current = new List<WorkplaceInfo>();
+		var availableMobile = new List<WorkplaceInfo>();
+		foreach (JsonElement wp in Query(client, urlBuilder,
+			"SysWorkplace", "$select=Id,Name,SysApplicationClientTypeId&$top=100")) {
+			string id = Str(wp, "Id");
+			string clientTypeId = Str(wp, "SysApplicationClientTypeId");
+			bool isMobile = mobileClientTypeId is not null
+				&& string.Equals(clientTypeId, mobileClientTypeId, StringComparison.OrdinalIgnoreCase);
+			bool contains = currentWorkplaceIds.Contains(id);
+			var info = new WorkplaceInfo { Id = id, Name = Str(wp, "Name"), IsMobile = isMobile, ContainsSection = contains };
+			if (contains) {
+				current.Add(info);
+			}
+			if (isMobile) {
+				availableMobile.Add(info);
+			}
+		}
+
+		return new SectionRegistrationInfo {
+			SourcePageIsSection = true,
+			SysModuleId = sysModuleId,
+			SectionCode = Str(module, "Code"),
+			SectionCaption = Str(module, "Caption"),
+			EntitySchemaName = entitySchemaName,
+			MobileSectionSchemaUId = mobileRegistered ? mobileUId : null,
+			MobileSectionRegistered = mobileRegistered,
+			IsFormPage = isFormPage,
+			CurrentWorkplaces = current,
+			AvailableMobileWorkplaces = availableMobile,
+			ProbeOk = true,
+			Note = note,
+			RegistrationActions = BuildActions(sysModuleId, Str(module, "Code"), mobileRegistered, availableMobile, isFormPage)
+		};
 	}
 
 	private static List<string> BuildActions(

--- a/clio/Command/McpServer/Tools/MobilePageConverter/WebToMobilePageConversionRulesModels.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/WebToMobilePageConversionRulesModels.cs
@@ -134,9 +134,210 @@ public sealed class WebToMobilePageConversionRules {
 	[JsonPropertyName("nonConvertingScopeContainers")]
 	public IReadOnlyList<string> NonConvertingScopeContainers { get; init; } = [];
 
+	/// <summary>
+	/// Group: the shipped mobile templates a LEGACY Mobile-wizard settings source is converted onto, and the
+	/// names of the template-provided elements the converted page merges onto (ENG-95733). Unlike
+	/// <see cref="Templates"/> these are not keyed by a web template — a legacy source has no web counterpart,
+	/// only a <c>settingsType</c>. Absent from the rules file means the bundled defaults on
+	/// <see cref="MobileLegacyTemplateRule"/> apply, so an older CDN-served file never breaks the legacy branch.
+	/// </summary>
+	[JsonPropertyName("mobileLegacyTemplates")]
+	public MobileLegacyTemplatesRule MobileLegacyTemplates { get; init; }
+
+	/// <summary>
+	/// Group: the element names the MOBILE RUNTIME generates when it converts a classic wizard settings schema on
+	/// the device (ENG-95733). Embedded <c>viewConfigDiff</c> / <c>viewModelConfigDiff</c> / <c>modelConfigDiff</c>
+	/// operations address THESE names, not the designer names in <see cref="MobileLegacyTemplates"/>; the table
+	/// here is what lets an override be re-pointed by lookup instead of by branching code. Absent switches the
+	/// override pass off — every embedded section is then reported rather than converted (data-driven, like
+	/// <see cref="TabAreaLayers"/>).
+	/// </summary>
+	[JsonPropertyName("mobileLegacyRuntimeNames")]
+	public MobileLegacyRuntimeNamesRule MobileLegacyRuntimeNames { get; init; }
+
 	/// <summary>Any future producer field not yet mapped to a typed group.</summary>
 	[JsonExtensionData]
 	public IDictionary<string, JsonElement> Extensions { get; init; }
+}
+
+/// <summary>
+/// Per-<c>settingsType</c> mobile template configuration for the legacy Mobile-wizard converter.
+/// </summary>
+public sealed class MobileLegacyTemplatesRule {
+	/// <summary>Target template for a classic <c>GridPage</c> settings schema (the mobile list page).</summary>
+	[JsonPropertyName("gridPage")]
+	public MobileLegacyTemplateRule GridPage { get; init; }
+}
+
+/// <summary>
+/// One shipped mobile template plus the names and types of the template-provided elements the converted
+/// legacy page merges onto. Every member carries the bundled value as its default, so a rules file that
+/// predates this group leaves the legacy branch behaving exactly as before.
+/// </summary>
+/// <remarks>
+/// These are DESIGNER-dialect names (what the Mobile Freedom UI designer writes for a generated page), not
+/// the runtime converter's generated names (<c>&lt;Entity&gt;_ListItem</c>, …). Re-pointing an embedded
+/// override from the runtime dialect onto these is what ENG-95733 does; keeping the target side in data
+/// rather than in constants is what lets that mapping be a table instead of a branch.
+/// </remarks>
+public sealed class MobileLegacyTemplateRule {
+	/// <summary>Mobile base page template schema name the converted page inherits.</summary>
+	[JsonPropertyName("templateName")]
+	public string TemplateName { get; init; } = "BaseMobileListTemplate";
+
+	/// <summary>The template's list component (bound to the primary collection attribute).</summary>
+	[JsonPropertyName("listName")]
+	public string ListName { get; init; } = "List";
+
+	/// <summary>The template's container that hosts the list component.</summary>
+	[JsonPropertyName("listContainerName")]
+	public string ListContainerName { get; init; } = "ListContainer";
+
+	/// <summary>The template's row element every converted column merges onto.</summary>
+	[JsonPropertyName("listItemName")]
+	public string ListItemName { get; init; } = "ListItem";
+
+	/// <summary>Component type of the row element.</summary>
+	[JsonPropertyName("listItemType")]
+	public string ListItemType { get; init; } = "crt.ListItem";
+
+	/// <summary>The template's folder-tree action element the converted page binds to the section entity.</summary>
+	[JsonPropertyName("folderTreeActionsName")]
+	public string FolderTreeActionsName { get; init; } = "FolderTreeActions";
+
+	/// <summary>Component type of the folder-tree action element.</summary>
+	[JsonPropertyName("folderTreeActionsType")]
+	public string FolderTreeActionsType { get; init; } = "crt.FolderTreeActions";
+
+	/// <summary>The folder schema name the shipped template and the designer both put on the folder-tree element.</summary>
+	[JsonPropertyName("folderSourceSchemaName")]
+	public string FolderSourceSchemaName { get; init; } = "FolderTree";
+
+	/// <summary>The template's primary collection attribute the list is bound to.</summary>
+	[JsonPropertyName("itemsAttributeName")]
+	public string ItemsAttributeName { get; init; } = "Items";
+
+	/// <summary>The template's screen root. The runtime's own screen root is <c>ViewConfig</c>.</summary>
+	[JsonPropertyName("scaffoldName")]
+	public string ScaffoldName { get; init; } = "Scaffold";
+
+	/// <summary>The template's outer content container.</summary>
+	[JsonPropertyName("mainContainerName")]
+	public string MainContainerName { get; init; } = "MainContainer";
+
+	/// <summary>The template's header strip, host of the filter, sort and folder tools.</summary>
+	[JsonPropertyName("headerContainerName")]
+	public string HeaderContainerName { get; init; } = "HeaderContainer";
+
+	/// <summary>The template's search action. Runtime counterpart: <c>&lt;Entity&gt;_Action_StartSearch_Button</c>.</summary>
+	[JsonPropertyName("searchButtonName")]
+	public string SearchButtonName { get; init; } = "SearchButton";
+
+	/// <summary>Runtime counterpart: <c>&lt;Entity&gt;_ListScreen_Tools_FilterGroupButton</c>.</summary>
+	[JsonPropertyName("filterGroupButtonName")]
+	public string FilterGroupButtonName { get; init; } = "FilterGroupButton";
+
+	/// <summary>Runtime counterpart: <c>&lt;Entity&gt;_ListScreen_Tools_ListSortToolItem</c>.</summary>
+	[JsonPropertyName("sortButtonName")]
+	public string SortButtonName { get; init; } = "SortButton";
+
+	/// <summary>Quick-filter panel; the runtime happens to use the same name.</summary>
+	[JsonPropertyName("quickFilterGroupName")]
+	public string QuickFilterGroupName { get; init; } = "QuickFilterGroup";
+
+	/// <summary>
+	/// The template's floating "add record" action, a NAMED element under the scaffold's <c>floatAction</c>.
+	/// The runtime instead carries the float action as a PROPERTY of its screen root, so
+	/// <c>remove ViewConfig properties:["floatAction"]</c> re-points to <c>remove &lt;this element&gt;</c>.
+	/// </summary>
+	[JsonPropertyName("createRecordButtonName")]
+	public string CreateRecordButtonName { get; init; } = "CreateRecordButton";
+
+	[JsonPropertyName("note")]
+	public string Note { get; init; }
+}
+
+/// <summary>
+/// Per-<c>settingsType</c> table of the names the mobile runtime's own converter generates.
+/// </summary>
+public sealed class MobileLegacyRuntimeNamesRule {
+	/// <summary>Runtime names generated for a classic <c>GridPage</c> settings schema.</summary>
+	[JsonPropertyName("gridPage")]
+	public MobileLegacyRuntimeNameSet GridPage { get; init; }
+}
+
+/// <summary>One source type's runtime-name table.</summary>
+public sealed class MobileLegacyRuntimeNameSet {
+	/// <summary>
+	/// The name templates, in resolution order. A template with no placeholder is matched first so a literal
+	/// marker (<c>&lt;Entity&gt;_ListItem_Body_Column</c>) is never mistaken for a column named "Column".
+	/// </summary>
+	[JsonPropertyName("anchors")]
+	public IReadOnlyList<MobileLegacyRuntimeAnchorRule> Anchors { get; init; } = [];
+
+	[JsonPropertyName("note")]
+	public string Note { get; init; }
+}
+
+/// <summary>
+/// One runtime-generated name template and the meaning it carries. The meaning — not the name — is what an
+/// embedded override operation is re-pointed through, so a new runtime element is added here as DATA rather
+/// than as a branch in the rebaser.
+/// </summary>
+public sealed class MobileLegacyRuntimeAnchorRule {
+	/// <summary>
+	/// What the element IS (e.g. <c>listRow</c>, <c>bodyField</c>, <c>addButton</c>). A role the converter does
+	/// not recognise is reported rather than applied — never guessed.
+	/// </summary>
+	[JsonPropertyName("role")]
+	public string Role { get; init; }
+
+	/// <summary>
+	/// The generated name, with <c>{entity}</c> for the settings' <c>entitySchemaName</c> and <c>{column}</c>
+	/// for a wizard column path (dots kept, exactly as the runtime writes the NAME).
+	/// </summary>
+	[JsonPropertyName("pattern")]
+	public string Pattern { get; init; }
+
+	/// <summary>
+	/// Wizard bucket that supplies <c>{column}</c> (<c>items</c> / <c>subtitleItems</c> / <c>groupItems</c>).
+	/// Absent on a template whose columns cannot be enumerated from the settings alone (search expressions come
+	/// from the entity schema): such a template still resolves by pattern, it just contributes no inventory.
+	/// </summary>
+	[JsonPropertyName("bucket")]
+	public string Bucket { get; init; }
+
+	/// <summary>The runtime slot the element is inserted into (<c>subtitles</c>, <c>body</c>), when it has one.</summary>
+	[JsonPropertyName("slot")]
+	public string Slot { get; init; }
+
+	/// <summary>
+	/// The DESIGNER element this runtime element corresponds to, for a <c>viewConfigDiff</c> target. Absent means
+	/// there is no element-level equivalent, and an operation addressing it is reported rather than re-pointed.
+	/// </summary>
+	[JsonPropertyName("designerName")]
+	public string DesignerName { get; init; }
+
+	/// <summary>
+	/// The DESIGNER path this runtime element corresponds to, for a <c>viewModelConfigDiff</c> /
+	/// <c>modelConfigDiff</c> target — the target dialect addresses those by path, not by name. Supports
+	/// <c>{items}</c> (the template's collection attribute) and <c>{pds}</c> (the primary data-source alias).
+	/// Absent means there is no path-level equivalent.
+	/// </summary>
+	[JsonPropertyName("designerPath")]
+	public IReadOnlyList<string> DesignerPath { get; init; }
+
+	/// <summary>
+	/// Runtime PROPERTY of this element → the designer ELEMENT that carries the same thing. The runtime keeps the
+	/// floating action as a property of its screen root, the designer keeps it as a named element, so
+	/// <c>remove ViewConfig properties:["floatAction"]</c> becomes a removal of that element. A property absent
+	/// from this map has no equivalent and is reported.
+	/// </summary>
+	[JsonPropertyName("propertyTargets")]
+	public IReadOnlyDictionary<string, string> PropertyTargets { get; init; }
+
+	[JsonPropertyName("note")]
+	public string Note { get; init; }
 }
 
 /// <summary>

--- a/clio/Command/PageSchemaMetadataHelper.cs
+++ b/clio/Command/PageSchemaMetadataHelper.cs
@@ -265,11 +265,44 @@ namespace Clio.Command {
 			return (rows[0], null);
 		}
 
+		/// <summary>
+		/// Queries EVERY <c>SysSchema</c> row (client unit schemas) that carries <paramref name="schemaName"/> —
+		/// one per package that holds the schema or a replacing schema of it. Used to cross-check a resolved
+		/// hierarchy against the packages that actually store the schema.
+		/// </summary>
+		/// <returns>The matching rows (possibly empty), or <c>null</c> with a non-empty error when the query fails.</returns>
+		internal static (JArray rows, string error) QuerySysSchemaRowsByName(
+			IApplicationClient applicationClient,
+			IServiceUrlBuilder serviceUrlBuilder,
+			string schemaName,
+			params (string alias, string path)[] columns) {
+			JObject query = BuildSysSchemaByNameQuery(schemaName, columns, rowCount: -1);
+			var (rows, success) = ExecuteSelectQuery(applicationClient, serviceUrlBuilder, query);
+			return success ? (rows, null) : (null, "Failed to query schema metadata");
+		}
+
 		internal static (JToken row, string error) QuerySysSchemaRow(
 			IApplicationClient applicationClient,
 			IServiceUrlBuilder serviceUrlBuilder,
 			string schemaName,
 			params (string alias, string path)[] columns) {
+			JObject query = BuildSysSchemaByNameQuery(schemaName, columns, rowCount: 1);
+			// Route through the shared, guarded ExecuteSelectQuery (like QuerySysSchemaRowByUId and every other
+			// lookup in this helper) instead of a raw ExecutePostRequest + JObject.Parse: an expired session that
+			// returns an HTML/redirect body then surfaces as a clean lookup failure rather than a raw
+			// "Unexpected character '<'" JSON parse exception.
+			var (rows, success) = ExecuteSelectQuery(applicationClient, serviceUrlBuilder, query);
+			if (!success)
+				return (null, "Failed to query schema metadata");
+			if (rows.Count == 0)
+				return (null, $"Schema '{schemaName}' not found");
+			return (rows[0], null);
+		}
+
+		private static JObject BuildSysSchemaByNameQuery(
+			string schemaName,
+			(string alias, string path)[] columns,
+			int rowCount) {
 			var columnsItems = new JObject();
 			foreach ((string alias, string path) in columns) {
 				columnsItems[alias] = new JObject {
@@ -299,18 +332,9 @@ namespace Clio.Command {
 					}
 				},
 				[ColumnsKey] = new JObject { [ItemsKey] = columnsItems },
-				[RowCountKey] = 1
+				[RowCountKey] = rowCount
 			};
-			// Route through the shared, guarded ExecuteSelectQuery (like QuerySysSchemaRowByUId and every other
-			// lookup in this helper) instead of a raw ExecutePostRequest + JObject.Parse: an expired session that
-			// returns an HTML/redirect body then surfaces as a clean lookup failure rather than a raw
-			// "Unexpected character '<'" JSON parse exception.
-			var (rows, success) = ExecuteSelectQuery(applicationClient, serviceUrlBuilder, query);
-			if (!success)
-				return (null, "Failed to query schema metadata");
-			if (rows.Count == 0)
-				return (null, $"Schema '{schemaName}' not found");
-			return (rows[0], null);
+			return query;
 		}
 	}
 }

--- a/docs/knowledge/McpServer/legacy-list-conversion-divergences-from-the-mobile-runtime.md
+++ b/docs/knowledge/McpServer/legacy-list-conversion-divergences-from-the-mobile-runtime.md
@@ -1,0 +1,29 @@
+---
+description: The legacy Mobile-wizard list conversion targets the Mobile Freedom UI DESIGNER vocabulary, not the mobile runtime converter's — subtitle columns go to ListItem.body (not subtitles), no search-column list is emitted, FolderTreeActions is bound by merge, QuickFilterGroup is not re-emitted
+applies-to:
+  - clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileListAnalysisService.cs
+ticket: ENG-95730
+date: 2026-09-02
+---
+
+**What is true** — The mobile app converts wizard settings at runtime into its own vocabulary (a separate subtitle
+slot, explicit `searchExpressions`, its own list/row names). clio converts them into a page the Mobile Freedom UI
+designer can open, and takes the designer's OWN output for a generated list page (`<App>_MobileListPage` from
+create-app, verified on DevMK: `UsrMK_Test_MobileListPage`) as the reference shape. Hence the deliberate divergences:
+
+- `subtitleItems` and `groupItems` both become `ListItem.body` rows; the template's `subtitles: []` slot is left
+  untouched (the designer never fills it).
+- No search-column list: `BaseMobileListTemplate` opens search via `crt.OpenSearchListRequest` over `$Items` and the
+  runtime searches the bound Items attributes, i.e. the converted columns.
+- `FolderTreeActions` gets `merge { sourceSchemaName: "FolderTree", rootSchemaName: <entity> }` — the designer writes
+  exactly this; without it folder filtering does not resolve the entity.
+- The `QuickFilterGroup._filterOptions` block is template-provided and is NOT re-emitted.
+
+**Why it is this way** — The feature's purpose is a page the designer can edit; emitting the runtime's vocabulary
+would give pages the app renders but nobody can open in the designer.
+
+**What breaks if you ignore it** — Porting the runtime's `subtitles` / `searchExpressions` shapes "for fidelity"
+produces a body the designer shows differently from every generated list page, and the golden test
+(`LegacyMobileListAnalysisServiceTests`) pins the designer shape on purpose. Each divergence has its own test
+(`Analyze_ShouldPutSubtitlesInBodyAndEmitNoSearchColumns_AsRecordedDivergences`, the golden test's FolderTreeActions
+assertion) and is echoed to the user in `guide.legacySource.notes`.

--- a/docs/knowledge/McpServer/legacy-mobile-settings-are-layered-per-package-and-must-be-read-from-the-root.md
+++ b/docs/knowledge/McpServer/legacy-mobile-settings-are-layered-per-package-and-must-be-read-from-the-root.md
@@ -1,0 +1,22 @@
+---
+description: The effective legacy Mobile-wizard settings are the ordered application of EVERY package layer (CrtBase → product → Custom); the designer hierarchy must be re-queried from the ROOT schema or upper replacing layers are silently missing
+applies-to:
+  - clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReader.cs
+  - clio/Command/PageSchemaMetadataHelper.cs
+ticket: ENG-95730
+date: 2026-09-02
+---
+
+**What is true** — `MobileCaseGridPageSettingsDefaultWorkplace` (and every other wizard settings schema) can exist
+in several packages as replacing schemas. Each layer is its own diff array (insert / merge / remove by `name`), and
+only the ROOT → HEAD application of all of them is what the classic designer and the mobile runtime show.
+`ClientUnitSchemaDesignerService.GetParentSchemas` returns the full chain only when asked from the root schema UId;
+asked from a lower layer it omits the upper ones (the same trap `PageGetCommand.ResolveHierarchy` handles).
+
+**Why it is this way** — Package-hierarchy replacement is resolved by the designer service per request; the SysSchema
+row a name resolves to is whichever package the DataService returns first, not the head.
+
+**What breaks if you ignore it** — A converted mobile list page misses columns a product or Custom package added, or
+shows columns a later layer removed — with no error. `LegacyMobileSettingsReader` re-queries from the root, applies
+ROOT → HEAD with `IJsonDiffApplier`, and cross-checks the layer set against `QuerySysSchemaRowsByName`; a package that
+stores the schema but is absent from the hierarchy is reported as a guide constraint, never silently dropped.

--- a/docs/knowledge/McpServer/legacy-mobile-settings-body-reads-as-an-empty-web-bundle.md
+++ b/docs/knowledge/McpServer/legacy-mobile-settings-body-reads-as-an-empty-web-bundle.md
@@ -1,0 +1,25 @@
+---
+description: A legacy Mobile-wizard settings schema (Mobile<Entity>GridPageSettings<Workplace>) passes PageGetCommand.TryGetPage successfully with schema-type "unknown" and an EMPTY bundle, so source-type detection must not rely on the bundle
+applies-to:
+  - clio/Command/PageGetOptions.cs
+  - clio/Command/PageSchemaBodyParser.cs
+  - clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
+  - clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsReader.cs
+ticket: ENG-95730
+date: 2026-09-02
+---
+
+**What is true** — A classic Mobile-wizard settings schema stores a JSON *operation array* (`[ { "operation": "insert",
+"name": "settings", … } ]`) and has a `ClientUnitSchemaType` that is neither 9 (web) nor 10 (mobile). `TryGetPage`
+therefore reports `schema-type: "unknown"`, and because `PageSchemaTypeExtensions.FromBody` treats every body that
+does not start with `{` as an AMD module, the marker-based parser finds no sections and yields an **empty** bundle
+without throwing. The read SUCCEEDS; `Raw.Body` carries only the editable layer.
+
+**Why it is this way** — `PageGetCommand` was written for Freedom UI pages; the AMD parser is tolerant by design so
+a page with a missing section still resolves. Nothing in that path knows the legacy format, and adding chain bodies to
+`PageGetResponse` would echo N raw bodies into every `get-page` call.
+
+**What breaks if you ignore it** — Detecting the legacy source from `pageResponse.Bundle` (empty) or from
+`Raw.Body` (one layer only) silently misclassifies or under-reads the page. `get-mobile-page-conversion-guide` detects
+the legacy source by the `unknown` label plus the schema-name pattern, then reads ALL package layers through
+`ILegacyMobileSettingsReader` (designer hierarchy + `IJsonDiffApplier`), never through the page bundle.

--- a/docs/knowledge/McpServer/legacy-settings-override-sections-may-be-json-encoded-strings.md
+++ b/docs/knowledge/McpServer/legacy-settings-override-sections-may-be-json-encoded-strings.md
@@ -1,0 +1,21 @@
+---
+description: Freedom UI override sections embedded in legacy Mobile-wizard settings (viewConfigDiff / viewModelConfigDiff / modelConfigDiff / diffV2) are stored as JSON-ENCODED STRINGS, not arrays, and an EMPTY section is not an override
+applies-to:
+  - clio/Command/McpServer/Tools/MobilePageConverter/Legacy/LegacyMobileSettingsClassifier.cs
+ticket: ENG-95730
+date: 2026-09-02
+---
+
+**What is true** — When a legacy `settings` node carries Freedom UI override sections, the classic wizard writes
+them as strings containing JSON (the mobile runtime reads them with `values.getString(prop)` and parses). An array
+value can also appear (hand-edited schemas), and so can an empty placeholder (`[]` / `"[]"`). Converting them is
+ENG-95733; this slice only classifies and reports.
+
+**Why it is this way** — The wizard serialises the nested diff into the settings `values` as text; the runtime
+converter re-parses it. Nothing normalises the representation on the server.
+
+**What breaks if you ignore it** — A classifier that checks only `token is JArray` reports a page with overrides as
+`plain`, the guide converts the wizard buckets and the user never learns the overrides were dropped. A classifier that
+counts an empty placeholder as an override tells the user something was lost when nothing was.
+`LegacyMobileSettingsClassifier` treats a non-blank string as present, parses it to count operations, and reports a
+zero-operation section as a note rather than an override.

--- a/docs/knowledge/platform/odata-filter-addresses-lookup-columns-by-navigation-path.md
+++ b/docs/knowledge/platform/odata-filter-addresses-lookup-columns-by-navigation-path.md
@@ -3,6 +3,7 @@ description: Creatio OData $filter must address a lookup column by its navigatio
 applies-to:
   - clio/Command/Branding/SetBackgroundImageCommand.cs
   - clio.tests/Command/SetBackgroundImageCommandTests.cs
+  - clio/Command/McpServer/Tools/MobilePageConverter/MobileSectionRegistrationProbe.cs
 ticket: ENG-92981
 date: 2026-08-19
 ---
@@ -23,3 +24,8 @@ permission problem rather than a syntax one and sends you looking for a missing 
 mistake (a navigation path in an insert body) is worse: the property is ignored, the row is created with
 a null lookup, and the request succeeds. `SetBackgroundImageCommandTests` pins the read form; nothing
 pins the write form, so re-check the payload spelling by hand when adding an OData insert.
+
+The same trap bit `MobileSectionRegistrationProbe` (ENG-95730): its `SysModuleInWorkplace?$filter=SysModuleId eq …`
+failed on the server, and because the probe's `Query()` returns an empty array for any non-`value` response, it
+silently reported "no workplaces" for every section. Both probes now filter through `SysModule/Id` and
+`SysModuleEntity/Id`.

--- a/spec/mobile-pages/mobile-pages-reference.md
+++ b/spec/mobile-pages/mobile-pages-reference.md
@@ -259,3 +259,33 @@ Facts derived from source verification (not prescriptive rules — see `MobilePa
 - The mobile component registry is separate from web; not all `crt.*` web components are available.
 - A mobile page must be linked through an app section to be visible in the mobile app.
 
+---
+
+## 13. Legacy Mobile-wizard list settings → `BaseMobileListTemplate` (ENG-95730)
+
+Pages built by the classic Mobile application wizard are stored as `Mobile<Entity>GridPageSettings<Workplace>`
+client schemas: a JSON operation array rooted at a `settings` node (`settingsType: "GridPage"`) with three column
+buckets — `items` (exactly one title column), `subtitleItems`, `groupItems`. The schema may be layered across several
+packages (replacing schemas); the effective settings are the ROOT → HEAD application of every layer.
+
+`get-mobile-page-conversion-guide` converts such a schema into a page inheriting `BaseMobileListTemplate` by
+MERGING onto the template's own `ListItem` (never inserting a second one):
+
+| Wizard | Mobile page |
+|---|---|
+| `entitySchemaName = Order` | `merge FolderTreeActions { sourceSchemaName: "FolderTree", rootSchemaName: "Order" }` (folder filtering; the designer writes the same merge) |
+| `items[0].columnName = Number` | `ListItem.title = "$PDS_Number"` |
+| `subtitleItems` then `groupItems`, by `row` | `ListItem.body = [ { "value": "$PDS_<Column>" }, … ]` |
+| every bound column + `Id` | `viewModelConfigDiff` merge at `["attributes","Items","viewModelConfig","attributes"]`: `PDS_<Column>: { modelConfig: { path: "PDS.<Column>" } }` |
+| every bound column + `entitySchemaName` | `modelConfigDiff` merge at `["dataSources","PDS","config"]`: `attributes.<Column>: { path: "<Column>" }` (+ `type: ForwardReference` for a dotted path) |
+
+A dotted column `Account.Type` binds as `PDS_Account_Type` / `PDS.Account_Type` with data-source attribute
+`{ "path": "Account.Type", "type": "ForwardReference" }`. The template already carries the header
+(`QuickFilterGroup`, search, sort, folder tree) and the `List` bound to `$Items`, so nothing else is emitted.
+Column captions and per-column view types (phone / email / url / map / preview) have no counterpart on a
+`ListItem` row and are reported in `guide.legacySource.columnPropertyCoverage`.
+
+Recorded divergences from the mobile runtime's own converter (design-time target, not runtime vocabulary): subtitle
+columns go to `ListItem.body`, not to the template's `subtitles` slot (the designer generates `body`); no search-column
+list is emitted (the template searches `$Items` through `crt.OpenSearchListRequest`); the QuickFilterGroup filter
+options are template-provided and not re-emitted.


### PR DESCRIPTION
…age-conversion-guide (ENG-95730)

Second source type behind the same tool, args, result shape, feature flag and skill: a classic Mobile-wizard LIST settings schema (Mobile<Entity>GridPageSettings<Workplace>, schema-type "unknown") is detected, read across every package layer and analysed into the guide contract the Freedom UI web path already returns.

- Detection: the "unknown" platform label is refined by the wizard name pattern; a RecordPageSettings schema is recognised and rejected with ENG-95731; the response states the mechanism that ran (conversionMechanism: freedom-web-analysis | legacy-mobile-settings-converter).
- Reading (ILegacyMobileSettingsReader): SysSchema row -> designer hierarchy re-queried from the ROOT schema -> \$ unescape -> ROOT->HEAD ApplyDiff with the page diff applier; the layer set is cross-checked against every SysSchema package and a missing package becomes a guide constraint. Raw bodies never reach the guide.
- Classification: plain / freedom-ui-overrides (recognised, not converted, ENG-95733) / custom-viewconfig (clean refusal). Empty placeholder sections are not overrides.
- Analysis (LegacyMobileListAnalysisService): the two merges the Mobile designer itself writes for a generated list page (FolderTreeActions bound to the entity, ListItem with title from `items` and body from subtitleItems then groupItems by row), targeted viewModelConfigDiff / modelConfigDiff merges (PDS_<col>, PDS_Id last, ForwardReference for dotted paths), and guide.legacySource (column mapping, package layers, coverage table, decisions, recorded divergences from the mobile runtime converter).
- Section registration by entity (MobileSectionRegistrationProbe.ProbeByEntity) through the ROOT entity schema (ExtendParent = false) -> SysModuleEntity -> SysModule.
- Fixes a pre-existing probe defect: OData lookup filters must use the navigation path (SysModule/Id); the flat SysModuleId filter failed server-side and silently reported no workplaces. IsFormPage now receives the resolved effective template.

Tests: golden fixture from the Order sample, reader multi-package merge, classifier, detection matrix, ProbeByEntity, E2E (NoEnvironment description contract + Sandbox legacy conversion, verified against DevMK). Docs: McpServer AGENTS.md, mobile-pages reference, four docs/knowledge records.

MCP reviewed: tool description updated, E2E added, no curated contract / core profile / template change. ClioRing compatibility reviewed, no Ring-consumed contract changed.

Validated: dotnet test --filter "Category=Unit&Module=McpServer" (4135 passed); dotnet test clio.mcp.e2e --filter MobilePageConversionGuide* (6 passed, Sandbox on DevMK)