### PR TITLE
feat: add simple scheduled updates

### DIFF
--- a/clio.tests/Command/AutomaticUpdateStartupTests.cs
+++ b/clio.tests/Command/AutomaticUpdateStartupTests.cs
@@ -1,7 +1,8 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
+using Clio.Command;
 using Clio.Common;
+using Clio.Common.Skills;
 using Clio.UserEnvironment;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,33 +16,30 @@ namespace Clio.Tests.Command;
 [Property("Module", "Command")]
 public sealed class AutomaticUpdateStartupTests {
 	[Test]
-	[Description("Starts the existing knowledge and toolkit commands independently when their schedules are due.")]
+	[Description("Runs the existing clio, knowledge, and toolkit services independently when their schedules are due.")]
 	public void RunStartupUpdateCheck_ShouldStartExistingCommands_WhenSchedulesAreDue() {
 		// Arrange
 		ISettingsRepository settings = Substitute.For<ISettingsRepository>();
 		settings.TryScheduleAutoupdate(Arg.Any<AutoUpdateTarget>(), Arg.Any<DateTimeOffset>()).Returns(true);
 		IAppUpdater appUpdater = Substitute.For<IAppUpdater>();
-		appUpdater.CheckForUpdateWithCacheAsync(Arg.Any<string>())
-			.Returns(Task.FromResult((false, (string)null)));
-		IProcessExecutor processExecutor = Substitute.For<IProcessExecutor>();
-		processExecutor.FireAndForgetAsync(Arg.Any<ProcessExecutionOptions>())
-			.Returns(call => call.Arg<ProcessExecutionOptions>().ArgumentList.Contains("update-knowledge")
-				? throw new InvalidOperationException("unavailable")
-				: Task.FromResult(new ProcessLaunchResult { Started = true }));
+		appUpdater.UpdateInBackgroundAsync().Returns(Task.CompletedTask);
+		IKnowledgeSourceManagementService knowledge = Substitute.For<IKnowledgeSourceManagementService>();
+		knowledge.When(service => service.Update(null)).Do(_ => throw new InvalidOperationException("unavailable"));
+		ISkillInstallService toolkit = Substitute.For<ISkillInstallService>();
 		ServiceProvider services = new ServiceCollection()
 			.AddSingleton(settings)
 			.AddSingleton(appUpdater)
-			.AddSingleton(processExecutor)
+			.AddSingleton(knowledge)
+			.AddSingleton(toolkit)
 			.BuildServiceProvider();
 
 		// Act
 		Program.RunStartupUpdateCheck(["ver"], services);
 
 		// Assert
-		processExecutor.Received(1).FireAndForgetAsync(Arg.Is<ProcessExecutionOptions>(options =>
-			options.Program == "dotnet" && options.ArgumentList.Contains("update-knowledge")));
-		processExecutor.Received(1).FireAndForgetAsync(Arg.Is<ProcessExecutionOptions>(options =>
-			options.Program == "dotnet" && options.ArgumentList.Contains("update-toolkit")));
+		appUpdater.Received(1).UpdateInBackgroundAsync();
+		knowledge.Received(1).Update(null);
+		toolkit.Received(1).Update(null, null);
 	}
 
 	[Test]
@@ -50,12 +48,49 @@ public sealed class AutomaticUpdateStartupTests {
 		// Arrange
 		ISettingsRepository settings = Substitute.For<ISettingsRepository>();
 		settings.TryScheduleAutoupdate(Arg.Any<AutoUpdateTarget>(), Arg.Any<DateTimeOffset>()).Returns(false);
+		IAppUpdater appUpdater = Substitute.For<IAppUpdater>();
+		IKnowledgeSourceManagementService knowledge = Substitute.For<IKnowledgeSourceManagementService>();
+		ISkillInstallService toolkit = Substitute.For<ISkillInstallService>();
+		ServiceProvider services = new ServiceCollection()
+			.AddSingleton(settings)
+			.AddSingleton(appUpdater)
+			.AddSingleton(knowledge)
+			.AddSingleton(toolkit)
+			.BuildServiceProvider();
+
+		// Act
+		Program.RunStartupUpdateCheck(["ver"], services);
+
+		// Assert
+		appUpdater.DidNotReceive().UpdateInBackgroundAsync();
+		knowledge.DidNotReceive().Update(null);
+		toolkit.DidNotReceive().Update(null, null);
+	}
+
+	[TestCase("install-knowledge")]
+	[TestCase("update-knowledge")]
+	[TestCase("delete-knowledge")]
+	[TestCase("add-knowledge-source")]
+	[TestCase("remove-knowledge-source")]
+	[TestCase("enable-knowledge-source")]
+	[TestCase("disable-knowledge-source")]
+	[TestCase("install-toolkit")]
+	[TestCase("install-skills")]
+	[TestCase("update-toolkit")]
+	[TestCase("update-skill")]
+	[TestCase("delete-toolkit")]
+	[TestCase("delete-skill")]
+	[Description("Skips automatic updates while an explicit command changes knowledge or toolkit files.")]
+	public void RunStartupUpdateCheck_ShouldSkipUpdate_WhenCommandMutatesUpdateTarget(string command) {
+		// Arrange
+		ISettingsRepository settings = Substitute.For<ISettingsRepository>();
 		ServiceProvider services = new ServiceCollection().AddSingleton(settings).BuildServiceProvider();
 
 		// Act
-		Action act = () => Program.RunStartupUpdateCheck(["ver"], services);
+		Program.RunStartupUpdateCheck([command], services);
 
 		// Assert
-		act.Should().NotThrow(because: "not-due schedules must avoid resolving update services entirely");
+		settings.DidNotReceive().TryScheduleAutoupdate(
+			Arg.Any<AutoUpdateTarget>(), Arg.Any<DateTimeOffset>());
 	}
 }

--- a/clio.tests/Command/AutomaticUpdateStartupTests.cs
+++ b/clio.tests/Command/AutomaticUpdateStartupTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Clio.Common;
+using Clio.UserEnvironment;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Command")]
+public sealed class AutomaticUpdateStartupTests {
+	[Test]
+	[Description("Starts the existing knowledge and toolkit commands independently when their schedules are due.")]
+	public void RunStartupUpdateCheck_ShouldStartExistingCommands_WhenSchedulesAreDue() {
+		// Arrange
+		ISettingsRepository settings = Substitute.For<ISettingsRepository>();
+		settings.TryScheduleAutoupdate(Arg.Any<AutoUpdateTarget>(), Arg.Any<DateTimeOffset>()).Returns(true);
+		IAppUpdater appUpdater = Substitute.For<IAppUpdater>();
+		appUpdater.CheckForUpdateWithCacheAsync(Arg.Any<string>())
+			.Returns(Task.FromResult((false, (string)null)));
+		IProcessExecutor processExecutor = Substitute.For<IProcessExecutor>();
+		processExecutor.FireAndForgetAsync(Arg.Any<ProcessExecutionOptions>())
+			.Returns(call => call.Arg<ProcessExecutionOptions>().ArgumentList.Contains("update-knowledge")
+				? throw new InvalidOperationException("unavailable")
+				: Task.FromResult(new ProcessLaunchResult { Started = true }));
+		ServiceProvider services = new ServiceCollection()
+			.AddSingleton(settings)
+			.AddSingleton(appUpdater)
+			.AddSingleton(processExecutor)
+			.BuildServiceProvider();
+
+		// Act
+		Program.RunStartupUpdateCheck(["ver"], services);
+
+		// Assert
+		processExecutor.Received(1).FireAndForgetAsync(Arg.Is<ProcessExecutionOptions>(options =>
+			options.Program == "dotnet" && options.ArgumentList.Contains("update-knowledge")));
+		processExecutor.Received(1).FireAndForgetAsync(Arg.Is<ProcessExecutionOptions>(options =>
+			options.Program == "dotnet" && options.ArgumentList.Contains("update-toolkit")));
+	}
+
+	[Test]
+	[Description("Does not resolve or launch an updater whose schedule is disabled or not yet due.")]
+	public void RunStartupUpdateCheck_ShouldNotLaunchCommand_WhenScheduleIsNotDue() {
+		// Arrange
+		ISettingsRepository settings = Substitute.For<ISettingsRepository>();
+		settings.TryScheduleAutoupdate(Arg.Any<AutoUpdateTarget>(), Arg.Any<DateTimeOffset>()).Returns(false);
+		ServiceProvider services = new ServiceCollection().AddSingleton(settings).BuildServiceProvider();
+
+		// Act
+		Action act = () => Program.RunStartupUpdateCheck(["ver"], services);
+
+		// Assert
+		act.Should().NotThrow(because: "not-due schedules must avoid resolving update services entirely");
+	}
+}

--- a/clio.tests/Command/SettingsBootstrapServiceTests.cs
+++ b/clio.tests/Command/SettingsBootstrapServiceTests.cs
@@ -196,16 +196,16 @@ public sealed class SettingsBootstrapServiceTests {
 		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
 
 		// Assert
-		result.Settings.Autoupdate.Should().BeNull(
-			because: "the legacy false must be cleared so GetAutoupdate() falls back to the enabled opt-out default");
+		result.Settings.Autoupdate.Clio.Enabled.Should().BeTrue(
+			because: "the legacy false must be cleared so the enabled opt-out default applies");
 		result.Report.RepairsApplied.Should().ContainSingle(repair => repair.Code == "autoupdate-legacy-default-reset",
 			because: "the migration must surface that auto-update was re-enabled so the user is informed");
-		persisted.Autoupdate.Should().BeNull(
-			because: "the cleared value must be persisted — NullValueHandling.Ignore drops the key entirely");
-		persisted.SettingsVersion.Should().Be(2,
+		persisted.Autoupdate.Clio.Enabled.Should().BeTrue(
+			because: "the repaired clio policy must be persisted as enabled");
+		persisted.SettingsVersion.Should().Be(3,
 			because: "the settings version must be stamped so the one-time migration never runs again");
-		persistedContent.Should().NotContain("Autoupdate",
-			because: "a null Autoupdate is omitted from the file, restoring the pristine default state");
+		persistedContent.Should().Contain("\"autoupdate\"",
+			because: "the scalar setting is replaced by the scheduled policy object");
 	}
 
 	[Test]
@@ -232,9 +232,9 @@ public sealed class SettingsBootstrapServiceTests {
 		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
 
 		// Assert
-		result.Settings.Autoupdate.Should().BeFalse(
+		result.Settings.Autoupdate.Clio.Enabled.Should().BeFalse(
 			because: "once the file is at the current settings version the migration must not touch a deliberate opt-out");
-		persisted.Autoupdate.Should().BeFalse(
+		persisted.Autoupdate.Clio.Enabled.Should().BeFalse(
 			because: "the deliberate --disable must survive bootstrap so 'clio autoupdate --disable' is not silently broken");
 		result.Report.RepairsApplied.Should().BeEmpty(
 			because: "no migration should run when the settings version is already current");
@@ -281,10 +281,10 @@ public sealed class SettingsBootstrapServiceTests {
 		JArray persistedRange = (JArray)JObject.Parse(persistedContent)["deploy-creatio-defaults"]!["site-port-range"]!;
 
 		// Assert
-		persisted.SettingsVersion.Should().Be(2,
+		persisted.SettingsVersion.Should().Be(3,
 			because: "new installs must be born at the current settings version so the legacy migration never runs for them");
-		result.Settings.Autoupdate.Should().BeNull(
-			because: "a fresh file has no Autoupdate key, so auto-update stays at the enabled opt-out default");
+		result.Settings.Autoupdate.Clio.Enabled.Should().BeTrue(
+			because: "a fresh file has no autoupdate key, so the enabled opt-out default applies");
 		persisted.DeployCreatioDefaults.Should().NotBeNull(
 			because: "fresh installations must visibly persist deploy-creatio-defaults in appsettings.json");
 		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },
@@ -321,7 +321,7 @@ public sealed class SettingsBootstrapServiceTests {
 		result.Report.RepairsApplied.Should().ContainSingle(
 			repair => repair.Code == "deploy-creatio-site-port-range-added",
 			because: "the version-2 migration should report the newly materialized automatic range");
-		persisted.SettingsVersion.Should().Be(2,
+		persisted.SettingsVersion.Should().Be(3,
 			because: "the upgraded file must be stamped so the migration runs once");
 		persisted.DeployCreatioDefaults.DbServerName.Should().Be("postgres-local",
 			because: "upgrading the range must preserve the configured database default");

--- a/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
+++ b/clio.tests/Command/SettingsRepositoryConcurrencyTests.cs
@@ -519,6 +519,7 @@ public sealed class SettingsRepositoryProcessConcurrencyTests {
 					CreateNoWindow = true
 				};
 				startInfo.Environment["CLIO_HOME"] = clioHome;
+				startInfo.Environment["CLIO_NO_UPDATE_CHECK"] = "true";
 				startInfo.ArgumentList.Add(clioAssemblyPath);
 				startInfo.ArgumentList.Add("reg-web-app");
 				startInfo.ArgumentList.Add($"env-{index}");

--- a/clio.tests/Command/SettingsRepositoryFeatureTests.cs
+++ b/clio.tests/Command/SettingsRepositoryFeatureTests.cs
@@ -4,9 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.IO.Abstractions.TestingHelpers;
+using Clio.Common;
 using Clio.Common.McpWorker;
 using Clio.Tests.Infrastructure;
+using Clio.UserEnvironment;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -342,5 +345,85 @@ public sealed class SettingsRepositoryFeatureTests {
 		// Assert
 		snapshot.Should().ContainKey("snapshot-feature", because: "the snapshot reflects the stored feature flags");
 		stillEnabled.Should().BeTrue(because: "mutating the returned snapshot must not change the repository's stored state");
+	}
+
+	[Test]
+	[Description("Claims each due automatic update once and advances its independent next-run timestamp by the configured frequency.")]
+	public void TryScheduleAutoupdate_ShouldAdvanceIndependentTimestamp_WhenPolicyIsDue() {
+		// Arrange
+		DateTimeOffset now = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+		SettingsRepository sut = new(_fileSystem);
+
+		// Act
+		bool first = sut.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge, now);
+		bool repeated = new SettingsRepository(_fileSystem)
+			.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge, now.AddMinutes(59));
+		bool toolkit = new SettingsRepository(_fileSystem)
+			.TryScheduleAutoupdate(AutoUpdateTarget.Toolkit, now);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		first.Should().BeTrue(because: "a missing next-run timestamp makes the enabled policy due immediately");
+		repeated.Should().BeFalse(because: "the same policy must wait for its configured frequency");
+		toolkit.Should().BeTrue(because: "the toolkit schedule is independent from knowledge");
+		persisted.Autoupdate.Knowledge.NextRun.Should().Be(now.AddMinutes(60),
+			because: "knowledge uses its one-hour default frequency");
+		persisted.Autoupdate.Toolkit.NextRun.Should().Be(now.AddMinutes(60),
+			because: "toolkit uses its own one-hour default frequency");
+	}
+
+	[Test]
+	[Description("Leaves a disabled automatic update untouched even when its next-run timestamp is in the past.")]
+	public void TryScheduleAutoupdate_ShouldNotAdvanceTimestamp_WhenPolicyIsDisabled() {
+		// Arrange
+		const string json = """
+			{
+			  "SettingsVersion": 2,
+			  "autoupdate": {
+			    "knowledge": {
+			      "enabled": false,
+			      "frequency-minutes": 15,
+			      "next-run": "2026-09-03T10:00:00+00:00"
+			    }
+			  },
+			  "Environments": {}
+			}
+			""";
+		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, json);
+		SettingsRepository sut = new(_fileSystem);
+		string beforeSchedule = _fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+
+		// Act
+		bool result = sut.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge,
+			new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+
+		// Assert
+		result.Should().BeFalse(because: "disabled policies do not run automatically");
+		_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile).Should().Be(beforeSchedule,
+			because: "a skipped check must not rewrite appsettings.json");
+	}
+
+	[Test]
+	[Description("Preserves the existing pre-version migration when startup schedules content before normal repairs run.")]
+	public void TryScheduleAutoupdate_ShouldResetHistoricalFalse_WhenBootstrapRepairsAreDeferred() {
+		// Arrange
+		const string json = """
+			{
+			  "Autoupdate": false,
+			  "Environments": {}
+			}
+			""";
+		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, json);
+		SettingsRepository sut = new(_fileSystem, new SettingsBootstrapService(_fileSystem, applyRepairs: false));
+
+		// Act
+		sut.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge,
+			new DateTimeOffset(2026, 9, 3, 12, 0, 0, TimeSpan.Zero));
+		SettingsRepository reloaded = new(_fileSystem);
+
+		// Assert
+		reloaded.GetAutoupdate().Should().BeTrue(
+			because: "the historical serialized false default must not become a deliberate clio opt-out");
 	}
 }

--- a/clio.tests/Command/SettingsRepositoryFeatureTests.cs
+++ b/clio.tests/Command/SettingsRepositoryFeatureTests.cs
@@ -383,7 +383,6 @@ public sealed class SettingsRepositoryFeatureTests {
 			  "autoupdate": {
 			    "knowledge": {
 			      "enabled": false,
-			      "frequency-minutes": 15,
 			      "next-run": "2026-09-03T10:00:00+00:00"
 			    }
 			  },
@@ -393,6 +392,7 @@ public sealed class SettingsRepositoryFeatureTests {
 		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, json);
 		SettingsRepository sut = new(_fileSystem);
 		string beforeSchedule = _fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile);
+		Settings normalized = JsonConvert.DeserializeObject<Settings>(beforeSchedule);
 
 		// Act
 		bool result = sut.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge,
@@ -400,6 +400,8 @@ public sealed class SettingsRepositoryFeatureTests {
 
 		// Assert
 		result.Should().BeFalse(because: "disabled policies do not run automatically");
+		normalized.Autoupdate.Knowledge.FrequencyMinutes.Should().Be(60,
+			because: "omitted frequencies use the component default");
 		_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile).Should().Be(beforeSchedule,
 			because: "a skipped check must not rewrite appsettings.json");
 	}

--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -219,13 +219,7 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 	/// <inheritdoc/>
 	public async Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder) {
 		try {
-			UpdateCheckCache cache = UpdateCheckCache.Load(cacheFolder);
 			string currentVersion = GetCurrentVersion();
-
-			if (!cache.IsCheckDue() && !string.IsNullOrEmpty(cache.LatestVersion)) {
-				bool available = CompareVersions(currentVersion, cache.LatestVersion) < 0;
-				return (available, cache.LatestVersion);
-			}
 
 			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
 			string latestVersion = await GetLatestPackageVersionAsync("clio", cts.Token)
@@ -365,8 +359,7 @@ public interface IAppUpdater {
 	Task<string> GetReleaseNotesAsync(string version);
 
 	/// <summary>
-	/// Checks whether an update is available, using a local cache to avoid hitting NuGet more
-	/// than once every 8 hours.
+	/// Checks whether an update is available and caches the latest result locally.
 	/// </summary>
 	Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder);
 

--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -250,8 +250,7 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 	public async Task UpdateInBackgroundAsync() {
 		ProcessExecutionOptions options = new("dotnet", string.Empty) {
 			ArgumentList = ["tool", "update", "clio", "-g"],
-			ResolveProgramPath = true,
-			WorkingDirectory = Path.GetFullPath(SettingsRepository.AppSettingsFolderPath)
+			ResolveProgramPath = true
 		};
 		await processExecutor.FireAndForgetAsync(options).ConfigureAwait(false);
 	}

--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -219,7 +219,13 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 	/// <inheritdoc/>
 	public async Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder) {
 		try {
+			UpdateCheckCache cache = UpdateCheckCache.Load(cacheFolder);
 			string currentVersion = GetCurrentVersion();
+
+			if (!cache.IsCheckDue() && !string.IsNullOrEmpty(cache.LatestVersion)) {
+				bool available = CompareVersions(currentVersion, cache.LatestVersion) < 0;
+				return (available, cache.LatestVersion);
+			}
 
 			using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
 			string latestVersion = await GetLatestPackageVersionAsync("clio", cts.Token)
@@ -242,7 +248,11 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 
 	/// <inheritdoc/>
 	public async Task UpdateInBackgroundAsync() {
-		ProcessExecutionOptions options = new("dotnet", "tool update clio -g");
+		ProcessExecutionOptions options = new("dotnet", string.Empty) {
+			ArgumentList = ["tool", "update", "clio", "-g"],
+			ResolveProgramPath = true,
+			WorkingDirectory = Path.GetFullPath(SettingsRepository.AppSettingsFolderPath)
+		};
 		await processExecutor.FireAndForgetAsync(options).ConfigureAwait(false);
 	}
 
@@ -359,7 +369,8 @@ public interface IAppUpdater {
 	Task<string> GetReleaseNotesAsync(string version);
 
 	/// <summary>
-	/// Checks whether an update is available and caches the latest result locally.
+	/// Checks whether an update is available, using a local cache to avoid hitting NuGet more
+	/// than once every 8 hours.
 	/// </summary>
 	Task<(bool Available, string LatestVersion)> CheckForUpdateWithCacheAsync(string cacheFolder);
 

--- a/clio/AppUpdater.cs
+++ b/clio/AppUpdater.cs
@@ -250,7 +250,8 @@ public class AppUpdater(ILogger logger, IProcessExecutor processExecutor) : IApp
 	public async Task UpdateInBackgroundAsync() {
 		ProcessExecutionOptions options = new("dotnet", string.Empty) {
 			ArgumentList = ["tool", "update", "clio", "-g"],
-			ResolveProgramPath = true
+			ResolveProgramPath = true,
+			WorkingDirectory = Path.GetFullPath(SettingsRepository.AppSettingsFolderPath)
 		};
 		await processExecutor.FireAndForgetAsync(options).ConfigureAwait(false);
 	}

--- a/clio/Command/Update/SetAutoupdateCommand.cs
+++ b/clio/Command/Update/SetAutoupdateCommand.cs
@@ -4,7 +4,7 @@ using CommandLine;
 
 namespace Clio.Command.Update;
 
-[Verb("autoupdate", HelpText = "Enable or disable automatic updates on startup")]
+[Verb("autoupdate", HelpText = "Enable or disable automatic clio updates on startup")]
 public class SetAutoupdateOptions {
 
 	[Option("enable", SetName = "enable", HelpText = "Enable automatic updates on startup (default behavior)")]
@@ -28,16 +28,16 @@ public class SetAutoupdateCommand : Command<SetAutoupdateOptions> {
 	public override int Execute(SetAutoupdateOptions options) {
 		if (options.Enable) {
 			_settingsRepository.SetAutoupdate(true);
-			_logger.WriteInfo("Auto-update enabled. clio will update automatically on startup.");
+			_logger.WriteInfo("Automatic clio updates enabled.");
 			return 0;
 		}
 		if (options.Disable) {
 			_settingsRepository.SetAutoupdate(false);
-			_logger.WriteInfo("Auto-update disabled. Run 'clio update' to update manually.");
+			_logger.WriteInfo("Automatic clio updates disabled. Run 'clio update' to update manually.");
 			return 0;
 		}
 		bool current = _settingsRepository.GetAutoupdate();
-		_logger.WriteInfo($"Auto-update is currently {(current ? "enabled" : "disabled")}.");
+		_logger.WriteInfo($"Automatic clio updates are currently {(current ? "enabled" : "disabled")}.");
 		_logger.WriteInfo("Use --enable or --disable to change.");
 		return 0;
 	}

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -227,7 +227,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="up"></a>
 - [`unlock-package`](docs/commands/unlock-package.md) - Unlock a package in Creatio, `up`
 <a id="autoupdate"></a>
-- [`autoupdate`](docs/commands/autoupdate.md) - Enable or disable automatic updates on startup
+- [`autoupdate`](docs/commands/autoupdate.md) - Enable or disable automatic clio updates on startup
 <a id="experimental"></a>
 <a id="exp"></a>
 - [`experimental`](docs/commands/experimental.md) - List and toggle clio experimental feature flags, `exp`

--- a/clio/Common/AutoUpdateSettings.cs
+++ b/clio/Common/AutoUpdateSettings.cs
@@ -1,0 +1,75 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Clio.Common;
+
+/// <summary>Identifies an automatically updated local component.</summary>
+public enum AutoUpdateTarget {
+	/// <summary>The clio global tool.</summary>
+	Clio,
+	/// <summary>Installed Clio knowledge.</summary>
+	Knowledge,
+	/// <summary>The Creatio development toolkit.</summary>
+	Toolkit
+}
+
+/// <summary>Controls one best-effort automatic update.</summary>
+public sealed class AutoUpdatePolicy {
+	/// <summary>Gets or sets whether the update runs automatically.</summary>
+	[JsonProperty("enabled")]
+	public bool Enabled { get; set; } = true;
+
+	/// <summary>Gets or sets the interval between attempts, in minutes.</summary>
+	[JsonProperty("frequency-minutes")]
+	public int FrequencyMinutes { get; set; }
+
+	/// <summary>Gets or sets the next scheduled attempt.</summary>
+	[JsonProperty("next-run")]
+	public DateTimeOffset NextRun { get; set; }
+}
+
+/// <summary>Contains independent schedules for clio, knowledge, and toolkit updates.</summary>
+[JsonConverter(typeof(AutoUpdateSettingsConverter))]
+public sealed class AutoUpdateSettings {
+	/// <summary>Gets or sets the clio update schedule.</summary>
+	[JsonProperty("clio")]
+	public AutoUpdatePolicy Clio { get; set; } = CreatePolicy(480);
+
+	/// <summary>Gets or sets the knowledge update schedule.</summary>
+	[JsonProperty("knowledge")]
+	public AutoUpdatePolicy Knowledge { get; set; } = CreatePolicy(60);
+
+	/// <summary>Gets or sets the toolkit update schedule.</summary>
+	[JsonProperty("toolkit")]
+	public AutoUpdatePolicy Toolkit { get; set; } = CreatePolicy(60);
+
+	[JsonIgnore]
+	internal bool WasLegacyScalar { get; set; }
+
+	private static AutoUpdatePolicy CreatePolicy(int frequencyMinutes) => new() {
+		FrequencyMinutes = frequencyMinutes
+	};
+}
+
+internal sealed class AutoUpdateSettingsConverter : JsonConverter<AutoUpdateSettings> {
+	public override bool CanWrite => false;
+
+	public override AutoUpdateSettings ReadJson(JsonReader reader, Type objectType,
+		AutoUpdateSettings existingValue, bool hasExistingValue, JsonSerializer serializer) {
+		JToken token = JToken.Load(reader);
+		AutoUpdateSettings settings = new();
+		if (token.Type == JTokenType.Boolean) {
+			settings.Clio.Enabled = token.Value<bool>();
+			settings.WasLegacyScalar = true;
+		}
+		else if (token.Type == JTokenType.Object) {
+			serializer.Populate(token.CreateReader(), settings);
+		}
+		return settings;
+	}
+
+	public override void WriteJson(JsonWriter writer, AutoUpdateSettings value, JsonSerializer serializer) {
+		throw new NotSupportedException();
+	}
+}

--- a/clio/Common/Skills/AgentCliRunner.cs
+++ b/clio/Common/Skills/AgentCliRunner.cs
@@ -63,6 +63,7 @@ public sealed class AgentCliRunner(IProcessExecutor processExecutor, IFileSystem
 		string[] pathDirectories = pathVariable.Split(Path.PathSeparator,
 			StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 		foreach (string directory in pathDirectories) {
+			if (!Path.IsPathFullyQualified(directory)) continue;
 			foreach (string candidate in CandidateFileNames(cliName)) {
 				string fullPath = _fileSystem.Combine(directory, candidate);
 				if (_fileSystem.ExistsFile(fullPath)) {

--- a/clio/Common/Skills/AgentCliRunner.cs
+++ b/clio/Common/Skills/AgentCliRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Clio.UserEnvironment;
 
 namespace Clio.Common.Skills;
 
@@ -26,7 +27,10 @@ public sealed class AgentCliRunner(IProcessExecutor processExecutor, IFileSystem
 
 		(string program, string arguments) = BuildCommand(resolved, args ?? []);
 		ProcessExecutionResult result = _processExecutor
-			.ExecuteAndCaptureAsync(new ProcessExecutionOptions(program, arguments))
+			.ExecuteAndCaptureAsync(new ProcessExecutionOptions(program, arguments) {
+				ResolveProgramPath = true,
+				WorkingDirectory = Path.GetFullPath(SettingsRepository.AppSettingsFolderPath)
+			})
 			.GetAwaiter()
 			.GetResult();
 

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -413,6 +413,7 @@ namespace Clio
 			Features = new Dictionary<string, bool>();
 			Knowledge = new KnowledgeConfiguration();
 			KnowledgeFeedback = new KnowledgeFeedbackSettings();
+			Autoupdate = new AutoUpdateSettings();
 		}
 
 		//TODO: This wont work for Mac and Linux
@@ -531,7 +532,8 @@ namespace Clio
 			}
 		}
 
-		public bool? Autoupdate {
+		[JsonProperty("autoupdate")]
+		public AutoUpdateSettings Autoupdate {
 			get; set;
 		}
 
@@ -1002,6 +1004,10 @@ namespace Clio
 			result.Features ??= new Dictionary<string, bool>();
 			result.Knowledge ??= new KnowledgeConfiguration();
 			result.KnowledgeFeedback ??= new KnowledgeFeedbackSettings();
+			result.Autoupdate ??= new AutoUpdateSettings();
+			result.Autoupdate.Clio ??= new AutoUpdatePolicy { FrequencyMinutes = 480 };
+			result.Autoupdate.Knowledge ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
+			result.Autoupdate.Toolkit ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
 			result.Knowledge.Sources ??= new Dictionary<string, KnowledgeSourceConfiguration>(
 				StringComparer.OrdinalIgnoreCase);
 			result.Knowledge.TopicPins ??= new Dictionary<string, string>(StringComparer.Ordinal);
@@ -1317,12 +1323,36 @@ namespace Clio
 		}
 
 		public bool GetAutoupdate() {
-			return _settings.Autoupdate ?? true;
+			return _settings.Autoupdate.Clio.Enabled;
 		}
 
 		public void SetAutoupdate(bool value) {
-			UpdateSettings(settings => settings.Autoupdate = value);
+			UpdateSettings(settings => settings.Autoupdate.Clio.Enabled = value);
 		}
+
+		public bool TryScheduleAutoupdate(AutoUpdateTarget target, DateTimeOffset now) {
+			bool due = false;
+			UpdateSettingsIfChanged(settings => {
+				if ((settings.SettingsVersion ?? 0) < 1
+					&& settings.Autoupdate is { WasLegacyScalar: true, Clio.Enabled: false }) {
+					settings.Autoupdate.Clio.Enabled = true;
+				}
+				AutoUpdatePolicy policy = GetPolicy(settings.Autoupdate, target);
+				due = policy.Enabled && now > policy.NextRun;
+				if (due) {
+					policy.NextRun = now.AddMinutes(Math.Max(1, policy.FrequencyMinutes));
+				}
+				return due;
+			});
+			return due;
+		}
+
+		private static AutoUpdatePolicy GetPolicy(AutoUpdateSettings settings, AutoUpdateTarget target) => target switch {
+			AutoUpdateTarget.Clio => settings.Clio,
+			AutoUpdateTarget.Knowledge => settings.Knowledge,
+			AutoUpdateTarget.Toolkit => settings.Toolkit,
+			_ => throw new ArgumentOutOfRangeException(nameof(target))
+		};
 
 		public bool IsFeatureEnabled(string featureName) {
 			if (string.IsNullOrWhiteSpace(featureName)) {

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -1008,6 +1008,9 @@ namespace Clio
 			result.Autoupdate.Clio ??= new AutoUpdatePolicy { FrequencyMinutes = 480 };
 			result.Autoupdate.Knowledge ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
 			result.Autoupdate.Toolkit ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
+			if (result.Autoupdate.Clio.FrequencyMinutes <= 0) result.Autoupdate.Clio.FrequencyMinutes = 480;
+			if (result.Autoupdate.Knowledge.FrequencyMinutes <= 0) result.Autoupdate.Knowledge.FrequencyMinutes = 60;
+			if (result.Autoupdate.Toolkit.FrequencyMinutes <= 0) result.Autoupdate.Toolkit.FrequencyMinutes = 60;
 			result.Knowledge.Sources ??= new Dictionary<string, KnowledgeSourceConfiguration>(
 				StringComparer.OrdinalIgnoreCase);
 			result.Knowledge.TopicPins ??= new Dictionary<string, string>(StringComparer.Ordinal);

--- a/clio/Environment/ISettingsRepository.cs
+++ b/clio/Environment/ISettingsRepository.cs
@@ -377,6 +377,12 @@ namespace Clio.UserEnvironment
 		/// </summary>
 		void SetAutoupdate(bool value);
 
+		/// <summary>Advances a due enabled update schedule and reports whether its update should run.</summary>
+		/// <param name="target">Component whose schedule is checked.</param>
+		/// <param name="now">Current time.</param>
+		/// <returns><c>true</c> when the component should be updated.</returns>
+		bool TryScheduleAutoupdate(global::Clio.Common.AutoUpdateTarget target, DateTimeOffset now);
+
 		/// <summary>
 		/// Determines whether the named feature flag is enabled.
 		/// </summary>

--- a/clio/Environment/ISettingsRepository.cs
+++ b/clio/Environment/ISettingsRepository.cs
@@ -381,7 +381,7 @@ namespace Clio.UserEnvironment
 		/// <param name="target">Component whose schedule is checked.</param>
 		/// <param name="now">Current time.</param>
 		/// <returns><c>true</c> when the component should be updated.</returns>
-		bool TryScheduleAutoupdate(global::Clio.Common.AutoUpdateTarget target, DateTimeOffset now);
+		bool TryScheduleAutoupdate(global::Clio.Common.AutoUpdateTarget target, DateTimeOffset now) => false;
 
 		/// <summary>
 		/// Determines whether the named feature flag is enabled.

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -59,7 +59,7 @@ public sealed record SettingsBootstrapResult(
 public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 	private const string SettingsFileUnreadableCode = "settings-file-unreadable";
 	private const string SettingsFileMissingCode = "settings-file-missing";
-	private const int CurrentSettingsVersion = 2;
+	private const int CurrentSettingsVersion = 3;
 
 	/// <summary>
 	/// Status reported when appsettings.json does not exist and the caller asked for no repair write.
@@ -186,8 +186,9 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 		// silently disabling auto-update. Clear that legacy artifact so the opt-out default
 		// (enabled) applies again. Guarded by SettingsVersion, this runs once — a deliberate
 		// 'clio autoupdate --disable' made afterwards is preserved.
-		if ((settings.SettingsVersion ?? 0) < 1 && settings.Autoupdate == false) {
-			settings.Autoupdate = null;
+		if ((settings.SettingsVersion ?? 0) < 1
+			&& settings.Autoupdate is { WasLegacyScalar: true, Clio.Enabled: false }) {
+			settings.Autoupdate.Clio.Enabled = true;
 			repairs.Add(new SettingsRepair(
 				"autoupdate-legacy-default-reset",
 				"auto-update was disabled by a legacy default and has been re-enabled "

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -21,6 +21,7 @@ using Clio.Command.TIDE;
 using Clio.Command.Update;
 using Clio.Common;
 using Clio.Common.McpWorker;
+using Clio.Common.Skills;
 using Clio.Help;
 using Clio.Package;
 using Clio.Query;
@@ -1582,9 +1583,19 @@ internal class Program {
 		string first = args[0];
 		if (string.Equals(first, "update-cli", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "update", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "install-knowledge", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "update-knowledge", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "delete-knowledge", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "add-knowledge-source", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "remove-knowledge-source", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "enable-knowledge-source", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "disable-knowledge-source", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "install-toolkit", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "install-skills", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "update-toolkit", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "update-skill", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "delete-toolkit", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "delete-skill", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "autoupdate", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "mcp-http", StringComparison.OrdinalIgnoreCase)) {
 			return true;
@@ -1606,29 +1617,12 @@ internal class Program {
 		}
 		RunIfDue(settingsRepository, AutoUpdateTarget.Clio, () => {
 			IAppUpdater appUpdater = serviceProvider.GetRequiredService<IAppUpdater>();
-			(bool available, string latestVersion) = appUpdater
-				.CheckForUpdateWithCacheAsync(SettingsRepository.AppSettingsFolderPath)
-				.GetAwaiter().GetResult();
-
-			if (!available || string.IsNullOrEmpty(latestVersion)) return;
-
-			string currentVersion = appUpdater.GetCurrentVersion();
-			ConsoleLogger.Instance.WriteInfo(
-				$"Updating clio {currentVersion} -> {latestVersion} in background...");
 			appUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
 		});
 		RunIfDue(settingsRepository, AutoUpdateTarget.Knowledge,
-			() => StartUpdateCommand(serviceProvider, "update-knowledge"));
+			() => serviceProvider.GetRequiredService<IKnowledgeSourceManagementService>().Update(sourceAlias: null));
 		RunIfDue(settingsRepository, AutoUpdateTarget.Toolkit,
-			() => StartUpdateCommand(serviceProvider, "update-toolkit"));
-	}
-
-	private static void StartUpdateCommand(IServiceProvider serviceProvider, string command) {
-		string clioAssembly = Assembly.GetExecutingAssembly().Location;
-		ProcessExecutionOptions options = new("dotnet", string.Empty) {
-			ArgumentList = [clioAssembly, command]
-		};
-		serviceProvider.GetRequiredService<IProcessExecutor>().FireAndForgetAsync(options).GetAwaiter().GetResult();
+			() => serviceProvider.GetRequiredService<ISkillInstallService>().Update(target: null, repo: null));
 	}
 
 	private static void RunIfDue(ISettingsRepository settingsRepository, AutoUpdateTarget target, Action update) {

--- a/clio/Program.cs
+++ b/clio/Program.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
@@ -1583,6 +1582,9 @@ internal class Program {
 		string first = args[0];
 		if (string.Equals(first, "update-cli", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "update", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "update-knowledge", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "update-toolkit", StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(first, "update-skill", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "autoupdate", StringComparison.OrdinalIgnoreCase)
 			|| string.Equals(first, "mcp-http", StringComparison.OrdinalIgnoreCase)) {
 			return true;
@@ -1593,31 +1595,49 @@ internal class Program {
 			|| string.Equals(arg, "--version", StringComparison.OrdinalIgnoreCase));
 	}
 
-	private static void RunStartupUpdateCheck(string[] args, IServiceProvider serviceProvider) {
+	internal static void RunStartupUpdateCheck(string[] args, IServiceProvider serviceProvider) {
 		if (ShouldSkipUpdateCheck(args)) return;
+		ISettingsRepository settingsRepository;
 		try {
+			settingsRepository = serviceProvider.GetRequiredService<ISettingsRepository>();
+		}
+		catch {
+			return;
+		}
+		RunIfDue(settingsRepository, AutoUpdateTarget.Clio, () => {
 			IAppUpdater appUpdater = serviceProvider.GetRequiredService<IAppUpdater>();
-			ISettingsRepository settingsRepository = serviceProvider.GetRequiredService<ISettingsRepository>();
-			string cacheFolder = SettingsRepository.AppSettingsFolderPath;
 			(bool available, string latestVersion) = appUpdater
-				.CheckForUpdateWithCacheAsync(cacheFolder)
+				.CheckForUpdateWithCacheAsync(SettingsRepository.AppSettingsFolderPath)
 				.GetAwaiter().GetResult();
 
 			if (!available || string.IsNullOrEmpty(latestVersion)) return;
 
 			string currentVersion = appUpdater.GetCurrentVersion();
-			if (settingsRepository.GetAutoupdate()) {
-				ConsoleLogger.Instance.WriteInfo(
-					$"Updating clio {currentVersion} -> {latestVersion} in background...");
-				appUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
-			} else {
-				ConsoleLogger.Instance.WriteWarning(
-					RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
-						? $"clio {latestVersion} is available. Run 'dotnet tool update clio -g' to update." 
-						: $"clio {latestVersion} is available. Run 'clio update' to update.");
+			ConsoleLogger.Instance.WriteInfo(
+				$"Updating clio {currentVersion} -> {latestVersion} in background...");
+			appUpdater.UpdateInBackgroundAsync().GetAwaiter().GetResult();
+		});
+		RunIfDue(settingsRepository, AutoUpdateTarget.Knowledge,
+			() => StartUpdateCommand(serviceProvider, "update-knowledge"));
+		RunIfDue(settingsRepository, AutoUpdateTarget.Toolkit,
+			() => StartUpdateCommand(serviceProvider, "update-toolkit"));
+	}
+
+	private static void StartUpdateCommand(IServiceProvider serviceProvider, string command) {
+		string clioAssembly = Assembly.GetExecutingAssembly().Location;
+		ProcessExecutionOptions options = new("dotnet", string.Empty) {
+			ArgumentList = [clioAssembly, command]
+		};
+		serviceProvider.GetRequiredService<IProcessExecutor>().FireAndForgetAsync(options).GetAwaiter().GetResult();
+	}
+
+	private static void RunIfDue(ISettingsRepository settingsRepository, AutoUpdateTarget target, Action update) {
+		try {
+			if (settingsRepository.TryScheduleAutoupdate(target, DateTimeOffset.UtcNow)) {
+				update();
 			}
 		} catch {
-			// startup update check must never crash the tool
+			// automatic updates are best effort and must never fail the requested command
 		}
 	}
 

--- a/clio/docs/commands/autoupdate.md
+++ b/clio/docs/commands/autoupdate.md
@@ -6,7 +6,7 @@
 
 ## Name
 
-autoupdate - Enable or disable automatic updates on startup
+autoupdate - Enable or disable automatic clio updates on startup
 
 ## Synopsis
 
@@ -16,25 +16,30 @@ autoupdate [--enable | --disable]
 
 ## Description
 
-Controls whether clio automatically checks for and installs newer versions
-in the background each time it starts.
+Controls the `clio` policy in the automatic-update settings. Running the
+command without arguments displays whether automatic clio updates are enabled.
 
-When enabled (the default), clio queries NuGet at most once every 8 hours.
-If a newer version is found, it launches `dotnet tool update clio -g` as a
-background process and immediately continues with the requested command.
-The updated binary becomes active on the next invocation.
+Clio also has independent knowledge and toolkit policies. On an eligible
+command startup, each due enabled policy advances its `next-run` timestamp and
+starts the existing updater on a best-effort basis.
 
-When disabled, clio shows a one-line notice that a newer version is
-available and suggests running `clio update` manually.
+```json
+"autoupdate": {
+  "clio":      { "enabled": true, "frequency-minutes": 480, "next-run": "2026-09-04T08:00:00Z" },
+  "knowledge": { "enabled": true, "frequency-minutes": 60,  "next-run": "2026-09-04T01:00:00Z" },
+  "toolkit":   { "enabled": true, "frequency-minutes": 60,  "next-run": "2026-09-04T01:00:00Z" }
+}
+```
 
-Running `autoupdate` without arguments displays the current setting.
+The timestamps are maintained by clio. An existing scalar `Autoupdate` value
+is accepted and applied only to the clio policy.
 
 ## Options
 
 ```bash
---enable    Enable automatic updates on startup (default behavior)
+--enable    Enable automatic clio updates (default behavior)
 
---disable   Disable automatic updates on startup
+--disable   Disable automatic clio updates
 ```
 
 ## Examples
@@ -53,11 +58,10 @@ autoupdate --enable
 ## Behavior
 
 - With no flags: prints whether auto-update is currently enabled or disabled
-- --enable: sets Autoupdate = true in appsettings.json and confirms
-- --disable: sets Autoupdate = false in appsettings.json and confirms
-- The update check is cached for 8 hours to avoid hitting NuGet on every run
-- Background update never blocks or delays the current command
-- A network timeout of 3 seconds is applied to the version check
+- --enable and --disable control only `autoupdate.clio.enabled`
+- Default frequencies are 480 minutes for clio and 60 minutes for knowledge and toolkit
+- Due knowledge and toolkit updates run as detached `update-knowledge` and `update-toolkit` commands
+- Manual update commands remain available and bypass the schedule
 
 ## Exit Codes
 

--- a/clio/docs/commands/autoupdate.md
+++ b/clio/docs/commands/autoupdate.md
@@ -21,7 +21,7 @@ command without arguments displays whether automatic clio updates are enabled.
 
 Clio also has independent knowledge and toolkit policies. On an eligible
 command startup, each due enabled policy advances its `next-run` timestamp and
-starts the existing updater on a best-effort basis.
+calls the existing updater on a best-effort basis.
 
 ```json
 "autoupdate": {
@@ -60,7 +60,7 @@ autoupdate --enable
 - With no flags: prints whether auto-update is currently enabled or disabled
 - --enable and --disable control only `autoupdate.clio.enabled`
 - Default frequencies are 480 minutes for clio and 60 minutes for knowledge and toolkit
-- Due knowledge and toolkit updates run as detached `update-knowledge` and `update-toolkit` commands
+- Due policies reuse the existing clio, knowledge, and toolkit update services
 - Manual update commands remain available and bypass the schedule
 
 ## Exit Codes

--- a/clio/help/en/autoupdate.txt
+++ b/clio/help/en/autoupdate.txt
@@ -9,7 +9,8 @@ SYNOPSIS
 
 DESCRIPTION
     Controls the clio policy in appsettings.json. Knowledge and toolkit have
-    independent enabled, frequency-minutes, and next-run settings.
+    independent enabled, frequency-minutes, and next-run settings. Due policies
+    reuse the existing update behavior on a best-effort basis.
 
 OPTIONS
     --enable     Enable automatic clio updates (default behavior)

--- a/clio/help/en/autoupdate.txt
+++ b/clio/help/en/autoupdate.txt
@@ -1,0 +1,27 @@
+COMMAND TYPE
+    Application management
+
+NAME
+    autoupdate - Enable or disable automatic clio updates on startup
+
+SYNOPSIS
+    autoupdate [--enable | --disable]
+
+DESCRIPTION
+    Controls the clio policy in appsettings.json. Knowledge and toolkit have
+    independent enabled, frequency-minutes, and next-run settings.
+
+OPTIONS
+    --enable     Enable automatic clio updates (default behavior)
+    --disable    Disable automatic clio updates
+
+EXAMPLES
+    autoupdate
+    autoupdate --disable
+    autoupdate --enable
+
+EXIT CODES
+    0   Setting applied successfully (or status displayed)
+
+REPORTING BUGS
+    https://github.com/Advance-Technologies-Foundation/clio

--- a/clio/help/en/help.txt
+++ b/clio/help/en/help.txt
@@ -16,7 +16,7 @@ Commands:
   alm-deploy                                  Deploy a package to Creatio, deploy
   apply-manifest                              Apply an environment manifest, apply-environment-manifest, applym
   assert                                      Validates infrastructure and filesystem resources
-  autoupdate                                  Enable or disable automatic updates on startup
+  autoupdate                                  Enable or disable automatic clio updates on startup
   build-docker-image                          Build a Docker image for a Creatio .NET 8+ distribution or bundled database backup
   build-theme                                 Build the artifacts of a Creatio theme from brand colours and fonts
   build-workspace                             Build the current workspace in Creatio, build, compile, compile-all, rebuild

--- a/clio/tpl/jsonschema/schema.json.tpl
+++ b/clio/tpl/jsonschema/schema.json.tpl
@@ -37,10 +37,9 @@
 			"type": "string",
 			"description": "Default environment key"
 		},
-		"Autoupdate": {
-			"type": "boolean",
-			"description": "Auto update clio",
-			"default": false
+		"autoupdate": {
+			"$ref": "#/definitions/autoupdatesettings",
+			"description": "Independent best-effort update schedules for clio, knowledge, and the Creatio toolkit"
 		},
 		"dbConnectionStringKeys": {
 			"type": "object",
@@ -113,10 +112,39 @@
 	"description": "Clio environment description file",
 	"required": [
 		"ActiveEnvironmentKey",
-		"Autoupdate",
+		"autoupdate",
 		"Environments"
 	],
 	"definitions": {
+		"autoupdatepolicy": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["enabled", "frequency-minutes"],
+			"properties": {
+				"enabled": { "type": "boolean", "default": true },
+				"frequency-minutes": { "type": "integer", "minimum": 1 },
+				"next-run": { "type": "string", "format": "date-time" }
+			}
+		},
+		"autoupdatesettings": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["clio", "knowledge", "toolkit"],
+			"properties": {
+				"clio": {
+					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
+					"default": { "enabled": true, "frequency-minutes": 480 }
+				},
+				"knowledge": {
+					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
+					"default": { "enabled": true, "frequency-minutes": 60 }
+				},
+				"toolkit": {
+					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
+					"default": { "enabled": true, "frequency-minutes": 60 }
+				}
+			}
+		},
 		"deploycreatiodefaults": {
 			"type": "object",
 			"additionalProperties": false,


### PR DESCRIPTION
## Summary

- replace the discarded update-coordination design with three small `appsettings.json` policies: `enabled`, `frequency-minutes`, and `next-run`
- on eligible startup, advance a due timestamp through the existing settings transaction, then invoke the existing clio, knowledge, or toolkit updater on a best-effort basis
- keep manual commands and legacy scalar `Autoupdate` compatibility; skip automatic work during explicit lifecycle commands, help, and MCP modes
- document the settings shape and update the JSON schema

## KISS check

The end-to-end flow is `enabled && now > next-run` -> persist `now + frequency` -> call the existing updater -> ignore failure. There is no new scheduler, locking protocol, coordinator, broker, PID ownership, retry history, worker lifecycle, installer change, or OS task integration.

## Validation

- `dotnet build clio/clio.csproj -c Debug --no-restore` (passed for net8.0 and net10.0)
- focused scheduling/settings tests (46 passed)
- process-concurrency harness regression test (passed)
- `dotnet test clio.tests/clio.tests.csproj -c Debug --no-restore` (11,152 passed; 26 skipped; 0 failed)
- JSON schema parsed successfully and `git diff --check` passed

## Reviews

- exact-head seven-perspective agentic review completed; all Blocker/High/Medium findings resolved
- exact-head security recheck clean
- prior Claude review applied to the discarded design; the user-directed minimal replacement intentionally received no second Claude pass
- command documentation reviewed with the repository documentation workflow
- no MCP contract or Creatio runtime changes

Fixes #1367
