### PR TITLE
fix(reg-web-app): treat a 404 login marker as proof the runtime is absent

### DIFF
--- a/clio.mcp.e2e/RegWebAppToolE2ETests.cs
+++ b/clio.mcp.e2e/RegWebAppToolE2ETests.cs
@@ -27,21 +27,8 @@ public sealed class RegWebAppToolE2ETests {
 	[AllureDescription("Starts the real clio MCP server with isolated settings, invokes reg-web-app and verifies that the stored environment has IsNetCore=false when only the framework DataService route succeeds.")]
 	[Description("Auto-detects the .NET Framework runtime through MCP registration and persists IsNetCore=false in the clio settings file.")]
 	public async Task RegisterWebApp_Should_Persist_Framework_Runtime_When_AutoDetection_Finds_Framework_Route() {
-		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-reg-web-app-e2e-{Guid.NewGuid():N}");
-		Directory.CreateDirectory(tempHome);
-		string envVarName = OperatingSystem.IsWindows() ? "LOCALAPPDATA" : "HOME";
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		settings.ProcessEnvironmentVariables[envVarName] = tempHome;
-		using TemporaryClioSettingsOverride settingsOverride = TemporaryClioSettingsOverride.ReplaceContent(
-			"""
-			{
-			  "ActiveEnvironmentKey": null,
-			  "Environments": {}
-			}
-			""",
-			settings.ClioProcessPath,
-			settings.ProcessEnvironmentVariables);
+		(McpE2ESettings settings, TemporaryClioSettingsOverride settingsOverride) = ArrangeIsolatedClio();
+		using TemporaryClioSettingsOverride _ = settingsOverride;
 		await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
 			new RuntimeDetectionStubServerConfiguration(
 				NetCoreHealthEnabled: true,
@@ -58,6 +45,83 @@ public sealed class RegWebAppToolE2ETests {
 		AssertCommandSucceeded(actResult);
 		AssertInfoOutputIncludesAutoDetectedFrameworkMessage(actResult);
 		AssertSettingsPersistedFrameworkRuntime(context.SettingsFilePath, actResult.EnvironmentName);
+	}
+
+	[Test]
+	[AllureTag(ToolName)]
+	[AllureName("reg-web-app auto-detects .NET Framework on a cold site where the framework login marker drops the connection")]
+	[AllureDescription("Reproduces issue #1428 end to end: neither SelectQuery route works, the .NET Core login marker answers 404, and the framework login marker drops the connection the way a Creatio site does on the first request after an application-pool start. Registration must still resolve .NET Framework instead of demanding --IsNetCore.")]
+	[Description("Auto-detects the .NET Framework runtime when the only conclusive evidence is a 404 on the .NET Core login marker and the framework marker never answers.")]
+	public async Task RegisterWebApp_Should_Persist_Framework_Runtime_When_Only_The_NetCore_Login_Marker_Answers() {
+		// Arrange
+		(McpE2ESettings settings, TemporaryClioSettingsOverride settingsOverride) = ArrangeIsolatedClio();
+		using TemporaryClioSettingsOverride _ = settingsOverride;
+		await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
+			new RuntimeDetectionStubServerConfiguration(
+				NetCoreHealthEnabled: true,
+				NetFrameworkHealthEnabled: true,
+				NetCoreServiceEnabled: false,
+				NetFrameworkServiceEnabled: false,
+				NetCoreUiMarkerMode: "notfound",
+				NetFrameworkUiMarkerMode: "drop"));
+		await using ArrangeContext context = await ArrangeAsync(settings, stubServer);
+
+		// Act
+		RegWebAppActResult actResult = await ActAsync(context);
+
+		// Assert
+		AssertToolCallSucceeded(actResult);
+		AssertCommandSucceeded(actResult);
+		AssertInfoOutputIncludesAutoDetectedFrameworkMessage(actResult);
+		AssertSettingsPersistedFrameworkRuntime(context.SettingsFilePath, actResult.EnvironmentName);
+	}
+
+	[Test]
+	[AllureTag(ToolName)]
+	[AllureName("reg-web-app auto-detects .NET Framework when the framework login marker answers with a redirect")]
+	[AllureDescription("A real .NET Framework site answers /0/Login/NuiLogin.aspx with a 302 to the same page off the site root. The probe client must not follow it, and the redirect itself must count as the route being served.")]
+	[Description("Treats a 302 on the framework login marker as the route being served rather than as a probe failure.")]
+	public async Task RegisterWebApp_Should_Persist_Framework_Runtime_When_The_Framework_Login_Marker_Redirects() {
+		// Arrange
+		(McpE2ESettings settings, TemporaryClioSettingsOverride settingsOverride) = ArrangeIsolatedClio();
+		using TemporaryClioSettingsOverride _ = settingsOverride;
+		await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
+			new RuntimeDetectionStubServerConfiguration(
+				NetCoreHealthEnabled: true,
+				NetFrameworkHealthEnabled: true,
+				NetCoreServiceEnabled: false,
+				NetFrameworkServiceEnabled: false,
+				NetCoreUiMarkerMode: "notfound",
+				NetFrameworkUiMarkerMode: "redirect"));
+		await using ArrangeContext context = await ArrangeAsync(settings, stubServer);
+
+		// Act
+		RegWebAppActResult actResult = await ActAsync(context);
+
+		// Assert
+		AssertToolCallSucceeded(actResult);
+		AssertCommandSucceeded(actResult);
+		AssertInfoOutputIncludesAutoDetectedFrameworkMessage(actResult);
+		AssertSettingsPersistedFrameworkRuntime(context.SettingsFilePath, actResult.EnvironmentName);
+	}
+
+	private static (McpE2ESettings Settings, TemporaryClioSettingsOverride Override) ArrangeIsolatedClio() {
+		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-reg-web-app-e2e-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempHome);
+		string envVarName = OperatingSystem.IsWindows() ? "LOCALAPPDATA" : "HOME";
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		settings.ProcessEnvironmentVariables[envVarName] = tempHome;
+		TemporaryClioSettingsOverride settingsOverride = TemporaryClioSettingsOverride.ReplaceContent(
+			"""
+			{
+			  "ActiveEnvironmentKey": null,
+			  "Environments": {}
+			}
+			""",
+			settings.ClioProcessPath,
+			settings.ProcessEnvironmentVariables);
+		return (settings, settingsOverride);
 	}
 
 	private static async Task<ArrangeContext> ArrangeAsync(

--- a/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
+++ b/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
@@ -151,6 +151,27 @@ const recordedRequests = [];
 
 // CSDL 4.0 served at the SERVICE-ROOT odata/$metadata. Declares only Id and Name, so any other
 // field name in an odata-update payload must be rejected before the PATCH.
+// A login marker answers in one of four ways. "drop" destroys the socket without a response, which is what a
+// Creatio site does on the first request after an application-pool start - the case issue #1428 reports, and the
+// one a status code cannot express. "redirect" is what a .NET Framework site really answers on the /0 login page.
+function serveUiMarker(request, response, mode, enabled, redirectLocation) {
+  const effective = mode || (enabled ? "ok" : "notfound");
+  if (effective === "drop") {
+    request.socket.destroy();
+    return;
+  }
+  if (effective === "redirect") {
+    response.writeHead(302, { "Location": redirectLocation });
+    response.end();
+    return;
+  }
+  if (effective === "gone") {
+    sendText(response, 410, "Gone");
+    return;
+  }
+  sendText(response, effective === "ok" ? 200 : 404, effective === "ok" ? "OK" : "Not Found");
+}
+
 function metadataCsdl(entity) {
   return '<?xml version="1.0" encoding="utf-8" standalone="no"?>'
     + '<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">'
@@ -216,11 +237,11 @@ http.createServer((request, response) => {
       return;
     }
     if (request.method === "GET" && url === "/Login/Login.html") {
-      sendText(response, config.NetCoreUiMarkerEnabled ? 200 : 404, config.NetCoreUiMarkerEnabled ? "OK" : "Not Found");
+      serveUiMarker(request, response, config.NetCoreUiMarkerMode, config.NetCoreUiMarkerEnabled, "/Login/Login.html");
       return;
     }
     if (request.method === "GET" && url === "/0/Login/NuiLogin.aspx") {
-      sendText(response, config.NetFrameworkUiMarkerEnabled ? 200 : 404, config.NetFrameworkUiMarkerEnabled ? "OK" : "Not Found");
+      serveUiMarker(request, response, config.NetFrameworkUiMarkerMode, config.NetFrameworkUiMarkerEnabled, "/Login/NuiLogin.aspx");
       return;
     }
     if (request.method === "POST"
@@ -366,6 +387,8 @@ internal sealed record RuntimeDetectionStubServerConfiguration(
 	bool NetFrameworkServiceEnabled,
 	bool NetCoreUiMarkerEnabled = false,
 	bool NetFrameworkUiMarkerEnabled = false,
+	string? NetCoreUiMarkerMode = null,
+	string? NetFrameworkUiMarkerMode = null,
 	string? ODataRoutingErrorEntity = null,
 	string? HtmlSelectQuerySchemaName = null,
 	string? ODataNonJsonEntity = null,

--- a/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
+++ b/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
@@ -9,6 +9,7 @@ using Clio.Common;
 using FluentAssertions;
 using Microsoft.Extensions.Http;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -266,6 +267,124 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 			because: "the diagnostic should identify which host could not be reached");
 	}
 
+	[Test]
+	[Description("Chooses .NET Framework when the .NET Core login marker answers 404 and the framework marker fails at transport level on a cold site.")]
+	public void Detect_Should_Return_False_When_NetCore_Ui_Marker_Is_NotFound_And_NetFramework_Ui_Marker_Fails_To_Respond() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
+			new Dictionary<string, HttpStatusCode> {
+				[BuildHealthUrl(true)] = HttpStatusCode.OK,
+				[BuildHealthUrl(false)] = HttpStatusCode.OK,
+				[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound
+			},
+			new Dictionary<string, Exception> {
+				[BuildUiMarkerUrl(false)] =
+					new HttpRequestException("An existing connection was forcibly closed by the remote host.")
+			});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "SelectQuery failed.");
+		ConfigureServiceThrows(netFrameworkClient, false, new TaskCanceledException("A task was canceled."));
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(CreateEnvironment());
+
+		// Assert
+		result.Should().BeFalse(
+			because: "a 404 proves Login.html is absent, while a reset connection on NuiLogin.aspx proves nothing, so the framework route is the only runtime not ruled out");
+	}
+
+	[Test]
+	[Description("Chooses .NET Core when the framework login marker answers 404 and the .NET Core marker fails at transport level on a cold site.")]
+	public void Detect_Should_Return_True_When_NetFramework_Ui_Marker_Is_NotFound_And_NetCore_Ui_Marker_Fails_To_Respond() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
+			new Dictionary<string, HttpStatusCode> {
+				[BuildHealthUrl(true)] = HttpStatusCode.OK,
+				[BuildHealthUrl(false)] = HttpStatusCode.OK,
+				[BuildUiMarkerUrl(false)] = HttpStatusCode.NotFound
+			},
+			new Dictionary<string, Exception> {
+				[BuildUiMarkerUrl(true)] = new TaskCanceledException("A task was canceled.")
+			});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "NetCore SelectQuery failed.");
+		ConfigureServiceFailure(netFrameworkClient, false, "Framework SelectQuery failed.");
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(CreateEnvironment());
+
+		// Assert
+		result.Should().BeTrue(
+			because: "an explicit 404 on NuiLogin.aspx rules out the framework route even when the NET8 marker never answered");
+	}
+
+	[Test]
+	[Description("Prefers the conclusive login markers over the health endpoints when no credentials are supplied.")]
+	public void Detect_Should_Prefer_Ui_Markers_Over_Health_Probes_When_Credentials_Are_Missing() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
+			new Dictionary<string, HttpStatusCode> {
+				[BuildHealthUrl(true)] = HttpStatusCode.OK,
+				[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound
+			},
+			new Dictionary<string, Exception> {
+				[BuildHealthUrl(false)] = new TaskCanceledException("A task was canceled."),
+				[BuildUiMarkerUrl(false)] =
+					new HttpRequestException("An existing connection was forcibly closed by the remote host.")
+			});
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(new EnvironmentSettings {
+			Uri = BaseUri
+		});
+
+		// Assert
+		result.Should().BeFalse(
+			because: "/api/HealthCheck/Ping also answers on a .NET Framework site, so a single successful health probe must not outweigh a 404 on Login.html");
+	}
+
+	[Test]
+	[Description("Still fails with diagnostics when both login markers answer 404 and neither runtime can be ruled in.")]
+	public void Detect_Should_Throw_When_Both_Ui_Markers_Are_NotFound() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.OK,
+			[BuildHealthUrl(false)] = HttpStatusCode.OK,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.NotFound
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "NetCore SelectQuery failed.");
+		ConfigureServiceFailure(netFrameworkClient, false, "Framework SelectQuery failed.");
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(CreateEnvironment());
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+			because: "two absent markers rule out both runtimes, so guessing one of them would be worse than asking for --IsNetCore");
+	}
+
 	private static void ConfigureFactory(
 		IApplicationClientFactory applicationClientFactory,
 		IOwnedApplicationClient netCoreClient,
@@ -303,6 +422,16 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 				.Returns($"{{\"success\":false,\"errorInfo\":{{\"message\":\"{errorMessage}\"}}}}");
 	}
 
+	private static void ConfigureServiceThrows(IApplicationClient client, bool isNetCore, Exception exception) {
+		client.ExecutePostRequest(
+				BuildSelectUrl(isNetCore),
+				Arg.Any<string>(),
+				Arg.Any<int>(),
+				Arg.Any<int>(),
+				Arg.Any<int>())
+			.Throws(exception);
+	}
+
 	private static void ConfigureClientWarmup(IApplicationClient client, bool isNetCore) {
 		client.ExecuteGetRequest(
 				BuildHealthUrl(isNetCore),
@@ -324,10 +453,15 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 	private static string BuildUiMarkerUrl(bool isNetCore) =>
 		$"{BaseUri}{(isNetCore ? "/Login/Login.html" : "/0/Login/NuiLogin.aspx")}";
 
-	private static IHttpClientFactory CreateHttpClientFactory(IReadOnlyDictionary<string, HttpStatusCode> responsesByUrl) {
+	private static IHttpClientFactory CreateHttpClientFactory(IReadOnlyDictionary<string, HttpStatusCode> responsesByUrl) =>
+		CreateHttpClientFactory(responsesByUrl, new Dictionary<string, Exception>());
+
+	private static IHttpClientFactory CreateHttpClientFactory(
+		IReadOnlyDictionary<string, HttpStatusCode> responsesByUrl,
+		IReadOnlyDictionary<string, Exception> exceptionsByUrl) {
 		IHttpClientFactory httpClientFactory = Substitute.For<IHttpClientFactory>();
 		httpClientFactory.CreateClient(Arg.Any<string>())
-			.Returns(_ => new HttpClient(new StubHttpMessageHandler(responsesByUrl), disposeHandler: true));
+			.Returns(_ => new HttpClient(new StubHttpMessageHandler(responsesByUrl, exceptionsByUrl), disposeHandler: true));
 		return httpClientFactory;
 	}
 
@@ -338,8 +472,13 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 		return httpClientFactory;
 	}
 
-	private sealed class StubHttpMessageHandler(IReadOnlyDictionary<string, HttpStatusCode> responsesByUrl) : HttpMessageHandler {
+	private sealed class StubHttpMessageHandler(
+		IReadOnlyDictionary<string, HttpStatusCode> responsesByUrl,
+		IReadOnlyDictionary<string, Exception> exceptionsByUrl) : HttpMessageHandler {
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+			if (exceptionsByUrl.TryGetValue(request.RequestUri!.ToString(), out Exception? mappedException)) {
+				return Task.FromException<HttpResponseMessage>(mappedException);
+			}
 			HttpStatusCode statusCode = responsesByUrl.TryGetValue(request.RequestUri!.ToString(), out HttpStatusCode mappedStatusCode)
 				? mappedStatusCode
 				: HttpStatusCode.NotFound;

--- a/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
+++ b/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
@@ -91,7 +91,8 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 
 		Action act = () => sut.Detect(CreateEnvironment());
 
-		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>()
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "no probe distinguished the runtimes, and guessing one would misconfigure every later command")
 			.Which;
 		exception.Message.Should().Contain(BuildSelectUrl(true),
 			because: "the failure should name the .NET Core service probe URL for troubleshooting");
@@ -220,7 +221,8 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 
 		Action act = () => sut.Detect(CreateEnvironment());
 
-		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>()
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "both route families answered, so nothing in the probe results names one runtime")
 			.Which;
 		exception.Message.Should().Contain("both .NET Core / NET8 and .NET Framework service probes succeeded",
 			because: "the detector should stop instead of silently guessing when both route families look valid");
@@ -259,7 +261,8 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 			Uri = "http://ts1-infr-web01:88/studioenu_14771250_0401"
 		});
 
-		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>()
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "an unreachable host is a connectivity problem, not an undecidable runtime")
 			.Which;
 		exception.Message.Should().Contain("could not be reached from this machine",
 			because: "the detector should explain that the host is unreachable instead of implying a runtime mismatch");
@@ -267,16 +270,18 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 			because: "the diagnostic should identify which host could not be reached");
 	}
 
-	[Test]
-	[Description("Chooses .NET Framework when the .NET Core login marker answers 404 and the framework marker fails at transport level on a cold site.")]
-	public void Detect_Should_Return_False_When_NetCore_Ui_Marker_Is_NotFound_And_NetFramework_Ui_Marker_Fails_To_Respond() {
+	[TestCase(HttpStatusCode.NotFound)]
+	[TestCase(HttpStatusCode.Gone)]
+	[Description("Chooses .NET Framework when the .NET Core login marker answers 404 or 410 and the framework marker fails at transport level on a cold site.")]
+	public void Detect_Should_Return_False_When_NetCore_Ui_Marker_Is_Absent_And_NetFramework_Ui_Marker_Fails_To_Respond(
+		HttpStatusCode absenceStatusCode) {
 		// Arrange
 		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
 		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
 			new Dictionary<string, HttpStatusCode> {
 				[BuildHealthUrl(true)] = HttpStatusCode.OK,
 				[BuildHealthUrl(false)] = HttpStatusCode.OK,
-				[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound
+				[BuildUiMarkerUrl(true)] = absenceStatusCode
 			},
 			new Dictionary<string, Exception> {
 				[BuildUiMarkerUrl(false)] =
@@ -331,8 +336,8 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 	}
 
 	[Test]
-	[Description("Prefers the conclusive login markers over the health endpoints when no credentials are supplied.")]
-	public void Detect_Should_Prefer_Ui_Markers_Over_Health_Probes_When_Credentials_Are_Missing() {
+	[Description("Prefers an absent login marker over a lone successful health probe when no credentials are supplied and the other marker never answered.")]
+	public void Detect_Should_Prefer_An_Absent_Ui_Marker_Over_A_Lone_Health_Probe_When_Credentials_Are_Missing() {
 		// Arrange
 		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
 		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
@@ -381,8 +386,127 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 		Action act = () => sut.Detect(CreateEnvironment());
 
 		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "two absent markers rule out both runtimes, so guessing one of them would be worse than asking for --IsNetCore")
+			.Which;
+		exception.Message.Should().Contain("--IsNetCore true",
+			because: "the diagnostic has to tell the caller how to get past detection");
+		exception.Message.Should().Contain(BuildUiMarkerUrl(true),
+			because: "naming the probed marker URLs is what makes the failure reproducible by hand");
+	}
+
+	[Test]
+	[Description("Refuses to decide when the .NET Core login marker answers 404 but the framework marker answers a non-404 error, because that pairing is equally consistent with a wrong base URL.")]
+	public void Detect_Should_Throw_When_One_Ui_Marker_Is_NotFound_And_The_Other_Answers_A_Non_Absence_Error() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.OK,
+			[BuildHealthUrl(false)] = HttpStatusCode.OK,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.Forbidden
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "NetCore SelectQuery failed.");
+		ConfigureServiceFailure(netFrameworkClient, false, "Framework SelectQuery failed.");
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(CreateEnvironment());
+
+		// Assert
 		act.Should().Throw<InvalidOperationException>(
-			because: "two absent markers rule out both runtimes, so guessing one of them would be worse than asking for --IsNetCore");
+			because: "a 403 says the route answered something, not that the runtime is present, so the 404 on the other side is not enough to pick a runtime");
+	}
+
+	[Test]
+	[Description("Applies the absent-marker rule on the ambiguous path too, when both authenticated SelectQuery probes succeed.")]
+	public void Detect_Should_Return_False_When_Both_Service_Probes_Succeed_And_Only_The_NetCore_Ui_Marker_Is_Absent() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
+			new Dictionary<string, HttpStatusCode> {
+				[BuildHealthUrl(true)] = HttpStatusCode.OK,
+				[BuildHealthUrl(false)] = HttpStatusCode.OK,
+				[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound
+			},
+			new Dictionary<string, Exception> {
+				[BuildUiMarkerUrl(false)] =
+					new HttpRequestException("An existing connection was forcibly closed by the remote host.")
+			});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceSuccess(netCoreClient, true);
+		ConfigureServiceSuccess(netFrameworkClient, false);
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(CreateEnvironment());
+
+		// Assert
+		result.Should().BeFalse(
+			because: "the tie-break between two working service routes must use the same evidence rules as every other path");
+	}
+
+	[Test]
+	[Description("Counts a redirect on a login marker as the route being served, because a .NET Framework site answers the /0 login page with a 302 to the site root.")]
+	public void Detect_Should_Return_False_When_The_NetFramework_Ui_Marker_Answers_A_Redirect() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.OK,
+			[BuildHealthUrl(false)] = HttpStatusCode.OK,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.Found
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "NetCore SelectQuery failed.");
+		ConfigureServiceFailure(netFrameworkClient, false, "Framework SelectQuery failed.");
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(CreateEnvironment());
+
+		// Assert
+		result.Should().BeFalse(
+			because: "the probe client does not follow redirects, so the 302 is the framework login page answering rather than a status borrowed from another URL");
+	}
+
+	[Test]
+	[Description("Prefers a conclusive login marker over a lone successful health probe when no credentials are supplied.")]
+	public void Detect_Should_Prefer_A_Conclusive_Ui_Marker_Over_A_Lone_Health_Probe_When_Credentials_Are_Missing() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(
+			new Dictionary<string, HttpStatusCode> {
+				[BuildHealthUrl(true)] = HttpStatusCode.OK,
+				[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound,
+				[BuildUiMarkerUrl(false)] = HttpStatusCode.OK
+			},
+			new Dictionary<string, Exception> {
+				[BuildHealthUrl(false)] = new TaskCanceledException("A task was canceled.")
+			});
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		bool result = sut.Detect(new EnvironmentSettings {
+			Uri = BaseUri
+		});
+
+		// Assert
+		result.Should().BeFalse(
+			because: "/api/HealthCheck/Ping also answers on a .NET Framework site, so a single successful health probe must not outrank the login markers");
 	}
 
 	private static void ConfigureFactory(
@@ -479,9 +603,11 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 			if (exceptionsByUrl.TryGetValue(request.RequestUri!.ToString(), out Exception? mappedException)) {
 				return Task.FromException<HttpResponseMessage>(mappedException);
 			}
+			// A 404 is proof that a runtime is absent, so an unmapped URL must never quietly become one - a test that
+			// forgets a route would otherwise pass for the wrong reason.
 			HttpStatusCode statusCode = responsesByUrl.TryGetValue(request.RequestUri!.ToString(), out HttpStatusCode mappedStatusCode)
 				? mappedStatusCode
-				: HttpStatusCode.NotFound;
+				: throw new InvalidOperationException($"Unmapped probe URL: {request.RequestUri}");
 			return Task.FromResult(new HttpResponseMessage(statusCode) {
 				RequestMessage = request,
 				Content = new StringContent(string.Empty)

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -288,6 +288,17 @@ public class BindingsModule {
 		// unauthenticated GET to an operator-registered host has no reason to follow a redirect. The response-size
 		// cap is a defence-in-depth bound: sysenums.js is a small static file (~50KB today), so a multi-megabyte
 		// response is itself the signal something is wrong, well before the brace-matched parser would need to look at it.
+		// Dedicated client for the unauthenticated runtime-detection probes of reg-web-app. AllowAutoRedirect=false
+		// is load-bearing, not hygiene: a .NET Framework site answers /0/Login/NuiLogin.aspx with a 302 to the same
+		// page off the site root, and detection reads a 404 as proof that a runtime is absent — so following the
+		// redirect would let the status of a different URL convict the wrong runtime. Timeout is set here, once,
+		// under the same rule as the clients above.
+		services.AddHttpClient(EnvironmentRuntimeDetectionService.HttpClientName)
+			.ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(10))
+			.ConfigurePrimaryHttpMessageHandler(() => new System.Net.Http.HttpClientHandler {
+				UseCookies = false,
+				AllowAutoRedirect = false
+			});
 		services.AddHttpClient(ClassicEnumVocabularyResolver.HttpClientName)
 			.ConfigureHttpClient(client => {
 				client.Timeout = TimeSpan.FromSeconds(120);

--- a/clio/Command/EnvironmentRuntimeDetectionService.cs
+++ b/clio/Command/EnvironmentRuntimeDetectionService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -54,45 +55,60 @@ internal sealed class EnvironmentRuntimeDetectionService(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe) {
+		if (TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)) {
+			return resolvedByUiMarkers;
+		}
 		int successfulHealthProbeCount = (netCoreProbe.HealthProbe.Succeeded ? 1 : 0)
 			+ (netFrameworkProbe.HealthProbe.Succeeded ? 1 : 0);
 		if (successfulHealthProbeCount == 1) {
 			return netCoreProbe.HealthProbe.Succeeded;
 		}
-		int successfulUiMarkerProbeCount = (netCoreProbe.UiMarkerProbe.Succeeded ? 1 : 0)
-			+ (netFrameworkProbe.UiMarkerProbe.Succeeded ? 1 : 0);
-		return successfulUiMarkerProbeCount switch {
-			1 when netCoreProbe.UiMarkerProbe.Succeeded => true,
-			1 => false,
-			_ => throw new InvalidOperationException(BuildUnauthenticatedFailureMessage(baseUri, netCoreProbe, netFrameworkProbe))
-		};
+		throw new InvalidOperationException(BuildUnauthenticatedFailureMessage(baseUri, netCoreProbe, netFrameworkProbe));
 	}
 
 	private static bool ResolveAmbiguousServiceSuccess(
 		RuntimeProbeResult netCoreProbe,
-		RuntimeProbeResult netFrameworkProbe) {
-		int successfulUiMarkerProbeCount = (netCoreProbe.UiMarkerProbe.Succeeded ? 1 : 0)
-			+ (netFrameworkProbe.UiMarkerProbe.Succeeded ? 1 : 0);
-
-		return successfulUiMarkerProbeCount switch {
-			1 when netCoreProbe.UiMarkerProbe.Succeeded => true,
-			1 => false,
-			_ => throw new InvalidOperationException(BuildAmbiguousMessage(netCoreProbe, netFrameworkProbe))
-		};
-	}
+		RuntimeProbeResult netFrameworkProbe) =>
+		TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)
+			? resolvedByUiMarkers
+			: throw new InvalidOperationException(BuildAmbiguousMessage(netCoreProbe, netFrameworkProbe));
 
 	private static bool ResolveByUiMarkersOrThrow(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
-		RuntimeProbeResult netFrameworkProbe) {
+		RuntimeProbeResult netFrameworkProbe) =>
+		TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)
+			? resolvedByUiMarkers
+			: throw new InvalidOperationException(BuildFailureMessage(baseUri, netCoreProbe, netFrameworkProbe));
+
+	/// <summary>
+	/// Resolves the runtime from the login-page markers.
+	/// A marker that answered <see cref="HttpStatusCode.NotFound"/> or <see cref="HttpStatusCode.Gone"/> proves the
+	/// runtime is absent, while a transport error (timeout, reset connection on a cold site) proves nothing, so an
+	/// explicit "not found" on one side decides the runtime even when the other side never answered at all.
+	/// </summary>
+	private static bool TryResolveByUiMarkers(
+		RuntimeProbeResult netCoreProbe,
+		RuntimeProbeResult netFrameworkProbe,
+		out bool isNetCore) {
 		int successfulUiMarkerProbeCount = (netCoreProbe.UiMarkerProbe.Succeeded ? 1 : 0)
 			+ (netFrameworkProbe.UiMarkerProbe.Succeeded ? 1 : 0);
-		return successfulUiMarkerProbeCount switch {
-			1 when netCoreProbe.UiMarkerProbe.Succeeded => true,
-			1 => false,
-			_ => throw new InvalidOperationException(BuildFailureMessage(baseUri, netCoreProbe, netFrameworkProbe))
-		};
+		if (successfulUiMarkerProbeCount == 1) {
+			isNetCore = netCoreProbe.UiMarkerProbe.Succeeded;
+			return true;
+		}
+		bool isNetCoreMarkerAbsent = IsDefinitiveAbsence(netCoreProbe.UiMarkerProbe);
+		bool isNetFrameworkMarkerAbsent = IsDefinitiveAbsence(netFrameworkProbe.UiMarkerProbe);
+		if (isNetCoreMarkerAbsent ^ isNetFrameworkMarkerAbsent) {
+			isNetCore = isNetFrameworkMarkerAbsent;
+			return true;
+		}
+		isNetCore = false;
+		return false;
 	}
+
+	private static bool IsDefinitiveAbsence(ProbeAttempt attempt) =>
+		!attempt.Succeeded && attempt.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone;
 
 	private RuntimeProbeResult Probe(EnvironmentSettings baseSettings, bool isNetCore, bool canAuthenticate) {
 		EnvironmentSettings probeSettings = Clone(baseSettings, isNetCore);
@@ -148,10 +164,11 @@ internal sealed class EnvironmentRuntimeDetectionService(
 			using HttpResponseMessage response = client.GetAsync(url).GetAwaiter().GetResult();
 			if (!response.IsSuccessStatusCode) {
 				return new ProbeAttempt(false,
-					$"The remote server returned an error: ({(int)response.StatusCode}) {response.ReasonPhrase}.");
+					$"The remote server returned an error: ({(int)response.StatusCode}) {response.ReasonPhrase}.",
+					response.StatusCode);
 			}
 
-			return new ProbeAttempt(true, null);
+			return new ProbeAttempt(true, null, response.StatusCode);
 		} catch (Exception exception) {
 			return new ProbeAttempt(false, exception.GetBaseException().Message);
 		}
@@ -300,7 +317,7 @@ internal sealed class EnvironmentRuntimeDetectionService(
 		string UiMarkerUrl,
 		ProbeAttempt UiMarkerProbe);
 
-	private sealed record ProbeAttempt(bool Succeeded, string? ErrorMessage);
+	private sealed record ProbeAttempt(bool Succeeded, string? ErrorMessage, HttpStatusCode? StatusCode = null);
 
 	private sealed class SelectQueryProbeResponse {
 		[JsonPropertyName("success")]

--- a/clio/Command/EnvironmentRuntimeDetectionService.cs
+++ b/clio/Command/EnvironmentRuntimeDetectionService.cs
@@ -7,7 +7,15 @@ using System.Linq;
 using Clio.Common;
 namespace Clio.Command;
 
+/// <summary>Decides whether a Creatio site runs on .NET Core / NET8 or on .NET Framework.</summary>
 public interface IEnvironmentRuntimeDetectionService {
+	/// <summary>Probes the site and reports which runtime serves it.</summary>
+	/// <param name="environmentSettings">Environment to probe. The URI is required; credentials are optional and
+	/// enable the authenticated SelectQuery probe, which is the strongest signal available.</param>
+	/// <returns><see langword="true"/> for .NET Core / NET8, <see langword="false"/> for .NET Framework.</returns>
+	/// <exception cref="InvalidOperationException">The probes were inconclusive, or the host could not be reached.
+	/// This is an ordinary outcome, not a malfunction: the caller is expected to surface the diagnostic and let the
+	/// user override detection with <c>--IsNetCore</c>.</exception>
 	bool Detect(EnvironmentSettings environmentSettings);
 }
 
@@ -16,6 +24,13 @@ internal sealed class EnvironmentRuntimeDetectionService(
 	IHttpClientFactory httpClientFactory,
 	IServiceUrlBuilderFactory serviceUrlBuilderFactory)
 	: IEnvironmentRuntimeDetectionService {
+	/// <summary>Name of the registered <see cref="HttpClient"/> used for the unauthenticated probes.</summary>
+	/// <remarks>The registration in <c>BindingsModule</c> disables automatic redirects on purpose - see
+	/// <see cref="ExecuteHttpGetProbe"/>.</remarks>
+	internal const string HttpClientName = "environment-runtime-detection";
+
+	/// <summary>Timeout of the authenticated SelectQuery probe. The unauthenticated GET probes take theirs from
+	/// the <see cref="HttpClientName"/> registration.</summary>
 	private const int ProbeTimeoutMs = 10000;
 	private static readonly JsonSerializerOptions JsonOptions = new() {
 		PropertyNameCaseInsensitive = true
@@ -55,7 +70,7 @@ internal sealed class EnvironmentRuntimeDetectionService(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe) {
-		if (TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)) {
+		if (ResolveByUiMarkers(netCoreProbe, netFrameworkProbe) is bool resolvedByUiMarkers) {
 			return resolvedByUiMarkers;
 		}
 		int successfulHealthProbeCount = (netCoreProbe.HealthProbe.Succeeded ? 1 : 0)
@@ -69,46 +84,51 @@ internal sealed class EnvironmentRuntimeDetectionService(
 	private static bool ResolveAmbiguousServiceSuccess(
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe) =>
-		TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)
-			? resolvedByUiMarkers
-			: throw new InvalidOperationException(BuildAmbiguousMessage(netCoreProbe, netFrameworkProbe));
+		ResolveByUiMarkers(netCoreProbe, netFrameworkProbe)
+			?? throw new InvalidOperationException(BuildAmbiguousMessage(netCoreProbe, netFrameworkProbe));
 
 	private static bool ResolveByUiMarkersOrThrow(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe) =>
-		TryResolveByUiMarkers(netCoreProbe, netFrameworkProbe, out bool resolvedByUiMarkers)
-			? resolvedByUiMarkers
-			: throw new InvalidOperationException(BuildFailureMessage(baseUri, netCoreProbe, netFrameworkProbe));
+		ResolveByUiMarkers(netCoreProbe, netFrameworkProbe)
+			?? throw new InvalidOperationException(BuildFailureMessage(baseUri, netCoreProbe, netFrameworkProbe));
 
-	/// <summary>
-	/// Resolves the runtime from the login-page markers.
-	/// A marker that answered <see cref="HttpStatusCode.NotFound"/> or <see cref="HttpStatusCode.Gone"/> proves the
-	/// runtime is absent, while a transport error (timeout, reset connection on a cold site) proves nothing, so an
-	/// explicit "not found" on one side decides the runtime even when the other side never answered at all.
-	/// </summary>
-	private static bool TryResolveByUiMarkers(
+	/// <summary>Resolves the runtime from the two login-page markers.</summary>
+	/// <param name="netCoreProbe">Probe results taken against the .NET Core / NET8 routes.</param>
+	/// <param name="netFrameworkProbe">Probe results taken against the .NET Framework <c>0/</c> routes.</param>
+	/// <returns><see langword="true"/> for .NET Core / NET8, <see langword="false"/> for .NET Framework, and
+	/// <see langword="null"/> when the markers do not decide, which leaves the caller to raise its own diagnostic.</returns>
+	/// <remarks>
+	/// Two rules, in order. First, exactly one marker route answering (see <see cref="ExecuteHttpGetProbe"/> for what
+	/// counts as answering) names the runtime outright. Second, a marker that answered
+	/// <see cref="HttpStatusCode.NotFound"/> or <see cref="HttpStatusCode.Gone"/> proves that runtime is absent - but
+	/// this only decides the runtime when the other marker produced no HTTP response at all, which is what a cold site
+	/// does when it drops the connection or runs out of time. Any other status on the other side (401, 403, 500, a
+	/// gateway error) is left undecided on purpose: it is as consistent with a wrong base URL, or with a host that is
+	/// not Creatio, as it is with the runtime this rule would pick.
+	/// </remarks>
+	private static bool? ResolveByUiMarkers(
 		RuntimeProbeResult netCoreProbe,
-		RuntimeProbeResult netFrameworkProbe,
-		out bool isNetCore) {
-		int successfulUiMarkerProbeCount = (netCoreProbe.UiMarkerProbe.Succeeded ? 1 : 0)
+		RuntimeProbeResult netFrameworkProbe) {
+		int answeringUiMarkerProbeCount = (netCoreProbe.UiMarkerProbe.Succeeded ? 1 : 0)
 			+ (netFrameworkProbe.UiMarkerProbe.Succeeded ? 1 : 0);
-		if (successfulUiMarkerProbeCount == 1) {
-			isNetCore = netCoreProbe.UiMarkerProbe.Succeeded;
+		if (answeringUiMarkerProbeCount == 1) {
+			return netCoreProbe.UiMarkerProbe.Succeeded;
+		}
+		if (ProvesAbsence(netCoreProbe.UiMarkerProbe) && DidNotAnswer(netFrameworkProbe.UiMarkerProbe)) {
+			return false;
+		}
+		if (ProvesAbsence(netFrameworkProbe.UiMarkerProbe) && DidNotAnswer(netCoreProbe.UiMarkerProbe)) {
 			return true;
 		}
-		bool isNetCoreMarkerAbsent = IsDefinitiveAbsence(netCoreProbe.UiMarkerProbe);
-		bool isNetFrameworkMarkerAbsent = IsDefinitiveAbsence(netFrameworkProbe.UiMarkerProbe);
-		if (isNetCoreMarkerAbsent ^ isNetFrameworkMarkerAbsent) {
-			isNetCore = isNetFrameworkMarkerAbsent;
-			return true;
-		}
-		isNetCore = false;
-		return false;
+		return null;
 	}
 
-	private static bool IsDefinitiveAbsence(ProbeAttempt attempt) =>
-		!attempt.Succeeded && attempt.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone;
+	private static bool ProvesAbsence(ProbeAttempt attempt) =>
+		attempt.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone;
+
+	private static bool DidNotAnswer(ProbeAttempt attempt) => !attempt.Succeeded && attempt.StatusCode is null;
 
 	private RuntimeProbeResult Probe(EnvironmentSettings baseSettings, bool isNetCore, bool canAuthenticate) {
 		EnvironmentSettings probeSettings = Clone(baseSettings, isNetCore);
@@ -157,21 +177,31 @@ internal sealed class EnvironmentRuntimeDetectionService(
 		}
 	}
 
+	/// <summary>Sends one unauthenticated GET and reports what the route answered.</summary>
+	/// <remarks>
+	/// The registered client does not follow redirects, and a 3xx counts as the route existing. Both halves matter.
+	/// A .NET Framework site answers <c>0/Login/NuiLogin.aspx</c> with a 302 to the same page off the site root, so
+	/// following the redirect would report the status of a different URL than the one being probed - and since a 404
+	/// is read as proof that a runtime is absent, a redirect that lands on a 404 would convict the wrong runtime.
+	/// </remarks>
 	private ProbeAttempt ExecuteHttpGetProbe(string url) {
 		try {
-			using HttpClient client = httpClientFactory.CreateClient(nameof(EnvironmentRuntimeDetectionService));
-			client.Timeout = TimeSpan.FromMilliseconds(ProbeTimeoutMs);
+			using HttpClient client = httpClientFactory.CreateClient(HttpClientName);
 			using HttpResponseMessage response = client.GetAsync(url).GetAwaiter().GetResult();
-			if (!response.IsSuccessStatusCode) {
-				return new ProbeAttempt(false,
-					$"The remote server returned an error: ({(int)response.StatusCode}) {response.ReasonPhrase}.",
-					response.StatusCode);
+			if (IsRouteServed(response.StatusCode)) {
+				return new ProbeAttempt(true, null, response.StatusCode);
 			}
-
-			return new ProbeAttempt(true, null, response.StatusCode);
+			return new ProbeAttempt(false,
+				$"The remote server returned an error: ({(int)response.StatusCode}) {response.ReasonPhrase}.",
+				response.StatusCode);
 		} catch (Exception exception) {
 			return new ProbeAttempt(false, exception.GetBaseException().Message);
 		}
+	}
+
+	private static bool IsRouteServed(HttpStatusCode statusCode) {
+		int code = (int)statusCode;
+		return code is >= 200 and < 400;
 	}
 
 	private static string ExecuteAuthenticatedServiceProbe(IApplicationClient client, string serviceUrl) {

--- a/clio/docs/commands/reg-web-app.md
+++ b/clio/docs/commands/reg-web-app.md
@@ -11,10 +11,20 @@ reg-web-app - create/update a web application (website)
 ## Description
 
 Register new web application settings or update existing ones.
-When credentials are available, clio also validates the chosen route with an
-authenticated `SelectQuery` probe. Without credentials, clio falls back to
-unauthenticated health and login-marker probes and stops if the result remains
-ambiguous.
+
+Omit `--IsNetCore` and clio detects the runtime itself, in this order:
+
+1. **Authenticated `SelectQuery` probe** on each route family, when login/password or
+   OAuth credentials are available. This is the strongest signal.
+2. **Login-page markers** — `/Login/Login.html` for .NET Core / NET8 and
+   `/0/Login/NuiLogin.aspx` for .NET Framework. A page that answers, redirect included,
+   names the runtime; a page that answers `404` proves that runtime is absent, which
+   settles the case even when the other page never answered at all.
+3. **Health endpoints**, last and only as a tiebreaker: `/api/HealthCheck/Ping` answers
+   on a .NET Framework site as well, so it cannot tell the runtimes apart on its own.
+
+When the probes stay inconclusive clio stops with a diagnostic naming every URL it tried,
+rather than guessing — pass `--IsNetCore` to skip detection entirely.
 
 ## Synopsis
 
@@ -38,6 +48,10 @@ Name (pos. 0)	Environment(web application) name
 --Login                 -l          User login (administrator permission required)
 
 --Maintainer            -m          Maintainer name
+
+--IsNetCore             -i          Override runtime auto-detection:
+                                    true for .NET Core / NET8,
+                                    false for .NET Framework
 ```
 
 ## Example

--- a/clio/help/en/reg-web-app.txt
+++ b/clio/help/en/reg-web-app.txt
@@ -6,10 +6,15 @@ NAME
 
 DESCRIPTION
     Register new web application settings or update existing ones.
-    When login/password or OAuth credentials are provided, clio also validates
-    the resolved route with an authenticated SelectQuery probe. Without
-    credentials, clio falls back to unauthenticated health and login-marker
-    probes and stops if that signal is inconclusive.
+    Omit --IsNetCore and clio detects the runtime itself. When login/password or
+    OAuth credentials are provided, the strongest signal is an authenticated
+    SelectQuery probe on each route family. Otherwise, and whenever both service
+    probes fail, clio compares the two login pages: a login page that answers
+    (including with a redirect) names the runtime, and a login page that answers
+    404 proves that runtime is absent. The health endpoints are only a last
+    resort, because /api/HealthCheck/Ping answers on a .NET Framework site too.
+    Detection stops with a diagnostic rather than guessing when the probes stay
+    inconclusive - pass --IsNetCore to skip it entirely.
 
 SYNOPSIS
     clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password
@@ -29,9 +34,16 @@ OPTIONS
 
     --Maintainer            -m          Maintainer name
 
+    --IsNetCore             -i          Override runtime auto-detection:
+                                        true for .NET Core / NET8,
+                                        false for .NET Framework
+
 EXAMPLE
     clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password
         creates new environment, named <ENVIRONMENT_NAME> or updates existing environment settings
+
+    clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password --IsNetCore false
+        same, but skips runtime detection and registers the environment as .NET Framework
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio

--- a/docs/knowledge/Command/runtime-detection-treats-404-as-proof-of-absence.md
+++ b/docs/knowledge/Command/runtime-detection-treats-404-as-proof-of-absence.md
@@ -1,30 +1,40 @@
 ---
-description: runtime auto-detection must separate an HTTP 404 (marker absent) from a transport failure (no information) or a cold Creatio site defeats it
+description: runtime auto-detection reads a login-marker 404 as proof of absence, which only holds because the probe client does not follow redirects and the other marker gave no answer at all
 applies-to:
   - clio/Command/EnvironmentRuntimeDetectionService.cs
+  - clio/BindingsModule.cs
 date: 2026-09-09
 ---
 
-**What is true** — `EnvironmentRuntimeDetectionService` decides between .NET Core and .NET Framework from two
-login-page markers, and the two ways a marker probe can fail are not equivalent:
+**What is true** — three constraints hold this rule together, and none of them is visible from the call site.
 
-- `404 Not Found` / `410 Gone` — the site answered and the page does not exist. This *proves* that runtime is
-  not the one behind the URL.
-- a timeout, a reset connection, a DNS failure — nothing was learned.
+1. `ProbeAttempt` carries `HttpStatusCode?` so the decision can tell an answer apart from silence. Folding the
+   status back into the message string (the shape before this record existed) is the rejected alternative:
+   the resolver then sees only "failed" and cannot use the strongest evidence it already holds.
+2. The `404`/`410` rule fires **only when the other marker produced no HTTP response at all**. Any other status
+   on the other side — `401`, `403`, `500`, a gateway error — leaves the pair undecided on purpose. A wrong base
+   URL produces `404` on one path and a WAF `403` on the other just as readily as a real Creatio site does, so
+   the narrow form is what keeps the rule from naming a runtime for a host that is not Creatio at all.
+3. The probe client (`EnvironmentRuntimeDetectionService.HttpClientName`, registered in `BindingsModule`) has
+   `AllowAutoRedirect = false`, and a `3xx` counts as the route being served. This is load-bearing. A .NET
+   Framework site answers `/0/Login/NuiLogin.aspx` with a `302` to the same page off the site root; with
+   redirects followed, the recorded status belongs to the redirect target rather than to the probed URL.
 
-So when exactly one marker answers 404 and the other never answered, the runtime is the other one.
-`ProbeAttempt` carries `StatusCode` for this reason; do not collapse it back into the message string.
-
-Only 404 and 410 count as absence. `401` and `403` mean the page exists and is gated, and a proxy that returns
-404 for everything leaves both markers absent, which correctly resolves to nothing and throws.
+The `404` also does not mean quite what its name suggests on the framework side: it says this deployment does
+not serve the `/0` login form, which is close to but not identical with "not .NET Framework".
 
 **Why it is this way** — a cold Creatio site (first request after an application-pool start) drops connections
-and blows past the 10 s probe timeout on the routes that have to warm up. Measured on
+and outlasts the probe timeout on the routes that still have to warm up. Measured on
 `ts1-infr-web03:88/sae_m_seeenu_15999009_0909`: `/0/api/HealthCheck/Ping` did not answer within 20 s on the
-first request and returned 200 in 60 ms a minute later.
+first request and returned 200 in 60 ms a minute later. So on a cold site the evidence is genuinely one-sided,
+and a resolver that only counts successes throws away the half it did receive.
 
-**What breaks if you ignore it** — the original code counted only successes, so a run against a cold
-.NET Framework site saw `Login/Login.html => 404` (conclusive) and `0/Login/NuiLogin.aspx => An existing
-connection was forcibly closed` (inconclusive), counted "zero successes", and aborted `reg-web-app` with
-"Unable to auto-detect the Creatio runtime", forcing the user to pass `--IsNetCore false` by hand — even
-though the 404 alone already answered the question.
+**What breaks if you ignore it** — score every failed marker probe the same and a cold .NET Framework site
+aborts registration with "Unable to auto-detect the Creatio runtime", because the conclusive `404` on
+`Login.html` is filed next to a reset connection on `NuiLogin.aspx`. Widen the rule past "the other side never
+answered" and a mistyped base URL registers as a runtime instead of failing. Turn redirect-following back on
+and a `302` whose target happens to answer `404` convicts the wrong runtime silently — `BuildProbeSummary`
+would print that `404` beside a marker URL that never returns one, so nobody can reproduce it by hand.
+
+`clio.mcp.e2e/RegWebAppToolE2ETests.cs` exercises all three constraints against a stub that can drop a socket
+and redirect; `clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs` carries the marker modes.

--- a/docs/knowledge/Command/runtime-detection-treats-404-as-proof-of-absence.md
+++ b/docs/knowledge/Command/runtime-detection-treats-404-as-proof-of-absence.md
@@ -1,0 +1,30 @@
+---
+description: runtime auto-detection must separate an HTTP 404 (marker absent) from a transport failure (no information) or a cold Creatio site defeats it
+applies-to:
+  - clio/Command/EnvironmentRuntimeDetectionService.cs
+date: 2026-09-09
+---
+
+**What is true** — `EnvironmentRuntimeDetectionService` decides between .NET Core and .NET Framework from two
+login-page markers, and the two ways a marker probe can fail are not equivalent:
+
+- `404 Not Found` / `410 Gone` — the site answered and the page does not exist. This *proves* that runtime is
+  not the one behind the URL.
+- a timeout, a reset connection, a DNS failure — nothing was learned.
+
+So when exactly one marker answers 404 and the other never answered, the runtime is the other one.
+`ProbeAttempt` carries `StatusCode` for this reason; do not collapse it back into the message string.
+
+Only 404 and 410 count as absence. `401` and `403` mean the page exists and is gated, and a proxy that returns
+404 for everything leaves both markers absent, which correctly resolves to nothing and throws.
+
+**Why it is this way** — a cold Creatio site (first request after an application-pool start) drops connections
+and blows past the 10 s probe timeout on the routes that have to warm up. Measured on
+`ts1-infr-web03:88/sae_m_seeenu_15999009_0909`: `/0/api/HealthCheck/Ping` did not answer within 20 s on the
+first request and returned 200 in 60 ms a minute later.
+
+**What breaks if you ignore it** — the original code counted only successes, so a run against a cold
+.NET Framework site saw `Login/Login.html => 404` (conclusive) and `0/Login/NuiLogin.aspx => An existing
+connection was forcibly closed` (inconclusive), counted "zero successes", and aborted `reg-web-app` with
+"Unable to auto-detect the Creatio runtime", forcing the user to pass `--IsNetCore false` by hand — even
+though the 404 alone already answered the question.

--- a/docs/knowledge/platform/healthcheck-ping-answers-on-both-runtime-routes.md
+++ b/docs/knowledge/platform/healthcheck-ping-answers-on-both-runtime-routes.md
@@ -2,34 +2,36 @@
 description: /api/HealthCheck/Ping returns 200 on a .NET Framework Creatio site, so the health probe cannot tell the two runtimes apart
 applies-to:
   - clio/Command/EnvironmentRuntimeDetectionService.cs
-  - clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
+  - clio/Command/ClassicEnumVocabularyResolver.cs
+  - clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
 date: 2026-09-09
 ---
 
 **What is true** — on a .NET Framework Creatio site, `<base>/api/HealthCheck/Ping` (no `0/` segment) answers
-`200 OK`, exactly like `<base>/0/api/HealthCheck/Ping`. Verified on
-`http://ts1-infr-web03:88/sae_m_seeenu_15999009_0909` (Creatio on .NET Framework) on 2026-09-09: both routes
-returned 200. The health endpoint therefore carries no information about which runtime is behind the URL.
+`200 OK`, exactly like `<base>/0/api/HealthCheck/Ping`. The health endpoint therefore carries no information
+about which runtime is behind the URL. The login pages do:
 
-The login-page markers do discriminate on that same site:
-
-| URL | Answer |
+| URL | .NET Framework answer |
 |---|---|
-| `<base>/Login/Login.html` | `404 Not Found` |
-| `<base>/0/Login/NuiLogin.aspx` | `302` to `<base>/Login/NuiLogin.aspx?ReturnUrl=…`, then `200` |
+| `/api/HealthCheck/Ping` | `200` |
+| `/0/api/HealthCheck/Ping` | `200` |
+| `/Login/Login.html` | `404` |
+| `/0/Login/NuiLogin.aspx` | `302` to `<base>/Login/NuiLogin.aspx?ReturnUrl=…`, then `200` |
 
-Measured on three .NET Framework stands on 2026-09-09 — `ts1-infr-web03:88/sae_m_seeenu_15999009_0909`,
-`ts1-infr-web01:88/sae_m_seeenu_15998736_0909` and `a_kravchuk2:88/workenu_15970796_0919`. All three answered
-200 on both health routes, 404 on `/Login/Login.html` and 200 on `/0/Login/NuiLogin.aspx`.
+Measured on three .NET Framework stands on 2026-09-09: `ts1-infr-web03:88/sae_m_seeenu_15999009_0909`,
+`ts1-infr-web01:88/sae_m_seeenu_15998736_0909`, `a_kravchuk2:88/workenu_15970796_0919`. All three answered
+identically.
 
 **Why it is this way** — not investigated. The routing rule that makes the `0/` segment optional for the API
-routes was not confirmed; only the responses above were measured. The mirror direction (what a .NET Core stand
-answers on the `0/` routes) was NOT measured either — no .NET Core environment was reachable from this
-machine; `clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs` only states what the authors assumed.
+routes was not confirmed; only the responses above were measured. The mirror direction — what a .NET Core stand
+answers on the `0/` routes — was NOT measured either: no .NET Core environment was reachable from the machine
+this was written on. `RuntimeDetectionStubServer.cs` and the comment in `ClassicEnumVocabularyResolver.cs`
+around the login-page split state only what their authors assumed, so neither is evidence. Measuring
+`/0/Login/NuiLogin.aspx` and `/0/api/HealthCheck/Ping` on any .NET Core stand closes this, and is worth doing
+before anyone leans harder on the health probe.
 
-**What breaks if you ignore it** — `EnvironmentRuntimeDetectionService.ResolveWithoutAuthentication` used to
-return `netCoreProbe.HealthProbe.Succeeded` whenever exactly one health probe succeeded. On a cold .NET
-Framework site the `0/` health probe times out while the plain one answers, so `reg-web-app <name> -u <url>`
-without credentials registered the environment as .NET Core with no error at all — every later command then
-built `/rest/...` URLs without the `0/` prefix and failed for reasons that look unrelated to registration.
-Health is now only a last-resort tiebreaker, after the login markers.
+**What breaks if you ignore it** — rank a lone successful health probe above the login markers, and a cold
+.NET Framework site registered without credentials comes out as .NET Core with no error at all: the `0/` health
+route times out while the plain one answers. Every later command then builds `/rest/...` URLs without the `0/`
+prefix and fails for reasons that look nothing like a registration problem. That is why health sits last in
+`ResolveWithoutAuthentication`, after the markers, rather than first.

--- a/docs/knowledge/platform/healthcheck-ping-answers-on-both-runtime-routes.md
+++ b/docs/knowledge/platform/healthcheck-ping-answers-on-both-runtime-routes.md
@@ -1,0 +1,35 @@
+---
+description: /api/HealthCheck/Ping returns 200 on a .NET Framework Creatio site, so the health probe cannot tell the two runtimes apart
+applies-to:
+  - clio/Command/EnvironmentRuntimeDetectionService.cs
+  - clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
+date: 2026-09-09
+---
+
+**What is true** — on a .NET Framework Creatio site, `<base>/api/HealthCheck/Ping` (no `0/` segment) answers
+`200 OK`, exactly like `<base>/0/api/HealthCheck/Ping`. Verified on
+`http://ts1-infr-web03:88/sae_m_seeenu_15999009_0909` (Creatio on .NET Framework) on 2026-09-09: both routes
+returned 200. The health endpoint therefore carries no information about which runtime is behind the URL.
+
+The login-page markers do discriminate on that same site:
+
+| URL | Answer |
+|---|---|
+| `<base>/Login/Login.html` | `404 Not Found` |
+| `<base>/0/Login/NuiLogin.aspx` | `302` to `<base>/Login/NuiLogin.aspx?ReturnUrl=…`, then `200` |
+
+Measured on three .NET Framework stands on 2026-09-09 — `ts1-infr-web03:88/sae_m_seeenu_15999009_0909`,
+`ts1-infr-web01:88/sae_m_seeenu_15998736_0909` and `a_kravchuk2:88/workenu_15970796_0919`. All three answered
+200 on both health routes, 404 on `/Login/Login.html` and 200 on `/0/Login/NuiLogin.aspx`.
+
+**Why it is this way** — not investigated. The routing rule that makes the `0/` segment optional for the API
+routes was not confirmed; only the responses above were measured. The mirror direction (what a .NET Core stand
+answers on the `0/` routes) was NOT measured either — no .NET Core environment was reachable from this
+machine; `clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs` only states what the authors assumed.
+
+**What breaks if you ignore it** — `EnvironmentRuntimeDetectionService.ResolveWithoutAuthentication` used to
+return `netCoreProbe.HealthProbe.Succeeded` whenever exactly one health probe succeeded. On a cold .NET
+Framework site the `0/` health probe times out while the plain one answers, so `reg-web-app <name> -u <url>`
+without credentials registered the environment as .NET Core with no error at all — every later command then
+built `/rest/...` URLs without the `0/` prefix and failed for reasons that look unrelated to registration.
+Health is now only a last-resort tiebreaker, after the login markers.


### PR DESCRIPTION
🔗 **Issue:** [#1428](https://github.com/Advance-Technologies-Foundation/clio/issues/1428)

Closes #1428

## What was wrong

`reg-web-app` scored every failed login-marker probe the same way, so a conclusive `404 Not Found` carried no
more weight than a dropped connection. Against a cold .NET Framework site that combination aborted
registration: `/Login/Login.html` answered `404` (the .NET Core page is not served here — conclusive) while
`/0/Login/NuiLogin.aspx` had its connection reset (inconclusive). Both counted as failures, detection gave up,
and the user had to pass `--IsNetCore false` by hand.

The unauthenticated path was worse, because it failed silently. It returned `netCoreProbe.HealthProbe.Succeeded`
whenever exactly one health probe succeeded — but `/api/HealthCheck/Ping` answers `200` on a .NET Framework
site too, so a cold framework site registered as .NET Core with no error at all, and every later command then
built `/rest/...` URLs without the `0/` prefix.

## What changed

- `ProbeAttempt` carries the HTTP status code instead of folding it into a message string.
- New `TryResolveByUiMarkers`: when exactly one login marker answered `404`/`410`, that runtime is proven
  absent and the other one wins — even if the other marker never answered. Transport failures still carry no
  information, and two absent markers still fail with the existing diagnostic rather than guess. Only `404`
  and `410` count as absence; `401`/`403` mean the page exists and is gated.
- `ResolveWithoutAuthentication` now consults the login markers first and keeps health only as a last-resort
  tiebreaker.
- Two knowledge records under `docs/knowledge/` for the two platform facts whose failure modes are silent.

## Evidence

Measured on three .NET Framework stands on 2026-09-09 (`ts1-infr-web03:88/sae_m_seeenu_15999009_0909`,
`ts1-infr-web01:88/sae_m_seeenu_15998736_0909`, `a_kravchuk2:88/workenu_15970796_0919`):

| URL | Answer on all three |
|---|---|
| `/api/HealthCheck/Ping` | `200` |
| `/0/api/HealthCheck/Ping` | `200` |
| `/Login/Login.html` | `404` |
| `/0/Login/NuiLogin.aspx` | `302` → `200` |

Cold-start timing on the first of those: `/0/api/HealthCheck/Ping` did not answer within 20 s on the first
request and returned `200` in 60 ms a minute later — which is what produced the inconclusive probes in the
original report.

## Review round

A three-lens agentic review after the first commit found three real problems, fixed in the second commit.

**The absent-marker rule was too wide.** It fired whenever one marker answered `404`/`410` and the other was
anything else, so a mistyped base URL — `404` on one path, a WAF `403` on the other — would name a runtime for
a host that is not Creatio. It now fires only when the other marker produced **no HTTP response at all**, which
is what a cold site does and what this issue actually hit. Every other status leaves the pair undecided.

**The probe client followed redirects, which undermined the rule it feeds.** A .NET Framework site answers
`/0/Login/NuiLogin.aspx` with a `302` to the same page off the site root, so the recorded status belonged to the
redirect target, not to the probed URL — and a redirect landing on a `404` would convict the wrong runtime while
the diagnostic printed that `404` beside a marker URL that never returns one. The client is now registered
explicitly with `AllowAutoRedirect = false`, its timeout set at registration, and a `3xx` counts as the route
being served. Incidentally this was the only named-client caller mutating `HttpClient.Timeout` after
construction, against the rule the neighbouring registrations state in a comment.

**The public contract had no documentation.** `IEnvironmentRuntimeDetectionService` now states the polarity of
the result and that `InvalidOperationException` is an ordinary outcome the caller is expected to surface.

## Tests

`EnvironmentRuntimeDetectionServiceTests` — the stub handler can now throw per URL, so the reported case is
modelled as it actually happened (a marker that never answered) rather than as a status code, and it now
**throws on an unmapped probe URL** instead of quietly answering `404`: since this change a `404` is decisive
evidence, so a test that forgets a route must fail loudly rather than pass for the wrong reason. Cases added
across both commits: the reported pairing and its mirror, `410` alongside `404`, the narrowing guard
(`404` + `403` must still throw), the ambiguous-service call site, a redirecting framework marker, both markers
absent, and a no-credentials case that isolates the marker-before-health reordering. `because` added to the
three pre-existing throw assertions.

**E2E — the gap the review found.** The existing `RegWebAppToolE2ETests` always returned from the SelectQuery
branch, so its marker arguments were inert and the marker logic had no end-to-end coverage at all, old or new.
`RuntimeDetectionStubServer` now takes a per-marker mode, including one that destroys the socket, so the
reported failure is reproducible end to end for the first time. Two new cases: the cold-site reproduction of
this issue and the redirecting marker.

Mutation-checked at both levels. Unit: with the production change reverted, exactly the intended tests fail.
E2E: with the service and `BindingsModule` reverted to `master`, both new cases fail and the pre-existing one
still passes.

Validated:
- `dotnet test --filter "Category=Unit"` — 11769 passed, 0 failed (full suite, because `BindingsModule.cs` changed)
- `RegWebAppToolE2ETests` on net8.0 and net10.0 — 3 passed each

A live `reg-web-app` without `--IsNetCore` against the reported stand prints
`Auto-detected runtime: .NET Framework`. Read that as a sanity check only: the stand was warm by then, so the
run does not exercise the fixed branch. The mutation-checked tests are the actual proof of the cold-site case.

## Known limit of this verification

The mirror direction was not measured on a live site — no .NET Core environment was reachable from the machine
this was developed on. If a .NET Core site ever answered `404` on `/Login/Login.html`, the new rule would
register it as .NET Framework silently, where the old code threw. The risk looks low, because clio already
treats `/Login/Login.html` as the .NET Core fingerprint elsewhere (`ClassicEnumVocabularyResolver`,
`ReauthExecutor`), so such a site would already be broken on those paths — but that is an assessment, not a
measurement, and it is written into the knowledge record as such.

## Review notes

Docs updated. The first commit claimed no update was required; that was wrong. Both
`help/en/reg-web-app.txt` and `docs/commands/reg-web-app.md` do describe the detection order, they now described
it incorrectly, and neither listed `--IsNetCore` at all even though the failure message tells the user to pass
it. Both now state the probe order, that a `404` on a login page is what settles the case, why the health
endpoints come last, and carry the option with an example.

MCP reviewed, no update required — `RegWebAppPrompt` only states that the runtime is detected automatically,
which stays true.

ClioRing compatibility reviewed, no Ring-consumed contract changed — Ring reads the `IsNetCore` value out of
the environment catalog (`clio-ring/ClioRing/Services/ClioAdapter.cs:208`,
`clio-ring/ClioRing/Services/ClioModels.cs:19`) and never invokes `reg-web-app` or the detection service; the
catalog shape and that field are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
