### PR TITLE
Close the delivered process-versioning stories for the release

### DIFF
--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -3218,7 +3218,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-1.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3234,7 +3234,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-2.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3252,7 +3252,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-3.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3268,7 +3268,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: S
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-4.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3283,7 +3283,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: S
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-5.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3329,7 +3329,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: L
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-8.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3344,7 +3344,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-9.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3360,7 +3360,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-10.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3376,7 +3376,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-11.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3392,7 +3392,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-12.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3409,7 +3409,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: L
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-13.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3425,7 +3425,7 @@ stories:
     jira: "ENG-94374"
     repo: "crt-process-builder"
     size: S
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-14.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3442,7 +3442,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-15.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3459,7 +3459,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-16.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md
@@ -3477,7 +3477,7 @@ stories:
     jira: "ENG-94374"
     repo: "clio"
     size: M
-    status: review
+    status: done
     file: spec/stories/story-process-versioning-17.md
     prd: spec/prd/prd-process-versioning.md
     adr: spec/adr/adr-process-versioning.md

--- a/spec/stories/story-process-versioning-1.md
+++ b/spec/stories/story-process-versioning-1.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -66,7 +66,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-10.md
+++ b/spec/stories/story-process-versioning-10.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -59,7 +59,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] An assertion over the SOURCE instance's `Outgoings` counts and `Group` binding exists, because a row comparison cannot see this class of defect
 - [x] Code compiles clean; tests use fixture-level `[TestFixture(Category = "UnitTests")]` — this repo's convention, and the opposite of clio's
 - [x] Workspace-diary entry added (`CLAUDE.md:131-150`) — mandatory in this repo
-- [ ] PR description references this story file
+- [x] PR description references this story file
 - [x] `docs/process-builder-architecture.md` and `.puml` updated together
 - [x] ClioRing MCP compatibility verdict recorded — the anchor `AGENTS.md:241-299` does not resolve in this repository (no `AGENTS.md`; `CLAUDE.md` is 150 lines with no ClioRing section). Verdict: no MCP surface changes, nothing for ClioRing to be compatible with until stories 16-17.
 

--- a/spec/stories/story-process-versioning-11.md
+++ b/spec/stories/story-process-versioning-11.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -56,7 +56,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] The extracted middle excludes the authorization guard
 - [x] Code compiles clean; tests use fixture-level `[TestFixture(Category = "UnitTests")]` — this repo's convention, and the opposite of clio's
 - [x] Workspace-diary entry added (`CLAUDE.md:131-150`) — mandatory in this repo
-- [ ] PR description references this story file
+- [x] PR description references this story file
 - [x] `docs/process-builder-architecture.md` and `.puml` updated together
 - [x] ClioRing MCP compatibility verdict recorded — the anchor `AGENTS.md:241-299` does not resolve in this repository. Verdict: no MCP surface changes, nothing for ClioRing to be compatible with until stories 16-17.
 

--- a/spec/stories/story-process-versioning-12.md
+++ b/spec/stories/story-process-versioning-12.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -59,7 +59,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Both save-failure branches covered: the throw and the non-throwing `false`
 - [x] Code compiles clean; tests use fixture-level `[TestFixture(Category = "UnitTests")]` — this repo's convention, and the opposite of clio's
 - [x] Workspace-diary entry added (`CLAUDE.md:131-150`) — mandatory in this repo
-- [ ] PR description references this story file
+- [x] PR description references this story file
 - [x] `docs/process-builder-architecture.md` and `.puml` updated together
 - [x] ClioRing MCP compatibility verdict recorded — the anchor `AGENTS.md:241-299` does not resolve in this repository. Verdict: no MCP surface changes, nothing for ClioRing to be compatible with until stories 16-17.
 

--- a/spec/stories/story-process-versioning-13.md
+++ b/spec/stories/story-process-versioning-13.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: L
 
 ---
@@ -58,7 +58,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Operation count and gate call sites move together, expressed as deltas — `VersioningOperationContractCount` 1 → 2 (baseline 5 + 2 = 7), gate call sites 4 → 5, same commit
 - [x] Code compiles clean; tests use fixture-level `[TestFixture(Category = "UnitTests")]` — this repo's convention, and the opposite of clio's
 - [x] Workspace-diary entry added (`CLAUDE.md:131-150`) — mandatory in this repo
-- [ ] PR description references this story file
+- [x] PR description references this story file
 - [x] `docs/process-builder-architecture.md` and `.puml` updated together
 - [x] ClioRing MCP compatibility verdict recorded — the anchor `AGENTS.md:241-299` does not resolve in this repository. Verdict: no MCP surface changes, nothing for ClioRing to be compatible with until stories 16-17.
 

--- a/spec/stories/story-process-versioning-14.md
+++ b/spec/stories/story-process-versioning-14.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: S
 
 ---

--- a/spec/stories/story-process-versioning-15.md
+++ b/spec/stories/story-process-versioning-15.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---

--- a/spec/stories/story-process-versioning-16.md
+++ b/spec/stories/story-process-versioning-16.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---

--- a/spec/stories/story-process-versioning-17.md
+++ b/spec/stories/story-process-versioning-17.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---

--- a/spec/stories/story-process-versioning-18.md
+++ b/spec/stories/story-process-versioning-18.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio-knowledge
-**Status**: in-progress
+**Status**: review
 **Size**: S
 
 ---

--- a/spec/stories/story-process-versioning-2.md
+++ b/spec/stories/story-process-versioning-2.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -66,7 +66,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-3.md
+++ b/spec/stories/story-process-versioning-3.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -61,7 +61,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-4.md
+++ b/spec/stories/story-process-versioning-4.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: S
 
 ---
@@ -76,7 +76,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-5.md
+++ b/spec/stories/story-process-versioning-5.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: S
 
 ---
@@ -60,7 +60,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-6.md
+++ b/spec/stories/story-process-versioning-6.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio-knowledge
-**Status**: in-progress
+**Status**: review
 **Size**: M
 
 ---

--- a/spec/stories/story-process-versioning-8.md
+++ b/spec/stories/story-process-versioning-8.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: clio
-**Status**: in-progress
+**Status**: done
 **Size**: L
 
 ---
@@ -65,7 +65,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Knowledge records whose `applies-to` names a file this story touches are updated or deleted **in this PR** (`AGENTS.md:456-457`)
 - [x] Docs verdict stated explicitly in the PR body, including "no update required" where that is the verdict
 - [x] MCP verdict stated in the PR body ("MCP reviewed, no update required" where that applies)
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/stories/story-process-versioning-9.md
+++ b/spec/stories/story-process-versioning-9.md
@@ -7,7 +7,7 @@
 **ADR**: [adr-process-versioning.md](../adr/adr-process-versioning.md)
 **Test plan**: [tp-process-versioning.md](../test-plans/tp-process-versioning.md)
 **Repository**: crt-process-builder
-**Status**: in-progress
+**Status**: done
 **Size**: M
 
 ---
@@ -58,7 +58,7 @@ Test naming: `MethodName_ShouldBehavior_WhenCondition`
 - [x] Workspace-diary entry added (`CLAUDE.md:131-150`) — mandatory in this repo
 - [x] `docs/process-builder-architecture.md` and `.puml` updated together
 - [x] ClioRing MCP compatibility verdict recorded (`AGENTS.md:241-299`) — **the anchor does not exist**: crt-process-builder has no `AGENTS.md`, and its `CLAUDE.md` is 150 lines with no ClioRing section. Verdict stated in the PR body instead: no MCP surface changes here (the package operation is not reached by any clio tool until stories 16-17), so nothing for ClioRing to be compatible with yet.
-- [ ] PR description references this story file
+- [x] PR description references this story file
 
 ## Dev Agent Record
 

--- a/spec/test-plans/tp-process-versioning.md
+++ b/spec/test-plans/tp-process-versioning.md
@@ -4,7 +4,7 @@
 **Jira**: ENG-94374
 **Stories**: `spec/stories/story-process-versioning-1.md` … `-18.md`
 **Author**: QA Planner Agent
-**Status**: Draft (revised after adversarial review 2026-09-02)
+**Status**: Approved — revised after adversarial review 2026-09-02; carried in clio#1410 and crt-process-builder#47, both approved by d-krestov on 2026-09-09
 **Created**: 2026-09-02
 
 ---


### PR DESCRIPTION
Pre-release housekeeping for the next clio tag, working through the checklist in `RELEASE.md`. **Documentation only — no production code changes.**

## What this closes

`RELEASE.md` requires every story of the release to be `done` in `spec/sprint-status.yaml` before a tag is cut. Both ENG-94374 pull requests are merged — [crt-process-builder#47](https://creatio.ghe.com/engineering/crt-process-builder/pull/47) and [#1410](https://github.com/Advance-Technologies-Foundation/clio/pull/1410) — so **15 of the 18 stories** move to `done`.

**Three stay open, on purpose:**

| Story | Repo | Why |
|---|---|---|
| 6, 18 | `clio-knowledge` | [#136](https://github.com/Advance-Technologies-Foundation/clio-knowledge/pull/136) is still open and red **by design** on `<CLIO-READBACK-VERSION-TBD>`. Closing them would claim published guidance that is not published. |
| 7 | `clio` | Re-pins the guidance fixture to a generation that exists only *after* that library ships. Stays `ready-for-dev`. |

## The Definition-of-Done item, satisfied rather than ticked

`AGENTS.md` forbids closing a story with unchecked DoD items, and eleven had exactly one: *"PR description references this story file."*

Instead of ticking a box against a false statement, both merged PR bodies now carry an explicit per-story list linking each story file. The statement became true first; the box was ticked second.

## Pre-existing drift fixed while here

- **Every story file header read `in-progress` while `sprint-status.yaml` said `review`** — the two authoritative places disagreed on all seventeen. Headers now match: `done` for the fifteen, `review` for 6 and 18.
- **The test plan was still `Draft`**, which cannot satisfy the checklist's "approved test plan". It now names the review it actually rests on — carried in both PRs, each approved by d-krestov on 2026-09-09 — rather than an unattributed "Approved".

## What this deliberately does NOT do

Other features are sitting in `review`: `mcp-worker-execution-boundary` (19 stories), `mcp-passthrough-tool-parity` (17), `mcp-http-credential-passthrough` (13 + 2 in-progress), `ring-guided-deploy` (12), and more. The checklist reads as though *no* feature may be in `review`, but dozens have been for every recent release, several with in-progress stories — so that condition is not something this PR can satisfy, and marking another team's work done from the outside would be a false claim rather than a fix. Flagging it instead.

## Checklist state

| Item | State |
|---|---|
| Approved test plan in `spec/test-plans/` | ✅ now attributed |
| All stories of this release `done` | ✅ for ENG-94374; other features unchanged (above) |
| No feature stuck in `in-progress`/`review` | ⚠️ repo-wide condition, not met before this PR either |
| `make test-unit` | ✅ 11746 passed, 0 failed |
| CI green on master | ✅ run `34342446821` on the merge commit, all checks success/skipped |
| SonarCloud | ✅ `SonarCloud Code Analysis` success on that run |
| MCP E2E run manually | ✅ run on TeamCity (`Team_Atf_ClioMcpE2eTests`). Note the GitHub commit status on `25257339f` is still `pending`: the build reported back after the PR had already merged, so the status was never updated. |
| Command docs / help / `Commands.md` | ✅ reviewed in #1410; `install-process-builder` docs updated there, and they already state the two version operations are MCP-only with no CLI verb |
| `AGENTS.md` updated for new policies | ✅ updated on master independently — it now records that `RequiredPackageChecker` throws on a *convergence* refusal, not only a floor refusal |
| What's new draft ready | ✅ below |

## What's new — draft for `gh release create --notes`

Twelve pull requests merged since `8.1.0.121`:

```markdown
- Save a business process as a NEW version, and roll back by making any version actual: modify-business-process-as-new-version and set-active-business-process-version, with describe-business-process now reporting which version actually runs
- Build gateways and declared branches through the validator, the MCP surface and the bundled CrtProcessBuilder archive
- Accept flat MCP argument shapes for resident tools instead of requiring a wrapper object
- Reject silently-dropped MCP arguments instead of reporting success
- Reject zone-less OData date-time literals before the write rather than storing an ambiguous instant
- Serve local *.component.md from the registry override directory, so a documentation edit is validated against the local copy
- Classify unusable schema-designer responses in create-sql-schema
- Fix push-pkg reporting a finished installation as an error
- Fix pkg-to-db reporting success for package loads that did not happen
- Preserve every existing viewConfigDiff operation on an append merge
- Wait for the worker registry to drain instead of sampling it once
- Bound the known transient platform window in the MCP e2e suite
```

## After this merges

The release itself is still gated on one thing this PR cannot provide: **a clio tag.** `8.1.0.121` does not contain the ENG-94374 merge, and the guidance article in clio-knowledge#136 has to name the release that first reports version standing — so the order is *tag → fill the placeholder → merge #136 → story 7*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
