### PR TITLE
ENG-93202: report the real data type for decimal and money columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,7 @@ graphify-out
 # Python bytecode from scripts/ (twice swept into a commit by an add -A).
 __pycache__/
 *.pyc
+
+# Agent working artifacts (Jira analysis, implementation plans). Internal by nature - they carry
+# ticket URLs, stand names and internal repository references - and this repository is public.
+.ai_temp/

--- a/clio.mcp.e2e/DataForgeToolE2ETests.cs
+++ b/clio.mcp.e2e/DataForgeToolE2ETests.cs
@@ -308,11 +308,11 @@ public sealed class DataForgeToolE2ETests {
 		response.Success.Should().BeTrue(
 			because: "CurrencyRate runtime schema reads should succeed through the shared by-name runtime reader");
 
-		DataForgeColumnResult? rate = response.Columns.SingleOrDefault(column => column.Name == "Rate");
-		rate.Should().NotBeNull(
+		DataForgeColumnResult rate = response.Columns.Should().ContainSingle(column => column.Name == "Rate",
 			because: "Rate is declared on CurrencyRate itself, so it survives the non-inherited column filter; "
-				+ "if the platform ever moves it to a parent schema this assertion must be retargeted rather than relaxed");
-		rate!.DataType.Should().NotBe("Text",
+				+ "if the platform ever moves it to a parent schema this assertion must be retargeted rather than relaxed")
+			.Subject;
+		rate.DataType.Should().NotBe("Text",
 			because: "reporting a live Decimal8 column as Text is the defect ENG-93202 reported");
 		rate.DataType.Should().Be("Float8",
 			because: "dataValueType 40 is Float8 in the canonical registry, which the kind classifier resolves as numeric");

--- a/clio.mcp.e2e/DataForgeToolE2ETests.cs
+++ b/clio.mcp.e2e/DataForgeToolE2ETests.cs
@@ -1,9 +1,11 @@
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
+using Clio.Common;
 using Clio.Common.DataForge;
 using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
@@ -271,6 +273,58 @@ public sealed class DataForgeToolE2ETests {
 			because: "Contact should expose its primary display column through the Data Forge columns tool");
 		response.Columns.Should().Contain(column => column.Name == "Account",
 			because: "Contact should expose its Account lookup through the Data Forge columns tool");
+	}
+
+	[Test]
+	[Description("Starts the real clio MCP server, invokes dataforge-get-table-columns for the core CurrencyRate schema, and verifies that its live Decimal8 column reports a numeric type instead of the Text fallback that ENG-93202 reported.")]
+	[AllureTag(ColumnsToolName)]
+	[AllureName("DataForge get-table-columns reports a live decimal column as numeric")]
+	[AllureDescription("Uses the real clio MCP server to call dataforge-get-table-columns for CurrencyRate against the configured reachable sandbox environment and verifies that its own Decimal8 (Rate), Date (StartDate) and Lookup (Currency) columns report canonical Creatio type names, so the decimal scale that used to fall through to the Text fallback is now covered against real platform metadata.")]
+	public async Task DataForgeGetTableColumns_Should_Report_Live_Decimal_Column_As_Numeric() {
+		// Arrange — CurrencyRate is a core CrtBase schema present on every install, and unlike Currency its
+		// OWN (non-inherited) columns include a decimal: Rate is Decimal8 (dataValueType 40), one of the nine
+		// scales that the mapper's private table lacked and therefore reported as "Text" (ENG-93202). This is
+		// the ticket's exact failure mode against live platform metadata rather than a substituted schema.
+		// StartDate (dataValueType 8) is asserted alongside it because the designer's write-scoped readback
+		// vocabulary has no name for code 8 and reports the raw string "8" for this very column, so it also
+		// pins that the canonical read vocabulary covers codes the write vocabulary cannot express.
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3), requireReachableEnvironment: true);
+
+		// Act
+		CallToolResult callResult = await CallToolAsync(
+			arrangeContext,
+			ColumnsToolName,
+			new Dictionary<string, object?> {
+				["environment-name"] = arrangeContext.EnvironmentName,
+				["table-name"] = "CurrencyRate"
+			});
+		DataForgeColumnsResponse response = DeserializeStructuredContent<DataForgeColumnsResponse>(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "dataforge-get-table-columns should return a structured success payload for a reachable configured environment");
+		response.Success.Should().BeTrue(
+			because: "CurrencyRate runtime schema reads should succeed through the shared by-name runtime reader");
+
+		DataForgeColumnResult? rate = response.Columns.SingleOrDefault(column => column.Name == "Rate");
+		rate.Should().NotBeNull(
+			because: "Rate is declared on CurrencyRate itself, so it survives the non-inherited column filter; "
+				+ "if the platform ever moves it to a parent schema this assertion must be retargeted rather than relaxed");
+		rate!.DataType.Should().NotBe("Text",
+			because: "reporting a live Decimal8 column as Text is the defect ENG-93202 reported");
+		rate.DataType.Should().Be("Float8",
+			because: "dataValueType 40 is Float8 in the canonical registry, which the kind classifier resolves as numeric");
+		CreatioDataValueType.IsNumeric(rate.DataType).Should().BeTrue(
+			because: "a caller must be able to conclude from the reported name alone that the column compares numerically");
+
+		response.Columns.Should().Contain(column => column.Name == "StartDate" && column.DataType == "Date",
+			because: "the canonical read vocabulary names dataValueType 8, which the designer readback reports "
+				+ "as the raw string \"8\" because it is scoped to types clio can write");
+		response.Columns.Should().Contain(
+			column => column.Name == "Currency" && column.DataType == "Lookup" && column.ReferenceSchemaName == "Currency",
+			because: "the projection must keep carrying the lookup target alongside the data type");
 	}
 
 	[Test]

--- a/clio.tests/Command/ApplicationInfoServiceTests.cs
+++ b/clio.tests/Command/ApplicationInfoServiceTests.cs
@@ -459,6 +459,31 @@ public sealed class ApplicationInfoServiceTests {
 		_applicationClientFactory.DidNotReceiveWithAnyArgs().CreateEnvironmentClient(default);
 	}
 
+	[Test]
+	[Description("Keeps reporting the historical SCREAMING_SNAKE data-value-type spelling after the duplicate type table was folded into the canonical registry.")]
+	public void GetApplicationInfo_Should_Preserve_Historical_DataValueType_Spelling() {
+		// Arrange — dataValueType 32 is one of the 35 codes whose historical get-app-info spelling (FLOAT2)
+		// differs from the canonical name (Float2). Pinning it here is what catches an accidental swap of
+		// GetDisplayName for GetNameOrOrdinal, which would silently rewrite this tool's output (ENG-93202).
+		ConfigureHappyPathResponses();
+		_applicationClient.ExecutePostRequest(
+				Arg.Is<string>(url => url.EndsWith("RuntimeEntitySchemaRequest", StringComparison.Ordinal)),
+				Arg.Is<string>(body => body.Contains("\"uId\":\"entity-b\"", StringComparison.Ordinal)))
+			.Returns("""{"success":true,"schema":{"uId":"entity-b","name":"UsrBeta","caption":{"en-US":"Beta caption"},"columns":{"Items":{"amount":{"name":"UsrAmount","caption":{"en-US":"Amount"},"dataValueType":32,"isInherited":false},"hash":{"name":"UsrHash","caption":{"en-US":"Hash"},"dataValueType":23,"isInherited":false},"future":{"name":"UsrFuture","caption":{"en-US":"Future"},"dataValueType":999,"isInherited":false}}}}}""");
+
+		// Act
+		ApplicationInfoResult result = _sut.GetApplicationInfo("sandbox", null, "APP");
+
+		// Assert
+		result.Entities[1].Columns.Should().BeEquivalentTo(new[] {
+			new { Name = "UsrAmount", DataValueType = "FLOAT2" },
+			new { Name = "UsrFuture", DataValueType = "999" },
+			new { Name = "UsrHash", DataValueType = "HASH_TEXT" }
+		}, options => options.ExcludingMissingMembers(),
+			because: "get-app-info output must stay byte-identical to what it emitted before the duplicate "
+				+ "type table was removed, including its ordinal fallback for an unmodelled code");
+	}
+
 	private void ConfigureHappyPathResponses() {
 		_applicationClient.ExecutePostRequest(
 				Arg.Is<string>(url => url.EndsWith("SelectQuery", StringComparison.Ordinal)),

--- a/clio.tests/Command/EntitySchemaDesignerSupportTests.cs
+++ b/clio.tests/Command/EntitySchemaDesignerSupportTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Clio.Command.EntitySchemaDesigner;
+using Clio.Common;
 using FluentAssertions;
 using Terrasoft.Core.Entities;
 using NUnit.Framework;
@@ -29,7 +30,7 @@ internal sealed class EntitySchemaDesignerSupportTests {
 		dataValueType.Should().Be(expectedValue,
 			because: "resolved binary-like type names should map to the expected runtime data value type");
 	}
-	
+
 	[Test]
 	[Description("Every column type clio can write is read back as a name that resolves to the same runtime type, so a readback value can always be sent straight back through the write vocabulary.")]
 	public void GetFriendlyTypeName_Should_RoundTrip_EverySupportedWriteType() {
@@ -75,6 +76,109 @@ internal sealed class EntitySchemaDesignerSupportTests {
 		// Assert
 		friendlyName.Should().Be(expectedName,
 			because: "readback must report the semantic type name from the documented write vocabulary");
+	}
+
+	[Test]
+	[Description("Every column type clio can write is reported by the canonical read vocabulary under a name the write vocabulary accepts back, so a read value can be sent straight into a write call.")]
+	public void GetNameOrOrdinal_Should_RoundTrip_EverySupportedWriteType() {
+		// Arrange — the read-side mirror of GetFriendlyTypeName_Should_RoundTrip_EverySupportedWriteType, for
+		// the canonical vocabulary that dataforge-get-table-columns and get-app-info emit. Before ENG-93202
+		// none of the decimal or money scales resolved here, so a caller could read a Decimal(0.01) column's
+		// type and be rejected when sending it straight back. This fixture owns the guard (not the Common one)
+		// because it protects SupportedDataValueTypes/SupportedDataValueTypeAliases, which live in this module:
+		// under the AGENTS smart-regression policy a Module=Command-only change must execute it.
+		IReadOnlyCollection<int> writableDataValueTypes =
+			[.. EntitySchemaDesignerSupport.SupportedDataValueTypes.Values.Distinct()];
+
+		// Act & Assert
+		writableDataValueTypes.Should().NotBeEmpty(
+			because: "the write registry must actually yield types, otherwise this guard passes vacuously");
+		foreach (int dataValueType in writableDataValueTypes) {
+			string canonicalName = CreatioDataValueType.GetNameOrOrdinal(dataValueType);
+			canonicalName.Should().NotBe(dataValueType.ToString(CultureInfo.InvariantCulture),
+				because: $"runtime type {dataValueType} is writable, so the read surface must report a semantic "
+					+ "name rather than falling through to the raw ordinal");
+			EntitySchemaDesignerSupport.TryResolveDataValueType(canonicalName, out int resolved).Should().BeTrue(
+				because: $"the canonical read name '{canonicalName}' must be accepted by the write vocabulary");
+			resolved.Should().Be(dataValueType,
+				because: $"the canonical read name '{canonicalName}' must resolve back to the same runtime type");
+		}
+	}
+
+	// Read names that resolve to a DIFFERENT type on write. Pre-existing collisions, NOT a licence to add
+	// more — see docs/knowledge/Command/read-name-write-token-collisions.md for why neither side of code 5
+	// can be changed from here.
+	private static readonly IReadOnlyDictionary<int, int> KnownReadNameWriteCollisions = new Dictionary<int, int> {
+		// Documented, deliberate collapse: Creatio stores Date and Time as DateTime (issue #949).
+		[8] = 7,
+		[9] = 7,
+		// Code 5 is NOT a collapse: canonical "Float" (unbounded) hits the ["float"] = "decimal2" alias.
+		[5] = 32
+	};
+
+	[Test]
+	[Description("No canonical read name resolves to a different runtime type on write, apart from the known collisions, so a type read from a column cannot silently create a column of another type.")]
+	public void GetNameOrOrdinal_Should_Not_Resolve_To_A_Different_Type_On_Write() {
+		// Arrange — the inverse of the guard above, and the one that can see codes the write vocabulary does
+		// NOT cover. The forward guard iterates writable codes only, so a read-only code whose name collides
+		// with another type's write token is invisible to it. A read surface emits all 49 codes.
+		IReadOnlyList<CreatioDataValueTypeInfo> allTypes = CreatioDataValueType.Types;
+
+		// Act
+		Dictionary<int, int> collisions = [];
+		foreach (CreatioDataValueTypeInfo type in allTypes) {
+			if (EntitySchemaDesignerSupport.TryResolveDataValueType(CreatioDataValueType.GetNameOrOrdinal(type.Code), out int resolved)
+				&& resolved != type.Code) {
+				collisions[type.Code] = resolved;
+			}
+		}
+
+		// Assert
+		allTypes.Should().NotBeEmpty(
+			because: "the registry must actually yield types, otherwise this guard passes vacuously");
+		collisions.Should().BeEquivalentTo(KnownReadNameWriteCollisions,
+			because: "a canonical read name that resolves to a different type on write silently creates the "
+				+ "wrong column; the known set is documented on KnownReadNameWriteCollisions, so any addition "
+				+ "here is a new silent-corruption path and any removal means a collision was fixed and the "
+				+ "documented set should shrink with it");
+	}
+
+	// Canonical spelling, as emitted by dataforge-get-table-columns.
+	[TestCase("Float0", 47)]
+	[TestCase("Float1", 31)]
+	[TestCase("Float2", 32)]
+	[TestCase("Float3", 33)]
+	[TestCase("Float4", 34)]
+	[TestCase("Float8", 40)]
+	[TestCase("Money0", 48)]
+	[TestCase("Money1", 49)]
+	[TestCase("Money3", 50)]
+	[TestCase("PhoneText", 42)]
+	[TestCase("WebText", 44)]
+	[TestCase("EmailText", 45)]
+	// Historical display spelling, as emitted by get-app-info. One alias covers both because
+	// TryResolveDataValueType normalizes case-insensitively and strips non-alphanumerics.
+	[TestCase("FLOAT0", 47)]
+	[TestCase("FLOAT2", 32)]
+	[TestCase("FLOAT8", 40)]
+	[TestCase("MONEY0", 48)]
+	[TestCase("MONEY3", 50)]
+	[TestCase("PHONE_TEXT", 42)]
+	[TestCase("WEB_TEXT", 44)]
+	[TestCase("EMAIL_TEXT", 45)]
+	[Description("Resolves the canonical read-surface type names, so a type read back from a column can be sent straight into a write call without translation.")]
+	public void TryResolveDataValueType_Should_Resolve_CanonicalReadSurfaceNames(string typeName, int expectedValue) {
+		// Arrange — before ENG-93202 none of the decimal or money scales had a write token under their
+		// canonical spelling, so reading a Decimal(0.01) column as Float2 and sending it back was rejected.
+
+		// Act
+		bool resolved = EntitySchemaDesignerSupport.TryResolveDataValueType(typeName, out int dataValueType);
+
+		// Assert
+		resolved.Should().BeTrue(
+			because: $"'{typeName}' is a name a clio read surface emits, so the write vocabulary must accept it");
+		dataValueType.Should().Be(expectedValue,
+			because: $"'{typeName}' must resolve to the same runtime data value type it was read from");
 	}
 
 	[TestCase("Money", 6)]

--- a/clio.tests/Command/EntitySchemaDesignerSupportTests.cs
+++ b/clio.tests/Command/EntitySchemaDesignerSupportTests.cs
@@ -124,12 +124,15 @@ internal sealed class EntitySchemaDesignerSupportTests {
 		// with another type's write token is invisible to it. A read surface emits all 49 codes.
 		IReadOnlyList<CreatioDataValueTypeInfo> allTypes = CreatioDataValueType.Types;
 
-		// Act
+		// Act — both read vocabularies, because get-app-info emits DisplayName and carries the same echo
+		// hazard. They yield the same set today; iterating both keeps a future DisplayName edit guarded.
 		Dictionary<int, int> collisions = [];
 		foreach (CreatioDataValueTypeInfo type in allTypes) {
-			if (EntitySchemaDesignerSupport.TryResolveDataValueType(CreatioDataValueType.GetNameOrOrdinal(type.Code), out int resolved)
-				&& resolved != type.Code) {
-				collisions[type.Code] = resolved;
+			foreach (string readName in new[] { type.Name, type.DisplayName }) {
+				if (EntitySchemaDesignerSupport.TryResolveDataValueType(readName, out int resolved)
+					&& resolved != type.Code) {
+					collisions[type.Code] = resolved;
+				}
 			}
 		}
 

--- a/clio.tests/Command/McpServer/DataForgeToolTests.cs
+++ b/clio.tests/Command/McpServer/DataForgeToolTests.cs
@@ -57,7 +57,10 @@ public sealed class DataForgeToolTests {
 			Guid.NewGuid(), "Contact", Guid.NewGuid(), null, null,
 			[
 				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "Name", "Full name", null, 1, true, false, null),
-				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "Account", "Account", null, 10, false, false, "Account")
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "Account", "Account", null, 10, false, false, "Account"),
+				// dataValueType 32 is Float2 — "Decimal (0.01)" in the designer. This fixture asserted only
+				// the column COUNT, which is why a decimal reported as Text shipped unnoticed (ENG-93202).
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "Amount", "Amount", null, 32, false, false, null)
 			]));
 		DataForgeTool tool = CreateTool(runtimeEntitySchemaReader: runtimeReader);
 
@@ -69,8 +72,12 @@ public sealed class DataForgeToolTests {
 		// Assert
 		result.Success.Should().BeTrue(
 			because: "valid runtime schema results should produce a successful response");
-		result.Columns.Should().HaveCount(2,
-			because: "all non-inherited columns from the runtime schema should be returned");
+		result.Columns.Should().BeEquivalentTo(new[] {
+			new { Name = "Account", DataType = "Lookup" },
+			new { Name = "Amount", DataType = "Float2" },
+			new { Name = "Name", DataType = "Text" }
+		}, options => options.ExcludingMissingMembers(),
+			because: "the tool must report each column's real data type, not just the column set");
 		runtimeReader.Received(1).GetByName("Contact");
 	}
 

--- a/clio.tests/Common/CreatioDataValueTypeTests.cs
+++ b/clio.tests/Common/CreatioDataValueTypeTests.cs
@@ -42,9 +42,12 @@ public sealed class CreatioDataValueTypeTests {
 		// Assert
 		actualCodes.Should().Equal(expectedCodes,
 			because: "the registry must model every platform data value type code and no invented one");
-		types.Select(type => type.Name).Should().OnlyHaveUniqueItems(
-			because: "BuildByName is last-wins, so two rows sharing a canonical name would make GetCode, GetKind "
-				+ "and IsNumeric resolve that name to whichever row happens to be declared last");
+		// OrdinalIgnoreCase, not the default comparer: ByName is keyed case-insensitively, so two rows whose
+		// names differ only in case are distinct to an ordinal check yet collide last-wins in the index.
+		types.Select(type => type.Name).Distinct(StringComparer.OrdinalIgnoreCase).Should().HaveSameCount(types,
+			because: "BuildByName is keyed OrdinalIgnoreCase and is last-wins, so two rows whose names differ "
+				+ "only in case would make GetCode, GetKind and IsNumeric resolve that name to whichever row "
+				+ "happens to be declared last");
 		types.Should().AllSatisfy(type => type.DisplayName.Should().NotBeNullOrWhiteSpace(
 			because: $"code {type.Code} must carry a display spelling or get-app-info degrades it to an ordinal"));
 	}

--- a/clio.tests/Common/CreatioDataValueTypeTests.cs
+++ b/clio.tests/Common/CreatioDataValueTypeTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Clio.Common;
 using FluentAssertions;
 using NUnit.Framework;
@@ -22,5 +24,183 @@ public sealed class CreatioDataValueTypeTests {
 		// Assert
 		found.Should().BeTrue(because: "known Creatio type UIds must be available to semantic consumers");
 		info.Name.Should().Be(expectedName, because: "the canonical registry owns the type name mapping");
+	}
+
+	[Test]
+	[Description("The registry models exactly the platform's 49 data value type codes, with unique canonical names, so a dropped or duplicated row cannot silently change what a read surface reports.")]
+	public void Types_ShouldModelEveryPlatformCode_WithUniqueNames() {
+		// Arrange — the platform enum defines 49 members: codes 0, 1 and 4-50 (verified against a 10.0 stand's
+		// sysenums.js; 2 and 3 are not defined). Pinning the row SET matters because the older guard only
+		// checked that PRESENT rows carried both spellings: a deleted row was undetectable, and a read surface
+		// answers a missing row with a raw ordinal.
+		int[] expectedCodes = [0, 1, .. Enumerable.Range(4, 47)];
+		IReadOnlyList<CreatioDataValueTypeInfo> types = CreatioDataValueType.Types;
+
+		// Act
+		int[] actualCodes = [.. types.Select(type => type.Code).OrderBy(code => code)];
+
+		// Assert
+		actualCodes.Should().Equal(expectedCodes,
+			because: "the registry must model every platform data value type code and no invented one");
+		types.Select(type => type.Name).Should().OnlyHaveUniqueItems(
+			because: "BuildByName is last-wins, so two rows sharing a canonical name would make GetCode, GetKind "
+				+ "and IsNumeric resolve that name to whichever row happens to be declared last");
+		types.Should().AllSatisfy(type => type.DisplayName.Should().NotBeNullOrWhiteSpace(
+			because: $"code {type.Code} must carry a display spelling or get-app-info degrades it to an ordinal"));
+	}
+
+	// Transcribed from the 49-entry table ApplicationInfoService owned at HEAD. A deliberately
+	// independent copy: a typo in the registry DisplayName column fails here instead of silently
+	// rewriting get-app-info output.
+	private static readonly object[] HistoricalDisplayNames = [
+		new object[] { 0, "Guid" },
+		new object[] { 1, "Text" },
+		new object[] { 4, "Integer" },
+		new object[] { 5, "Float" },
+		new object[] { 6, "Money" },
+		new object[] { 7, "DateTime" },
+		new object[] { 8, "Date" },
+		new object[] { 9, "Time" },
+		new object[] { 10, "Lookup" },
+		new object[] { 11, "Enum" },
+		new object[] { 12, "Boolean" },
+		new object[] { 13, "Blob" },
+		new object[] { 14, "Image" },
+		new object[] { 15, "CUSTOM_OBJECT" },
+		new object[] { 16, "IMAGELOOKUP" },
+		new object[] { 17, "COLLECTION" },
+		new object[] { 18, "Color" },
+		new object[] { 19, "LOCALIZABLE_STRING" },
+		new object[] { 20, "ENTITY" },
+		new object[] { 21, "ENTITY_COLLECTION" },
+		new object[] { 22, "ENTITY_COLUMN_MAPPING_COLLECTION" },
+		new object[] { 23, "HASH_TEXT" },
+		new object[] { 24, "SECURE_TEXT" },
+		new object[] { 25, "FILE" },
+		new object[] { 26, "MAPPING" },
+		new object[] { 27, "SHORT_TEXT" },
+		new object[] { 28, "MEDIUM_TEXT" },
+		new object[] { 29, "MAXSIZE_TEXT" },
+		new object[] { 30, "LONG_TEXT" },
+		new object[] { 31, "FLOAT1" },
+		new object[] { 32, "FLOAT2" },
+		new object[] { 33, "FLOAT3" },
+		new object[] { 34, "FLOAT4" },
+		new object[] { 35, "LOCALIZABLE_PARAMETER_VALUES_LIST" },
+		new object[] { 36, "METADATA_TEXT" },
+		new object[] { 37, "STAGE_INDICATOR" },
+		new object[] { 38, "OBJECT_LIST" },
+		new object[] { 39, "COMPOSITE_OBJECT_LIST" },
+		new object[] { 40, "FLOAT8" },
+		new object[] { 41, "FILE_LOCATOR" },
+		new object[] { 42, "PHONE_TEXT" },
+		new object[] { 43, "RICH_TEXT" },
+		new object[] { 44, "WEB_TEXT" },
+		new object[] { 45, "EMAIL_TEXT" },
+		new object[] { 46, "COMPOSITE_OBJECT" },
+		new object[] { 47, "FLOAT0" },
+		new object[] { 48, "MONEY0" },
+		new object[] { 49, "MONEY1" },
+		new object[] { 50, "MONEY3" }
+	];
+
+	[TestCaseSource(nameof(HistoricalDisplayNames))]
+	[Description("Every data value type reports the exact display spelling get-app-info emitted before the duplicate type table was removed.")]
+	public void GetDisplayName_ShouldMatchHistoricalSpelling_ForEveryModelledCode(int code, string expectedName) {
+		// Arrange
+
+		// Act
+		string name = CreatioDataValueType.GetDisplayName(code);
+
+		// Assert
+		name.Should().Be(expectedName,
+			because: "get-app-info output must stay byte-identical for every code, not only for a hand-picked sample");
+	}
+
+	// The nine scales that ENG-93202 reported as "Text" — every one of them was absent from the Data Forge map.
+	[TestCase(31, "Float1")]
+	[TestCase(32, "Float2")]
+	[TestCase(33, "Float3")]
+	[TestCase(34, "Float4")]
+	[TestCase(40, "Float8")]
+	[TestCase(47, "Float0")]
+	[TestCase(48, "Money0")]
+	[TestCase(49, "Money1")]
+	[TestCase(50, "Money3")]
+	// The remaining codes the Data Forge map lacked.
+	[TestCase(14, "Image")]
+	[TestCase(15, "CustomObject")]
+	[TestCase(16, "ImageLookup")]
+	[TestCase(17, "Collection")]
+	[TestCase(19, "LocalizableString")]
+	[TestCase(20, "Entity")]
+	[TestCase(21, "EntityCollection")]
+	[TestCase(22, "EntityColumnMappingCollection")]
+	[TestCase(25, "File")]
+	[TestCase(26, "Mapping")]
+	[TestCase(35, "LocalizableParameterValuesList")]
+	[TestCase(36, "MetadataText")]
+	[TestCase(37, "StageIndicator")]
+	[TestCase(38, "ObjectList")]
+	[TestCase(39, "CompositeObjectList")]
+	[TestCase(41, "FileLocator")]
+	[TestCase(46, "CompositeObject")]
+	// Codes that already resolved before the fix must keep resolving.
+	[TestCase(1, "Text")]
+	[TestCase(5, "Float")]
+	[TestCase(8, "Date")]
+	[TestCase(9, "Time")]
+	[TestCase(11, "Enum")]
+	[TestCase(23, "HashText")]
+	[Description("Resolves the canonical read name for every data value type, including the decimal and money scales that used to be reported as Text.")]
+	public void GetNameOrOrdinal_ShouldReturnCanonicalName_ForModelledCode(int code, string expectedName) {
+		// Arrange
+
+		// Act
+		string name = CreatioDataValueType.GetNameOrOrdinal(code);
+
+		// Assert
+		name.Should().Be(expectedName,
+			because: "the canonical registry owns the read-surface name for every modelled data value type");
+	}
+
+	[Test]
+	[Description("An unmodelled data value type degrades to its ordinal rather than to a plausible type name, so a wrong answer cannot be mistaken for a right one.")]
+	public void Resolvers_ShouldDegradeToOrdinal_WhenCodeIsNotModelled() {
+		// Arrange — the ENG-93202 regression: the old Data Forge map answered "Text" for every unmapped code,
+		// and because "Text" is a real type the caller had no way to tell the answer was a fallback.
+		const int unmodelledCode = 999;
+
+		// Act
+		string canonicalName = CreatioDataValueType.GetNameOrOrdinal(unmodelledCode);
+		string displayName = CreatioDataValueType.GetDisplayName(unmodelledCode);
+
+		// Assert
+		canonicalName.Should().NotBe("Text",
+			because: "a plausible type name as a fallback is the defect ENG-93202 reported, not a safe default");
+		canonicalName.Should().Be("999",
+			because: "an unmodelled code must name the ordinal clio failed to model");
+		displayName.Should().Be("999",
+			because: "both read vocabularies share the ordinal-fallback contract");
+		CreatioDataValueType.GetName(unmodelledCode).Should().BeNull(
+			because: "the nullable lookup must stay honest about an unknown code for callers that can handle it");
+	}
+
+	[TestCase("Float2")]
+	[TestCase("FLOAT2")]
+	[TestCase("Money0")]
+	[TestCase("Float1")]
+	[Description("A decimal or money name emitted by a read surface is still classified as numeric by the kind classifier, so a caller does not treat a numeric column as text.")]
+	public void IsNumeric_ShouldClassifyEmittedDecimalName_AsNumeric(string emittedName) {
+		// Arrange — this is the property that decided the canonical vocabulary over the designer's friendly
+		// vocabulary, whose decimal names (Decimal1, Currency0) are absent from the canonical name index.
+
+		// Act
+		bool numeric = CreatioDataValueType.IsNumeric(emittedName);
+
+		// Assert
+		numeric.Should().BeTrue(
+			because: "the name a read surface emits must remain resolvable by the kind classifier, otherwise "
+				+ "a numeric column is filtered as a lexicographic string comparison (ENG-93202)");
 	}
 }

--- a/clio.tests/Common/DataForgeContextServiceTests.cs
+++ b/clio.tests/Common/DataForgeContextServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Clio.Common.DataForge;
 using Clio.Common.EntitySchema;
@@ -287,6 +288,124 @@ public sealed class DataForgeContextServiceTests {
 				"Data Forge subsystem the probe describes");
 		result.Health.CorrelationId.Should().Be("corr-offline",
 			because: "the health probe result is still reported alongside the successful reads");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A Decimal(0.01) column reports a numeric data type instead of Text, the defect reported in ENG-93202.")]
+	public void MapColumns_Should_Report_Decimal_As_Numeric_Type() {
+		// Arrange — dataValueType 32 is Float2, the "Decimal (0.01)" the EntitySchema designer shows. It was
+		// absent from the mapper's private table, so it fell through to the "Text" fallback and consumers
+		// filtered UsrAmount > 1000 as a lexicographic string comparison.
+		RuntimeEntitySchemaResult schema = new(
+			Guid.NewGuid(), "UsrClioFilterTest", Guid.NewGuid(), null, null,
+			[new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrAmount", "Amount", null, 32, false, false, null)]);
+
+		// Act
+		IReadOnlyList<DataForgeColumnResult> columns = DataForgeRuntimeSchemaMapper.MapColumns(schema);
+
+		// Assert
+		columns.Should().ContainSingle(because: "the schema declares exactly one non-inherited column");
+		columns[0].DataType.Should().NotBe("Text",
+			because: "reporting a Decimal column as Text is the defect ENG-93202 reported");
+		columns[0].DataType.Should().Be("Float2",
+			because: "the canonical registry names dataValueType 32 Float2, which the kind classifier "
+				+ "resolves as numeric and the write vocabulary accepts back");
+	}
+
+	[TestCase(31, "Float1")]
+	[TestCase(32, "Float2")]
+	[TestCase(33, "Float3")]
+	[TestCase(34, "Float4")]
+	[TestCase(40, "Float8")]
+	[TestCase(47, "Float0")]
+	[TestCase(48, "Money0")]
+	[TestCase(49, "Money1")]
+	[TestCase(50, "Money3")]
+	[Category("Unit")]
+	[Description("Every decimal and money scale reports its own type rather than the shared Text fallback.")]
+	public void MapColumns_Should_Report_Every_Numeric_Scale(int dataValueType, string expectedType) {
+		// Arrange — all nine scales were missing from the private table, so all nine read back as Text.
+		RuntimeEntitySchemaResult schema = new(
+			Guid.NewGuid(), "UsrClioFilterTest", Guid.NewGuid(), null, null,
+			[new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrValue", "Value", null, dataValueType, false, false, null)]);
+
+		// Act
+		IReadOnlyList<DataForgeColumnResult> columns = DataForgeRuntimeSchemaMapper.MapColumns(schema);
+
+		// Assert
+		columns.Should().ContainSingle(
+			because: "the schema declares exactly one non-inherited column, so an empty result must fail with a message rather than throw on indexing");
+		columns[0].DataType.Should().Be(expectedType,
+			because: $"dataValueType {dataValueType} is a distinct numeric scale and must not collapse into Text");
+	}
+
+	[Test]
+	[Description("Columns whose types already resolved keep resolving, including the five that a designer-vocabulary fix would have degraded to raw ordinals.")]
+	[Category("Unit")]
+	public void MapColumns_Should_Preserve_Previously_Working_Types() {
+		// Arrange — Float(5), Date(8), Time(9), Enum(11) and HashText(23) are readable but NOT writable by
+		// clio, so mapping through the designer's write-scoped friendly vocabulary would have reported them
+		// as "5"/"8"/"9"/"11"/"23". The canonical registry covers all 49 codes, so they keep their names.
+		RuntimeEntitySchemaResult schema = new(
+			Guid.NewGuid(), "UsrClioFilterTest", Guid.NewGuid(), null, null,
+			[
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrSubject", "Subject", null, 1, true, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrRate", "Rate", null, 5, false, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrDueDate", "Due date", null, 8, false, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrStartTime", "Start time", null, 9, false, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrKind", "Kind", null, 11, false, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrHash", "Hash", null, 23, false, false, null),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrStage", "Stage", null, 10, false, false, "UsrStageLookup"),
+				new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrIsActive", "Is active", null, 12, false, false, null)
+			]);
+
+		// Act
+		IReadOnlyList<DataForgeColumnResult> columns = DataForgeRuntimeSchemaMapper.MapColumns(schema);
+
+		// Assert
+		columns.Select(column => (column.Name, column.DataType)).Should().Equal([
+			("UsrDueDate", "Date"),
+			("UsrHash", "HashText"),
+			("UsrIsActive", "Boolean"),
+			("UsrKind", "Enum"),
+			("UsrRate", "Float"),
+			("UsrStage", "Lookup"),
+			("UsrStartTime", "Time"),
+			("UsrSubject", "Text")
+		], because: "the fix must widen coverage without regressing any type that already resolved, and the "
+			+ "projection stays ordered by column name (Equal, not BeEquivalentTo, so the ordering is asserted)");
+		DataForgeColumnResult stage = columns.Single(column => column.Name == "UsrStage");
+		stage.Caption.Should().Be("Stage",
+			because: "rewriting the projection must not drop the caption");
+		stage.ReferenceSchemaName.Should().Be("UsrStageLookup",
+			because: "the lookup target travels beside the data type and is the field an agent needs to follow "
+				+ "the relation; dropping this argument from the projection would otherwise go unnoticed");
+		columns.Single(column => column.Name == "UsrSubject").Required.Should().BeTrue(
+			because: "the required flag must survive the projection rewrite");
+		columns.Single(column => column.Name == "UsrRate").Required.Should().BeFalse(
+			because: "a non-required column must not acquire the flag");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("An unmodelled data value type reports its ordinal rather than the plausible Text fallback that hid the original defect.")]
+	public void MapColumns_Should_Report_Ordinal_For_Unmodelled_Type() {
+		// Arrange
+		RuntimeEntitySchemaResult schema = new(
+			Guid.NewGuid(), "UsrClioFilterTest", Guid.NewGuid(), null, null,
+			[new RuntimeEntitySchemaColumnResult(Guid.NewGuid(), "UsrFuture", "Future", null, 999, false, false, null)]);
+
+		// Act
+		IReadOnlyList<DataForgeColumnResult> columns = DataForgeRuntimeSchemaMapper.MapColumns(schema);
+
+		// Assert
+		columns.Should().ContainSingle(
+			because: "the schema declares exactly one non-inherited column, so an empty result must fail with a message rather than throw on indexing");
+		columns[0].DataType.Should().NotBe("Text",
+			because: "a plausible fallback made the original wrong answer indistinguishable from a right one");
+		columns[0].DataType.Should().Be("999",
+			because: "a type clio does not model yet must name the ordinal so the gap is self-diagnosing");
 	}
 
 	private static IDataForgeMaintenanceClient CreateReadyMaintenanceClient() {

--- a/clio/Command/ApplicationInfoService.cs
+++ b/clio/Command/ApplicationInfoService.cs
@@ -86,60 +86,6 @@ public sealed class ApplicationInfoService(
 			[4] = "Sequence"
 		};
 
-	private static readonly IReadOnlyDictionary<int, string> DataValueTypeNames =
-		new Dictionary<int, string>
-		{
-			[0] = "Guid",
-			[1] = "Text",
-			[4] = "Integer",
-			[5] = "Float",
-			[6] = "Money",
-			[7] = "DateTime",
-			[8] = "Date",
-			[9] = "Time",
-			[10] = "Lookup",
-			[11] = "Enum",
-			[12] = "Boolean",
-			[13] = "Blob",
-			[14] = "Image",
-			[15] = "CUSTOM_OBJECT",
-			[16] = "IMAGELOOKUP",
-			[17] = "COLLECTION",
-			[18] = "Color",
-			[19] = "LOCALIZABLE_STRING",
-			[20] = "ENTITY",
-			[21] = "ENTITY_COLLECTION",
-			[22] = "ENTITY_COLUMN_MAPPING_COLLECTION",
-			[23] = "HASH_TEXT",
-			[24] = "SECURE_TEXT",
-			[25] = "FILE",
-			[26] = "MAPPING",
-			[27] = "SHORT_TEXT",
-			[28] = "MEDIUM_TEXT",
-			[29] = "MAXSIZE_TEXT",
-			[30] = "LONG_TEXT",
-			[31] = "FLOAT1",
-			[32] = "FLOAT2",
-			[33] = "FLOAT3",
-			[34] = "FLOAT4",
-			[35] = "LOCALIZABLE_PARAMETER_VALUES_LIST",
-			[36] = "METADATA_TEXT",
-			[37] = "STAGE_INDICATOR",
-			[38] = "OBJECT_LIST",
-			[39] = "COMPOSITE_OBJECT_LIST",
-			[40] = "FLOAT8",
-			[41] = "FILE_LOCATOR",
-			[42] = "PHONE_TEXT",
-			[43] = "RICH_TEXT",
-			[44] = "WEB_TEXT",
-			[45] = "EMAIL_TEXT",
-			[46] = "COMPOSITE_OBJECT",
-			[47] = "FLOAT0",
-			[48] = "MONEY0",
-			[49] = "MONEY1",
-			[50] = "MONEY3"
-		};
-
 	/// <inheritdoc />
 	public ApplicationInfoResult GetApplicationInfo(string environmentName, string? id, string? code)
 	{
@@ -395,9 +341,9 @@ public sealed class ApplicationInfoService(
 		return new ApplicationColumnInfoResult(
 			name,
 			ResolveLocalizedText(column.Caption, designColumn?.Caption, name),
-			DataValueTypeNames.TryGetValue(column.DataValueType, out string? dataValueTypeName)
-				? dataValueTypeName
-				: column.DataValueType.ToString(),
+			// GetDisplayName, NOT GetNameOrOrdinal: this tool ships the platform client-enum spelling
+			// (SHORT_TEXT, FLOAT1) and its output must stay byte-identical (ENG-93202).
+			CreatioDataValueType.GetDisplayName(column.DataValueType),
 			column.ReferenceSchemaName,
 			defaultValueSource,
 			defaultValue,

--- a/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs
+++ b/clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs
@@ -96,7 +96,23 @@ internal static class EntitySchemaDesignerSupport
 			["time"] = DateTimeTypeName,
 			["encrypted"] = SecureTextTypeName,
 			["securetext"] = SecureTextTypeName,
-			["password"] = SecureTextTypeName
+			["password"] = SecureTextTypeName,
+			// Canonical read-surface spellings, so a type read off a column is accepted back (ENG-93202; the
+			// mirror of the readback gap fixed in issue #949). ONE entry per code suffices because
+			// TryResolveDataValueType normalizes case-insensitively AND strips non-alphanumerics, so it covers
+			// both the canonical Float2 and the display FLOAT2.
+			["float0"] = "decimal0",
+			["float1"] = "decimal1",
+			["float2"] = "decimal2",
+			["float3"] = "decimal3",
+			["float4"] = "decimal4",
+			["float8"] = "decimal8",
+			["money0"] = "currency0",
+			["money1"] = "currency1",
+			["money3"] = "currency3",
+			["phonetext"] = "phoneNumber",
+			["webtext"] = "webLink",
+			["emailtext"] = "email"
 		};
 
 	private static readonly HashSet<int> TextDataValueTypes = [

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -875,6 +875,14 @@ public sealed record CreateEntitySchemaColumnArgs(
 						  EmailAddress is accepted as an alias for Email.
 						  Money is accepted as an alias for Currency2 (the normal two-decimal Creatio money column),
 						  and Decimal for Decimal2 (same as Float).
+						  Most canonical names reported by the read tools (dataforge-get-table-columns, get-app-info)
+						  are accepted here too: Float0-Float4/Float8 = Decimal0-Decimal4/Decimal8,
+						  Money0/Money1/Money3 = Currency0/Currency1/Currency3,
+						  PhoneText = PhoneNumber, WebText = WebLink, EmailText = Email.
+						  Three read names mean a DIFFERENT type here, so do not echo a read value blindly:
+						  'Float' (reported for the unbounded float, dataValueType 5) resolves to Decimal2, and
+						  'Date'/'Time' resolve to DateTime. Read names of non-writable types (Enum, HashText,
+						  Collection, Entity, StageIndicator, FileLocator, ...) are rejected outright.
 						  For image/photo fields rendered by the crt.ImageInput Freedom UI component,
 						  use ImageLookup ("Image link") — NOT the binary Image type, which crt.ImageInput
 						  cannot read or write. ImageLookup references the SysImage schema automatically.
@@ -1022,6 +1030,14 @@ public abstract record ColumnModificationArgsBase(
 						   DateTime and reads it back as DateTime, so date-only or time-only intent is NOT preserved.
 						   Money is accepted as an alias for Currency2 (the normal two-decimal Creatio money column),
 						   and Decimal for Decimal2 (same as Float).
+						   Most canonical names reported by the read tools (dataforge-get-table-columns, get-app-info)
+						   are accepted here too: Float0-Float4/Float8 = Decimal0-Decimal4/Decimal8,
+						   Money0/Money1/Money3 = Currency0/Currency1/Currency3,
+						   PhoneText = PhoneNumber, WebText = WebLink, EmailText = Email.
+						   Three read names mean a DIFFERENT type here, so do not echo a read value blindly:
+						   'Float' (reported for the unbounded float, dataValueType 5) resolves to Decimal2, and
+						   'Date'/'Time' resolve to DateTime. Read names of non-writable types (Enum, HashText,
+						   Collection, Entity, StageIndicator, FileLocator, ...) are rejected outright.
 						   Color stores a hex color string (e.g. #RRGGBB) and is not a text column:
 						   text-only options (multiline / accent-insensitive / format-validated / masked) do not apply.
 						   Encrypted and Password are accepted as aliases for SecureText.

--- a/clio/Command/McpServer/Tools/EntitySchemaTool.cs
+++ b/clio/Command/McpServer/Tools/EntitySchemaTool.cs
@@ -862,7 +862,10 @@ public sealed record CreateEntitySchemaColumnArgs(
 	[property: Description("""
 						  Column type. Supported values:
 						  Guid, Text, ShortText, MediumText, LongText, MaxSizeText,
+						  Text50, Text250, Text500, TextUnlimited, RichText, PhoneNumber, WebLink,
 						  Integer, Float, Boolean, DateTime, Lookup,
+						  Decimal0, Decimal1, Decimal2, Decimal3, Decimal4, Decimal8,
+						  Currency0, Currency1, Currency2, Currency3,
 						  Binary, Image, ImageLookup, File, SecureText, Email, Color.
 						  Case-insensitive.
 						  Date and Time are accepted but are ALIASES of DateTime: Creatio stores the column as

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -509,7 +509,32 @@ internal static class ToolContractCatalog {
 		// The SecureText aliases are spelled out in prose rather than as `Password = SecureText`: the
 		// key-equals-value form reads as a hard-coded credential to static analysis (S2068).
 		"Other aliases: Blob = Binary, ImageLink = ImageLookup, EmailAddress = Email, " +
-		"Decimal/Float = Decimal2. The Creatio display names 'Encrypted' and 'Password' both map to SecureText.";
+		"Decimal/Float = Decimal2. The Creatio display names 'Encrypted' and 'Password' both map to SecureText. " +
+		"Most canonical names the read tools report are accepted here too: Float0-Float4/Float8 = " +
+		"Decimal0-Decimal4/Decimal8, Money0/Money1/Money3 = Currency0/Currency1/Currency3, " +
+		"PhoneText = PhoneNumber, WebText = WebLink, EmailText = Email. Three read names resolve to a " +
+		"DIFFERENT type here, so do not echo them blindly: 'Float' (the unbounded float a read reports for " +
+		"dataValueType 5) resolves to Decimal2, and 'Date'/'Time' resolve to DateTime. Read names for " +
+		"non-writable types (Enum, HashText, Collection, Entity, StageIndicator, FileLocator and the other " +
+		"structural types) are rejected — there is no way to create those columns through clio.";
+
+	// The `data-type` values are stated explicitly because a caller has to decide from them whether a column
+	// is numeric. A partial type map that fell back to "Text" once reported every decimal scale as text, and
+	// callers filtered a numeric column as a lexicographic string comparison (ENG-93202).
+	private const string DataForgeColumnsFieldDescription =
+		"Runtime column projections with `name`, `caption`, `description`, `data-type`, `required`, and " +
+		"`reference-schema-name`. `data-type` is the canonical Creatio type name — Text, Integer, Float, " +
+		"Float0-Float4/Float8 (decimal scales; Float2 is the common 'Decimal (0.01)'), Money/Money0/Money1/" +
+		"Money3 (currency scales), Boolean, DateTime, Date, Time, Lookup, Guid, ShortText/MediumText/LongText/" +
+		"MaxSizeText, PhoneText, WebText, EmailText, RichText, and so on. All Float*/Money*/Integer names are " +
+		"numeric, so compare them numerically rather than as strings. A type clio does not model yet is " +
+		"reported as its raw numeric ordinal (for example `51`) rather than as a guessed type name. " +
+		"Do NOT assume a name read here is writable: the write tools accept it back only for the types they " +
+		"can create, and three names mean a DIFFERENT type on write — " +
+		"`Float` writes Decimal2 (send Float2/Decimal2 explicitly for a scaled decimal, and note an " +
+		"unbounded Float column cannot be created by clio at all), while `Date` and `Time` both write " +
+		"DateTime. Names such as Enum, HashText, StageIndicator, Collection, Entity or FileLocator are " +
+		"read-only: the write tools reject them. Read the `type` field of those tools for the accepted list.";
 
 	// Shared by the create-lookup / create-entity-schema `columns` arrays. Spelling out the column identity
 	// field matters: these two contracts used to say only "Optional initial columns", so a caller had no way
@@ -2040,7 +2065,7 @@ internal static class ToolContractCatalog {
 					Field("table-name", StringType, "Target runtime entity schema name.")),
 				OutputFields = DataForgeEnvelopeFields(
 					QueryCorrelationIdentifierDescription,
-					Field(ColumnsFieldName, ArrayType, "Runtime column projections with `name`, `caption`, `description`, `data-type`, `required`, and `reference-schema-name`.")),
+					Field(ColumnsFieldName, ArrayType, DataForgeColumnsFieldDescription)),
 				Examples = [
 					Example("Read Contact runtime columns for a configured environment", new Dictionary<string, object?> {
 						["table-name"] = ExampleContactSchemaName,
@@ -2073,7 +2098,8 @@ internal static class ToolContractCatalog {
 					Field("similar-tables", ArrayType, "Similar table results."),
 					Field("similar-lookups", ArrayType, "Similar lookup results."),
 					Field("relations", ObjectType, "Resolved relation paths keyed by source-target pair."),
-					Field(ColumnsFieldName, ObjectType, "Resolved runtime column projections keyed by table name."),
+					Field(ColumnsFieldName, ObjectType, "Resolved runtime column projections keyed by table name. "
+						+ $"Each projection has the same shape and `data-type` vocabulary as {DataForgeTool.DataForgeGetTableColumnsToolName}."),
 					Field("coverage", ObjectType, "Coverage flags for health, tables, lookups, relations, and table-columns.")),
 				Examples = [
 					Example("Aggregate app-modeling context for a configured environment", new Dictionary<string, object?> {

--- a/clio/Common/CreatioDataValueType.cs
+++ b/clio/Common/CreatioDataValueType.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Clio.Common;
 
@@ -19,66 +20,89 @@ public enum CreatioDataValueKind {
 }
 
 /// <summary>Canonical metadata for a single Creatio data value type.</summary>
-public sealed record CreatioDataValueTypeInfo(int Code, string Name, CreatioDataValueKind Kind, Guid? UId);
+/// <param name="Name">The platform SERVER enum spelling (<c>Float2</c>), used by every read surface except <c>get-app-info</c>.</param>
+/// <param name="DisplayName">
+/// The platform CLIENT enum spelling (<c>FLOAT2</c>, from <c>sysenums.js</c>), which only <c>get-app-info</c>
+/// emits. Verified against a 10.0 stand: 35 of the 49 values match the client member name character for
+/// character, and the other 14 differ in case or an underscore (<c>Guid</c>/<c>GUID</c>,
+/// <c>DateTime</c>/<c>DATE_TIME</c>, <c>Color</c>/<c>COLOR</c>). The vocabulary is therefore MIXED — do not
+/// "normalize" one of those 14 rows to match its neighbours, because the inconsistency is the shipped output.
+/// </param>
+public sealed record CreatioDataValueTypeInfo(
+	int Code,
+	string Name,
+	CreatioDataValueKind Kind,
+	Guid? UId,
+	string DisplayName);
 
 /// <summary>
-/// Single source of truth for Creatio data value types, mirroring the platform ɵDataValueType enum (codes 0-50).
-/// Replaces the per-feature numeric→name dictionaries so classification and UId lookups stay consistent.
+/// Single source of truth for Creatio data value type CODES and for the two READ vocabularies
+/// (<see cref="CreatioDataValueTypeInfo.Name"/>, <see cref="CreatioDataValueTypeInfo.DisplayName"/>), plus
+/// kind classification and UId lookup. The table holds 49 rows — codes 0, 1 and 4-50; codes 2 and 3 are
+/// absent because the platform enum does not define them, verified against a 10.0 stand's <c>sysenums.js</c>.
 /// </summary>
+/// <remarks>
+/// This does NOT own the WRITE vocabulary. <c>EntitySchemaDesignerSupport.SupportedDataValueTypes</c> and
+/// <c>GetFriendlyTypeName</c> are a deliberately separate, write-scoped table with its own spellings
+/// (<c>decimal2</c>, <c>Currency2</c>), and they must stay separate: <c>AreColumnTypesEquivalent</c> depends
+/// on their divergences from the request vocabulary to decide that an unchanged column is unchanged, so
+/// folding them in here would put schema read-modify-write idempotency at risk. The two tables are bridged
+/// by aliases, guarded by the round-trip tests in <c>EntitySchemaDesignerSupportTests</c>.
+/// </remarks>
 public static class CreatioDataValueType {
 
 	private const string CurrencyUId = "{969093E2-2B4E-463B-883A-3D3B8C61F0CD}";
 
 	private static readonly IReadOnlyList<CreatioDataValueTypeInfo> All = [
-		new(0, "Guid", CreatioDataValueKind.Guid, new("{23018567-A13C-4320-8687-FD6F9E3699BD}")),
-		new(1, "Text", CreatioDataValueKind.Text, new("{8B3F29BB-EA14-4CE5-A5C5-293A929B6BA2}")),
-		new(4, "Integer", CreatioDataValueKind.Numeric, new("{6B6B74E2-820D-490E-A017-2B73D4CCF2B0}")),
-		new(5, "Float", CreatioDataValueKind.Numeric, null),
-		new(6, "Money", CreatioDataValueKind.Numeric, new(CurrencyUId)),
-		new(7, "DateTime", CreatioDataValueKind.DateTime, new("{D21E9EF4-C064-4012-B286-FA1A8171DA44}")),
-		new(8, "Date", CreatioDataValueKind.DateTime, null),
-		new(9, "Time", CreatioDataValueKind.DateTime, null),
-		new(10, "Lookup", CreatioDataValueKind.Lookup, new("{B295071F-7EA9-4E62-8D1A-919BF3732FF2}")),
-		new(11, "Enum", CreatioDataValueKind.Enum, null),
-		new(12, "Boolean", CreatioDataValueKind.Boolean, new("{90B65BF8-0FFC-4141-8779-2420877AF907}")),
-		new(13, "Blob", CreatioDataValueKind.NonFilterable, null),
-		new(14, "Image", CreatioDataValueKind.NonFilterable, null),
-		new(15, "CustomObject", CreatioDataValueKind.NonFilterable, null),
-		new(16, "ImageLookup", CreatioDataValueKind.NonFilterable, null),
-		new(17, "Collection", CreatioDataValueKind.NonFilterable, null),
-		new(18, "Color", CreatioDataValueKind.Text, null),
-		new(19, "LocalizableString", CreatioDataValueKind.Text, null),
-		new(20, "Entity", CreatioDataValueKind.NonFilterable, null),
-		new(21, "EntityCollection", CreatioDataValueKind.NonFilterable, null),
-		new(22, "EntityColumnMappingCollection", CreatioDataValueKind.NonFilterable, null),
-		new(23, "HashText", CreatioDataValueKind.Text, null),
-		new(24, "SecureText", CreatioDataValueKind.Text, new("{3509B9DD-2C90-4540-B82E-8F6AE85D8248}")),
-		new(25, "File", CreatioDataValueKind.NonFilterable, null),
-		new(26, "Mapping", CreatioDataValueKind.NonFilterable, null),
-		new(27, "ShortText", CreatioDataValueKind.Text, new("{325A73B8-0F47-44A0-8412-7606F78003AC}")),
-		new(28, "MediumText", CreatioDataValueKind.Text, new("{DDB3A1EE-07E8-4D62-B7A9-D0E618B00FBD}")),
-		new(29, "MaxSizeText", CreatioDataValueKind.Text, new("{C0F04627-4620-4BC0-84E5-9419DC8516B1}")),
-		new(30, "LongText", CreatioDataValueKind.Text, new("{5CA35F10-A101-4C67-A96A-383DA6AFACFC}")),
-		new(31, "Float1", CreatioDataValueKind.Numeric, new("{07BA84CE-0BF7-44B4-9F2C-7B15032EB98C}")),
-		new(32, "Float2", CreatioDataValueKind.Numeric, new("{5CC8060D-6D10-4773-89FC-8C12D6F659A6}")),
-		new(33, "Float3", CreatioDataValueKind.Numeric, new("{3F62414E-6C25-4182-BCEF-A73C9E396F31}")),
-		new(34, "Float4", CreatioDataValueKind.Numeric, new("{FF22E049-4D16-46EE-A529-92D8808932DC}")),
-		new(35, "LocalizableParameterValuesList", CreatioDataValueKind.NonFilterable, null),
-		new(36, "MetadataText", CreatioDataValueKind.Text, null),
-		new(37, "StageIndicator", CreatioDataValueKind.NonFilterable, null),
-		new(38, "ObjectList", CreatioDataValueKind.NonFilterable, null),
-		new(39, "CompositeObjectList", CreatioDataValueKind.NonFilterable, null),
-		new(40, "Float8", CreatioDataValueKind.Numeric, new("{A4AAF398-3531-4A0D-9D75-A587F5B5B59E}")),
-		new(41, "FileLocator", CreatioDataValueKind.NonFilterable, null),
-		new(42, "PhoneText", CreatioDataValueKind.Text, new("{26CBA63C-DAF1-4F36-B2EA-73C0D675D90C}")),
-		new(43, "RichText", CreatioDataValueKind.Text, new("{79BCCFFA-8C8B-4863-B376-A69D2244182B}")),
-		new(44, "WebText", CreatioDataValueKind.Text, new("{26CBA64C-DAF1-4F36-B2EA-73C0D695D90C}")),
-		new(45, "EmailText", CreatioDataValueKind.Text, new("{66CBA64C-DAF1-4F36-B8EA-73C0D695D90C}")),
-		new(46, "CompositeObject", CreatioDataValueKind.NonFilterable, null),
-		new(47, "Float0", CreatioDataValueKind.Numeric, new("{57EE4C31-5EC4-45FA-B95D-3A2868AA89A8}")),
-		new(48, "Money0", CreatioDataValueKind.Numeric, new(CurrencyUId)),
-		new(49, "Money1", CreatioDataValueKind.Numeric, new(CurrencyUId)),
-		new(50, "Money3", CreatioDataValueKind.Numeric, new(CurrencyUId))
+		new(0, "Guid", CreatioDataValueKind.Guid, new("{23018567-A13C-4320-8687-FD6F9E3699BD}"), "Guid"),
+		new(1, "Text", CreatioDataValueKind.Text, new("{8B3F29BB-EA14-4CE5-A5C5-293A929B6BA2}"), "Text"),
+		new(4, "Integer", CreatioDataValueKind.Numeric, new("{6B6B74E2-820D-490E-A017-2B73D4CCF2B0}"), "Integer"),
+		new(5, "Float", CreatioDataValueKind.Numeric, null, "Float"),
+		new(6, "Money", CreatioDataValueKind.Numeric, new(CurrencyUId), "Money"),
+		new(7, "DateTime", CreatioDataValueKind.DateTime, new("{D21E9EF4-C064-4012-B286-FA1A8171DA44}"), "DateTime"),
+		new(8, "Date", CreatioDataValueKind.DateTime, null, "Date"),
+		new(9, "Time", CreatioDataValueKind.DateTime, null, "Time"),
+		new(10, "Lookup", CreatioDataValueKind.Lookup, new("{B295071F-7EA9-4E62-8D1A-919BF3732FF2}"), "Lookup"),
+		new(11, "Enum", CreatioDataValueKind.Enum, null, "Enum"),
+		new(12, "Boolean", CreatioDataValueKind.Boolean, new("{90B65BF8-0FFC-4141-8779-2420877AF907}"), "Boolean"),
+		new(13, "Blob", CreatioDataValueKind.NonFilterable, null, "Blob"),
+		new(14, "Image", CreatioDataValueKind.NonFilterable, null, "Image"),
+		new(15, "CustomObject", CreatioDataValueKind.NonFilterable, null, "CUSTOM_OBJECT"),
+		new(16, "ImageLookup", CreatioDataValueKind.NonFilterable, null, "IMAGELOOKUP"),
+		new(17, "Collection", CreatioDataValueKind.NonFilterable, null, "COLLECTION"),
+		new(18, "Color", CreatioDataValueKind.Text, null, "Color"),
+		new(19, "LocalizableString", CreatioDataValueKind.Text, null, "LOCALIZABLE_STRING"),
+		new(20, "Entity", CreatioDataValueKind.NonFilterable, null, "ENTITY"),
+		new(21, "EntityCollection", CreatioDataValueKind.NonFilterable, null, "ENTITY_COLLECTION"),
+		new(22, "EntityColumnMappingCollection", CreatioDataValueKind.NonFilterable, null, "ENTITY_COLUMN_MAPPING_COLLECTION"),
+		new(23, "HashText", CreatioDataValueKind.Text, null, "HASH_TEXT"),
+		new(24, "SecureText", CreatioDataValueKind.Text, new("{3509B9DD-2C90-4540-B82E-8F6AE85D8248}"), "SECURE_TEXT"),
+		new(25, "File", CreatioDataValueKind.NonFilterable, null, "FILE"),
+		new(26, "Mapping", CreatioDataValueKind.NonFilterable, null, "MAPPING"),
+		new(27, "ShortText", CreatioDataValueKind.Text, new("{325A73B8-0F47-44A0-8412-7606F78003AC}"), "SHORT_TEXT"),
+		new(28, "MediumText", CreatioDataValueKind.Text, new("{DDB3A1EE-07E8-4D62-B7A9-D0E618B00FBD}"), "MEDIUM_TEXT"),
+		new(29, "MaxSizeText", CreatioDataValueKind.Text, new("{C0F04627-4620-4BC0-84E5-9419DC8516B1}"), "MAXSIZE_TEXT"),
+		new(30, "LongText", CreatioDataValueKind.Text, new("{5CA35F10-A101-4C67-A96A-383DA6AFACFC}"), "LONG_TEXT"),
+		new(31, "Float1", CreatioDataValueKind.Numeric, new("{07BA84CE-0BF7-44B4-9F2C-7B15032EB98C}"), "FLOAT1"),
+		new(32, "Float2", CreatioDataValueKind.Numeric, new("{5CC8060D-6D10-4773-89FC-8C12D6F659A6}"), "FLOAT2"),
+		new(33, "Float3", CreatioDataValueKind.Numeric, new("{3F62414E-6C25-4182-BCEF-A73C9E396F31}"), "FLOAT3"),
+		new(34, "Float4", CreatioDataValueKind.Numeric, new("{FF22E049-4D16-46EE-A529-92D8808932DC}"), "FLOAT4"),
+		new(35, "LocalizableParameterValuesList", CreatioDataValueKind.NonFilterable, null, "LOCALIZABLE_PARAMETER_VALUES_LIST"),
+		new(36, "MetadataText", CreatioDataValueKind.Text, null, "METADATA_TEXT"),
+		new(37, "StageIndicator", CreatioDataValueKind.NonFilterable, null, "STAGE_INDICATOR"),
+		new(38, "ObjectList", CreatioDataValueKind.NonFilterable, null, "OBJECT_LIST"),
+		new(39, "CompositeObjectList", CreatioDataValueKind.NonFilterable, null, "COMPOSITE_OBJECT_LIST"),
+		new(40, "Float8", CreatioDataValueKind.Numeric, new("{A4AAF398-3531-4A0D-9D75-A587F5B5B59E}"), "FLOAT8"),
+		new(41, "FileLocator", CreatioDataValueKind.NonFilterable, null, "FILE_LOCATOR"),
+		new(42, "PhoneText", CreatioDataValueKind.Text, new("{26CBA63C-DAF1-4F36-B2EA-73C0D675D90C}"), "PHONE_TEXT"),
+		new(43, "RichText", CreatioDataValueKind.Text, new("{79BCCFFA-8C8B-4863-B376-A69D2244182B}"), "RICH_TEXT"),
+		new(44, "WebText", CreatioDataValueKind.Text, new("{26CBA64C-DAF1-4F36-B2EA-73C0D695D90C}"), "WEB_TEXT"),
+		new(45, "EmailText", CreatioDataValueKind.Text, new("{66CBA64C-DAF1-4F36-B8EA-73C0D695D90C}"), "EMAIL_TEXT"),
+		new(46, "CompositeObject", CreatioDataValueKind.NonFilterable, null, "COMPOSITE_OBJECT"),
+		new(47, "Float0", CreatioDataValueKind.Numeric, new("{57EE4C31-5EC4-45FA-B95D-3A2868AA89A8}"), "FLOAT0"),
+		new(48, "Money0", CreatioDataValueKind.Numeric, new(CurrencyUId), "MONEY0"),
+		new(49, "Money1", CreatioDataValueKind.Numeric, new(CurrencyUId), "MONEY1"),
+		new(50, "Money3", CreatioDataValueKind.Numeric, new(CurrencyUId), "MONEY3")
 	];
 
 	private static readonly IReadOnlyDictionary<int, CreatioDataValueTypeInfo> ByCode = BuildByCode();
@@ -111,6 +135,13 @@ public static class CreatioDataValueType {
 		return map;
 	}
 
+	/// <summary>
+	/// Every Creatio data value type clio models, in code order. Exposed so the guard tests can enumerate the
+	/// real table instead of assuming a code range. Internal until a production caller needs it.
+	/// </summary>
+	internal static IReadOnlyList<CreatioDataValueTypeInfo> Types => All;
+
+	/// <summary>Gets canonical type metadata for a Creatio data value type code.</summary>
 	public static bool TryGet(int code, out CreatioDataValueTypeInfo info) => ByCode.TryGetValue(code, out info!);
 
 	/// <summary>Gets canonical type metadata for a Creatio data value type UId.</summary>
@@ -118,6 +149,24 @@ public static class CreatioDataValueType {
 
 	/// <summary>Returns the canonical type name for a numeric code, or null when the code is unknown.</summary>
 	public static string? GetName(int code) => ByCode.TryGetValue(code, out CreatioDataValueTypeInfo? info) ? info.Name : null;
+
+	/// <summary>
+	/// Canonical type name for a read surface that must always report something. An unmodelled code degrades
+	/// to its ordinal, NEVER to a plausible type name — a fallback that names a real type makes a wrong
+	/// answer indistinguishable from a right one (ENG-93202).
+	/// </summary>
+	public static string GetNameOrOrdinal(int code) => GetName(code) ?? Ordinal(code);
+
+	/// <summary>
+	/// The <c>get-app-info</c> display spelling, same ordinal-fallback contract as
+	/// <see cref="GetNameOrOrdinal"/>. See <see cref="CreatioDataValueTypeInfo.DisplayName"/> for why this
+	/// vocabulary exists and which surfaces may use it.
+	/// </summary>
+	public static string GetDisplayName(int code) =>
+		ByCode.TryGetValue(code, out CreatioDataValueTypeInfo? info) ? info.DisplayName : Ordinal(code);
+
+	// Invariant culture keeps the fallback stable across locales.
+	private static string Ordinal(int code) => code.ToString(CultureInfo.InvariantCulture);
 
 	/// <summary>Returns the numeric code for a canonical type name, or null when the name is unknown.</summary>
 	public static int? GetCode(string typeName) =>

--- a/clio/Common/DataForge/DataForgeContextService.cs
+++ b/clio/Common/DataForge/DataForgeContextService.cs
@@ -22,32 +22,8 @@ public interface IDataForgeContextService {
 }
 
 internal static class DataForgeRuntimeSchemaMapper {
-	private static readonly IReadOnlyDictionary<int, string> DataValueTypeNames = new Dictionary<int, string> {
-		[0] = "Guid",
-		[1] = "Text",
-		[4] = "Integer",
-		[5] = "Float",
-		[6] = "Money",
-		[7] = "DateTime",
-		[8] = "Date",
-		[9] = "Time",
-		[10] = "Lookup",
-		[11] = "Enum",
-		[12] = "Boolean",
-		[13] = "Blob",
-		[18] = "Color",
-		[23] = "HASH_TEXT",
-		[24] = "SECURE_TEXT",
-		[27] = "SHORT_TEXT",
-		[28] = "MEDIUM_TEXT",
-		[29] = "MAXSIZE_TEXT",
-		[30] = "LONG_TEXT",
-		[42] = "PHONE_TEXT",
-		[43] = "RICH_TEXT",
-		[44] = "WEB_TEXT",
-		[45] = "EMAIL_TEXT"
-	};
-
+	// Type names come from the canonical registry: never reintroduce a local numeric->name table here, and
+	// never fall back to a real type name for an unmapped code (ENG-93202).
 	internal static IReadOnlyList<DataForgeColumnResult> MapColumns(RuntimeEntitySchemaResult schema) {
 		return schema.Columns
 			.Where(column => !column.IsInherited)
@@ -55,17 +31,11 @@ internal static class DataForgeRuntimeSchemaMapper {
 				column.Name,
 				column.Caption,
 				column.Description,
-				ResolveDataType(column.DataValueType),
+				CreatioDataValueType.GetNameOrOrdinal(column.DataValueType),
 				column.IsRequired,
 				column.ReferenceSchemaName))
 			.OrderBy(column => column.Name, StringComparer.OrdinalIgnoreCase)
 			.ToList();
-	}
-
-	private static string ResolveDataType(int dataValueType) {
-		return DataValueTypeNames.TryGetValue(dataValueType, out string? dataTypeName)
-			? dataTypeName
-			: "Text";
 	}
 }
 

--- a/docs/knowledge/Command/read-name-write-token-collisions.md
+++ b/docs/knowledge/Command/read-name-write-token-collisions.md
@@ -35,7 +35,7 @@ columns at all.
 name for code 5 and is matched **case-sensitively** by `SimpleToFullFilterConverter`, so renaming the
 canonical spelling breaks filter parameter typing. The `float`/`decimal` → `decimal2` alias is documented
 in the shipped `type` contract and pinned by
-`TryResolveDataValueType_Should_Resolve_Decimal_As_Float`, so removing it breaks a released write
+`TryResolveDataValueType_Should_Resolve_Decimal_As_Decimal2`, so removing it breaks a released write
 contract. Fixing it needs a deliberate contract decision, not a drive-by rename.
 
 **What breaks if you ignore it** — an agent reads a column as `Float` and, following a contract that says

--- a/docs/knowledge/Command/read-name-write-token-collisions.md
+++ b/docs/knowledge/Command/read-name-write-token-collisions.md
@@ -1,0 +1,50 @@
+---
+description: Three type names a clio read surface reports resolve to a DIFFERENT type on write - Float writes Decimal2, Date and Time write DateTime - so echoing a read value back into create-entity-schema or modify-entity-schema-column silently creates the wrong column
+applies-to:
+  - clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs
+  - clio/Command/McpServer/Tools/ToolContractGetTool.cs
+  - clio/Command/McpServer/Tools/EntitySchemaTool.cs
+ticket: ENG-93202
+date: 2026-09-09
+---
+
+**What is true** — the read vocabulary and the write vocabulary share three tokens that mean **different
+data-value types**. Sending a read value straight back is therefore not universally safe:
+
+| read reports | for code | `TryResolveDataValueType` gives | i.e. |
+|---|---|---|---|
+| `Float` | 5 (unbounded float) | 32 | `Decimal2`, a 0.01-scaled decimal |
+| `Date` | 8 | 7 | `DateTime` |
+| `Time` | 9 | 7 | `DateTime` |
+
+`Date`/`Time` are a documented, deliberate collapse — Creatio stores both as DateTime and the aliases exist
+so date-only intent is accepted rather than hard-rejected (issue #949). **`Float` is not a collapse and was
+not documented**: the platform's own enum names code 5 `FLOAT`, but clio's write alias
+`["float"] = "decimal2"` claims that same token for code 32.
+
+`EntitySchemaDesignerSupportTests.GetNameOrOrdinal_Should_Not_Resolve_To_A_Different_Type_On_Write` pins the
+set to exactly these three, so a fourth cannot appear unnoticed. Note the forward guard alone cannot see
+them: it iterates `SupportedDataValueTypes.Values`, the *writable* codes, and 5/8/9 are read-only.
+
+Separately, the canonical names of the read-only codes (`Enum`, `HashText`, `Collection`, `Entity`,
+`StageIndicator`, `FileLocator`, `CustomObject`, `Mapping`, `MetadataText`, `ObjectList`,
+`CompositeObject`, `LocalizableString`, …) are **rejected** by the write tools — clio cannot create those
+columns at all.
+
+**Why it is this way** — neither side can be changed from here. `Float` is the platform's own enum member
+name for code 5 and is matched **case-sensitively** by `SimpleToFullFilterConverter`, so renaming the
+canonical spelling breaks filter parameter typing. The `float`/`decimal` → `decimal2` alias is documented
+in the shipped `type` contract and pinned by
+`TryResolveDataValueType_Should_Resolve_Decimal_As_Float`, so removing it breaks a released write
+contract. Fixing it needs a deliberate contract decision, not a drive-by rename.
+
+**What breaks if you ignore it** — an agent reads a column as `Float` and, following a contract that says
+read names are accepted back, sends `Float` to `create-entity-schema`: it gets a Decimal(0.01) column, no
+error, no warning. The sharper path is `schema-sync`: `AreColumnTypesEquivalent("Float", "Float")` resolves
+BOTH sides to 32, so a genuine code-5-versus-32 divergence is reported as equivalent and no modify is
+issued — while a desired state that echoes clio's own read output of an existing code-5 column compares
+requested 32 against existing 5, decides "not equivalent", and **mutates a live column's type** on what was
+meant to be an idempotent replay. This is why the `data-type` and `type` tool descriptions must keep naming
+the three exceptions instead of promising that read output is writable.
+
+Related: [[data-value-type-vocabularies]].

--- a/docs/knowledge/Common/data-value-type-vocabularies.md
+++ b/docs/knowledge/Common/data-value-type-vocabularies.md
@@ -1,0 +1,65 @@
+---
+description: clio has three data-value-type name vocabularies on purpose (canonical read, get-app-info display, designer write) - which consumer demands which, why DisplayName is the platform client enum and is mixed-case, and why an unmodelled code must degrade to its ordinal and never to "Text"
+applies-to:
+  - clio/Common/CreatioDataValueType.cs
+  - clio/Common/DataForge/DataForgeContextService.cs
+  - clio/Command/ApplicationInfoService.cs
+ticket: ENG-93202
+date: 2026-09-09
+---
+
+**What is true** — a Creatio data-value-type code has **three** string spellings in clio, each because a
+different consumer demands it:
+
+| vocabulary | code 32 | code 6 | owner | who demands it |
+|---|---|---|---|---|
+| canonical | `Float2` | `Money` | `CreatioDataValueTypeInfo.Name` | the kind classifier (`GetKind`/`IsNumeric`/`IsFilterable`) resolves names through `ByName`, keyed by this column. Emitted by `dataforge-get-table-columns` and `dataforge-context`. |
+| display | `FLOAT2` | `Money` | `CreatioDataValueTypeInfo.DisplayName` | `get-app-info` only |
+| designer write | `decimal2` (readback `Float`) | `currency2` (readback `Currency2`) | `EntitySchemaDesignerSupport.SupportedDataValueTypes` + `GetFriendlyTypeName` | `create-entity-schema` / `modify-entity-schema-column` input, and `get-entity-schema-column-properties` readback |
+
+`Name` is the platform **server** enum spelling. `DisplayName` is the platform **client** enum
+`Terrasoft.DataValueType` from `sysenums.js` — verified against a 10.0 stand: 35 of the 49 values are the
+client member name character for character (`FLOAT2`, `SHORT_TEXT`, `IMAGELOOKUP`, `MAXSIZE_TEXT`), and the
+other 14 differ only in case or an underscore (`Guid`/`GUID`, `DateTime`/`DATE_TIME`, `Color`/`COLOR`, and
+the rest of the primitives). So the display vocabulary is **mixed-case, not uniformly SCREAMING_SNAKE**, and
+that inconsistency is the shipped `get-app-info` output — do not "normalize" one of those 14 rows to match
+its neighbours.
+
+Both name columns live in the **same** 49-row table, so they cannot drift in code coverage. The table holds
+codes 0, 1 and 4-50; **codes 2 and 3 are absent because the platform enum does not define them** (same
+stand check: the client enum has exactly 49 members).
+
+`TryResolveDataValueType` normalises **case-insensitively and strips non-alphanumerics**, so `FLOAT2`,
+`Float2` and `float_2` are one input token. That is why a single alias entry (`["float2"] = "decimal2"`)
+covers both read vocabularies, and why a new read-surface name needs an **alias**, not a key.
+
+**Why it is this way** — the three consumers genuinely disagree and no single vocabulary satisfies all of
+them. Measured at ENG-93202: of the 30 codes clio can write, the designer's friendly names are accepted by
+the write path 30/30 but **14 are absent from the canonical name index** (so `IsNumeric("Decimal1")` is
+`false`); the canonical names are 49/49 resolvable by the kind classifier by construction but needed 12
+aliases to be accepted on write. The canonical vocabulary won for the read surfaces because it covers all
+49 codes, whereas `GetFriendlyTypeName` is scoped to *writable* types — its guard test iterates
+`SupportedDataValueTypes.Values` — and a read surface sees all 49. The display vocabulary survives only so
+`get-app-info` output does not churn.
+
+**What breaks if you ignore it**
+
+* **A fallback that names a real type turns a gap into a wrong answer.** The Data Forge mapper used to own
+  a private 23-entry table falling back to `"Text"`. It lacked 26 codes including every decimal and money
+  scale, so a Decimal(0.01) column (code 32) reported `Text`; because `Text` is a real type the caller
+  could not tell, and filtered `UsrAmount > 1000` as a lexicographic string comparison. Any resolver on
+  this table must degrade to the **ordinal** — visibly not a type name, and it names the code clio failed
+  to model.
+* **Collapsing the read surfaces onto `GetFriendlyTypeName` silently regresses five live types.** Codes
+  5 `Float`, 8 `Date`, 9 `Time`, 11 `Enum` and 23 `HashText` are readable but not writable, so they hit
+  that switch's default branch and read back as `"5"`, `"8"`, `"9"`, `"11"`, `"23"`. 19 of 49 codes are
+  unnamed by it. This is observable on a stand today: `get-entity-schema-properties` reports
+  `CurrencyRate.StartDate` (code 8) as the raw string `"8"`.
+* **`TryGet(Guid)` is last-wins across the four currency scales.** Codes 6, 48, 49 and 50 all carry the
+  same `CurrencyUId`, so `BuildByUId` keeps only the last row and a UId lookup answers `Money3` for any
+  currency column. `CreatioArtifactMergeService` labels merge-conflict questions from that lookup, and it
+  compares persisted `TypeUId` strings — so a `Money` (2 decimals) versus `Money0` (0 decimals) divergence
+  is invisible to it and merges silently. Pre-existing; do not assume a UId identifies a scale.
+
+Related: [[read-name-write-token-collisions]],
+[[process-parameter-type-compatibility-is-kind-level]].

--- a/docs/knowledge/Common/data-value-type-vocabularies.md
+++ b/docs/knowledge/Common/data-value-type-vocabularies.md
@@ -35,9 +35,10 @@ covers both read vocabularies, and why a new read-surface name needs an **alias*
 
 **Why it is this way** — the three consumers genuinely disagree and no single vocabulary satisfies all of
 them. Measured at ENG-93202: of the 30 codes clio can write, the designer's friendly names are accepted by
-the write path 30/30 but **14 are absent from the canonical name index** (so `IsNumeric("Decimal1")` is
-`false`); the canonical names are 49/49 resolvable by the kind classifier by construction but needed 12
-aliases to be accepted on write. The canonical vocabulary won for the read surfaces because it covers all
+the write path 30/30 but **14 do not resolve to their own code through the canonical name index** — 13 are
+absent from it outright (so `IsNumeric("Decimal1")` is `false`), and `Float` is present but keyed to code
+**5**, so looking up the friendly name of code 32 answers for a different type. The canonical names are
+49/49 resolvable by the kind classifier by construction but needed 12 aliases to be accepted on write. The canonical vocabulary won for the read surfaces because it covers all
 49 codes, whereas `GetFriendlyTypeName` is scoped to *writable* types — its guard test iterates
 `SupportedDataValueTypes.Values` — and a read surface sees all 49. The display vocabulary survives only so
 `get-app-info` output does not churn.

--- a/docs/knowledge/platform/process-parameter-type-compatibility-is-kind-level.md
+++ b/docs/knowledge/platform/process-parameter-type-compatibility-is-kind-level.md
@@ -26,3 +26,7 @@ never stricter than what the server will accept.
 happily, including processes that already exist and work on the stand. The error blames the caller's
 parameter types, so it reads as a modelling mistake rather than as an over-strict clio check, and the
 only way out is to bypass the guard.
+
+A second reason not to compare by UId, recorded under ENG-93202: the four currency scales (codes 6, 48,
+49, 50) all carry the SAME `DataValueType` UId, so a UId lookup cannot even distinguish them from each
+other. See [[data-value-type-vocabularies]].


### PR DESCRIPTION
Fixes [ENG-93202](https://creatio.atlassian.net/browse/ENG-93202).

## The defect, and why the ticket pointed at the wrong repository

`dataforge-get-table-columns` reported a **Decimal (0.01)** column as `"data-type": "Text"`, so an AI
consumer filtered a numeric column as a lexicographic string comparison.

The ticket concluded that clio only relays the string and that the fault is in the DataForge service
index. Both halves are false:

1. **The tool never calls the DataForge service.** `DataForgeTool.GetTableColumns` resolves
   `IRuntimeEntitySchemaReader.GetByName` and maps locally; `IDataForgeReadClient` exposes only
   `FindSimilarTables` / `FindSimilarLookups` / `GetTableRelationships` — there is no column method on it
   at all. There is therefore no index in this read path, which also rules out the "stale index" theory.
2. **clio computed the type, and that computation was the defect.** `DataForgeRuntimeSchemaMapper` owned a
   private 23-entry map whose fallback was the literal `"Text"`. 26 of the platform's 49 codes were
   missing, including every decimal and money scale (31–34, 40, 47–50). Decimal (0.01) is code 32 → absent
   → `"Text"`.

The missing rows were only half of it. The other half is that `"Text"` is a real type, so the wrong
answer was indistinguishable from a right one — which is why an unmodelled code now degrades to its **raw
ordinal** instead.

A [Jira comment](https://creatio.atlassian.net/browse/ENG-93202?focusedCommentId=493747) corrects the
ticket's analysis so the next reader is not sent to the wrong repository.

## What changed

| Path | Change |
|---|---|
| `clio/Common/CreatioDataValueType.cs` | `DisplayName` column on all 49 rows; `GetNameOrOrdinal` / `GetDisplayName` with a shared ordinal fallback |
| `clio/Common/DataForge/DataForgeContextService.cs` | private map and `ResolveDataType` deleted; names come from the canonical registry |
| `clio/Command/ApplicationInfoService.cs` | duplicate 49-entry table deleted; reads `DisplayName` |
| `clio/Command/EntitySchemaDesigner/EntitySchemaDesignerSupport.cs` | 12 write-vocabulary aliases |
| `clio/Command/McpServer/Tools/{ToolContractGetTool,EntitySchemaTool}.cs` | `data-type` and `type` descriptions |
| `docs/knowledge/` | two new records, one cross-link |

**Effect on `dataforge-get-table-columns` / `dataforge-context`:** 26 codes stop being reported as `Text`,
10 change spelling within the same type family (`SHORT_TEXT`→`ShortText`, `HASH_TEXT`→`HashText`, …), 13
are untouched, and there are **no regressions** — the canonical registry covers all 49 codes.
`get-app-info` output is **byte-identical**: its historical client-enum spelling moved into the canonical
table as a second, documented name column, so the two vocabularies can no longer drift in code coverage
while the shipped output stays put.

The 12 aliases take the write path from 18/30 to 30/30 on read-surface names, so a type read off a column
is accepted back by `create-entity-schema` / `modify-entity-schema-column`.

### Why this vocabulary and not the designer's

Three candidates were measured against the three things that consume a type name. Switching the read
surfaces to the designer's friendly vocabulary looked obvious and is wrong twice over: it is scoped to
*writable* types, so codes 5 `Float`, 8 `Date`, 9 `Time`, 11 `Enum` and 23 `HashText` would have regressed
to raw ordinals (19 of 49 codes are unnamed by it); and 14 of its 30 names do not resolve to their own
code through the canonical name index — 13 are absent outright, so `IsNumeric("Decimal1")` is `false`,
and `Float` is present but keyed to code 5. The canonical vocabulary is complete for all 49 codes
and *is* the kind classifier's own table, so it needs only the aliases to reach the write path.

## A pre-existing hazard this surfaced — not fixed here

Three names a read surface reports resolve to a **different** type on write: `Float` (code 5) → Decimal2,
`Date` (8) and `Time` (9) → DateTime. `Date`/`Time` are a documented deliberate collapse; **`Float` is
not** — the platform names code 5 `FLOAT`, but clio's write alias `float` → `decimal2` claims that token
for code 32. Echoing a read value back can create the wrong scale, and through `schema-sync` can alter a
live column's type on what was meant to be an idempotent replay.

Both the alias and the canonical name predate this change, and neither side can be moved from here:
`Float` is matched case-sensitively by `SimpleToFullFilterConverter`, and the `float` → `decimal2` alias
is a released, tested part of the write contract. So this PR does three things instead of a silent fix —
the tool descriptions name the three exceptions rather than promising that read output is writable, a
guard test pins the collision set so a fourth cannot appear unnoticed, and
`docs/knowledge/Command/read-name-write-token-collisions.md` records why. **A real fix needs a contract
decision and its own ticket.**

## Testing

- **Unit** — `Types_ShouldModelEveryPlatformCode_WithUniqueNames` (row set + canonical-name uniqueness),
  a 49-row characterization pin of every `get-app-info` display spelling transcribed from the deleted
  table, per-code resolver cases for all 26 previously-missing codes, the ordinal fallback asserted
  `NotBe("Text")`, `MapColumns` regressions, and the 12 aliases in both spellings.
- **Cross-vocabulary guards** (in the `Module=Command` fixture, so a write-vocabulary-only change
  executes them): `GetNameOrOrdinal_Should_RoundTrip_EverySupportedWriteType` and its inverse,
  `GetNameOrOrdinal_Should_Not_Resolve_To_A_Different_Type_On_Write`. The forward guard iterates
  *writable* codes and structurally cannot see the `Float` collision; the inverse one can.
- **E2E** — `DataForgeGetTableColumns_Should_Report_Live_Decimal_Column_As_Numeric` against the core
  `CurrencyRate` schema, whose own `Rate` column is `Decimal8`. **Run against a live 10.0 stand: `Text`
  before, `Float8` after.**

`Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit"` — 11868 passed, 0 failed,
25 skipped. `clio/Common/` is a full-suite trigger under the AGENTS smart-regression policy, so the
targeted `Module=Common|Command|McpServer` filter (10505 passed) was not treated as sufficient.
MCP e2e: 2 passed against a configured stand.

## Policy statements

**MCP reviewed.** Updated: the `columns` output-field description on `dataforge-get-table-columns`
(previously silent about what `data-type` values are), the `dataforge-context` `columns` field, and the
`type` descriptions on `create-entity-schema` / `modify-entity-schema-column`. `DataForgeTool`'s own
`[Description]` reviewed, still accurate. DataForge is long-tail (removed from `McpCoreToolProfile` under
ENG-92761), so no `clio/tpl/**` template names these tools imperatively and
`WorkspaceTemplateGuidanceDriftTests` is green. The published guidance article `dataforge-orchestration`
was checked and states no type vocabulary, so no `clio-knowledge` PR is needed.

**Docs reviewed, no update required.** The DataForge tools are MCP-only (no `[Verb]`). `get-app-info`
*does* have a CLI verb, and `clio/docs/commands/get-app-info.md` plus `clio/help/en/get-app-info.txt`
were inspected: they document the output field names but never enumerate type values, and that tool's
output is unchanged. `Commands.md` and `WikiAnchors.txt` unaffected — no verb added or renamed.

**ClioRing compatibility reviewed, no Ring-consumed contract changed.** `clio-ring/ClioRing.Ipc`,
`clio-ring/ClioRing` and `clio-ring/ClioRing.Desktop/actions.json` contain zero `dataforge` references and
no consumer of the `data-type` field. Noted explicitly: the `data-type` **value** vocabulary did change
for 26 codes, which is an agent-facing behavioural change even though the JSON schema
(`DataForgeModels.cs`) is untouched.

**Review.** Full 3-lens adversarial fan-out over the complete diff (the diff touches `clio/Common/**`, so
the triage tier did not apply), then a comments-only cleanup pass, then a scoped incremental pass over
the remediations — the third commit is that pass's output. Its one substantive finding is worth naming:
the new uniqueness guard asserted `OnlyHaveUniqueItems` over `Name`, which compares **ordinally**, while
`BuildByName` keys the index **OrdinalIgnoreCase** — so the guard could not fail for the collision its own
`because` describes. Every Blocker/High finding is resolved. One reviewer claim was **rejected on
evidence** — that the `money0` alias collides with the platform's spelling of code 6: the real
`sysenums.js` on a 10.0 stand says `MONEY = 6` and `MONEY0 = 48`, exactly as clio's table does; the
`MONEY0: 6` fixture in `ClassicEnumVocabularySourceParserTests` is a hand-written excerpt, not platform
data. That same check corrected a claim of my own, and the knowledge record now states the verified
provenance instead.

## Not in scope

- The `Float` write-token collision above — needs a contract decision.
- `dataforge-get-table-columns` reports `Float2` while `get-entity-schema-column-properties` reports
  `Float` for the same column. Closing that means changing the designer readback, on whose divergences
  `AreColumnTypesEquivalent` depends to decide that an unchanged column is unchanged — a schema
  read-modify-write idempotency risk not worth taking in a Major bug fix.
- `GetFriendlyTypeName(32)` returns `Float` where its siblings return `Decimal1`/`Decimal3`/`Decimal4`;
  code 32 is the only decimal scale not pinned by a test. A free consistency win, but same blast radius.
- `MapColumns` still filters inherited columns — pre-existing and deliberate.

The second commit adds `.ai_temp/` to `.gitignore` (agent working artifacts carry ticket URLs and stand
names, and this repository is public). Drop it if you would rather keep that out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENG-93202]: https://creatio.atlassian.net/browse/ENG-93202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ