### PR TITLE
Close the last ENG-91853 sprint story

### DIFF
--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -3306,7 +3306,7 @@ stories:
     feature: "eng-91853-gateways-and-flows"
     repo: "clio"
     size: M
-    status: review
+    status: done
     pr: https://github.com/Advance-Technologies-Foundation/clio/pull/1398
     jira: ENG-91853
     file: spec/eng-91853-gateways-and-flows/eng-91853-gateways-and-flows-plan.md
@@ -3351,9 +3351,12 @@ stories:
       Category=Unit&(Module=ProcessModel|Module=McpServer|Module=Command|Module=Common). Release rather
       than Debug, because a running MCP server holds the Debug output open; only Release/net10.0 received
       the new archive, so an install run from any other output ships whatever archive that folder holds.
-      STILL OPEN: nothing on this story. PR 1398 is open with all 10 threads resolved; both manual legs
-      and the stand verification have run (four blind rounds on 2026-09-08, evidence committed under
-      spec/eng-91853-gateways-and-flows/). The merge is a human's.
+      MERGED into master 2026-09-08 as ddff7cc62, all 10 threads resolved, 17 checks green including the
+      CLIO MCP e2e (ATF) lane that had been red for days and resolved itself with nothing touched.
+      Both manual legs and the stand verification ran (four blind rounds on 2026-09-08, evidence under
+      spec/eng-91853-gateways-and-flows/). All three repositories are now merged: package 4a000d035,
+      knowledge 8a21fd9c4 released as 1.13.99, clio ddff7cc62 - in that order, because
+      ExpectedProducingCommit pins a package commit.
     depends_on:
       - story-eng-91853-gateways-and-flows-1
     blocks:


### PR DESCRIPTION
`story-eng-91853-gateways-and-flows-2` was left at `review` because the tracker cannot be updated from inside the pull request it describes — the status changes when that PR merges, which is after its last commit. This is that follow-up, and it is the only thing the sprint rule still owed.

**One line of YAML plus its note.** All three ENG-91853 repositories are now merged, in the order the dependency required:

| Repository | Merge | Note |
|---|---|---|
| `crt-process-builder#45` | `4a000d035` | **first**, because clio's `ExpectedProducingCommit` pins `016dd61` — merging clio first would have left that pin naming a commit reachable only from an unmerged branch |
| `clio-knowledge#135` | `8a21fd9c4` | released as `libraryVersion` 1.13.99 |
| `clio#1398` | `ddff7cc62` | 10 threads resolved, 17 checks green |

The note also records what the ATF lane did, because it is the kind of thing that gets misremembered: it was red for days and went green with **nothing touched**, on the head carrying the widest shipped-to-floor gap of the ticket (1.6.0.6 shipped against a floor of 1.6.0.3). Under the floor hypothesis that head should have been the most likely to fail. Refuted, not merely unconfirmed — and had the floor been lowered while it was red, it would have gone green and confirmed the wrong fix.

**Docs reviewed, no update required** — this touches only `spec/sprint-status.yaml`. **MCP reviewed, no update required**: no command, tool, prompt, resource or contract is involved.

Tests not run and none are affected: the change is one status field and a prose note in a tracker no code reads. `python -c "import yaml; yaml.safe_load(...)"` parses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)