### PR TITLE
fix(mcp): stop the emitted schema from demanding optional and alternative connection fields

### DIFF
--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -1208,6 +1208,48 @@ public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 				because: "the served contract must not restore a fixed list of producer fields"));
 	}
 
+	[Test]
+	[Description("Verifies the live registry-derived contracts of the page/addon long-tail tools advertise no connection field as required and state the environment-name OR uri/login/password alternative instead (issue #965).")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract stops demanding every connection field at once")]
+	[AllureDescription("Starts the real clio MCP server without a Creatio environment, requests the contracts of list-page-templates, create-page, get-related-page-addon and create-related-page-addon, and verifies each one advertises only its genuine inputs as required while carrying the connection any-of.")]
+	public async Task ToolContractGet_ShouldNotRequireConnectionFields_ForPageAndAddonTools() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+		string[] connectionFields = ["environment-name", "uri", "login", "password"];
+		Dictionary<string, string[]> expectedRequired = new() {
+			[PageTemplatesListTool.ToolName] = [],
+			[PageCreateTool.ToolName] = ["schema-name", "template", "package-name"],
+			[GetRelatedPageAddonTool.ToolName] = ["entity-schema-name", "package-name"],
+			[CreateRelatedPageAddonTool.ToolName] = ["entity-schema-name", "package-name", "pages"]
+		};
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["tool-names"] = expectedRequired.Keys.ToArray()
+			});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "each of these long-tail tools must expose a registry-derived contract");
+		foreach ((string toolName, string[] required) in expectedRequired) {
+			ToolContractDefinition contract = response.Tools!.Single(definition => definition.Name == toolName);
+			(contract.InputSchema.Required ?? []).Should().BeEquivalentTo(required,
+				because: $"'{toolName}' accepts an environment-name-only payload, so its live contract must " +
+					"advertise only the inputs it genuinely cannot run without");
+			(contract.InputSchema.Required ?? []).Should().NotContain(connectionFields,
+				because: $"a strict client validating '{toolName}' against this contract would otherwise refuse " +
+					"to send the very payload the tool documentation advertises");
+			contract.InputSchema.AnyOf.Should().BeEquivalentTo(
+				new[] { new[] { "environment-name" }, new[] { "uri", "login", "password" } },
+				because: $"'{toolName}' must still tell the caller HOW to connect now that no single connection " +
+					"field is mandatory");
+		}
+	}
+
 	private static async Task<ToolContractGetResponse> CallAsync(
 		McpServerSession session,
 		CancellationToken cancellationToken,

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -1250,6 +1250,66 @@ public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 		}
 	}
 
+	[Test]
+	[Description("Verifies the live contract of get-entity-schema-properties no longer demands package-name, so an agent planning from get-tool-contract can reach the merged all-packages column view its own description recommends (issue #965).")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract agrees with the emitted schema on optional package-name")]
+	[AllureDescription("Starts the real clio MCP server and requests the curated contract of get-entity-schema-properties, verifying package-name is advertised but not required — the exact disagreement with tools/list that issue #965 reports.")]
+	public async Task ToolContractGet_ShouldNotRequirePackageName_ForGetEntitySchemaProperties() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["tool-names"] = new[] { GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName }
+			});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "get-entity-schema-properties has a curated contract and must resolve");
+		ToolContractDefinition contract = response.Tools!.Single();
+		(contract.InputSchema.Required ?? []).Should().BeEquivalentTo(
+			["environment-name", "schema-name"],
+			because: "supplying package-name switches the tool to a single package layer and reports zero own " +
+				"columns, so the contract must not force it on every caller");
+		contract.InputSchema.Properties.Select(field => field.Name).Should().Contain("package-name",
+			because: "the single-package-layer read stays available, it is simply no longer mandatory");
+	}
+
+	[Test]
+	[Description("Verifies the live registry-derived contract of reg-web-app carries no connection any-of, because there uri is the application being registered and a credential-only payload is rejected with exit code 1 (issue #965, PR #1396 review).")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract does not offer reg-web-app a credential-only branch")]
+	[AllureDescription("Starts the real clio MCP server and requests the registry-derived contract of reg-web-app, verifying it advertises environment-name and uri without claiming the two are alternatives.")]
+	public async Task ToolContractGet_ShouldOmitConnectionAlternative_ForRegWebApp() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(
+			context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> {
+				["tool-names"] = new[] { "reg-web-app" }
+			});
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "reg-web-app is a registered tool and must expose a registry-derived contract");
+		ToolContractDefinition contract = response.Tools!.Single();
+		contract.InputSchema.Properties.Select(field => field.Name)
+			.Should().Contain(["environment-name", "uri"],
+				because: "this is the control case precisely BECAUSE it advertises both names the any-of " +
+					"heuristic keys on");
+		contract.InputSchema.AnyOf.Should().BeNull(
+			because: "a uri/login/password payload with no environment-name, active-environment or " +
+				"add-from-iis is refused by the tool itself, so advertising it as a complete alternative " +
+				"would send an agent into a guaranteed failure with credentials attached");
+	}
+
 	private static async Task<ToolContractGetResponse> CallAsync(
 		McpServerSession session,
 		CancellationToken cancellationToken,

--- a/clio.tests/Command/McpServer/CaptionCultureArgMappingToolTests.cs
+++ b/clio.tests/Command/McpServer/CaptionCultureArgMappingToolTests.cs
@@ -79,8 +79,7 @@ public sealed class CaptionCultureArgMappingToolTests {
 		commandResolver.Resolve<PageCreateCommand>(Arg.Any<PageCreateOptions>())
 			.Returns(command);
 		PageCreateTool tool = new(command, ConsoleLogger.Instance, commandResolver);
-		PageCreateArgs args = new("UsrPage", "BlankPageTemplate", "Custom", null, null, null, "dev", null, null, null,
-			CaptionCultureValue);
+		PageCreateArgs args = new("UsrPage", "BlankPageTemplate", "Custom", null, null, null, CaptionCultureValue) { EnvironmentName = "dev" };
 
 		// Act
 		ConsoleLogger.Instance.ClearMessages();
@@ -104,8 +103,7 @@ public sealed class CaptionCultureArgMappingToolTests {
 		commandResolver.Resolve<PageCreateCommand>(Arg.Any<PageCreateOptions>())
 			.Returns(command);
 		PageCreateTool tool = new(command, ConsoleLogger.Instance, commandResolver);
-		PageCreateArgs args = new("UsrPage", "BaseDashboardTemplate", "Custom", null, null, null, "dev", null, null, null,
-			OptionalProperties: optionalProperties);
+		PageCreateArgs args = new("UsrPage", "BaseDashboardTemplate", "Custom", OptionalProperties: optionalProperties) { EnvironmentName = "dev" };
 
 		// Act
 		ConsoleLogger.Instance.ClearMessages();

--- a/clio.tests/Command/McpServer/ClientUnitSchemaUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/ClientUnitSchemaUpdateToolTests.cs
@@ -30,7 +30,7 @@ public class ClientUnitSchemaUpdateToolTests {
 
 		// Act
 		ClientUnitSchemaUpdateResponse response = tool.UpdateSchema(
-			new ClientUnitSchemaUpdateArgs("NetworkUtilities", "var x = 1;", null, false, "dev", null, null, null));
+			new ClientUnitSchemaUpdateArgs("NetworkUtilities", "var x = 1;", null, false) { EnvironmentName = "dev" });
 
 		// Assert
 		response.Success.Should().BeFalse(because: "the resolved command reported a failure");
@@ -58,7 +58,7 @@ public class ClientUnitSchemaUpdateToolTests {
 
 		// Act
 		ClientUnitSchemaUpdateResponse response = tool.UpdateSchema(
-			new ClientUnitSchemaUpdateArgs("NetworkUtilities", "var x = 1;", null, false, "dev", null, null, null));
+			new ClientUnitSchemaUpdateArgs("NetworkUtilities", "var x = 1;", null, false) { EnvironmentName = "dev" });
 
 		// Assert
 		response.Success.Should().BeFalse(because: "a resolution failure must surface as a failed response, not an exception");

--- a/clio.tests/Command/McpServer/ConnectionAlternativeDispatchTests.cs
+++ b/clio.tests/Command/McpServer/ConnectionAlternativeDispatchTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using Clio.Command;
+using Clio.Command.McpServer;
+using Clio.Command.McpServer.Tools;
+using Clio.Tests.Infrastructure;
+using Clio.UserEnvironment;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+/// <summary>
+/// DISPATCH-level counterpart to <see cref="EmittedSchemaRequiredContractTests"/>: the schema guards
+/// assert what the contract SAYS, these assert what the resolver actually ACCEPTS, so the two are held
+/// against each other instead of only against themselves (issue #965, AC-4).
+/// </summary>
+/// <remarks>
+/// The connection alternative every environment-sensitive contract advertises is
+/// <c>[["environment-name"], ["uri","login","password"]]</c>. Only a real resolve settles whether that
+/// second branch describes the runtime: <see cref="ToolCommandResolver"/>'s environment-less path fills an
+/// <see cref="Clio.EnvironmentSettings"/> from the options and gates solely on a non-empty
+/// <c>Uri</c>. It therefore accepts a uri WITHOUT credentials too — the advertised triple is stricter than
+/// the runtime, deliberately, for consistency with the 75 curated contracts that already spell it that
+/// way. That asymmetry is recorded here so it stays a decision instead of drifting into a surprise.
+/// </remarks>
+[TestFixture]
+[Property("Module", "McpServer")]
+[NonParallelizable]
+public sealed class ConnectionAlternativeDispatchTests {
+
+	private const string EnvironmentNameValue = "dev";
+	private const string UriValue = "http://localhost";
+	private const string CredentialValue = "Supervisor";
+
+	private IFileSystem _originalFileSystem;
+
+	[SetUp]
+	public void SetUp() {
+		// SettingsRepository.FileSystem is a process-wide static; swapping it is why this fixture is
+		// [NonParallelizable].
+		_originalFileSystem = SettingsRepository.FileSystem;
+		SettingsRepository.FileSystem = TestFileSystem.MockFileSystem();
+	}
+
+	[TearDown]
+	public void TearDown() {
+		SettingsRepository.FileSystem = _originalFileSystem;
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A payload carrying ONLY environment-name resolves a command, because the first branch of the advertised connection any-of must be dispatchable on its own (issue #965).")]
+	public void Resolve_Should_Accept_EnvironmentNameOnlyPayload() {
+		// Arrange
+		ToolCommandResolver resolver = CreateResolverWithRegisteredEnvironment();
+		EnvironmentOptions options = new() { Environment = EnvironmentNameValue };
+
+		// Act
+		Action act = () => resolver.Resolve<CreateEntitySchemaCommand>(options);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "the contract tells a caller that a registered environment name alone is a complete " +
+				"connection payload, so a call shaped that way must not be rejected");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A payload carrying ONLY the uri/login/password triple resolves a command, because the second branch of the advertised connection any-of must be dispatchable on its own (issue #965).")]
+	public void Resolve_Should_Accept_DirectCredentialPayload() {
+		// Arrange
+		ToolCommandResolver resolver = CreateResolverWithoutRegisteredEnvironments();
+		EnvironmentOptions options = new() {
+			Uri = UriValue,
+			Login = CredentialValue,
+			Password = CredentialValue
+		};
+
+		// Act
+		Action act = () => resolver.Resolve<CreateEntitySchemaCommand>(options);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "the explicit uri/login/password triple is the documented emergency fallback, so the " +
+				"branch the contract advertises must actually dispatch");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A payload carrying a uri and NO credentials also resolves, recording that the advertised uri/login/password triple is deliberately stricter than the runtime rather than a description of it (issue #965).")]
+	public void Resolve_Should_Accept_UriWithoutCredentials_ShowingTheAdvertisedTripleIsStricterThanRuntime() {
+		// Arrange
+		ToolCommandResolver resolver = CreateResolverWithoutRegisteredEnvironments();
+		EnvironmentOptions options = new() { Uri = UriValue };
+
+		// Act
+		Action act = () => resolver.Resolve<CreateEntitySchemaCommand>(options);
+
+		// Assert
+		act.Should().NotThrow(
+			because: "the environment-less resolution path gates only on a non-empty Uri, so login and " +
+				"password are not what makes the second branch dispatchable; the contract keeps asking for " +
+				"the full triple for consistency with the curated contracts, and this test is what stops " +
+				"that consistency choice from being mistaken for a runtime requirement");
+	}
+
+	private static ToolCommandResolver CreateResolverWithRegisteredEnvironment() {
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		settingsRepository.IsEnvironmentExists(EnvironmentNameValue).Returns(true);
+		settingsRepository.FindEnvironment(EnvironmentNameValue).Returns(new Clio.EnvironmentSettings {
+			Uri = UriValue,
+			Login = CredentialValue,
+			Password = CredentialValue
+		});
+		return CreateResolver(settingsRepository, HealthyBootstrap());
+	}
+
+	private static ToolCommandResolver CreateResolverWithoutRegisteredEnvironments() {
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		settingsRepository.IsEnvironmentExists(Arg.Any<string>()).Returns(false);
+		return CreateResolver(settingsRepository, HealthyBootstrap());
+	}
+
+	private static ISettingsBootstrapService HealthyBootstrap() {
+		ISettingsBootstrapService settingsBootstrapService = Substitute.For<ISettingsBootstrapService>();
+		settingsBootstrapService.GetReport().Returns(new SettingsBootstrapReport(
+			"healthy", SettingsRepository.AppSettingsFile, EnvironmentNameValue, EnvironmentNameValue,
+			1, [], [], true, true));
+		return settingsBootstrapService;
+	}
+
+	private static ToolCommandResolver CreateResolver(
+		ISettingsRepository settingsRepository,
+		ISettingsBootstrapService settingsBootstrapService) =>
+		new(
+			settingsRepository,
+			settingsBootstrapService,
+			// Null Current keeps the resolver on the ordinary stdio (non-passthrough) path.
+			Substitute.For<ICredentialContextAccessor>(),
+			Substitute.For<ITargetUrlValidator>(),
+			new SessionContainerCache(SessionContainerCacheDefaults.IdleTtl, SessionContainerCacheDefaults.MaxSessions),
+			new SessionTargetNormalizer());
+}

--- a/clio.tests/Command/McpServer/DataBindingToolTests.cs
+++ b/clio.tests/Command/McpServer/DataBindingToolTests.cs
@@ -198,10 +198,10 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 
 		// Act
 		CommandExecutionResult result = tool.CreateDataBinding(new CreateDataBindingArgs(
-			null,
-			_packageName,
-			"SysSettings",
-			_workspaceRoot,
+			EnvironmentName: null,
+			PackageName: _packageName,
+			SchemaName: "SysSettings",
+			WorkspacePath: _workspaceRoot,
 			ValuesJson: """{"Name":"Tool row"}"""));
 
 		// Assert
@@ -238,10 +238,10 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 
 		// Act
 		CommandExecutionResult result = tool.CreateDataBinding(new CreateDataBindingArgs(
-			"dev",
-			_packageName,
-			"UsrImageBinding",
-			_workspaceRoot,
+			EnvironmentName: "dev",
+			PackageName: _packageName,
+			SchemaName: "UsrImageBinding",
+			WorkspacePath: _workspaceRoot,
 			ValuesJson: JsonSerializer.Serialize(new Dictionary<string, string> {
 				["Name"] = "UsrImageBinding row",
 				["UsrImage"] = Path.Combine("assets", "icon.png")
@@ -270,10 +270,10 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 
 		// Act
 		CommandExecutionResult result = tool.CreateDataBinding(new CreateDataBindingArgs(
-			"dev",
-			_packageName,
-			"UsrLookupBinding",
-			_workspaceRoot,
+			EnvironmentName: "dev",
+			PackageName: _packageName,
+			SchemaName: "UsrLookupBinding",
+			WorkspacePath: _workspaceRoot,
 			ValuesJson:
 				"""{"Name":"Lookup row","StatusId":{"value":"b659d704-3955-e011-981f-00155d043204","displayValue":"Prompt status"}}"""));
 
@@ -300,10 +300,10 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 
 		// Act
 		CommandExecutionResult result = tool.CreateDataBinding(new CreateDataBindingArgs(
-			"dev",
-			_packageName,
-			"UsrOfflineOnly",
-			_workspaceRoot,
+			EnvironmentName: "dev",
+			PackageName: _packageName,
+			SchemaName: "UsrOfflineOnly",
+			WorkspacePath: _workspaceRoot,
 			ValuesJson: """{"Id":"4f41bcc2-7ed0-45e8-a1fd-474918966d15","Name":"Tool row"}"""));
 
 		// Assert

--- a/clio.tests/Command/McpServer/EmittedSchemaProbe.cs
+++ b/clio.tests/Command/McpServer/EmittedSchemaProbe.cs
@@ -86,6 +86,39 @@ public static class EmittedSchemaProbe {
 		return description.GetString() ?? string.Empty;
 	}
 
+	/// <summary>
+	/// Determines whether an object schema is the SYNTHETIC single-<c>args</c> wrapper the SDK emits for a
+	/// tool method that takes one complex record parameter.
+	/// </summary>
+	/// <remarks>
+	/// The distinction matters to every registry-wide guard: on a wrapper root the sole <c>required</c>
+	/// entry is the machine-generated <c>args</c> name and the real user-facing fields live one level down,
+	/// whereas on a METHOD-PARAMETER tool (for example <c>link-from-repository-by-environment</c>) the SDK
+	/// puts the real fields on the root itself. Skipping every root indiscriminately therefore exempts the
+	/// whole method-parameter family — the shape that carried this defect in ENG-93347.
+	/// </remarks>
+	/// <param name="objectSchema">The candidate root schema.</param>
+	public static bool IsSingleArgsWrapper(JsonElement objectSchema) {
+		if (objectSchema.ValueKind != JsonValueKind.Object ||
+			!objectSchema.TryGetProperty("properties", out JsonElement properties) ||
+			properties.ValueKind != JsonValueKind.Object) {
+			return false;
+		}
+		List<JsonProperty> topLevel = [.. properties.EnumerateObject()];
+		return topLevel.Count == 1 && topLevel[0].NameEquals("args");
+	}
+
+	/// <summary>
+	/// Returns the schema a caller's arguments are actually validated against: the inner <c>args</c> object
+	/// for a single-record tool, or the root itself for a method-parameter tool.
+	/// </summary>
+	/// <param name="rootSchema">The tool's emitted top-level input schema.</param>
+	public static JsonElement EffectiveArgumentSchema(JsonElement rootSchema) =>
+		IsSingleArgsWrapper(rootSchema) &&
+		rootSchema.GetProperty("properties").GetProperty("args") is { ValueKind: JsonValueKind.Object } args
+			? args
+			: rootSchema;
+
 	/// <summary>Determines whether an object schema advertises a property of the given name.</summary>
 	public static bool Advertises(JsonElement objectSchema, string propertyName) =>
 		objectSchema.ValueKind == JsonValueKind.Object &&

--- a/clio.tests/Command/McpServer/EmittedSchemaProbe.cs
+++ b/clio.tests/Command/McpServer/EmittedSchemaProbe.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Clio.Command;
+using Clio.Command.McpServer;
+using Clio.Command.McpServer.Tools;
+using ModelContextProtocol.Server;
+using NSubstitute;
+
+namespace Clio.Tests.Command.McpServer;
+
+/// <summary>
+/// One object schema found somewhere inside an emitted MCP tool input schema.
+/// </summary>
+/// <param name="ToolName">The MCP tool the schema belongs to.</param>
+/// <param name="Path">A JSON-pointer-like path of the object inside that tool's schema, for diagnostics.</param>
+/// <param name="IsRoot"><c>true</c> for the tool's own top-level schema, <c>false</c> for anything nested.</param>
+/// <param name="Schema">The object schema node itself.</param>
+public sealed record EmittedObjectSchema(string ToolName, string Path, bool IsRoot, JsonElement Schema);
+
+/// <summary>
+/// Reads the REAL emitted MCP input schemas out of the production tool registry, so a guard can assert
+/// against the exact JSON a strict client validates a payload against.
+/// </summary>
+/// <remarks>
+/// Shared by <see cref="ColumnIdentityEmittedSchemaTests" /> and
+/// <see cref="EmittedSchemaRequiredContractTests" />. The MCP SDK derives <c>required</c> from the bound
+/// record's non-nullable, non-defaulted positional parameters, and nothing in-process validates it — the
+/// STJ binder happily binds a missing nullable parameter to <c>null</c>. Schema and binder therefore
+/// disagree silently, and only a strict client ever sees the defect, which is why these guards read the
+/// emitted schema instead of exercising the binder (issue #965).
+/// </remarks>
+public static class EmittedSchemaProbe {
+
+	/// <summary>Builds the registry over the real production tool assembly with every feature enabled.</summary>
+	public static McpToolInvokerRegistry BuildProductionRegistry() {
+		IServiceProvider provider = Substitute.For<IServiceProvider>();
+		IFeatureToggleService featureToggle = Substitute.For<IFeatureToggleService>();
+		featureToggle.IsEnabled(Arg.Any<Type>()).Returns(true);
+		return new McpToolInvokerRegistry(
+			provider,
+			typeof(SchemaSyncTool).Assembly,
+			featureToggle,
+			BindingsModule.CreateMcpSerializerOptions());
+	}
+
+	/// <summary>Serializes one registered tool's emitted input schema.</summary>
+	/// <param name="toolName">The MCP tool name.</param>
+	/// <returns>The parsed emitted input schema; the caller owns the document.</returns>
+	/// <exception cref="InvalidOperationException">When the tool is not registered.</exception>
+	public static JsonDocument EmittedInputSchema(string toolName) {
+		McpToolInvokerRegistry registry = BuildProductionRegistry();
+		if (!registry.TryGetTool(toolName, out McpServerTool tool)) {
+			throw new InvalidOperationException($"'{toolName}' is not a registered MCP tool.");
+		}
+		return JsonDocument.Parse(JsonSerializer.Serialize(tool.ProtocolTool.InputSchema));
+	}
+
+	/// <summary>Reads the <c>required</c> entries declared directly on one object schema.</summary>
+	public static string[] RequiredNames(JsonElement objectSchema) {
+		if (objectSchema.ValueKind != JsonValueKind.Object ||
+			!objectSchema.TryGetProperty("required", out JsonElement required) ||
+			required.ValueKind != JsonValueKind.Array) {
+			return [];
+		}
+		List<string> names = [];
+		foreach (JsonElement item in required.EnumerateArray()) {
+			if (item.ValueKind == JsonValueKind.String) {
+				names.Add(item.GetString() ?? string.Empty);
+			}
+		}
+		return [.. names];
+	}
+
+	/// <summary>Reads one property's <c>description</c>, or an empty string when it declares none.</summary>
+	public static string PropertyDescription(JsonElement objectSchema, string propertyName) {
+		if (objectSchema.ValueKind != JsonValueKind.Object ||
+			!objectSchema.TryGetProperty("properties", out JsonElement properties) ||
+			properties.ValueKind != JsonValueKind.Object ||
+			!properties.TryGetProperty(propertyName, out JsonElement property) ||
+			property.ValueKind != JsonValueKind.Object ||
+			!property.TryGetProperty("description", out JsonElement description) ||
+			description.ValueKind != JsonValueKind.String) {
+			return string.Empty;
+		}
+		return description.GetString() ?? string.Empty;
+	}
+
+	/// <summary>Determines whether an object schema advertises a property of the given name.</summary>
+	public static bool Advertises(JsonElement objectSchema, string propertyName) =>
+		objectSchema.ValueKind == JsonValueKind.Object &&
+		objectSchema.TryGetProperty("properties", out JsonElement properties) &&
+		properties.ValueKind == JsonValueKind.Object &&
+		properties.TryGetProperty(propertyName, out _);
+
+	/// <summary>
+	/// Enumerates every object schema that declares a <c>required</c> array, across every registered tool.
+	/// </summary>
+	public static IReadOnlyList<EmittedObjectSchema> EnumerateRequiredBearingSchemas() {
+		McpToolInvokerRegistry registry = BuildProductionRegistry();
+		List<EmittedObjectSchema> found = [];
+		foreach (string toolName in registry.ToolNames) {
+			if (!registry.TryGetTool(toolName, out McpServerTool tool)) {
+				continue;
+			}
+			// The JsonDocument is kept alive by the JsonElement instances collected from it; the returned
+			// clones survive the walk because JsonSerializer.Serialize produced a self-contained document.
+			JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(tool.ProtocolTool.InputSchema));
+			Walk(toolName, document.RootElement.Clone(), "$", isRoot: true, found);
+		}
+		return found;
+	}
+
+	private static void Walk(string toolName, JsonElement node, string path, bool isRoot, List<EmittedObjectSchema> found) {
+		switch (node.ValueKind) {
+			case JsonValueKind.Object:
+				if (node.TryGetProperty("required", out JsonElement required) &&
+					required.ValueKind == JsonValueKind.Array) {
+					found.Add(new EmittedObjectSchema(toolName, path, isRoot, node));
+				}
+				foreach (JsonProperty property in node.EnumerateObject()) {
+					if (property.NameEquals("required")) {
+						continue;
+					}
+					Walk(toolName, property.Value, $"{path}.{property.Name}", isRoot: false, found);
+				}
+				break;
+			case JsonValueKind.Array:
+				int index = 0;
+				foreach (JsonElement item in node.EnumerateArray()) {
+					Walk(toolName, item, $"{path}[{index++}]", isRoot: false, found);
+				}
+				break;
+		}
+	}
+}

--- a/clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
+++ b/clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
@@ -1,0 +1,208 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Clio.Command.McpServer.Tools;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+/// <summary>
+/// Registry-WIDE guards over the emitted <c>required</c> arrays of every registered MCP tool.
+/// </summary>
+/// <remarks>
+/// This defect class has now landed three times (PR #984, ENG-93347, issue #965), always as one more
+/// per-tool oversight, so the guard is deliberately written once over the whole catalog instead of once
+/// per tool. The MCP SDK puts a positional record parameter into <c>required</c> whenever it has no
+/// default value — nullability and <c>[Required]</c> are both irrelevant — while the STJ binder binds a
+/// missing nullable parameter to <c>null</c> and never consults <c>required</c>. Nothing in-process
+/// therefore fails when the two disagree: only a STRICT client sees it, by refusing to send a payload the
+/// tool documentation says is valid, with no server-side log at all.
+/// </remarks>
+[TestFixture]
+[Property("Module", "McpServer")]
+public sealed class EmittedSchemaRequiredContractTests {
+
+	private const string EnvironmentName = "environment-name";
+	private const string Uri = "uri";
+	private const string Login = "login";
+	private const string Password = "password";
+
+	private static readonly string[] ConnectionFieldNames = [EnvironmentName, Uri, Login, Password];
+
+	[Test]
+	[Category("Unit")]
+	[Description("No registered MCP tool lists a connection field as required in an object schema that advertises BOTH environment-name and uri, because the runtime accepts either connection path and demanding both spellings makes a documented environment-name-only payload fail client-side validation (issue #965).")]
+	public void RegisteredTools_Should_NotRequireConnectionFields_WhenBothConnectionPathsAreAdvertised() {
+		// Arrange
+		IReadOnlyList<EmittedObjectSchema> schemas = EmittedSchemaProbe.EnumerateRequiredBearingSchemas();
+
+		// Act
+		List<string> violations = [];
+		foreach (EmittedObjectSchema schema in schemas) {
+			// Only an object offering BOTH paths can be over-constrained: where a tool advertises just
+			// environment-name there is no alternative, so requiring it states the truth.
+			if (!EmittedSchemaProbe.Advertises(schema.Schema, EnvironmentName) ||
+				!EmittedSchemaProbe.Advertises(schema.Schema, Uri)) {
+				continue;
+			}
+			violations.AddRange(EmittedSchemaProbe.RequiredNames(schema.Schema)
+				.Where(ConnectionFieldNames.Contains)
+				.Select(name => $"{schema.ToolName} {schema.Path} requires '{name}'"));
+		}
+
+		// Assert
+		violations.Should().BeEmpty(
+			because: "a tool that offers both a registered environment-name and the explicit uri fallback " +
+				"accepts either one, so neither may be advertised as unconditionally mandatory");
+
+		// Anti-vacuity: the predicate must actually select something, otherwise the assertion above would
+		// pass over an empty set the day the connection args stop being advertised at all.
+		schemas.Count(schema =>
+			EmittedSchemaProbe.Advertises(schema.Schema, EnvironmentName) &&
+			EmittedSchemaProbe.Advertises(schema.Schema, Uri))
+			.Should().BeGreaterThan(0,
+				because: "the catalog must still contain tools offering both connection paths for this guard to mean anything");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("No registered MCP tool lists a field whose own description begins with 'Optional' as required, because a contract that calls a field optional and a schema that demands it cannot both be true (issue #965).")]
+	public void RegisteredTools_Should_NotRequireFields_DocumentedAsOptional() {
+		// Arrange
+		IReadOnlyList<EmittedObjectSchema> schemas = EmittedSchemaProbe.EnumerateRequiredBearingSchemas();
+
+		// Act
+		List<string> violations = [];
+		foreach (EmittedObjectSchema schema in schemas) {
+			// The root schema's single `args` wrapper is genuinely mandatory; its description is the tool
+			// method's parameter text, which legitimately opens by describing an optional inner field.
+			if (schema.IsRoot) {
+				continue;
+			}
+			violations.AddRange(EmittedSchemaProbe.RequiredNames(schema.Schema)
+				.Where(name => EmittedSchemaProbe.PropertyDescription(schema.Schema, name)
+					.TrimStart()
+					.StartsWith("Optional", System.StringComparison.OrdinalIgnoreCase))
+				.Select(name => $"{schema.ToolName} {schema.Path} requires '{name}' while describing it as optional"));
+		}
+
+		// Assert — no allow-list is needed: the deliberately-required nullable fields (the four
+		// merge-creatio-artifact contents and validate-page's body) describe themselves as required, so
+		// they never match this predicate and keep returning their typed {success:false} instead of an SDK
+		// binding error.
+		violations.Should().BeEmpty(
+			because: "a field the contract text calls optional must not be one a strict client is forced to send");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A registry-derived get-tool-contract envelope states the environment-name OR uri/login/password alternative through the same any-of the curated contracts use, so an empty required array is not the only thing telling a caller how to connect (issue #965).")]
+	public void RegistryDerivedContract_Should_AdvertiseConnectionAlternative_ForToolsOfferingBothPaths() {
+		// Arrange
+		McpToolInvokerRegistry registry = EmittedSchemaProbe.BuildProductionRegistry();
+		string[] toolsOfferingBothPaths = ["list-page-templates", "create-page", "get-related-page-addon",
+			"create-related-page-addon"];
+
+		foreach (string toolName in toolsOfferingBothPaths) {
+			// Act
+			bool built = McpToolRegistrySchemaContract.TryBuild(registry, toolName, out ToolContractDefinition contract);
+
+			// Assert
+			built.Should().BeTrue(because: $"'{toolName}' must be registered for its contract to be derivable");
+			contract.InputSchema.AnyOf.Should().BeEquivalentTo(
+				new[] { new[] { EnvironmentName }, new[] { Uri, Login, Password } },
+				because: "the derived contract must state the same connection alternative the 75 curated " +
+					$"contracts state, so '{toolName}' does not look like it needs no connection at all");
+		}
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A tool that offers only environment-name gets no connection any-of, so the alternative is advertised where it exists and nowhere else (issue #965).")]
+	public void RegistryDerivedContract_Should_OmitConnectionAlternative_ForToolsOfferingOnlyEnvironmentName() {
+		// Arrange
+		McpToolInvokerRegistry registry = EmittedSchemaProbe.BuildProductionRegistry();
+
+		// Act
+		bool built = McpToolRegistrySchemaContract.TryBuild(registry, "compile-status", out ToolContractDefinition contract);
+
+		// Assert
+		built.Should().BeTrue(because: "compile-status must be registered for its contract to be derivable");
+		contract.InputSchema.Properties.Select(field => field.Name).Should().NotContain(Uri,
+			because: "compile-status is the control case: it advertises no explicit-uri fallback");
+		(contract.InputSchema.Required ?? []).Should().Contain(EnvironmentName,
+			because: "with no alternative connection path, environment-name genuinely IS mandatory here — " +
+				"which is why this guard relaxes only the tools that offer a second path");
+		contract.InputSchema.AnyOf.Should().BeNull(
+			because: "advertising an alternative a tool does not offer would send callers down a path its " +
+				"schema rejects");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("list-page-templates requires nothing at all, because its schema-type filter and every connection field are optional (issue #965).")]
+	public void ListPageTemplates_Should_RequireNothing_InEmittedInputSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedSchemaProbe.EmittedInputSchema("list-page-templates");
+		JsonElement argsSchema = schema.RootElement.GetProperty("properties").GetProperty("args");
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEmpty(
+			because: "an environment-name-only call is the documented way to list templates, so demanding " +
+				"schema-type plus the whole uri/login/password triple contradicts the tool's own contract");
+		EmittedSchemaProbe.Advertises(argsSchema, "schema-type").Should().BeTrue(
+			because: "relaxing the field must not remove it from the advertised argument surface");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("create-page requires only the three fields that genuinely identify the new page, not its optional captions or any connection field (issue #965).")]
+	public void CreatePage_Should_RequireOnlyPageIdentity_InEmittedInputSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedSchemaProbe.EmittedInputSchema("create-page");
+		JsonElement argsSchema = schema.RootElement.GetProperty("properties").GetProperty("args");
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEquivalentTo(
+			["schema-name", "template", "package-name"],
+			because: "a page cannot be created without a name, a template and a target package, and " +
+				"everything else — caption, description, entity-schema-name and the connection args — is " +
+				"documented as optional");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("get-related-page-addon requires only the entity and package it reads, leaving the connection args optional (issue #965).")]
+	public void GetRelatedPageAddon_Should_RequireOnlyReadTarget_InEmittedInputSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedSchemaProbe.EmittedInputSchema("get-related-page-addon");
+		JsonElement argsSchema = schema.RootElement.GetProperty("properties").GetProperty("args");
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEquivalentTo(
+			["entity-schema-name", "package-name"],
+			because: "the read target is mandatory but the connection path is a choice between " +
+				"environment-name and the explicit uri triple");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("create-related-page-addon requires only the addon target and its pages, and its nested page entries require nothing, because a page entry may identify itself by page-schema-uid instead of page-schema-name (issue #965).")]
+	public void CreateRelatedPageAddon_Should_RequireOnlyWriteTarget_InEmittedInputSchema() {
+		// Arrange & Act
+		using JsonDocument schema = EmittedSchemaProbe.EmittedInputSchema("create-related-page-addon");
+		JsonElement argsSchema = schema.RootElement.GetProperty("properties").GetProperty("args");
+		JsonElement pageItemSchema = argsSchema.GetProperty("properties").GetProperty("pages").GetProperty("items");
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEquivalentTo(
+			["entity-schema-name", "package-name", "pages"],
+			because: "type-column-uid is documented as optional and the connection args are an either-or choice");
+		EmittedSchemaProbe.RequiredNames(pageItemSchema).Should().BeEmpty(
+			because: "page-schema-name is required only UNLESS page-schema-uid is supplied, so demanding it " +
+				"would reject the round-trip shape get-related-page-addon returns");
+		EmittedSchemaProbe.Advertises(pageItemSchema, "page-schema-name").Should().BeTrue(
+			because: "the name spelling must remain advertised even though it is no longer mandatory");
+	}
+}

--- a/clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
+++ b/clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using Clio.Command.McpServer;
 using Clio.Command.McpServer.Tools;
 using FluentAssertions;
 using NUnit.Framework;
@@ -76,8 +78,12 @@ public sealed class EmittedSchemaRequiredContractTests {
 		List<string> violations = [];
 		foreach (EmittedObjectSchema schema in schemas) {
 			// The root schema's single `args` wrapper is genuinely mandatory; its description is the tool
-			// method's parameter text, which legitimately opens by describing an optional inner field.
-			if (schema.IsRoot) {
+			// method's parameter text, which legitimately opens by describing an optional inner field. Only
+			// THAT synthetic shape is exempt: a method-parameter tool puts its real user-facing fields on
+			// the root, so skipping every root would exempt the whole family that carried this defect in
+			// ENG-93347 (link-from-repository-*), which is precisely what this registry-wide guard exists
+			// to cover.
+			if (schema.IsRoot && EmittedSchemaProbe.IsSingleArgsWrapper(schema.Schema)) {
 				continue;
 			}
 			violations.AddRange(EmittedSchemaProbe.RequiredNames(schema.Schema)
@@ -93,6 +99,143 @@ public sealed class EmittedSchemaRequiredContractTests {
 		// binding error.
 		violations.Should().BeEmpty(
 			because: "a field the contract text calls optional must not be one a strict client is forced to send");
+
+		// Anti-vacuity, in two parts: the walk must reach schemas at all, and — since narrowing the root
+		// skip is the whole point of the second condition — it must reach method-parameter roots too,
+		// otherwise the guard would silently go back to covering only the nested `args` objects.
+		schemas.Should().NotBeEmpty(
+			because: "a guard that scans nothing cannot fail, so the catalog must yield required-bearing schemas");
+		schemas.Count(schema => schema.IsRoot && !EmittedSchemaProbe.IsSingleArgsWrapper(schema.Schema))
+			.Should().BeGreaterThan(0,
+				because: "method-parameter tools put their real fields on the root, and this guard must " +
+					"still be scanning them");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[TestCase("update-page", new[] { "schema-name" })]
+	[TestCase("list-pages", new string[0])]
+	[TestCase("get-page-hierarchy", new[] { "schema-name" })]
+	[TestCase("update-schema", new[] { "schema-name" })]
+	[TestCase("update-sql-schema", new[] { "schema-name" })]
+	[TestCase("update-client-unit-schema", new[] { "schema-name" })]
+	[Description("Each record relaxed by issue #965 whose optional fields are NOT worded 'Optional…' is pinned to its exact emitted required set, because the registry-wide description heuristic cannot see wordings such as 'If true, validate without saving' or 'Filter by package name' and would let those relaxations be reverted while staying green.")]
+	public void RelaxedRecords_Should_RequireOnlyTheirIdentityFields_InEmittedInputSchema(
+		string toolName, string[] expectedRequired) {
+		// Arrange & Act
+		using JsonDocument schema = EmittedSchemaProbe.EmittedInputSchema(toolName);
+		JsonElement argsSchema = EmittedSchemaProbe.EffectiveArgumentSchema(schema.RootElement);
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEquivalentTo(expectedRequired,
+			because: $"'{toolName}' identifies its target by these fields alone — every dry-run flag, " +
+				"filter, limit and connection argument is optional, and a strict client must not be forced " +
+				"to send them");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("reg-web-app advertises environment-name and uri without gaining the connection any-of, because there uri is the application BEING REGISTERED rather than a fallback route to an existing one, and offering a credential-only branch would advertise a payload the tool rejects with exit code 1 (issue #965, PR #1396 review).")]
+	public void RegistryDerivedContract_Should_OmitConnectionAlternative_ForEnvironmentRegistrationTools() {
+		// Arrange
+		McpToolInvokerRegistry registry = EmittedSchemaProbe.BuildProductionRegistry();
+
+		// Act
+		bool built = McpToolRegistrySchemaContract.TryBuild(registry, "reg-web-app", out ToolContractDefinition contract);
+
+		// Assert
+		built.Should().BeTrue(because: "reg-web-app must be registered for its contract to be derivable");
+		string[] advertised = [.. contract.InputSchema.Properties.Select(field => field.Name)];
+		advertised.Should().Contain([EnvironmentName, Uri],
+			because: "this is the second negative control precisely BECAUSE it advertises both names the " +
+				"any-of heuristic keys on");
+		advertised.Should().Contain("active-environment",
+			because: "the environment-registration surface is what tells the heuristic these two names are " +
+				"the record being written, not a way of reaching an environment");
+		contract.InputSchema.AnyOf.Should().BeNull(
+			because: "reg-web-app rejects a uri/login/password payload that carries no environment-name, " +
+				"active-environment or add-from-iis, so advertising it as a complete alternative would " +
+				"send an agent into a guaranteed exit-code-1 failure with credentials attached");
+	}
+
+	/// <summary>
+	/// Tools whose curated <c>required</c> deliberately says MORE than the emitted schema does, with the
+	/// reason. The list is exhaustive and deliberately tiny: every other disagreement is a defect.
+	/// </summary>
+	private static readonly Dictionary<string, string> CuratedStricterThanEmittedByDesign = new() {
+		["get-guidance"] = "'name' is genuinely mandatory, but the record parameter is nullable so that a " +
+			"legacy-alias payload (topic/guide/article via [JsonExtensionData]) reaches the tool and comes " +
+			"back as a typed {success:false, availableGuides:[…]} answer instead of an SDK binding error. " +
+			"The curated contract states the requirement the caller has to satisfy; the emitted schema " +
+			"states what the binder accepts."
+	};
+
+	[Test]
+	[Category("Unit")]
+	[Description("Every resident tool's curated required set matches the required set its emitted schema advertises, because the two surfaces are read by the same agent — get-tool-contract to plan the call and tools/list to validate it — and a disagreement makes one of them a documented lie (issue #965).")]
+	public void CuratedContracts_Should_AgreeWithEmittedSchema_ForResidentTools() {
+		// Arrange
+		McpToolInvokerRegistry registry = EmittedSchemaProbe.BuildProductionRegistry();
+		// Scope is the RESIDENT surface on purpose: those are the tools whose emitted schema a strict
+		// client actually validates a payload against, because they ship in tools/list. A long-tail tool is
+		// dispatched through clio-run, so it is clio-run's schema — not its own — that gates the payload.
+		string[] curatedResidentTools = [.. registry.ToolNames
+			.Where(McpCoreToolProfile.IsResident)
+			.Where(ToolContractCatalog.CuratedToolNames.Contains)
+			.OrderBy(name => name, StringComparer.Ordinal)];
+
+		// Act
+		List<string> disagreements = [];
+		foreach (string toolName in curatedResidentTools) {
+			ToolContractDefinition curated = ToolContractCatalog
+				.GetContracts([toolName], registry).Tools.Single();
+			using JsonDocument emitted = EmittedSchemaProbe.EmittedInputSchema(toolName);
+			string[] emittedRequired = [.. EmittedSchemaProbe
+				.RequiredNames(EmittedSchemaProbe.EffectiveArgumentSchema(emitted.RootElement))
+				.OrderBy(name => name, StringComparer.Ordinal)];
+			string[] curatedRequired = [.. (curated.InputSchema.Required ?? [])
+				.OrderBy(name => name, StringComparer.Ordinal)];
+			if (emittedRequired.SequenceEqual(curatedRequired) ||
+				CuratedStricterThanEmittedByDesign.ContainsKey(toolName)) {
+				continue;
+			}
+			disagreements.Add(
+				$"{toolName}: emitted=[{string.Join(",", emittedRequired)}] curated=[{string.Join(",", curatedRequired)}]");
+		}
+
+		// Assert
+		disagreements.Should().BeEmpty(
+			because: "this is the comparison that was missing: the emitted-schema guards above pass while a " +
+				"curated contract still demands a field the tool's own description tells the caller to omit, " +
+				"which is how get-entity-schema-properties kept asking for package-name and denying every " +
+				"agent the merged, all-packages column view");
+		curatedResidentTools.Length.Should().BeGreaterThan(1,
+			because: "the comparison must cover a real population of resident curated tools, not an empty one");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("get-entity-schema-properties advertises package-name as optional on BOTH surfaces, because omitting it is the documented way to read the merged schema with the columns of every package (issue #965).")]
+	public void GetEntitySchemaProperties_Should_TreatPackageNameAsOptional_OnBothSurfaces() {
+		// Arrange
+		McpToolInvokerRegistry registry = EmittedSchemaProbe.BuildProductionRegistry();
+		const string toolName = "get-entity-schema-properties";
+
+		// Act
+		ToolContractDefinition curated = ToolContractCatalog.GetContracts([toolName], registry).Tools.Single();
+		using JsonDocument emitted = EmittedSchemaProbe.EmittedInputSchema(toolName);
+		JsonElement argsSchema = EmittedSchemaProbe.EffectiveArgumentSchema(emitted.RootElement);
+
+		// Assert
+		EmittedSchemaProbe.RequiredNames(argsSchema).Should().BeEquivalentTo(
+			[EnvironmentName, "schema-name"],
+			because: "the merged read needs an environment and a schema name and nothing else");
+		(curated.InputSchema.Required ?? []).Should().BeEquivalentTo(
+			[EnvironmentName, "schema-name"],
+			because: "the curated contract is what an agent plans the call from, so it must not demand the " +
+				"package-name that switches the tool from 49 own columns to 0");
+		curated.InputSchema.Properties.Should().Contain(field => field.Name == "package-name",
+			because: "the single-package-layer read stays available, it is simply no longer mandatory");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/EntitySchemaToolTests.cs
+++ b/clio.tests/Command/McpServer/EntitySchemaToolTests.cs
@@ -216,7 +216,8 @@ public sealed class EntitySchemaToolTests {
 
 		// Act
 		EntitySchemaPropertiesInfo result = tool.GetEntitySchemaProperties(
-			new GetEntitySchemaPropertiesArgs("dev", "UsrPkg", "UsrVehicle"));
+			new GetEntitySchemaPropertiesArgs(
+				EnvironmentName: "dev", SchemaName: "UsrVehicle", PackageName: "UsrPkg"));
 
 		// Assert
 		result.Should().BeEquivalentTo(expectedResult,
@@ -245,7 +246,8 @@ public sealed class EntitySchemaToolTests {
 
 		// Act
 		// Omitting package-name must flow through as a null package so the command returns the merged schema.
-		tool.GetEntitySchemaProperties(new GetEntitySchemaPropertiesArgs("dev", null, "Account"));
+		tool.GetEntitySchemaProperties(new GetEntitySchemaPropertiesArgs(
+			EnvironmentName: "dev", SchemaName: "Account", PackageName: null));
 
 		// Assert
 		commandResolver.Received(1).Resolve<GetEntitySchemaPropertiesCommand>(Arg.Is<GetEntitySchemaPropertiesOptions>(

--- a/clio.tests/Command/McpServer/GenerateProcessModelToolTests.cs
+++ b/clio.tests/Command/McpServer/GenerateProcessModelToolTests.cs
@@ -62,11 +62,11 @@ public sealed class GenerateProcessModelToolTests {
 
 		// Act
 		CommandExecutionResult result = tool.GenerateProcessModel(new GenerateProcessModelArgs(
-			"UsrProcess",
-			@"src\generated",
-			"Contoso.ProcessModels",
-			"uk-UA",
-			"dev"));
+			Code: "UsrProcess",
+			EnvironmentName: "dev",
+			DestinationPath: @"src\generated",
+			Namespace: "Contoso.ProcessModels",
+			Culture: "uk-UA"));
 
 		// Assert
 		result.ExitCode.Should().Be(0,
@@ -99,11 +99,11 @@ public sealed class GenerateProcessModelToolTests {
 
 		// Act
 		CommandExecutionResult result = tool.GenerateProcessModel(new GenerateProcessModelArgs(
-			"UsrProcess",
-			null,
-			null,
-			null,
-			"dev"));
+			Code: "UsrProcess",
+			EnvironmentName: "dev",
+			DestinationPath: null,
+			Namespace: null,
+			Culture: null));
 
 		// Assert
 		result.ExitCode.Should().Be(0,
@@ -133,11 +133,11 @@ public sealed class GenerateProcessModelToolTests {
 
 		// Act
 		CommandExecutionResult result = tool.GenerateProcessModel(new GenerateProcessModelArgs(
-			"UsrProcess",
-			null,
-			null,
-			null,
-			"missing-env"));
+			Code: "UsrProcess",
+			EnvironmentName: "missing-env",
+			DestinationPath: null,
+			Namespace: null,
+			Culture: null));
 
 		// Assert
 		result.ExitCode.Should().Be(1,

--- a/clio.tests/Command/McpServer/McpGuidanceForcingTests.cs
+++ b/clio.tests/Command/McpServer/McpGuidanceForcingTests.cs
@@ -164,8 +164,7 @@ public sealed class McpGuidanceForcingTests {
 
 	private static PageCreateArgs BuildPageCreateArgs() =>
 		new("UsrTestPage", "FormPage", "UsrPackage",
-			Caption: null, Description: null, EntitySchemaName: null,
-			EnvironmentName: "dev", Uri: null, Login: null, Password: null);
+			Caption: null, Description: null, EntitySchemaName: null) { EnvironmentName = "dev" };
 
 	private sealed class FakePageCreateCommand : PageCreateCommand {
 		private readonly bool _success;

--- a/clio.tests/Command/McpServer/McpProfileGatingTests.cs
+++ b/clio.tests/Command/McpServer/McpProfileGatingTests.cs
@@ -45,15 +45,21 @@ public sealed class McpProfileGatingTests
 	// tail dropped 2 more single-method schemas, bringing the measured payload down to 30233 bytes.
 	// Issue #1183 adds the semantic merge boundary to the default resident surface. The ratchet remains
 	// the deliberate guard against later default-surface growth.
-	// Issue #965 re-baselined it to 33*1024: master measured 32741 bytes against the previous 32*1024
-	// ceiling, i.e. 27 bytes of headroom, so ANY resident schema change was already blocked. Relaxing the
-	// 13 genuinely-optional resident record parameters (list-pages, get-page, get-entity-schema-properties)
-	// costs `,"default":null` — 15 bytes each, emitted by the SDK for every defaulted parameter — which
-	// outweighs the 163 bytes of `required` entries the same change removes; measured 32773 after. The
-	// 15-byte annotation could be stripped, but only by mirroring the SDK's per-method DI-factory
-	// registration (WithTools(IEnumerable<Type>) exposes no SchemaCreateOptions); see
+	// Issue #965 re-baselined it to 32*1024 + 256 = 33024: master measured 32741 bytes against the previous
+	// 32*1024 ceiling, i.e. 27 bytes of headroom, so ANY resident schema change was already blocked — that
+	// exhaustion is pre-existing, not caused by this change. Relaxing the 13 genuinely-optional resident
+	// record parameters (list-pages, get-page, get-entity-schema-properties) costs `,"default":null` —
+	// 15 bytes each, emitted by the SDK for every defaulted parameter — which outweighs the 163 bytes of
+	// `required` entries the same change removes; measured 32773 after. The ceiling is therefore pinned to
+	// the measured size rounded up to the next 256 bytes rather than the next whole kilobyte: rounding to
+	// 33*1024 would hand the resident surface ~990 bytes of silent room and stop the ratchet ratcheting,
+	// which is the only thing this constant is for. 251 bytes of headroom is deliberate — enough that a
+	// one-word description edit does not fail the build, small enough that the next real surface addition
+	// still forces the budget decision. The 15-byte annotation could be stripped, but only by mirroring the
+	// SDK's per-method DI-factory registration (WithTools(IEnumerable<Type>) exposes no
+	// SchemaCreateOptions); see
 	// docs/knowledge/McpServer/relaxing-a-record-parameter-costs-default-null-in-tools-list.md.
-	private const int MaxLazyToolsSerializedBytes = 33 * 1024;
+	private const int MaxLazyToolsSerializedBytes = (32 * 1024) + 256;
 
 	private static Assembly ClioAssembly => typeof(McpFeatureToggleFilter).Assembly;
 

--- a/clio.tests/Command/McpServer/McpProfileGatingTests.cs
+++ b/clio.tests/Command/McpServer/McpProfileGatingTests.cs
@@ -45,7 +45,15 @@ public sealed class McpProfileGatingTests
 	// tail dropped 2 more single-method schemas, bringing the measured payload down to 30233 bytes.
 	// Issue #1183 adds the semantic merge boundary to the default resident surface. The ratchet remains
 	// the deliberate guard against later default-surface growth.
-	private const int MaxLazyToolsSerializedBytes = 32 * 1024;
+	// Issue #965 re-baselined it to 33*1024: master measured 32741 bytes against the previous 32*1024
+	// ceiling, i.e. 27 bytes of headroom, so ANY resident schema change was already blocked. Relaxing the
+	// 13 genuinely-optional resident record parameters (list-pages, get-page, get-entity-schema-properties)
+	// costs `,"default":null` — 15 bytes each, emitted by the SDK for every defaulted parameter — which
+	// outweighs the 163 bytes of `required` entries the same change removes; measured 32773 after. The
+	// 15-byte annotation could be stripped, but only by mirroring the SDK's per-method DI-factory
+	// registration (WithTools(IEnumerable<Type>) exposes no SchemaCreateOptions); see
+	// docs/knowledge/McpServer/relaxing-a-record-parameter-costs-default-null-in-tools-list.md.
+	private const int MaxLazyToolsSerializedBytes = 33 * 1024;
 
 	private static Assembly ClioAssembly => typeof(McpFeatureToggleFilter).Assembly;
 

--- a/clio.tests/Command/McpServer/PageHierarchyGetToolTests.cs
+++ b/clio.tests/Command/McpServer/PageHierarchyGetToolTests.cs
@@ -27,15 +27,7 @@ public class PageHierarchyGetToolTests {
 		PageHierarchyGetTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
 		// Act
-		GetPageHierarchyResponse response = tool.GetHierarchy(new GetPageHierarchyArgs(
-			"UsrApplicants_FormPage",
-			MetadataOnly: true,
-			Offset: 2,
-			Limit: 5,
-			EnvironmentName: "workbuild103",
-			Uri: null,
-			Login: null,
-			Password: null));
+		GetPageHierarchyResponse response = tool.GetHierarchy(new GetPageHierarchyArgs("UsrApplicants_FormPage", MetadataOnly: true, Offset: 2, Limit: 5) { EnvironmentName = "workbuild103" });
 
 		// Assert
 		response.Success.Should().BeTrue(because: "the resolved command returns a successful canned response");
@@ -81,15 +73,7 @@ public class PageHierarchyGetToolTests {
 		PageHierarchyGetTool tool = new(new FakeGetPageHierarchyCommand(), ConsoleLogger.Instance, commandResolver);
 
 		// Act
-		GetPageHierarchyResponse response = tool.GetHierarchy(new GetPageHierarchyArgs(
-			"UsrLeaf_FormPage",
-			MetadataOnly: null,
-			Offset: null,
-			Limit: null,
-			EnvironmentName: "workbuild103",
-			Uri: null,
-			Login: null,
-			Password: null));
+		GetPageHierarchyResponse response = tool.GetHierarchy(new GetPageHierarchyArgs("UsrLeaf_FormPage", MetadataOnly: null, Offset: null, Limit: null) { EnvironmentName = "workbuild103" });
 
 		// Assert
 		response.Success.Should().BeFalse(

--- a/clio.tests/Command/McpServer/PageToolsTests.cs
+++ b/clio.tests/Command/McpServer/PageToolsTests.cs
@@ -60,8 +60,7 @@ public class PageToolsTests
 	[Description("Serializes the update-page validation escape hatch using the kebab-case MCP argument name.")]
 	public void PageUpdateArgs_ShouldSerializeValidateUsingKebabCase() {
 		// Arrange
-		PageUpdateArgs args = new("UsrValidationEscape_FormPage", "define(...)", null, null, null, null, null, null,
-			Validate: false);
+		PageUpdateArgs args = new("UsrValidationEscape_FormPage", "define(...)", Validate: false);
 
 		// Act
 		string json = System.Text.Json.JsonSerializer.Serialize(args);
@@ -93,8 +92,7 @@ public class PageToolsTests
 		PageUpdateTool tool = BuildAppendGuardTool(applicationClient);
 		string body = CreatePageBody(
 			viewConfigDiff: """[{"operation":"insert","name":"Playbook_g0bz14m","values":{"type":"crt.Playbook","_designOptions":{"templateValuesMapping":{"caption":"Playbook_KnowledgeBaseDS_Name"}}}},{"operation":"insert","name":"RunBpButton","values":{"type":"crt.Button","clicked":{"request":"crt.RunBusinessProcessRequest","params":{"processRunType":"RegardlessOfThePage"}}}}]""");
-		PageUpdateArgs args = new("UsrValidationEscape_FormPage", body, null, false, null, null, null, null,
-			SkipSampling: true, TargetSchemaUId: "validation-schema-uid", Validate: false);
+		PageUpdateArgs args = new("UsrValidationEscape_FormPage", body, null, false, SkipSampling: true, TargetSchemaUId: "validation-schema-uid", Validate: false);
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -126,15 +124,12 @@ public class PageToolsTests
 			}.ToString());
 		PageUpdateTool tool = BuildAppendGuardTool(applicationClient);
 		// A mobile body carrying an AMD-only 'handlers' section - a CONTENT rule, the half validate=false skips.
-		PageUpdateArgs args = new("UsrMobile_FormPage",
-			"""
+		PageUpdateArgs args = new("UsrMobile_FormPage", """
 			{
 			  "viewConfigDiff": [],
 			  "handlers": []
 			}
-			""",
-			null, true, null, null, null, null,
-			SkipSampling: true, TargetSchemaUId: "validation-schema-uid");
+			""", null, true, SkipSampling: true, TargetSchemaUId: "validation-schema-uid");
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -152,8 +147,7 @@ public class PageToolsTests
 	public async System.Threading.Tasks.Task PageUpdateTool_Should_WarnRatherThanReject_WhenValidationBypassMeetsForce() {
 		// Arrange
 		PageUpdateTool tool = BuildAppendGuardTool();
-		PageUpdateArgs args = new("UsrValidationEscape_FormPage", CreatePageBody(), null, true, null, null, null, null,
-			SkipSampling: true, Force: true, Validate: false);
+		PageUpdateArgs args = new("UsrValidationEscape_FormPage", CreatePageBody(), null, true, SkipSampling: true, Force: true, Validate: false);
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -171,8 +165,7 @@ public class PageToolsTests
 	public async System.Threading.Tasks.Task PageUpdateTool_Should_RetainSyntaxGate_WhenValidateIsFalse() {
 		// Arrange
 		PageUpdateTool tool = BuildSyntaxFailureTool(out IApplicationClient applicationClient);
-		PageUpdateArgs args = new("UsrValidationEscapeSyntax_FormPage", SyntaxBrokenMarkerBody, null, true, null, null, null, null,
-			SkipSampling: true, Validate: false);
+		PageUpdateArgs args = new("UsrValidationEscapeSyntax_FormPage", SyntaxBrokenMarkerBody, null, true, SkipSampling: true, Validate: false);
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -201,11 +194,7 @@ public class PageToolsTests
 	[Test]
 	[Description("Serializes create-page MCP request arguments using kebab-case field names")]
 	public void PageCreateToolArgs_Should_Serialize_Using_Kebab_Case_Field_Names() {
-		PageCreateArgs args = new(
-			"UsrDemo_BlankPage", "BlankPageTemplate", "Custom",
-			"Demo page", "Demo description", "UsrDemoEntity",
-			"sandbox", null, null, null,
-			OptionalProperties: """[{"key":"DashboardsEntitySchemaName","value":"Contact"}]""");
+		PageCreateArgs args = new("UsrDemo_BlankPage", "BlankPageTemplate", "Custom", "Demo page", "Demo description", "UsrDemoEntity", OptionalProperties: """[{"key":"DashboardsEntitySchemaName","value":"Contact"}]""") { EnvironmentName = "sandbox" };
 
 		string json = System.Text.Json.JsonSerializer.Serialize(args);
 
@@ -313,10 +302,10 @@ public class PageToolsTests
 	[Description("Serializes page MCP request arguments using kebab-case field names")]
 	public void PageToolArgs_Should_Serialize_Using_Kebab_Case_Field_Names() {
 		// Arrange
-		PageGetArgs getArgs = new("UsrTodo_FormPage", "sandbox", "https://sandbox", "Supervisor", "Supervisor");
-		PageListArgs listArgs = new("UsrTodo", null, "FormPage", 25, "sandbox", "https://sandbox", "Supervisor", "Supervisor");
-		PageListArgs listArgsByApp = new(null, "UsrTodo", "FormPage", 25, "sandbox", "https://sandbox", "Supervisor", "Supervisor");
-		PageUpdateArgs updateArgs = new("UsrTodo_FormPage", "define(...)", "{\"UsrTitle\":\"Title\"}", true, "sandbox", "https://sandbox", "Supervisor", "Supervisor");
+		PageGetArgs getArgs = new("UsrTodo_FormPage") { EnvironmentName = "sandbox", Uri = "https://sandbox", Login = "Supervisor", Password = "Supervisor" };
+		PageListArgs listArgs = new("UsrTodo", null, "FormPage", 25) { EnvironmentName = "sandbox", Uri = "https://sandbox", Login = "Supervisor", Password = "Supervisor" };
+		PageListArgs listArgsByApp = new(null, "UsrTodo", "FormPage", 25) { EnvironmentName = "sandbox", Uri = "https://sandbox", Login = "Supervisor", Password = "Supervisor" };
+		PageUpdateArgs updateArgs = new("UsrTodo_FormPage", "define(...)", "{\"UsrTitle\":\"Title\"}", true) { EnvironmentName = "sandbox", Uri = "https://sandbox", Login = "Supervisor", Password = "Supervisor" };
 
 		// Act
 		string getJson = System.Text.Json.JsonSerializer.Serialize(getArgs);
@@ -677,7 +666,7 @@ public class PageToolsTests
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		// Assert
 		response.Success.Should().BeTrue(
@@ -2304,7 +2293,7 @@ public class PageToolsTests
 		string body = CreatePageBody(
 			viewConfigDiff: """[{ "operation": "merge", "name": "UsrName", "values": { "label": "$Resources.Strings.UsrName" } }]""",
 			handlers: """[{ request: "crt.HandleViewModelInitRequest", handler: async (request, next) => { const x = $context["UsrMode"]; return next?.handle(request); } }]""");
-		PageUpdateArgs args = new("UsrMerge_FormPage", body, null, false, "dev", null, null, null, SkipSampling: true);
+		PageUpdateArgs args = new("UsrMerge_FormPage", body, null, false, SkipSampling: true) { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -2795,7 +2784,7 @@ public class PageToolsTests
 		IComponentInfoCatalog webCatalog = Substitute.For<IComponentInfoCatalog>();
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, Substitute.For<IPageBodySamplingService>(), new PageBaselineGuard(new MockFileSystem()));
 		string bodyWithBadJson = CreatePageBody(viewConfigDiff: "[{ bad json }]");
-		PageUpdateArgs args = new("UsrTest_FormPage", bodyWithBadJson, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", bodyWithBadJson);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -2836,7 +2825,7 @@ public class PageToolsTests
 			"        }]\n" +
 			"    };\n" +
 			"});";
-		PageUpdateArgs args = new("UsrTest_FormPage", incidentBody, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", incidentBody);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -2890,7 +2879,7 @@ public class PageToolsTests
 		PageUpdateTool tool = BuildSyntaxFailureTool(out IApplicationClient applicationClient);
 		PageUpdateArgs args = new(
 			"UsrBadOptionalProps_FormPage", SyntaxBrokenMarkerBody, null, DryRun: true,
-			"local", null, null, null, OptionalProperties: "{not-an-array}");
+			OptionalProperties: "{not-an-array}") { EnvironmentName = "local" };
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -2913,8 +2902,8 @@ public class PageToolsTests
 		// Arrange
 		PageUpdateTool tool = BuildSyntaxFailureTool(out IApplicationClient applicationClient);
 		PageUpdateArgs args = new(
-			"UsrValidationOnly_FormPage", SyntaxBrokenMarkerBody, Resources: "{\"UsrTitle\":", DryRun: true,
-			"local", null, null, null);
+			"UsrValidationOnly_FormPage", SyntaxBrokenMarkerBody, Resources: "{\"UsrTitle\":", DryRun: true)
+			{ EnvironmentName = "local" };
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -2947,8 +2936,8 @@ public class PageToolsTests
 			+ "/**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/, "
 			+ "/**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/ }; });";
 		PageUpdateArgs args = new(
-			"UsrRunProcessValidation_FormPage", runProcessBody, null, DryRun: true,
-			"local", null, null, null);
+			"UsrRunProcessValidation_FormPage", runProcessBody, null, DryRun: true)
+			{ EnvironmentName = "local" };
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3006,7 +2995,7 @@ public class PageToolsTests
 		string body = CreatePageBody(
 			viewModelConfig: """{"attributes":{"UsrName":{"modelConfig":{"path":"PDS.UsrName"},"validators":{"UpperCase":{"type":"usr.UpperCase","params":{"message":"$Resources.Strings.UsrUpperCaseValidator_Message"}}}}}}""",
 			validators: """{"usr.UpperCase":{"validator":function(config){return function(control){return null;}},"params":[{"name":"message"}],"async":false}}""");
-		PageUpdateArgs args = new("UsrTest_FormPage", body, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", body);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3041,7 +3030,7 @@ public class PageToolsTests
 		string body = CreatePageBody(
 			viewModelConfig: """{"attributes":{"UsrName":{"modelConfig":{"path":"PDS.UsrName"},"validators":{"UpperCase":{"type":"usr.UpperCase","params":{"message":"#ResourceString(UsrUpperCaseValidator_Message)#"}}}}}}""",
 			validators: """{"usr.UpperCase":{"validator":function(config){return function(control){return null;}},"params":[{"name":"message"}],"async":false}}""");
-		PageUpdateArgs args = new("UsrTest_FormPage", body, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", body);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3066,7 +3055,7 @@ public class PageToolsTests
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, Substitute.For<IPageBodySamplingService>(), new PageBaselineGuard(new MockFileSystem()));
 		string body = CreatePageBody(
 			handlers: """{ request: "crt.HandleViewModelInitRequest", handler: async (request, next) => { await next?.handle(request); } }""");
-		PageUpdateArgs args = new("UsrHandlerShape_FormPage", body, null, true, null, null, null, null);
+		PageUpdateArgs args = new("UsrHandlerShape_FormPage", body, null, true);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3097,7 +3086,7 @@ public class PageToolsTests
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, Substitute.For<IPageBodySamplingService>(), new PageBaselineGuard(new MockFileSystem()));
 		string body = CreatePageBody(
 			handlers: """[{ handler: async (request, next) => { await next?.handle(request); } }]""");
-		PageUpdateArgs args = new("UsrHandlerShape_FormPage", body, null, true, null, null, null, null);
+		PageUpdateArgs args = new("UsrHandlerShape_FormPage", body, null, true);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3128,7 +3117,7 @@ public class PageToolsTests
 		string body = CreatePageBody(
 			viewConfigDiff: """[{"operation":"insert","name":"UsrName","values":{"type":"crt.Input","control":"$UsrName"}}]""",
 			viewModelConfig: """{"attributes":{"UsrName":{"modelConfig":{"path":"PDS.UsrName"},"validators":{"NameMaxLength":{"type":"crt.MaxLength","params":{"max":4}}}}}}""");
-		PageUpdateArgs args = new("UsrTest_FormPage", body, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", body);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3161,7 +3150,7 @@ public class PageToolsTests
 			viewConfigDiff: """[{"operation":"insert","name":"UsrCode","values":{"type":"crt.Input","control":"$UsrCode","validators":[{"id":"usr.MaxLengthFromSysSettingValidator","params":{"settingCode":"MaxProcessLoopCount","message":"Too long"}}]}}]""",
 			viewModelConfig: """{"attributes":{"UsrCode":{"modelConfig":{"path":"PDS.UsrCode"}}}}""",
 			validators: """{"usr.MaxLengthFromSysSettingValidator":{"validator":function(config){return async function(control){return null;};},"params":[{"name":"settingCode"},{"name":"message"}],"async":true}}""");
-		PageUpdateArgs args = new("UsrTest_FormPage", body, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage", body);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -3427,7 +3416,7 @@ public class PageToolsTests
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", "sandbox", null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage") { EnvironmentName = "sandbox" });
 
 		// Assert
 		response.Success.Should().BeTrue(because: "the baseline capture must not affect a successful get-page");
@@ -3474,7 +3463,7 @@ public class PageToolsTests
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", "sandbox", null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage") { EnvironmentName = "sandbox" });
 
 		// Assert
 		response.Success.Should().BeTrue(because: "the baseline capture must not affect a successful get-page");
@@ -3520,7 +3509,7 @@ public class PageToolsTests
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", "sandbox", null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage") { EnvironmentName = "sandbox" });
 
 		// Assert
 		response.Success.Should().BeTrue(because: "a failed checksum capture must never fail get-page (best-effort, FR-10)");
@@ -3674,7 +3663,7 @@ public class PageToolsTests
 		MockFileSystem mockFs = new();
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		response.Success.Should().BeTrue(because: "page read and file write should both succeed");
 		response.Bundle.Should().BeNull(because: "bundle must be omitted from MCP response when written to disk");
@@ -3720,7 +3709,7 @@ public class PageToolsTests
 		MockFileSystem mockFs = new();
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(mockFs));
 
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		response.Files.BodyFile.Should().Contain(".clio-pages",
 			because: "files must be written under .clio-pages directory");
@@ -3817,7 +3806,7 @@ public class PageToolsTests
 		(PageGetTool tool, MockFileSystem mockFs) = CreatePageGetToolWithBody(proxyBody);
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		// Assert
 		response.Success.Should().BeTrue(because: "get-page should succeed even when the source body has proxy view-model attribute bindings");
@@ -3839,7 +3828,7 @@ public class PageToolsTests
 		(PageGetTool tool, MockFileSystem mockFs) = CreatePageGetToolWithBody(canonicalBody);
 
 		// Act
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		// Assert
 		response.Success.Should().BeTrue(because: "get-page should succeed for a body with canonical bindings");
@@ -3860,7 +3849,7 @@ public class PageToolsTests
 		string oldBodyPath = System.IO.Path.Combine(schemaDir, "body.js");
 		mockFs.File.WriteAllText(oldBodyPath, "previous session body");
 
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		response.Success.Should().BeTrue();
 		mockFs.File.Exists(stalePath).Should().BeFalse(
@@ -3877,7 +3866,7 @@ public class PageToolsTests
 	public void PageGetTool_WhenWriting_AddsGitIgnoreEntry() {
 		(PageGetTool tool, MockFileSystem mockFs) = CreatePageGetToolWithBody(CreatePageBody());
 
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		response.Success.Should().BeTrue();
 		string gitignorePath = System.IO.Path.Combine(mockFs.Directory.GetCurrentDirectory(), ".clio-pages", ".gitignore");
@@ -3930,7 +3919,7 @@ public class PageToolsTests
 			.Do(_ => throw new System.UnauthorizedAccessException("Access denied"));
 		PageGetTool tool = new(command, logger, commandResolver, new PageFileWriter(failingFs));
 
-		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage", null, null, null, null));
+		PageGetResponse response = tool.GetPage(new PageGetArgs("UsrMcp_FormPage"));
 
 		response.Success.Should().BeFalse(because: "directory creation failure should produce a failed response");
 		response.Error.Should().Contain("Failed to prepare output directory",
@@ -5668,7 +5657,7 @@ public class PageToolsTests
 			"handlers: /**SCHEMA_HANDLERS*/[]/**SCHEMA_HANDLERS*/, " +
 			"converters: /**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/, " +
 			"validators: /**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/ }; });";
-		PageUpdateArgs args = new("UsrX_FormPage", fullConfigBody, null, false, "dev", null, null, null, SkipSampling: true, Mode: "append");
+		PageUpdateArgs args = new("UsrX_FormPage", fullConfigBody, null, false, SkipSampling: true, Mode: "append") { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -5714,7 +5703,7 @@ public class PageToolsTests
 			  "modelConfigDiff": []
 			}
 			""";
-		PageUpdateArgs args = new("UsrMobile_FormPage", mobileBody, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrMobile_FormPage", mobileBody);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -5759,7 +5748,7 @@ public class PageToolsTests
 			.Returns((PageSamplingReview)null);
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, samplingService, new PageBaselineGuard(new MockFileSystem()));
 		string body = CreatePageBody();
-		PageUpdateArgs args = new("UsrValid_FormPage", body, "{\"caption\":\"Hello\"}", null, null, null, null, null);
+		PageUpdateArgs args = new("UsrValid_FormPage", body, "{\"caption\":\"Hello\"}");
 
 		// Act
 		_ = tool.UpdatePage(args, null).Result;
@@ -5792,7 +5781,7 @@ public class PageToolsTests
 		IComponentInfoCatalog webCatalog = Substitute.For<IComponentInfoCatalog>();
 		IPageBodySamplingService samplingService = Substitute.For<IPageBodySamplingService>();
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, samplingService, new PageBaselineGuard(new MockFileSystem()));
-		PageUpdateArgs args = new("UsrBad_FormPage", "define('BadPage', {})}", null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrBad_FormPage", "define('BadPage', {})}");
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -5822,7 +5811,7 @@ public class PageToolsTests
 		IMobileComponentInfoCatalog mobileCatalog = Substitute.For<IMobileComponentInfoCatalog>();
 		IComponentInfoCatalog webCatalog = Substitute.For<IComponentInfoCatalog>();
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, Substitute.For<IPageBodySamplingService>(), new PageBaselineGuard(new MockFileSystem()));
-		PageUpdateArgs args = new("UsrTest_FormPage", null, null, null, null, null, null, null);
+		PageUpdateArgs args = new("UsrTest_FormPage");
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -5853,7 +5842,7 @@ public class PageToolsTests
 		string tempFile = Path.Combine(Path.GetTempPath(), $"clio-bodyfile-{Path.GetRandomFileName()}.js");
 		File.WriteAllText(tempFile, bodyWithBadJson);
 		try {
-			PageUpdateArgs args = new("UsrTest_FormPage", null, null, null, null, null, null, null, BodyFile: tempFile);
+			PageUpdateArgs args = new("UsrTest_FormPage", BodyFile: tempFile);
 
 			// Act
 			PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -5888,7 +5877,7 @@ public class PageToolsTests
 		IComponentInfoCatalog webCatalog = Substitute.For<IComponentInfoCatalog>();
 		PageUpdateTool tool = new(command, logger, commandResolver, mobileCatalog, webCatalog, Substitute.For<IPageBodySamplingService>(), new PageBaselineGuard(new MockFileSystem()));
 		string missingPath = Path.Combine(Path.GetTempPath(), $"clio-missing-{Path.GetRandomFileName()}.js");
-		PageUpdateArgs args = new("UsrTest_FormPage", null, null, null, null, null, null, null, BodyFile: missingPath);
+		PageUpdateArgs args = new("UsrTest_FormPage", BodyFile: missingPath);
 
 		// Act
 		PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -5961,7 +5950,7 @@ public class PageToolsTests
 	public async System.Threading.Tasks.Task UpdatePage_ShouldNotRejectFullConfigBody_WhenModeIsReplace() {
 		// Arrange
 		PageUpdateTool tool = BuildAppendGuardTool();
-		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, "dev", null, null, null, SkipSampling: true, Mode: "replace");
+		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, SkipSampling: true, Mode: "replace") { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -5977,7 +5966,7 @@ public class PageToolsTests
 	public async System.Threading.Tasks.Task UpdatePage_ShouldNotRejectFullConfigBody_WhenModeIsDefault() {
 		// Arrange
 		PageUpdateTool tool = BuildAppendGuardTool();
-		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, "dev", null, null, null, SkipSampling: true, Mode: null);
+		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, SkipSampling: true, Mode: null) { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -5994,7 +5983,7 @@ public class PageToolsTests
 		// Arrange
 		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
 		PageUpdateTool tool = BuildAppendGuardTool(applicationClient);
-		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, "dev", null, null, null, SkipSampling: true, Mode: "Append");
+		PageUpdateArgs args = new("UsrX_FormPage", FullConfigWebBody, null, false, SkipSampling: true, Mode: "Append") { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);
@@ -6016,7 +6005,7 @@ public class PageToolsTests
 		string tempFile = Path.Combine(Path.GetTempPath(), $"clio-fullconfig-{Path.GetRandomFileName()}.js");
 		File.WriteAllText(tempFile, FullConfigWebBody);
 		try {
-			PageUpdateArgs args = new("UsrX_FormPage", null, null, false, "dev", null, null, null, SkipSampling: true, Mode: "append", BodyFile: tempFile);
+			PageUpdateArgs args = new("UsrX_FormPage", null, null, false, SkipSampling: true, Mode: "append", BodyFile: tempFile) { EnvironmentName = "dev" };
 
 			// Act
 			PageUpdateResponse response = tool.UpdatePage(args, null).Result;
@@ -6044,7 +6033,7 @@ public class PageToolsTests
 		string fullConfigButMalformed =
 			"define(\"UsrX_FormPage\", /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, function/**SCHEMA_ARGS*/()/**SCHEMA_ARGS*/ { return { " +
 			"viewModelConfig: /**SCHEMA_VIEW_MODEL_CONFIG*/{}/**SCHEMA_VIEW_MODEL_CONFIG*/, @@@ not valid javascript (((";
-		PageUpdateArgs args = new("UsrX_FormPage", fullConfigButMalformed, null, false, "dev", null, null, null, SkipSampling: true, Mode: "append");
+		PageUpdateArgs args = new("UsrX_FormPage", fullConfigButMalformed, null, false, SkipSampling: true, Mode: "append") { EnvironmentName = "dev" };
 
 		// Act
 		PageUpdateResponse response = await tool.UpdatePage(args, null);

--- a/clio.tests/Command/McpServer/PageUpdateToolBaselineTests.cs
+++ b/clio.tests/Command/McpServer/PageUpdateToolBaselineTests.cs
@@ -119,15 +119,14 @@ public sealed class PageUpdateToolBaselineTests
 	}
 
 	private static PageUpdateArgs CreateArgs(bool? force = null) =>
-		new(SchemaName, ValidBody, null, null, "sandbox", null, null, null,
-			SkipSampling: true, OutputDirectory: "/ws", Force: force);
+		new(SchemaName, ValidBody, SkipSampling: true, OutputDirectory: "/ws", Force: force)
+			{ EnvironmentName = "sandbox" };
 
 	[Test]
 	[Description("update-page scopes the registry-driven chart-widget validation to the platform version resolved from the target environment.")]
 	public async System.Threading.Tasks.Task UpdatePage_ShouldScopeChartValidationToResolvedEnvironmentVersion() {
 		// Arrange
-		PageUpdateArgs args = new(SchemaName, ValidBody, null, null, "sandbox", null, null, null,
-			SkipSampling: true, OutputDirectory: "/ws");
+		PageUpdateArgs args = new(SchemaName, ValidBody, SkipSampling: true, OutputDirectory: "/ws") { EnvironmentName = "sandbox" };
 
 		// Act
 		await _tool.UpdatePage(args, null);
@@ -256,9 +255,7 @@ public sealed class PageUpdateToolBaselineTests
 			"handlers: /**SCHEMA_HANDLERS*/[]/**SCHEMA_HANDLERS*/, " +
 			"converters: /**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/, " +
 			"validators: /**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/ }; });";
-		PageUpdateArgs args = new(SchemaName, bodyWithResourceBoundInsert,
-			"{\"PDS_UsrContactPhone\":\"Contact phone\"}", null, "sandbox", null, null, null,
-			SkipSampling: true, OutputDirectory: "/ws");
+		PageUpdateArgs args = new(SchemaName, bodyWithResourceBoundInsert, "{\"PDS_UsrContactPhone\":\"Contact phone\"}", SkipSampling: true, OutputDirectory: "/ws") { EnvironmentName = "sandbox" };
 
 		// Act
 		PageUpdateResponse response = _tool.UpdatePage(args, null).Result;

--- a/clio.tests/Command/McpServer/PageUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/PageUpdateToolTests.cs
@@ -92,7 +92,7 @@ public sealed class PageUpdateToolTests {
 	}
 
 	private static PageUpdateArgs CreateArgs(string environmentName) =>
-		new(SchemaName, ValidBody, null, null, environmentName, null, null, null, SkipSampling: true);
+		new(SchemaName, ValidBody, SkipSampling: true) { EnvironmentName = environmentName };
 
 	private string ReceivedChartValidationVersion() =>
 		(string)_webComponentCatalog.ReceivedCalls()
@@ -223,7 +223,7 @@ public sealed class PageUpdateToolTests {
 				Substitute.For<IPageFileWriter>());
 			_commandResolver.Resolve<PageGetCommand>(Arg.Do<EnvironmentOptions>(o => captured = o)).Returns(getCommand);
 
-			PageUpdateArgs args = new(SchemaName, mobileBody, null, true, "dev", null, null, null, SkipSampling: true, Mode: mode);
+			PageUpdateArgs args = new(SchemaName, mobileBody, null, true, SkipSampling: true, Mode: mode) { EnvironmentName = "dev" };
 			await _tool.UpdatePage(args, null);
 
 			captured.Should().BeOfType<PageGetOptions>(

--- a/clio.tests/Command/McpServer/RestoreDbToolTests.cs
+++ b/clio.tests/Command/McpServer/RestoreDbToolTests.cs
@@ -119,15 +119,15 @@ public sealed class RestoreDbToolTests {
 		FakeRestoreDbCommand command = new(logger, exitCode: 0, dbOperationLogSessionFactory);
 		RestoreDbTool tool = new(command, logger, Substitute.For<IToolCommandResolver>(), dbOperationLogContextAccessor);
 		RestoreDbByCredentialsArgs args = new(
-			"mssql://localhost:1433",
-			"sa",
-			"Password1!",
-			@"C:\sql-share",
-			@"C:\backups\db.bak",
-			"sandbox_db",
-			true,
-			true,
-			false);
+			DbServerUri: "mssql://localhost:1433",
+			DbUser: "sa",
+			DbPassword: "Password1!",
+			BackupPath: @"C:\backups\db.bak",
+			DbName: "sandbox_db",
+			Force: true,
+			AsTemplate: true,
+			DisableResetPassword: false,
+			DbWorkingFolder: @"C:\sql-share");
 
 		// Act
 		CommandExecutionResult result = tool.RestoreByCredentials(args);

--- a/clio.tests/Command/McpServer/SchemaNamePreValidationToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaNamePreValidationToolTests.cs
@@ -22,9 +22,7 @@ public sealed class SchemaNamePreValidationToolTests {
 
 		// Act
 		PageCreateResponse response = tool.CreatePage(
-			new PageCreateArgs("   ", "FormPage", "UsrPackage",
-				Caption: null, Description: null, EntitySchemaName: null,
-				EnvironmentName: "dev", Uri: null, Login: null, Password: null));
+			new PageCreateArgs("   ", "FormPage", "UsrPackage", Caption: null, Description: null, EntitySchemaName: null) { EnvironmentName = "dev" });
 
 		// Assert
 		response.Success.Should().BeFalse(
@@ -46,9 +44,7 @@ public sealed class SchemaNamePreValidationToolTests {
 
 		// Act
 		PageCreateResponse response = tool.CreatePage(
-			new PageCreateArgs("1BadName", "FormPage", "UsrPackage",
-				Caption: null, Description: null, EntitySchemaName: null,
-				EnvironmentName: "dev", Uri: null, Login: null, Password: null));
+			new PageCreateArgs("1BadName", "FormPage", "UsrPackage", Caption: null, Description: null, EntitySchemaName: null) { EnvironmentName = "dev" });
 
 		// Assert
 		response.Success.Should().BeFalse(

--- a/clio.tests/Command/McpServer/SqlSchemaInstallToolTests.cs
+++ b/clio.tests/Command/McpServer/SqlSchemaInstallToolTests.cs
@@ -22,8 +22,7 @@ public class SqlSchemaInstallToolTests {
 			.Returns(resolvedCommand);
 		SqlSchemaInstallTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		SqlSchemaInstallResponse response = tool.InstallSchema(new SqlSchemaInstallArgs(
-			"UsrScript", "dev", null, null, null));
+		SqlSchemaInstallResponse response = tool.InstallSchema(new SqlSchemaInstallArgs("UsrScript") { EnvironmentName = "dev" });
 
 		response.Success.Should().BeTrue();
 		resolvedCommand.CapturedOptions.Should().NotBeNull();
@@ -43,8 +42,7 @@ public class SqlSchemaInstallToolTests {
 			.Returns(_ => throw new System.InvalidOperationException("boom"));
 		SqlSchemaInstallTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		SqlSchemaInstallResponse response = tool.InstallSchema(new SqlSchemaInstallArgs(
-			"UsrScript", "missing", null, null, null));
+		SqlSchemaInstallResponse response = tool.InstallSchema(new SqlSchemaInstallArgs("UsrScript") { EnvironmentName = "missing" });
 
 		response.Success.Should().BeFalse();
 		response.Error.Should().Contain("boom");

--- a/clio.tests/Command/McpServer/SqlSchemaUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/SqlSchemaUpdateToolTests.cs
@@ -22,8 +22,7 @@ public class SqlSchemaUpdateToolTests {
 			.Returns(resolvedCommand);
 		SqlSchemaUpdateTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		SqlSchemaUpdateResponse response = tool.UpdateSchema(new SqlSchemaUpdateArgs(
-			"UsrScript", "SELECT 1;", "/tmp/body.sql", true, "dev", null, null, null));
+		SqlSchemaUpdateResponse response = tool.UpdateSchema(new SqlSchemaUpdateArgs("UsrScript", "SELECT 1;", "/tmp/body.sql", true) { EnvironmentName = "dev" });
 
 		response.Success.Should().BeTrue();
 		resolvedCommand.CapturedOptions.Should().NotBeNull();
@@ -47,8 +46,7 @@ public class SqlSchemaUpdateToolTests {
 			.Returns(resolvedCommand);
 		SqlSchemaUpdateTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		tool.UpdateSchema(new SqlSchemaUpdateArgs(
-			"UsrScript", "SELECT 1;", null, null, "dev", null, null, null));
+		tool.UpdateSchema(new SqlSchemaUpdateArgs("UsrScript", "SELECT 1;") { EnvironmentName = "dev" });
 
 		resolvedCommand.CapturedOptions.DryRun.Should().BeFalse();
 		ConsoleLogger.Instance.ClearMessages();
@@ -64,8 +62,7 @@ public class SqlSchemaUpdateToolTests {
 			.Returns(_ => throw new System.InvalidOperationException("boom"));
 		SqlSchemaUpdateTool tool = new(defaultCommand, ConsoleLogger.Instance, commandResolver);
 
-		SqlSchemaUpdateResponse response = tool.UpdateSchema(new SqlSchemaUpdateArgs(
-			"UsrScript", "SELECT 1;", null, null, "missing", null, null, null));
+		SqlSchemaUpdateResponse response = tool.UpdateSchema(new SqlSchemaUpdateArgs("UsrScript", "SELECT 1;") { EnvironmentName = "missing" });
 
 		response.Success.Should().BeFalse();
 		response.Error.Should().Contain("boom");

--- a/clio/Command/McpServer/Tools/AddPackageDependencyTool.cs
+++ b/clio/Command/McpServer/Tools/AddPackageDependencyTool.cs
@@ -102,5 +102,5 @@ public sealed record PackageDependencyArg(
 
 	[property: JsonPropertyName("version")]
 	[property: Description("Optional package version; defaults to the installed version of the dependency")]
-	string Version
+	string? Version = null
 );

--- a/clio/Command/McpServer/Tools/ApplicationDeleteTool.cs
+++ b/clio/Command/McpServer/Tools/ApplicationDeleteTool.cs
@@ -87,10 +87,6 @@ public sealed class ApplicationDeleteTool(
 /// Arguments for the <c>delete-app</c> MCP tool.
 /// </summary>
 public sealed record ApplicationDeleteArgs(
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
-
 	[property: JsonPropertyName("app-name")]
 	[property: Description("Application name or code to uninstall, e.g. 'UsrMyApp'")]
 	[property: Required]
@@ -104,7 +100,10 @@ public sealed record ApplicationDeleteArgs(
 	string? Login = null,
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
+	string? Password = null,
+	[property: JsonPropertyName("environment-name")]
+	[property: Description(McpToolDescriptions.EnvironmentName)]
+	string? EnvironmentName = null
 );
 
 /// <summary>

--- a/clio/Command/McpServer/Tools/ClientUnitSchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/ClientUnitSchemaUpdateTool.cs
@@ -78,29 +78,29 @@ public sealed record ClientUnitSchemaUpdateArgs(
 
 	[property: JsonPropertyName("body")]
 	[property: Description("Full raw JavaScript body to save as the schema body. Optional when body-file is provided.")]
-	string? Body,
+	string? Body = null,
 
 	[property: JsonPropertyName("body-file")]
 	[property: Description("Absolute path to a file whose contents are used as the new schema body. Recommended for large bodies (over a few KB). Takes precedence over body when both are provided.")]
-	string? BodyFile,
+	string? BodyFile = null,
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun,
+	bool? DryRun = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/ClientUnitSchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/ClientUnitSchemaUpdateTool.cs
@@ -86,21 +86,5 @@ public sealed record ClientUnitSchemaUpdateArgs(
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun = null,
-
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
-);
+	bool? DryRun = null
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/CompileCreatioTool.cs
+++ b/clio/Command/McpServer/Tools/CompileCreatioTool.cs
@@ -248,4 +248,4 @@ public sealed record CompileCreatioArgs(
 
 	[property: JsonPropertyName("package-name")]
 	[Description("Optional package name. When omitted, the tool performs a full compilation.")]
-	string? PackageName);
+	string? PackageName = null);

--- a/clio/Command/McpServer/Tools/CompileStatusTool.cs
+++ b/clio/Command/McpServer/Tools/CompileStatusTool.cs
@@ -81,7 +81,7 @@ public sealed record CompileStatusArgs(
 
 	[property: JsonPropertyName("operation-id")]
 	[Description("Optional operation id from a compile-creatio in-progress response. When omitted, returns the most recently started operation for this environment.")]
-	string? OperationId);
+	string? OperationId = null);
 
 /// <summary>
 /// Response payload for the compile-status tool.

--- a/clio/Command/McpServer/Tools/CreateRelatedPageAddonTool.cs
+++ b/clio/Command/McpServer/Tools/CreateRelatedPageAddonTool.cs
@@ -107,23 +107,23 @@ public sealed record CreateRelatedPageAddonArgs(
 
 	[property: JsonPropertyName("type-column-uid")]
 	[property: Description("Optional UId of the type column that drives type-specific page sets. Omit for a single page set.")]
-	string? TypeColumnUId,
+	string? TypeColumnUId = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description("Registered clio environment name, e.g. 'local'. Preferred for normal MCP work.")]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description("Direct Creatio URL. Use only when bootstrap is broken or before the environment can be registered through reg-web-app.")]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description("Direct Creatio login paired with `uri`. Emergency fallback only.")]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description("Direct Creatio password paired with `uri`. Emergency fallback only.")]
-	string? Password,
+	string? Password = null,
 
 	[property: JsonPropertyName("schema-type")]
 	[property: Description("Target UI: 'web' (RelatedPage add-on, default) or 'mobile' (MobileRelatedPage add-on — the page opened for a record in the Creatio Mobile app). For 'mobile' pass a single is-default page with no role and no type-column-value (the object's default mobile edit page); roles, record types and portal audiences are web-only concepts.")]
@@ -133,27 +133,27 @@ public sealed record CreateRelatedPageAddonArgs(
 public sealed record RelatedPageArg(
 	[property: JsonPropertyName("page-schema-name")]
 	[property: Description("Freedom UI page schema name, e.g. 'UsrDeliveryItemFormPage'. Required UNLESS page-schema-uid is supplied. When both are present, page-schema-uid wins and the name is ignored.")]
-	string PageSchemaName,
+	string? PageSchemaName = null,
 
 	[property: JsonPropertyName("is-default")]
 	[property: Description("When true, this page opens by default when a record is opened. Default false.")]
-	bool? IsDefault,
+	bool? IsDefault = null,
 
 	[property: JsonPropertyName("is-add")]
 	[property: Description("When true, this page is used when adding a new record. Default false.")]
-	bool? IsAdd,
+	bool? IsAdd = null,
 
 	[property: JsonPropertyName("is-ssp-default")]
 	[property: Description("Low-level RelatedPagesMetadata IsSspDefault flag; leave false. This is NOT how the portal audience is set — to target portal (self-service) users, add a page entry with role-name 'All external users'. Default false.")]
-	bool? IsSspDefault,
+	bool? IsSspDefault = null,
 
 	[property: JsonPropertyName("role")]
 	[property: Description("Optional audience role UId. Only two audiences are supported: 'All employees' (a29a3ba5-4b0d-de11-9a51-005056c00008) and the portal 'All external users' (720b771c-e7a7-4f31-9cfb-52cd21c3739f); any other role UId is rejected. Omit for all users (the general audience). Prefer role-name.")]
-	string? Role,
+	string? Role = null,
 
 	[property: JsonPropertyName("type-column-value")]
 	[property: Description("Optional type-column value (used with type-column-uid) for a type-specific page set.")]
-	string? TypeColumnValue,
+	string? TypeColumnValue = null,
 
 	[property: JsonPropertyName("role-name")]
 	[property: Description("Optional audience role NAME (alternative to role). Only 'All external users' (portal/self-service) and 'All employees' (internal) are supported — any other role name is rejected, because the Interface Designer offers no other audience. Omit for all users (the general audience).")]

--- a/clio/Command/McpServer/Tools/DataBindingTool.cs
+++ b/clio/Command/McpServer/Tools/DataBindingTool.cs
@@ -154,10 +154,6 @@ internal static class DataBindingToolPathValidator {
 /// Arguments for the <c>create-data-binding</c> MCP tool.
 /// </summary>
 public sealed record CreateDataBindingArgs(
-	[property: JsonPropertyName("environment-name")]
-	[property: Description("Optional Creatio environment name used only when the schema is not covered by a built-in offline template")]
-	string? EnvironmentName,
-
 	[property: JsonPropertyName("package-name")]
 	[property: Description("Target package name inside the workspace")]
 	[property: Required]
@@ -187,7 +183,10 @@ public sealed record CreateDataBindingArgs(
 
 	[property: JsonPropertyName("localizations")]
 	[property: Description("Optional JSON object keyed by culture then column name")]
-	string? LocalizationsJson = null
+	string? LocalizationsJson = null,
+	[property: JsonPropertyName("environment-name")]
+	[property: Description("Optional Creatio environment name used only when the schema is not covered by a built-in offline template")]
+	string? EnvironmentName = null
 );
 
 /// <summary>

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -1254,15 +1254,15 @@ public sealed record GetEntitySchemaPropertiesArgs(
 	[property: Required]
 	string EnvironmentName,
 
-	[property: JsonPropertyName("package-name")]
-	[property: Description("Optional target package name. Omit to read the merged/effective schema with columns "
-		+ "from ALL packages (recommended for column discovery). Supply only to inspect a single package layer's slice.")]
-	string? PackageName,
-
 	[property: JsonPropertyName("schema-name")]
 	[property: Description("Entity schema name")]
 	[property: Required]
-	string SchemaName
+	string SchemaName,
+
+	[property: JsonPropertyName("package-name")]
+	[property: Description("Optional target package name. Omit to read the merged/effective schema with columns "
+		+ "from ALL packages (recommended for column discovery). Supply only to inspect a single package layer's slice.")]
+	string? PackageName = null
 );
 
 /// <summary>

--- a/clio/Command/McpServer/Tools/GenerateProcessModelTool.cs
+++ b/clio/Command/McpServer/Tools/GenerateProcessModelTool.cs
@@ -64,20 +64,20 @@ public sealed record GenerateProcessModelArgs(
 	[property: Required]
 	string Code,
 
-	[property: JsonPropertyName("destination-path")]
-	[property: Description("Optional destination folder or explicit .cs file path for the generated process model. Preserves current command behavior when omitted.")]
-	string? DestinationPath,
-
-	[property: JsonPropertyName("namespace")]
-	[property: Description("Optional namespace for the generated process model class")]
-	string? Namespace,
-
-	[property: JsonPropertyName("culture")]
-	[property: Description("Optional culture used to resolve localized descriptions")]
-	string? Culture,
-
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
 	[property: Required]
-	string EnvironmentName
+	string EnvironmentName,
+
+	[property: JsonPropertyName("destination-path")]
+	[property: Description("Optional destination folder or explicit .cs file path for the generated process model. Preserves current command behavior when omitted.")]
+	string? DestinationPath = null,
+
+	[property: JsonPropertyName("namespace")]
+	[property: Description("Optional namespace for the generated process model class")]
+	string? Namespace = null,
+
+	[property: JsonPropertyName("culture")]
+	[property: Description("Optional culture used to resolve localized descriptions")]
+	string? Culture = null
 );

--- a/clio/Command/McpServer/Tools/GetRelatedPageAddonTool.cs
+++ b/clio/Command/McpServer/Tools/GetRelatedPageAddonTool.cs
@@ -79,19 +79,19 @@ public sealed record GetRelatedPageAddonArgs(
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description("Registered clio environment name, e.g. 'local'. Preferred for normal MCP work.")]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description("Direct Creatio URL. Use only when bootstrap is broken or before the environment can be registered through reg-web-app.")]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description("Direct Creatio login paired with `uri`. Emergency fallback only.")]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description("Direct Creatio password paired with `uri`. Emergency fallback only.")]
-	string? Password,
+	string? Password = null,
 
 	[property: JsonPropertyName("schema-type")]
 	[property: Description("Which add-on to read: 'web' (RelatedPage, default) or 'mobile' (MobileRelatedPage — the object's default mobile edit page).")]

--- a/clio/Command/McpServer/Tools/InstallApplicationTool.cs
+++ b/clio/Command/McpServer/Tools/InstallApplicationTool.cs
@@ -57,16 +57,16 @@ public sealed record InstallApplicationArgs(
 	[property: Required]
 	string Name,
 
-	[property: JsonPropertyName("report-path")]
-	[property: Description("Optional local path where the install report should be written")]
-	string? ReportPath,
-
-	[property: JsonPropertyName("check-compilation-errors")]
-	[property: Description("Optional flag that enables compilation-error checking during installation")]
-	bool? CheckCompilationErrors,
-
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
 	[property: Required]
-	string EnvironmentName
+	string EnvironmentName,
+
+	[property: JsonPropertyName("report-path")]
+	[property: Description("Optional local path where the install report should be written")]
+	string? ReportPath = null,
+
+	[property: JsonPropertyName("check-compilation-errors")]
+	[property: Description("Optional flag that enables compilation-error checking during installation")]
+	bool? CheckCompilationErrors = null
 );

--- a/clio/Command/McpServer/Tools/ListPrintablesTool.cs
+++ b/clio/Command/McpServer/Tools/ListPrintablesTool.cs
@@ -92,21 +92,21 @@ public sealed record ListPrintablesArgs(
 	[property: Description("Optional entity schema name to filter by (e.g. 'Contact'). Matches printables "
 		+ "attached to the entity directly or through their section module. Omit to list every "
 		+ "MS Word printable of the environment.")]
-	string? EntityName,
+	string? EntityName = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description("Creatio base URI (emergency fallback only; prefer environment-name)")]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/McpToolRegistrySchemaContract.cs
+++ b/clio/Command/McpServer/Tools/McpToolRegistrySchemaContract.cs
@@ -23,6 +23,8 @@ internal static class McpToolRegistrySchemaContract {
 	private const string PropertiesPropertyName = "properties";
 	private const string RequiredPropertyName = "required";
 	private const string DescriptionPropertyName = "description";
+	private const string EnvironmentNamePropertyName = "environment-name";
+	private const string UriPropertyName = "uri";
 	private const string Note =
 		"Auto-generated from the registered MCP tool input schema (the same schema clio-run dispatches against); no curated contract is available for this tool yet.";
 
@@ -107,10 +109,14 @@ internal static class McpToolRegistrySchemaContract {
 
 		List<string> required = ReadRequired(effective);
 		List<ToolContractField> properties = [];
+		bool advertisesEnvironmentName = false;
+		bool advertisesUri = false;
 		if (effective.TryGetProperty(PropertiesPropertyName, out JsonElement propertiesElement) &&
 			propertiesElement.ValueKind == JsonValueKind.Object) {
 			foreach (JsonProperty property in propertiesElement.EnumerateObject()) {
 				string name = property.Name;
+				advertisesEnvironmentName |= name == EnvironmentNamePropertyName;
+				advertisesUri |= name == UriPropertyName;
 				string type = ReadType(property.Value);
 				string description = property.Value.ValueKind == JsonValueKind.Object &&
 					property.Value.TryGetProperty(DescriptionPropertyName, out JsonElement descriptionElement) &&
@@ -120,7 +126,16 @@ internal static class McpToolRegistrySchemaContract {
 				properties.Add(new ToolContractField(name, type, description));
 			}
 		}
-		return new ToolInputSchemaContract(required, properties);
+
+		// A tool that advertises BOTH a registered environment-name AND the explicit uri fallback accepts
+		// either one, and neither is unconditionally mandatory — which is exactly what an empty `required`
+		// alone fails to say. Emit the SAME `any-of` the curated contracts carry so the derived contract
+		// states the alternative instead of leaving the caller to guess it (issue #965).
+		IReadOnlyList<IReadOnlyList<string>> anyOf =
+			advertisesEnvironmentName && advertisesUri
+				? ToolContractCatalog.EnvironmentOrExplicitConnectionRequirements()
+				: null;
+		return new ToolInputSchemaContract(required, properties, anyOf);
 	}
 
 	// clio tools that take a single complex args record are emitted by the SDK as a single top-level

--- a/clio/Command/McpServer/Tools/McpToolRegistrySchemaContract.cs
+++ b/clio/Command/McpServer/Tools/McpToolRegistrySchemaContract.cs
@@ -25,6 +25,15 @@ internal static class McpToolRegistrySchemaContract {
 	private const string DescriptionPropertyName = "description";
 	private const string EnvironmentNamePropertyName = "environment-name";
 	private const string UriPropertyName = "uri";
+
+	// reg-web-app is the one tool whose `environment-name` + `uri` pair is NOT a connection selector:
+	// `uri` is the application BEING REGISTERED and `environment-name` is the key it is stored under, so
+	// the two are conjunctive inputs, not alternatives. It is told apart from the genuine fallbacks by the
+	// environment-REGISTRATION surface it alone advertises. Description text deliberately is not used as
+	// the discriminator: get-related-page-addon, list-printables and the mobile-page-conversion-guide args
+	// all carry custom `uri` wording and are genuine fallbacks (issue #965, PR #1396 review).
+	private static readonly string[] EnvironmentRegistrationPropertyNames =
+		["active-environment", "add-from-iis"];
 	private const string Note =
 		"Auto-generated from the registered MCP tool input schema (the same schema clio-run dispatches against); no curated contract is available for this tool yet.";
 
@@ -111,12 +120,14 @@ internal static class McpToolRegistrySchemaContract {
 		List<ToolContractField> properties = [];
 		bool advertisesEnvironmentName = false;
 		bool advertisesUri = false;
+		bool registersEnvironments = false;
 		if (effective.TryGetProperty(PropertiesPropertyName, out JsonElement propertiesElement) &&
 			propertiesElement.ValueKind == JsonValueKind.Object) {
 			foreach (JsonProperty property in propertiesElement.EnumerateObject()) {
 				string name = property.Name;
 				advertisesEnvironmentName |= name == EnvironmentNamePropertyName;
 				advertisesUri |= name == UriPropertyName;
+				registersEnvironments |= EnvironmentRegistrationPropertyNames.Contains(name);
 				string type = ReadType(property.Value);
 				string description = property.Value.ValueKind == JsonValueKind.Object &&
 					property.Value.TryGetProperty(DescriptionPropertyName, out JsonElement descriptionElement) &&
@@ -130,9 +141,11 @@ internal static class McpToolRegistrySchemaContract {
 		// A tool that advertises BOTH a registered environment-name AND the explicit uri fallback accepts
 		// either one, and neither is unconditionally mandatory — which is exactly what an empty `required`
 		// alone fails to say. Emit the SAME `any-of` the curated contracts carry so the derived contract
-		// states the alternative instead of leaving the caller to guess it (issue #965).
+		// states the alternative instead of leaving the caller to guess it (issue #965). A tool that also
+		// advertises the environment-REGISTRATION surface is excluded: there the two names are the record
+		// being written, not a way of reaching an environment (see EnvironmentRegistrationPropertyNames).
 		IReadOnlyList<IReadOnlyList<string>> anyOf =
-			advertisesEnvironmentName && advertisesUri
+			advertisesEnvironmentName && advertisesUri && !registersEnvironments
 				? ToolContractCatalog.EnvironmentOrExplicitConnectionRequirements()
 				: null;
 		return new ToolInputSchemaContract(required, properties, anyOf);

--- a/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
+++ b/clio/Command/McpServer/Tools/MobilePageConverter/MobilePageConversionGuideTool.cs
@@ -666,25 +666,25 @@ public sealed record MobilePageConversionGuideArgs(
 
 	[property: JsonPropertyName("target-schema-name")]
 	[property: Description("Optional suggested target mobile page schema name. Defaults to the source name with a mobile suffix (e.g. UsrMyApp_FormPage -> UsrMyApp_MobileFormPage).")]
-	string TargetSchemaName,
+	string TargetSchemaName = null,
 
 	[property: JsonPropertyName("version")]
 	[property: Description("Optional Creatio/registry version used to resolve the mobile and web component registries. Defaults to the latest published registry.")]
-	string Version,
+	string Version = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description("Registered clio environment name, e.g. 'local'. Preferred for normal MCP work.")]
-	string EnvironmentName,
+	string EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description("Direct Creatio URL. Use only when bootstrap is broken or before the environment can be registered through reg-web-app.")]
-	string Uri,
+	string Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description("Direct Creatio login paired with `uri`. Emergency fallback only.")]
-	string Login,
+	string Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description("Direct Creatio password paired with `uri`. Emergency fallback only.")]
-	string Password
+	string Password = null
 );

--- a/clio/Command/McpServer/Tools/PageCreateTool.cs
+++ b/clio/Command/McpServer/Tools/PageCreateTool.cs
@@ -100,31 +100,31 @@ public sealed record PageCreateArgs(
 
 	[property: JsonPropertyName("caption")]
 	[property: Description("Optional display caption. Defaults to schema-name when omitted.")]
-	string? Caption,
+	string? Caption = null,
 
 	[property: JsonPropertyName("description")]
 	[property: Description("Optional schema description.")]
-	string? Description,
+	string? Description = null,
 
 	[property: JsonPropertyName("entity-schema-name")]
 	[property: Description("Optional entity schema name to record in the new page dependencies.")]
-	string? EntitySchemaName,
+	string? EntitySchemaName = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password,
+	string? Password = null,
 
 	[property: JsonPropertyName("caption-culture")]
 	[property: Description("Optional culture override for the page caption (e.g. 'en-US', 'uk-UA'). Precedence: caption-culture > detected profile culture > en-US. Skips the profile-culture lookup.")]

--- a/clio/Command/McpServer/Tools/PageCreateTool.cs
+++ b/clio/Command/McpServer/Tools/PageCreateTool.cs
@@ -110,22 +110,6 @@ public sealed record PageCreateArgs(
 	[property: Description("Optional entity schema name to record in the new page dependencies.")]
 	string? EntitySchemaName = null,
 
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null,
-
 	[property: JsonPropertyName("caption-culture")]
 	[property: Description("Optional culture override for the page caption (e.g. 'en-US', 'uk-UA'). Precedence: caption-culture > detected profile culture > en-US. Skips the profile-culture lookup.")]
 	string? CaptionCulture = null,
@@ -133,4 +117,4 @@ public sealed record PageCreateArgs(
 	[property: JsonPropertyName("optional-properties")]
 	[property: Description("Optional JSON array of {key, value} objects to seed into the new schema optionalProperties, e.g. '[{\"key\":\"DashboardsEntitySchemaName\",\"value\":\"UsrMyEntity\"}]'. Used to create a dashboard (template BaseDashboardTemplate): set DashboardsEntitySchemaName, DashboardsElementName, DashboardsClientUnitSchemaUId — read get-guidance name `dashboard-creation` for how to obtain each value.")]
 	string? OptionalProperties = null
-);
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/PageGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageGetTool.cs
@@ -87,17 +87,17 @@ public sealed record PageGetArgs(
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password,
+	string? Password = null,
 
 	[property: JsonPropertyName("output-directory")]
 	[property: Description("Optional. Directory to anchor .clio-pages output under (typically your project root). Defaults to the auto-detected workspace root.")]

--- a/clio/Command/McpServer/Tools/PageGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageGetTool.cs
@@ -85,21 +85,7 @@ public sealed record PageGetArgs(
 	[property: Required]
 	string SchemaName,
 
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null,
-
 	[property: JsonPropertyName("output-directory")]
 	[property: Description("Optional. Directory to anchor .clio-pages output under (typically your project root). Defaults to the auto-detected workspace root.")]
 	string? OutputDirectory = null
-);
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/PageHierarchyGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageHierarchyGetTool.cs
@@ -75,29 +75,29 @@ public sealed record GetPageHierarchyArgs(
 
 	[property: JsonPropertyName("metadata-only")]
 	[property: Description("Optional. When true, omit each schema's raw body and return chain metadata only.")]
-	bool? MetadataOnly,
+	bool? MetadataOnly = null,
 
 	[property: JsonPropertyName("offset")]
 	[property: Description("Optional. Zero-based index of the first chain entry to return (root first). Default 0.")]
-	int? Offset,
+	int? Offset = null,
 
 	[property: JsonPropertyName("limit")]
 	[property: Description("Optional. Maximum number of chain entries to return; 0/omitted returns the whole chain from offset.")]
-	int? Limit,
+	int? Limit = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/PageHierarchyGetTool.cs
+++ b/clio/Command/McpServer/Tools/PageHierarchyGetTool.cs
@@ -83,21 +83,5 @@ public sealed record GetPageHierarchyArgs(
 
 	[property: JsonPropertyName("limit")]
 	[property: Description("Optional. Maximum number of chain entries to return; 0/omitted returns the whole chain from offset.")]
-	int? Limit = null,
-
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
-);
+	int? Limit = null
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -91,33 +91,33 @@ public sealed class PageListTool(
 public sealed record PageListArgs(
 	[property: JsonPropertyName("package-name")]
 	[property: Description("Filter by package name")]
-	string? PackageName,
+	string? PackageName = null,
 
 	[property: JsonPropertyName("code")]
 	[property: Description("Filter by installed application code using its primary package")]
-	string? Code,
+	string? Code = null,
 
 	[property: JsonPropertyName("search-pattern")]
 	[property: Description("Filter by schema name pattern, e.g. 'UsrMyApp*'")]
-	string? SearchPattern,
+	string? SearchPattern = null,
 
 	[property: JsonPropertyName("limit")]
 	[property: Description("Maximum number of results. Omit or pass 0 to use the default of 50. A negative limit is rejected (it must not disable the cap). The response always carries total and truncated so a capped result is observable.")]
-	int? Limit,
+	int? Limit = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password,
+	string? Password = null,
 
 	[property: JsonPropertyName("uid")]
 	[property: Description("Filter by schema UId (exact match). Use to locate a specific page directly from its UId in a Creatio designer URL (#/PageDesigner/<pageUId>).")]

--- a/clio/Command/McpServer/Tools/PageListTool.cs
+++ b/clio/Command/McpServer/Tools/PageListTool.cs
@@ -105,24 +105,10 @@ public sealed record PageListArgs(
 	[property: Description("Maximum number of results. Omit or pass 0 to use the default of 50. A negative limit is rejected (it must not disable the cap). The response always carries total and truncated so a capped result is observable.")]
 	int? Limit = null,
 
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null,
-
 	[property: JsonPropertyName("uid")]
 	[property: Description("Filter by schema UId (exact match). Use to locate a specific page directly from its UId in a Creatio designer URL (#/PageDesigner/<pageUId>).")]
 	string? UId = null
-) {
+) : ConnectionArgsBase {
 	[JsonExtensionData]
 	public Dictionary<string, JsonElement>? ExtensionData { get; init; }
 }

--- a/clio/Command/McpServer/Tools/PageTemplatesListTool.cs
+++ b/clio/Command/McpServer/Tools/PageTemplatesListTool.cs
@@ -59,21 +59,21 @@ public sealed class PageTemplatesListTool(
 public sealed record PageTemplatesListArgs(
 	[property: JsonPropertyName("schema-type")]
 	[property: Description("Optional schema-type filter: 'web' (Freedom UI page) or 'mobile' (mobile page). Defaults to all.")]
-	string? SchemaType,
+	string? SchemaType = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/PageUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/PageUpdateTool.cs
@@ -711,29 +711,29 @@ public sealed record PageUpdateArgs(
 
 	[property: JsonPropertyName("body")]
 	[property: Description("Full JavaScript page body with markers, passed as a RAW STRING (not a JSON object/dict) — the schema source text with its /**MARKER*/ pairs. Pass either `body` (inline string) or `body-file` (path); one is required. WARNING: re-sending the full inherited body from `get-page.files.bodyFile` back verbatim is wrong in BOTH modes, and the two modes fail differently. In `append` a full-config body is rejected UP-FRONT, offline, and the rejection points at replace mode; that mode requires the diff form (SCHEMA_VIEW_MODEL_CONFIG_DIFF / SCHEMA_MODEL_CONFIG_DIFF) and only the new viewConfigDiff/handlers operations plus the required marker envelope. In `replace` the body REACHES THE SERVER and can fail there with 'Object vs Array' when it re-applies merges already inherited from the parent hierarchy — this is the mode the server error actually fires in.")]
-	string? Body,
+	string? Body = null,
 
 	[property: JsonPropertyName("resources")]
 	[property: Description(McpToolDescriptions.PageResources)]
-	string? Resources,
+	string? Resources = null,
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate without saving. Default: false")]
-	bool? DryRun,
+	bool? DryRun = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password,
+	string? Password = null,
 	[property: JsonPropertyName("skip-sampling")]
 	[property: Description("Reserved escape hatch. Omit by default. Pre-condition for setting true: the immediately preceding user message in this turn contains an explicit instruction to skip the AI semantic review, OR the MCP host has reported sampling as unavailable in this session. Absent that evidence, omit this field. Default: false")]
 	bool? SkipSampling = null,

--- a/clio/Command/McpServer/Tools/PageUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/PageUpdateTool.cs
@@ -721,19 +721,6 @@ public sealed record PageUpdateArgs(
 	[property: Description("If true, validate without saving. Default: false")]
 	bool? DryRun = null,
 
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null,
 	[property: JsonPropertyName("skip-sampling")]
 	[property: Description("Reserved escape hatch. Omit by default. Pre-condition for setting true: the immediately preceding user message in this turn contains an explicit instruction to skip the AI semantic review, OR the MCP host has reported sampling as unavailable in this session. Absent that evidence, omit this field. Default: false")]
 	bool? SkipSampling = null,
@@ -764,4 +751,4 @@ public sealed record PageUpdateArgs(
 	[property: JsonPropertyName("validate")]
 	[property: Description("Run client-side content and run-process validation before saving. Default: true. Set false only as an explicit escape hatch for a pre-existing page defect; JavaScript syntax, AST loadability, replace-mode marker integrity, the mobile JSON-object structure check, and the page baseline/conflict guard remain mandatory. It stays combinable with force=true - the two flags are orthogonal (one gates content checks, the other the baseline/conflict guard) - and the response then warns that both are relaxed.")]
 	bool? Validate = null
-);
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/ProcessDesigner/GetProcessSignatureTool.cs
+++ b/clio/Command/McpServer/Tools/ProcessDesigner/GetProcessSignatureTool.cs
@@ -76,21 +76,21 @@ public sealed record GetProcessSignatureArgs(
 
 	[property: JsonPropertyName("culture")]
 	[property: Description("Optional culture used to resolve localized parameter captions (default en-US)")]
-	string? Culture,
+	string? Culture = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description("Creatio base URI (emergency fallback only; prefer environment-name)")]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/RestartStatusTool.cs
+++ b/clio/Command/McpServer/Tools/RestartStatusTool.cs
@@ -84,7 +84,7 @@ public sealed record RestartStatusArgs(
 
 	[property: JsonPropertyName("operation-id")]
 	[Description("Optional operation id from a restart in-progress response. When omitted, returns the most recently started restart for this environment.")]
-	string? OperationId);
+	string? OperationId = null);
 
 /// <summary>
 /// Response payload for the restart-status tool.

--- a/clio/Command/McpServer/Tools/RestoreDbTool.cs
+++ b/clio/Command/McpServer/Tools/RestoreDbTool.cs
@@ -127,11 +127,11 @@ public sealed record RestoreDbByEnvironmentArgs(
 
 	[property: JsonPropertyName("backupPath")]
 	[property: Description("Optional backup file path override")]
-	string? BackupPath,
+	string? BackupPath = null,
 
 	[property: JsonPropertyName("dbName")]
 	[property: Description("Optional database name override")]
-	string? DbName,
+	string? DbName = null,
 
 	[property: JsonPropertyName("force")]
 	[property: Description("Force overwrite behavior in legacy environment restore mode")]
@@ -162,10 +162,6 @@ public sealed record RestoreDbByCredentialsArgs(
 	[property: Description("Database password")]
 	string? DbPassword,
 
-	[property: JsonPropertyName("dbWorkingFolder")]
-	[property: Description("Optional database-visible working folder for MSSQL restore mode")]
-	string? DbWorkingFolder,
-
 	[property: JsonPropertyName("backupPath")]
 	[property: Description("Backup file path")]
 	[property: Required]
@@ -186,7 +182,11 @@ public sealed record RestoreDbByCredentialsArgs(
 
 	[property: JsonPropertyName("disableResetPassword")]
 	[property: Description("Attempt to disable forced password reset after a successful restore when the existing version and environment checks allow it")]
-	bool DisableResetPassword = true);
+	bool DisableResetPassword = true,
+
+	[property: JsonPropertyName("dbWorkingFolder")]
+	[property: Description("Optional database-visible working folder for MSSQL restore mode")]
+	string? DbWorkingFolder = null);
 
 /// <summary>
 /// MCP arguments for restoring a database to a configured local database server.

--- a/clio/Command/McpServer/Tools/SchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaUpdateTool.cs
@@ -65,29 +65,29 @@ public sealed record SchemaUpdateArgs(
 
 	[property: JsonPropertyName("body")]
 	[property: Description("Full C# body to save as the schema body. Optional when body-file is provided.")]
-	string? Body,
+	string? Body = null,
 
 	[property: JsonPropertyName("body-file")]
 	[property: Description("Absolute path to a file whose contents are used as the new schema body. Recommended for large bodies (over a few KB). Takes precedence over body when both are provided.")]
-	string? BodyFile,
+	string? BodyFile = null,
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun,
+	bool? DryRun = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/SchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaUpdateTool.cs
@@ -73,21 +73,5 @@ public sealed record SchemaUpdateArgs(
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun = null,
-
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
-);
+	bool? DryRun = null
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/SqlSchemaInstallTool.cs
+++ b/clio/Command/McpServer/Tools/SqlSchemaInstallTool.cs
@@ -61,17 +61,17 @@ public sealed record SqlSchemaInstallArgs(
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/SqlSchemaInstallTool.cs
+++ b/clio/Command/McpServer/Tools/SqlSchemaInstallTool.cs
@@ -57,21 +57,5 @@ public sealed record SqlSchemaInstallArgs(
 	[property: JsonPropertyName("schema-name")]
 	[property: Description("SQL script schema name to execute, e.g. 'UsrMySqlScript'")]
 	[property: Required]
-	string SchemaName,
-
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
-);
+	string SchemaName
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/SqlSchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/SqlSchemaUpdateTool.cs
@@ -64,29 +64,29 @@ public sealed record SqlSchemaUpdateArgs(
 
 	[property: JsonPropertyName("body")]
 	[property: Description("Full SQL body to save as the schema body. Optional when body-file is provided.")]
-	string? Body,
+	string? Body = null,
 
 	[property: JsonPropertyName("body-file")]
 	[property: Description("Absolute path to a file whose contents are used as the new schema body. Recommended for large bodies. Takes precedence over body when both are provided.")]
-	string? BodyFile,
+	string? BodyFile = null,
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun,
+	bool? DryRun = null,
 
 	[property: JsonPropertyName("environment-name")]
 	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName,
+	string? EnvironmentName = null,
 
 	[property: JsonPropertyName("uri")]
 	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri,
+	string? Uri = null,
 
 	[property: JsonPropertyName("login")]
 	[property: Description(McpToolDescriptions.Login)]
-	string? Login,
+	string? Login = null,
 
 	[property: JsonPropertyName("password")]
 	[property: Description(McpToolDescriptions.Password)]
-	string? Password
+	string? Password = null
 );

--- a/clio/Command/McpServer/Tools/SqlSchemaUpdateTool.cs
+++ b/clio/Command/McpServer/Tools/SqlSchemaUpdateTool.cs
@@ -72,21 +72,5 @@ public sealed record SqlSchemaUpdateArgs(
 
 	[property: JsonPropertyName("dry-run")]
 	[property: Description("If true, validate and resolve the schema without saving. Default: false")]
-	bool? DryRun = null,
-
-	[property: JsonPropertyName("environment-name")]
-	[property: Description(McpToolDescriptions.EnvironmentName)]
-	string? EnvironmentName = null,
-
-	[property: JsonPropertyName("uri")]
-	[property: Description(McpToolDescriptions.Uri)]
-	string? Uri = null,
-
-	[property: JsonPropertyName("login")]
-	[property: Description(McpToolDescriptions.Login)]
-	string? Login = null,
-
-	[property: JsonPropertyName("password")]
-	[property: Description(McpToolDescriptions.Password)]
-	string? Password = null
-);
+	bool? DryRun = null
+) : ConnectionArgsBase;

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -743,6 +743,14 @@ internal static class ToolContractCatalog {
 	private const int MaxPurposeLength = 120;
 
 	/// <summary>
+	/// The names that have a HANDWRITTEN contract, as opposed to one synthesized from the registered tool
+	/// schema by <see cref="McpToolRegistrySchemaContract"/>. Exposed so a test can tell the two apart:
+	/// only a handwritten contract can disagree with the emitted schema, because the synthesized one is
+	/// read straight out of it (issue #965).
+	/// </summary>
+	internal static IReadOnlyCollection<string> CuratedToolNames => (IReadOnlyCollection<string>)Contracts.Keys;
+
+	/// <summary>
 	/// Resolves clio MCP tool contracts. When <paramref name="toolNames"/> is omitted the response depends
 	/// on <paramref name="detail"/> and <paramref name="legacyNoNamesFullShape"/>: any <paramref name="detail"/>
 	/// other than <c>full</c> (the default) returns the cheap compact INDEX of EVERY invokable tool — curated
@@ -4591,10 +4599,25 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildGetEntitySchemaProperties() {
 		return new ToolContractDefinition(
 			GetEntitySchemaPropertiesTool.GetEntitySchemaPropertiesToolName,
-			"Returns a structured summary of entity schema metadata for read-before-write inspection and read-back verification.",
+			"Returns a structured summary of entity schema metadata for read-before-write inspection and read-back verification. " +
+			"Omit package-name to read the merged/effective schema with columns from ALL packages (recommended for column " +
+			"discovery); supply it only to inspect a single package layer's slice, which reports that layer's own columns and " +
+			"treats everything else as inherited.",
+			// package-name is NOT required here: the emitted tool schema makes it optional and its own text
+			// recommends omitting it for column discovery. Spelling it as required in the curated contract is
+			// the exact divergence issue #965 reports — an agent that trusts get-tool-contract always sends a
+			// package name and never sees the merged view. Mirrors BuildGetEntitySchemaColumnProperties; the
+			// EnvironmentPackageSchemaFields helper cannot be reused because it hard-codes the terse
+			// "Target package name." text that hides the merged mode.
 			new ToolInputSchemaContract(
-				[EnvironmentNameFieldName, PackageNameFieldName, SchemaNameFieldName],
-				EnvironmentPackageSchemaFields(EntitySchemaNameDescription)),
+				[EnvironmentNameFieldName, SchemaNameFieldName],
+				[
+					Field(EnvironmentNameFieldName, StringType, RegisteredEnvironmentNameDescription),
+					Field(PackageNameFieldName, StringType,
+						"Optional target package name. Omit to read the merged/effective schema with columns from ALL " +
+						"packages (recommended for column discovery). Supply only to inspect a single package layer's slice."),
+					Field(SchemaNameFieldName, StringType, EntitySchemaNameDescription)
+				]),
 			StructuredResultOutput(
 				Field("name", StringType, "Schema name."),
 				Field("title", StringType, "Schema title."),
@@ -4604,7 +4627,11 @@ internal static class ToolContractCatalog {
 			EnvironmentPackageSchemaAliases(),
 			[],
 			[
-				Example("Read deployed schema properties", new Dictionary<string, object?> {
+				Example("Discover every column across all packages", new Dictionary<string, object?> {
+					[EnvironmentNameFieldName] = ExampleEnvironmentName,
+					[SchemaNameFieldName] = ExamplePackageName
+				}),
+				Example("Read one package layer's own slice", new Dictionary<string, object?> {
 					[EnvironmentNameFieldName] = ExampleEnvironmentName,
 					[PackageNameFieldName] = ExamplePackageName,
 					[SchemaNameFieldName] = ExamplePackageName

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5182,7 +5182,13 @@ internal static class ToolContractCatalog {
 		];
 	}
 
-	private static IReadOnlyList<IReadOnlyList<string>> EnvironmentOrExplicitConnectionRequirements() {
+	/// <summary>
+	/// The connection alternative every environment-sensitive contract advertises: EITHER a registered
+	/// <c>environment-name</c> OR the explicit <c>uri</c>/<c>login</c>/<c>password</c> triple. Exposed to
+	/// <see cref="McpToolRegistrySchemaContract" /> so a registry-derived contract states the same
+	/// alternative as the 75 curated ones instead of inventing a second spelling of it (issue #965).
+	/// </summary>
+	internal static IReadOnlyList<IReadOnlyList<string>> EnvironmentOrExplicitConnectionRequirements() {
 		return [
 			[EnvironmentNameFieldName],
 			["uri", LoginFieldName, PasswordFieldName]

--- a/clio/Command/McpServer/Tools/WatchCompilationTool.cs
+++ b/clio/Command/McpServer/Tools/WatchCompilationTool.cs
@@ -56,5 +56,5 @@ public sealed record WatchCompilationArgs(
 
 	[property: JsonPropertyName("give-up-after-seconds")]
 	[property: Description("Optional seconds to wait for the compilation to settle before giving up (exit code 2). Default: 300 (5 minutes).")]
-	int? GiveUpAfterSeconds
+	int? GiveUpAfterSeconds = null
 );

--- a/docs/knowledge/McpServer/emitted-schema-required-comes-from-the-record-stj-binds.md
+++ b/docs/knowledge/McpServer/emitted-schema-required-comes-from-the-record-stj-binds.md
@@ -3,6 +3,8 @@ description: the MCP SDK builds a tool schema's `required` array from the non-nu
 applies-to:
   - clio/Command/McpServer/Tools/
   - clio.tests/Command/McpServer/ColumnIdentityEmittedSchemaTests.cs
+  - clio.tests/Command/McpServer/EmittedSchemaProbe.cs
+  - clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
 date: 2026-08-19
 ---
 
@@ -23,3 +25,10 @@ a client-side rejection and no server log at all. Substring assertions over the 
 not catch it either: element order, whitespace, or one extra required field all keep a
 `NotContain("\"required\":[...]")` assertion green while the relaxation is reverted. Assert by
 navigating the emitted schema, as `ColumnIdentityEmittedSchemaTests` does.
+
+**Registry-wide guard (issue #965).** After the third recurrence of this defect (PR #984, ENG-93347,
+issue #965) the guard is no longer written per tool. `EmittedSchemaRequiredContractTests` walks EVERY
+registered tool's emitted schema and fails when (a) an object advertising BOTH `environment-name` and
+`uri` lists any connection field as required — the runtime accepts either path, so neither is
+mandatory — or (b) a required property's own `description` begins with "Optional". Add a new tool
+without a default on an optional parameter and that guard, not a reviewer, is what catches it.

--- a/docs/knowledge/McpServer/emitted-schema-required-comes-from-the-record-stj-binds.md
+++ b/docs/knowledge/McpServer/emitted-schema-required-comes-from-the-record-stj-binds.md
@@ -5,6 +5,7 @@ applies-to:
   - clio.tests/Command/McpServer/ColumnIdentityEmittedSchemaTests.cs
   - clio.tests/Command/McpServer/EmittedSchemaProbe.cs
   - clio.tests/Command/McpServer/EmittedSchemaRequiredContractTests.cs
+  - clio.tests/Command/McpServer/ConnectionAlternativeDispatchTests.cs
 date: 2026-08-19
 ---
 
@@ -32,3 +33,27 @@ registered tool's emitted schema and fails when (a) an object advertising BOTH `
 `uri` lists any connection field as required — the runtime accepts either path, so neither is
 mandatory — or (b) a required property's own `description` begins with "Optional". Add a new tool
 without a default on an optional parameter and that guard, not a reviewer, is what catches it.
+
+**Two surfaces, and only comparing them catches the third failure mode (PR #1396 review).** A tool has
+TWO published argument contracts: the emitted `tools/list` schema, and the `get-tool-contract` envelope
+— curated by hand in `ToolContractCatalog.Contracts` for a resident tool, derived from the emitted
+schema for everything else. Guard (a) and guard (b) above read the emitted schema ONLY, so relaxing a
+record while leaving the handwritten contract demanding the same field passes both and leaves the two
+surfaces contradicting each other. That is exactly what happened to `get-entity-schema-properties`: the
+record was relaxed, the curated contract still listed `package-name` as required, and an agent planning
+the call from `get-tool-contract` therefore always sent it — which switches the tool from the merged
+all-packages view (49 own columns) to a single package layer (0 own columns) and silently hides every
+column it was looking for. `CuratedContracts_Should_AgreeWithEmittedSchema_ForResidentTools` is the
+comparison; the scope is the resident set because those are the tools whose emitted schema a strict
+client actually validates against (a long-tail tool is dispatched through `clio-run`, so `clio-run`'s
+schema is what gates the payload). `get-guidance` is the one documented exception: its `name` parameter
+is nullable so a legacy-alias payload reaches the tool and returns a typed answer instead of an SDK
+binding error, while the curated contract keeps stating that a name is what the caller must supply.
+
+**A bare property-name pair is not a connection selector.** The registry-derived contract attaches the
+`environment-name` OR `uri`/`login`/`password` alternative when a schema advertises both names. On
+`reg-web-app` those two names are the record being WRITTEN, not a route to an existing environment, and
+the tool rejects a credential-only payload with a typed exit code 1. The discriminator is the
+environment-registration surface (`active-environment` / `add-from-iis`), NOT description text:
+`get-related-page-addon`, `list-printables` and `MobilePageConversionGuideArgs` all carry custom `uri`
+wording and are genuine fallbacks.

--- a/docs/knowledge/McpServer/relaxing-a-record-parameter-costs-default-null-in-tools-list.md
+++ b/docs/knowledge/McpServer/relaxing-a-record-parameter-costs-default-null-in-tools-list.md
@@ -1,0 +1,32 @@
+---
+description: adding `= null` to an MCP args-record parameter adds `,"default":null` (15 bytes) to the tools/list payload for every RESIDENT tool, so relaxing a resident record can trip the serialized-size ratchet even though it also shortens `required`
+applies-to:
+  - clio/Command/McpServer/McpFeatureToggleFilter.cs
+  - clio.tests/Command/McpServer/McpProfileGatingTests.cs
+date: 2026-09-06
+---
+
+**What is true** — giving an MCP argument-record parameter a default value does two opposite things to
+the serialized `tools/list` payload: it removes the parameter's name from the schema's `required` array,
+and it makes the SDK emit `,"default":null` on that property. The annotation costs a flat 15 bytes; the
+removed `required` entry saves only the length of the name plus quoting. Relaxing a parameter on a
+RESIDENT tool therefore GROWS the payload measured by
+`McpProfileGatingTests.RegisterEnabledPrimitives_ShouldKeepToolsSerializedSizeWithinBudget_WhenCalled`.
+Issue #965 relaxed 13 resident parameters (`list-pages`, `get-page`, `get-entity-schema-properties`) and
+the payload went from 32741 to 32773 bytes: +195 of annotation against −163 of `required`.
+
+**Why it is this way** — the annotation is emitted by the SDK's schema generator, and the resident
+surface is registered through `McpFeatureToggleFilter.RegisterEnabledPrimitives` →
+`IMcpServerBuilder.WithTools(IEnumerable<Type>, JsonSerializerOptions)`. That overload accepts no
+`McpServerToolCreateOptions`, so the `SchemaCreateOptions.TransformSchemaNode` hook that could strip a
+null-valued `default` is unreachable from it. Threading the hook in means re-implementing the SDK's
+per-method DI-factory registration inside `RegisterEnabledPrimitives`, and mirroring the same options in
+`McpToolInvokerRegistry` so the two surfaces do not diverge — two places to keep in step, both under
+`RequiresUnreferencedCode`. Measured saving if it were done: 56 occurrences, 840 bytes on the resident
+set alone.
+
+**What breaks if you ignore it** — the size ratchet fails with a difference of a few bytes and nothing in
+the diff explains it: the change that tripped it looks like a pure removal from `required`. Issue #965
+found the ceiling already at 27 bytes of headroom on master (32741 against 32*1024), i.e. saturated
+before the change under review, and re-baselined it to 33*1024. Read the measured number out of the
+failure message before assuming the branch caused the growth.


### PR DESCRIPTION
🔗 **Issue:** [#965](https://github.com/Advance-Technologies-Foundation/clio/issues/965)

> **Stacked PR.** Base is `Alexandr-Kravchuk/issue-722` (PR #1395), not `master`. Both change `clio/Command/McpServer/Tools/`, and this one reorders record parameters — a positional C# call site still *compiles* after a reorder and silently binds different values to different parameters, so branching from master would have created that hazard at merge time. **Retarget to `master` once #1395 merges.**

## The issue names the wrong locus

`McpToolRegistrySchemaContract.ReadRequired` is faithful — it copies `required` verbatim from the SDK-generated schema. The defect is in the **args records**: the MCP SDK puts a positional record parameter into `required` when it has **no default value**. Nullability does not matter, and `[Required]` does not matter.

Nothing in-process validates `required` — the `System.Text.Json` binder happily binds a missing nullable parameter to `null`. Schema and binder disagree, so only a **strict client** ever sees the defect. That is also why unit tests could not catch it and why a live `tools/list` dump was required.

The reporter's proposed fix ("preserve the source schema's real required/optional metadata") would achieve nothing: the source already says *required*, it just says it untruthfully. And their proposed "complete `uri`/`login`/`password` fallback" is **stricter than the runtime** — `ToolCommandResolver.cs:248-255` checks only `settings.Uri`.

## Scope — re-derived from the real emitted registry (187 tools, 717 `required` entries)

The issue names 4 tools. The investigation raised that. Re-measuring against the live registry raised it again *and* found the partition both had missed:

- **16 tools** advertise **both** `environment-name` and `uri`. Only there is requiring a connection field a lie. **61 connection-field `required` entries removed.**
- **91 tools** require `environment-name` and advertise **no** `uri` fallback. Their schema states the truth — **deliberately left alone.** This partition also naturally excludes `clear-redis-db-by-credentials` / `restart-by-credentials`, whose non-nullable `password` is genuinely required, so no name-based allow-list is needed.
- **29 fields** whose own description begins with "Optional" while the schema demanded them: **29 → 0**.

**Two different populations, so two different figures.** "16 tools / 61 entries" is the `required` population: the tools that listed a connection field as mandatory. The `any-of` landed on a larger population — **27** registry-derived tools now carry it (26 genuine connection fallbacks; `reg-web-app` is excluded, see the review round below). The five spelled out in the live-stand table are a sample of those 27, not the whole set.

The **resident** set was affected too — the half the reporter could not see, because `get-tool-contract` serves resident tools their correct *curated* contract while the real `tools/list` carried the untruth a strict client validates.

## Changes — 28 records, 112 parameters

**Set A** (both connection paths): `PageTemplatesListArgs`, `ListPrintablesArgs`, `PageCreateArgs`, `PageGetArgs`, `PageListArgs`, `PageUpdateArgs`, `GetPageHierarchyArgs`, `GetRelatedPageAddonArgs`, `CreateRelatedPageAddonArgs`, `ClientUnitSchemaUpdateArgs`, `SchemaUpdateArgs`, `SqlSchemaUpdateArgs`, `SqlSchemaInstallArgs`, `GetProcessSignatureArgs`, `MobilePageConversionGuideArgs`, `ApplicationDeleteArgs`, plus nested `RelatedPageArg`.

**Set B** ("Optional"-described): `PackageDependencyArg`, `CompileCreatioArgs`, `CompileStatusArgs`, `RestartStatusArgs`, `WatchCompilationArgs`, `RestoreDbByEnvironmentArgs`, `RestoreDbByCredentialsArgs`, `CreateDataBindingArgs`, `GenerateProcessModelArgs`, `GetEntitySchemaPropertiesArgs`, `InstallApplicationArgs`.

Type changes: `RelatedPageArg.PageSchemaName` → `string? = null` (required only unless `page-schema-uid` is supplied), `PackageDependencyArg.Version` → `string? = null`.

**Left alone deliberately**: the four `merge-creatio-artifact` contents and `validate-page`'s `body`. Making them non-nullable would move validation from a typed `{success:false}` into an SDK binding error — a behavior change with e2e and Ring consequences.

## Reorders and call sites — the risky part

Six records reordered. Call sites were enumerated by temporarily **renaming each declaration** and reading the compiler errors from all three projects, rather than trusting grep.

| Record | Moved | Positional call sites converted to named |
|---|---|---|
| `ApplicationDeleteArgs` | `environment-name` → end | none (already named) |
| `CreateDataBindingArgs` | `environment-name` → end | `DataBindingToolTests.cs:200, 240, 272, 302` |
| `GenerateProcessModelArgs` | `destination-path`, `namespace`, `culture` → after `environment-name` | `GenerateProcessModelToolTests.cs:64, 101, 135` |
| `GetEntitySchemaPropertiesArgs` | `package-name` → after `schema-name` | `EntitySchemaToolTests.cs:219, 248` |
| `InstallApplicationArgs` | `report-path`, `check-compilation-errors` → after `environment-name` | none (already named) |
| `RestoreDbByCredentialsArgs` | `dbWorkingFolder` → end | `RestoreDbToolTests.cs:121` |

`nameof`/`typeof` references are order-independent. `EntitySchemaCreateArgsBase` / `EntitySchemaTargetArgsBase` were not touched — they are in the env-name-only set, so no base-initializer call site moved.

## Connection alternatives — existing mechanism, not a new one

`ToolInputSchemaContract` already has `[JsonPropertyName("any-of")]` and `EnvironmentOrExplicitConnectionRequirements()` already returns `[["environment-name"],["uri","login","password"]]`; curated contracts already pass it. `McpToolRegistrySchemaContract.TryBuild` now populates the same `AnyOf` when a schema carries both `environment-name` and `uri`.

**Deliberate divergence, recorded:** that constant demands the triple `uri`+`login`+`password` while the runtime demands only `uri`. The convention is kept for consistency with the 75 curated contracts — but NOT because a credential-less uri fails anyway. It does not: measured on the stand, `list-page-templates` with a uri and no credentials returns `{"success":true,"count":16}` (the URI matches a registered environment, or clio's own defaults supply credentials). The earlier version of this paragraph claimed otherwise and was wrong. The advertised triple is therefore stricter than the runtime by choice, and `ConnectionAlternativeDispatchTests` now pins all three shapes — environment-name only, the full triple, and uri alone — so the choice cannot be mistaken for a runtime requirement.

**Deliberately not done:** `anyOf`/`oneOf` was *not* put into the `inputSchema` the SDK serves in `tools/list`. Strict-client tolerance is unverifiable from here, and a client refusing a contract-following payload is precisely the failure being fixed.

## Live-stand proof (Creatio 10.1.725)

Resident `tools/list`, before → after:
```
list-pages                   [package-name,code,search-pattern,limit,environment-name,uri,login,password] → (no required array)
get-page                     [schema-name,environment-name,uri,login,password]                            → [schema-name]
get-entity-schema-properties [environment-name,package-name,schema-name]                                  → [environment-name,schema-name]
```
`get-tool-contract`, before → after:
```
list-page-templates       [schema-type,environment-name,uri,login,password] → []
create-page               [schema-name,template,package-name,caption,description,entity-schema-name,environment-name,uri,login,password] → [schema-name,template,package-name]
get-related-page-addon    [entity-schema-name,package-name,environment-name,uri,login,password] → [entity-schema-name,package-name]
create-related-page-addon [entity-schema-name,package-name,pages,type-column-uid,environment-name,uri,login,password] → [entity-schema-name,package-name,pages]
get-page-hierarchy        [schema-name,metadata-only,offset,limit,environment-name,uri,login,password] → [schema-name]
install-application       [name,report-path,check-compilation-errors,environment-name] → [name,environment-name]
compile-status            [environment-name,operation-id] → [environment-name]
```
All five two-path tools now carry `any-of=[[environment-name],[uri,login,password]]`; `install-application` and `compile-status` (env-name only) correctly carry no `any-of`.

Minimal calls all succeed: `list-page-templates {environment-name}` → `success:true, count:16`; `list-pages {environment-name}` → `success:true, count:50, total:4678`; `get-page {environment-name, schema-name}` → `success:true`; `get-entity-schema-properties {environment-name, schema-name}` → merged view.

## ⚠️ The `tools/list` budget — please review this decision explicitly

Four measured numbers: **master 32741**, **this branch's base 32741**, **after 32773**, **cap raised 32768 → 33024**.

The ceiling is the measured size rounded up to the next **256** bytes, not the next kilobyte (review [4]). Rounding to `33*1024` would have handed the resident surface ~990 bytes of silent room and stopped the ratchet ratcheting, which is the only thing this constant is for. 251 bytes of headroom is deliberate: enough that a one-word description edit does not fail the build, small enough that the next real surface addition still forces the budget decision. `MaxLazyToolsSerializedBytes` is a private const backing one assertion; nothing else depends on it.

**The old cap was already saturated on master with 27 bytes to spare — not by this change.** The growth here is `,"default":null`, 15 bytes, which the SDK emits for every defaulted parameter: +195 for the 13 relaxed resident parameters against −163 of removed `required`.

Stripping that annotation would recover ~840 bytes on the resident set, but `WithTools(IEnumerable<Type>, JsonSerializerOptions)` exposes no `SchemaCreateOptions`, so it means re-implementing the SDK's per-method DI-factory registration in two places. That is a separate change; it is recorded in a new knowledge article rather than bundled here.

Note this contradicts an earlier working figure of ~2.3 KB headroom — that number was wrong; 32741/32768 is what the live registry actually measures.

## Tests

New `EmittedSchemaRequiredContractTests` plus a shared `EmittedSchemaProbe`, walking **every** registered tool — this is the third recurrence of this defect (PR #984, ENG-93347, now #965), so the guard is registry-wide rather than another per-tool test:
(a) no connection field required where both paths are advertised; (b) no required field whose description begins with "Optional", now scanning method-parameter roots too; (c) `any-of` present/absent correctly, with `compile-status` and `reg-web-app` as negative controls; (d) **curated contract vs emitted schema agree for every resident tool**; plus per-record tests for the four named tools and a `[TestCase]` set pinning the six records the description heuristic cannot see. `ConnectionAlternativeDispatchTests` covers the three connection payload shapes at dispatch level (AC-4).

**Mutation-checked**, each fix independently: reverting `PageTemplatesListArgs` fails 3 tests; restoring `package-name` to the curated `get-entity-schema-properties` contract fails `CuratedContracts_Should_AgreeWithEmittedSchema_ForResidentTools` and `GetEntitySchemaProperties_Should_TreatPackageNameAsOptional_OnBothSurfaces`; dropping the `!registersEnvironments` discriminator fails `RegistryDerivedContract_Should_OmitConnectionAlternative_ForEnvironmentRegistrationTools`.

e2e `ToolContractGetToolE2ETests` gains three cases — `…_ShouldNotRequireConnectionFields_ForPageAndAddonTools`, `…_ShouldNotRequirePackageName_ForGetEntitySchemaProperties` and `…_ShouldOmitConnectionAlternative_ForRegWebApp`. All compile; the local e2e transport is known-broken, so they were not executed here — the equivalent assertions were driven against a live `mcp-server` over stdio instead (see the re-verification block above).

```
Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit"
```
**64 failed / 11022 passed / 40 skipped** — the same macOS baseline set (DbHubTomlStore `Upsert`/`EnsureRunnable`/`Remove`/`ValidateForInstallation`, IIS uninstall, `NetFrameworkHttps`, profile-path, `ExtractIdentityService`); the failure *list* is unchanged after the review round, only the passed count moved (+13 new tests). Zero McpServer failures. `Category=Unit&Module=McpServer` → **4692 passed / 0 failed**. `RegisterEnabledPrimitives_ShouldKeepToolsSerializedSizeWithinBudget` passes at 32773 bytes / 19 tools against the 33024 ceiling. No new `CLIO*` warnings in the touched files.

## Review round — beta code review + an independent live-stand test

Two independent passes; both found the `reg-web-app` defect, and the stand found one the review did not.

**[High, stand only] `get-entity-schema-properties`: the curated contract still demanded `package-name`.**
Fixed. The record was relaxed here but `ToolContractGetTool.BuildGetEntitySchemaProperties` still hardcoded
`[environment-name, package-name, schema-name]`, so this PR turned an agreement into a contradiction: `tools/list` said
`[environment-name, schema-name]` and `get-tool-contract` said the old triple. Material, not cosmetic — an agent that
plans from `get-tool-contract` always sends `package-name`, which switches the tool from the merged all-packages view
(`own-column-count: 49`) to a single package layer (`own-column-count: 0`) and hides exactly the columns it was looking
for. `EnvironmentPackageSchemaFields` could not be reused: it hard-codes the terse "Target package name." that hides the
merged mode, so the fields are spelled out the way `BuildGetEntitySchemaColumnProperties` already does, plus a second
example without a package and a merged-vs-scoped sentence in the description. **The CLI docs were already correct** —
`clio/docs/commands/get-entity-schema-properties.md` has documented `--package` as optional all along; only the MCP
curated contract lied.

**And the structural gap that let it through.** `EmittedSchemaRequiredContractTests` reads *emitted* schemas only, so a
registry-wide guard written specifically for this defect class could not see it. New
`CuratedContracts_Should_AgreeWithEmittedSchema_ForResidentTools` compares the two surfaces for every resident tool.
Scope is the resident set on purpose: those are the tools whose emitted schema a strict client actually validates a
payload against, since a long-tail tool is dispatched through `clio-run` and it is `clio-run`'s schema that gates the
payload. One documented exception, `get-guidance`: its `name` is nullable so a legacy-alias payload
(`topic`/`guide`/`article`) reaches the tool and comes back as a typed `{success:false, availableGuides:[…]}` instead of
an SDK binding error, while the curated contract keeps stating what the caller must supply.
Curated-vs-emitted divergence across the registry: base **12** → this PR before the fix **7** → **6** now, and the only
resident one left is that documented exception.

**[Major review [1] / Medium stand] `reg-web-app` gained an `any-of` its own runtime rejects.** Fixed. The heuristic
keyed on the bare names `environment-name` + `uri`; on `reg-web-app` those are the record being *written*, not a route
to an existing environment, so the derived contract started advertising raw credentials with no name as a complete
payload — which `RegWebAppTool.cs:37-44` refuses with a typed exit code 1 — while omitting the two paths that really are
valid. The discriminator is the environment-registration surface (`active-environment` / `add-from-iis`), which no other
tool advertises. Deliberately **not** description-text matching: `get-related-page-addon`, `list-printables` and
`MobilePageConversionGuideArgs` all carry custom `uri` wording and are genuine fallbacks. `reg-web-app` joins
`compile-status` as a second negative control, in its own test since it *does* advertise `uri`.

**[Major review [2]] The "Optional" guard had two holes.** Fixed both.
*Hole A* — the description-prefix heuristic misses wordings such as "If true, validate without saving. Default: false",
"Filter by package name" and "Maximum number of results…", leaving ~15 of this PR's own relaxations unpinned. Added
`RelaxedRecords_Should_RequireOnlyTheirIdentityFields_InEmittedInputSchema`, one `[TestCase]` per record, asserting the
exact expected `required` set: `update-page`, `get-page-hierarchy`, `update-schema`, `update-sql-schema`,
`update-client-unit-schema` → `[schema-name]`; `list-pages` → `[]`.
*Hole B* — `if (schema.IsRoot) continue;` exempted **method-parameter** tools entirely, where the SDK puts real
user-facing fields on the root (`link-from-repository-by-environment` emits `required: ["repoPath","packages"]`) — the
exact shape of one of the three prior recurrences, ENG-93347. Narrowed to the synthetic single-`args` wrapper only
(`EmittedSchemaProbe.IsSingleArgsWrapper`). 16 method-parameter roots are now scanned for the first time: **zero
violations**, so this half is a latent-weakness fix, not a bug fix. Both anti-vacuity assertions added, including one
that fails if the walk stops reaching those roots.

**[Minor review [3]] No dispatch-level test.** Added `ConnectionAlternativeDispatchTests` — three cases against
`ToolCommandResolver`: environment-name only, the full `uri`/`login`/`password` triple, and uri alone. All three resolve,
which is what settles the divergence note above.

**[Minor review [4]] Byte ceiling raised too far.** See the budget section: 33792 → **33024**.

**[Low, stand] The PR body claimed a credential-less uri fails authentication.** It does not — corrected above.

**Noted, pre-existing, deliberately out of scope** (identical on master): `get-component-info` / `get-request-info`
advertise both connection paths but carry no `any-of`; 11 env-name-only curated contracts carry an `any-of` promising a
`uri` path they do not advertise; `get-mobile-page-conversion-guide` suggests itself in its unknown-tool message; and
the five non-resident curated/emitted disagreements (`create-app`, `dataforge-context`, `odata-delete`, `odata-update`,
`update-email-template` — mostly a `confirm` field the emitted schema makes optional).

### Re-verified on the stand after the fixes (Creatio 10.1.725)

```
tools/list          get-entity-schema-properties required = ['environment-name','schema-name']
get-tool-contract   get-entity-schema-properties required = ['environment-name','schema-name']   (descriptions match too)
get-tool-contract   reg-web-app  any-of = null,  required = []
get-tool-contract   list-page-templates any-of = [['environment-name'],['uri','login','password']]   (the 26 genuine fallbacks unaffected)
get-entity-schema-properties {environment-name, schema-name}          -> package-name "(merged: all packages)", own 49 / inherited 19
get-entity-schema-properties {environment-name, package-name: Base, …} -> package-name "Base",                  own 0  / inherited 55
```
Strict-client pass (jsonschema 4.26.0, Draft 2020-12): payloads built from what `get-tool-contract` tells an agent to
send, validated against the emitted `tools/list` schema — **0 rejections across all 19 resident tools**.
`~/creatio/clio/appsettings.json` md5 `ce5b67c791234add16172558288ebf64`, unchanged before and after — the `reg-web-app`
probe returns before any write.

Emitted `tools/list` payload re-measured at **32773 bytes / 19 tools — unchanged by this round**, as expected: curated
and registry-derived contracts are `get-tool-contract` output, not emitted schemas.

## Docs / MCP / ClioRing

- **MCP reviewed.** Curated `ToolContractGetTool` text DID change in the review round: `get-entity-schema-properties` lost `package-name` from its `required`, gained the merged-vs-scoped description and a second package-less example. No tool was renamed or removed, so `McpToolCompatibilityCatalog` and `clio/tpl/**` are untouched.
- **Docs reviewed, no update required.** No `[Verb]`/`[Option]`, command handler or CLI behavior changed.
- **ClioRing compatibility reviewed, no Ring-consumed contract changed.** Grepping `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing` and `clio-ring/ClioRing.Desktop/actions.json` for every changed tool name — including `get-entity-schema-properties` and `reg-web-app` — returns only a log-redaction test string in `ClioToolUpdateServiceTests.cs`. `ClioCatalogEntry` carries no `input-schema` field and a single contract is kept as `RawText`, so a `required` / `any-of` value change is invisible to Ring; `actions.json` invokes only `get-info`/`list-packages`/`deploy-creatio`/`restart`. The added `any-of` is additive.
  `dotnet test clio-ring/ClioRing.Tests -c Release` → **156 passed / 1 failed**: `DeploymentReceiptTests.ResolveContainedReceiptPath_ShouldRejectEscape…_WhenRunKeyIsHostile`, a Windows-backslash path-traversal test that cannot pass on macOS (`\` is a legal filename character there); `clio-ring/` is untouched by this diff.
  **The NativeAOT publish could not run**: `error : Cross-OS native compilation is not supported`. The managed win-x64 build of `ClioRing.Desktop` did succeed with no new IL2026/IL3050 warnings, but the AOT link step needs a Windows host or CI. Stating this rather than claiming a pass.
- **Knowledge**: `emitted-schema-required-comes-from-the-record-stj-binds.md` gained the two new test files in `applies-to` plus a registry-wide-guard paragraph; new record `relaxing-a-record-parameter-costs-default-null-in-tools-list.md`.


