### PR TITLE
Verify saved OAuth credentials against CRM

### DIFF
--- a/clio.mcp.e2e/DeployIdentityToolE2ETests.cs
+++ b/clio.mcp.e2e/DeployIdentityToolE2ETests.cs
@@ -60,6 +60,7 @@ public sealed class DeployIdentityToolE2ETests
 			because: "agents must be able to expand deploy-identity into its full contract before calling it through clio-run");
 
 		ToolContractDefinition contract = contracts.Tools!.Single(tool => tool.Name == ToolName);
+		contract.Description.Should().Contain("CRM bearer request", because: "deployment must verify CRM token acceptance before saving credentials");
 		contract.Description.Should().Contain("Never echo the generated client secret",
 			because: "the tool contract should prevent public disclosure of generated OAuth secrets");
 		FieldDescription(contract, "zipFile").Should().Contain("EnvironmentPath",

--- a/clio.mcp.e2e/OAuthConfigurationToolsE2ETests.cs
+++ b/clio.mcp.e2e/OAuthConfigurationToolsE2ETests.cs
@@ -136,30 +136,32 @@ public sealed class OAuthConfigurationToolsE2ETests : McpContractFixtureBase
 				because: "resolve-oauth-system-user requires only the environment name; name and id are optional");
 
 		ContractOf(contracts, VerifyOAuthAppTool.VerifyOAuthAppToolName).InputSchema.Required
-			.Should().BeEquivalentTo(["environment-name", "client-id", "client-secret"],
-				because: "verify-oauth-app requires the environment plus the client credentials to verify");
+			.Should().BeEquivalentTo(["environment-name"],
+				because: "verify-oauth-app defaults to the registered environment credentials");
 	}
 
-	[Test]
+	[TestCase(false)]
+	[TestCase(true)]
 	[Description("Invokes verify-oauth-app through the real MCP server and proves the acquired bearer token reaches the Creatio DataService smoke request.")]
 	[AllureTag(VerifyOAuthAppTool.VerifyOAuthAppToolName)]
 	[AllureName("verify-oauth-app completes token acquisition and bearer smoke test end to end")]
 	[AllureDescription("Uses a loopback IdentityService and Creatio surface to verify the real MCP command acquires a client_credentials token and sends it through CreatioClient to DataService.")]
-	public async Task VerifyOAuthApp_Should_AcquireToken_And_RunBearerSmokeTest_WhenEndpointsAcceptCredentials()
+	public async Task VerifyOAuthApp_Should_AcquireToken_And_RunBearerSmokeTest_WhenEndpointsAcceptCredentials(bool explicitCredentials)
 	{
 		// Arrange
 		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+		Dictionary<string, object?> args = new() { ["environment-name"] = StubEnvironmentName };
+		if (explicitCredentials) {
+			args["client-id"] = "client-id";
+			args["client-secret"] = "client-secret";
+			args["identity-server-url"] = _stub!.BaseUri;
+		}
 
 		// Act
 		CallToolResult callResult = await context.Session.CallToolAsync(
 			VerifyOAuthAppTool.VerifyOAuthAppToolName,
 			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = StubEnvironmentName,
-					["client-id"] = "client-id",
-					["client-secret"] = "client-secret",
-					["identity-server-url"] = _stub!.BaseUri
-				}
+				["args"] = args
 			},
 			context.CancellationTokenSource.Token);
 		VerifyOAuthAppResponse response =
@@ -174,7 +176,7 @@ public sealed class OAuthConfigurationToolsE2ETests : McpContractFixtureBase
 			because: "the tool must return its end-to-end verification result");
 		response.Result!.Ok.Should().BeTrue(
 			because: "both token acquisition and the bearer DataService probe succeeded");
-		_stub.TokenRequestBody.Should().Contain("client_id=client-id",
+		_stub!.TokenRequestBody.Should().Contain("client_id=client-id",
 			because: "the requested OAuth application must be the one verified");
 		_stub.AuthorizationHeader.Should().Be("Bearer stub-access-token",
 			because: "CreatioClient must carry the acquired token into the DataService request");
@@ -183,6 +185,36 @@ public sealed class OAuthConfigurationToolsE2ETests : McpContractFixtureBase
 			because: "the acquired access token is secret and must never cross the MCP response boundary");
 		serializedResult.Should().NotContain("client-secret",
 			because: "the supplied client secret must never be echoed by the tool");
+	}
+
+	[TestCase("invalid-token", false, 0)]
+	[TestCase("rejected-token", true, 401)]
+	[Description("The real MCP path fails verification for invalid token responses and tokens rejected by CRM.")]
+	[AllureTag(VerifyOAuthAppTool.VerifyOAuthAppToolName)]
+	[AllureName("OAuth verification rejects invalid responses and CRM authentication failure")]
+	[AllureDescription("Exercises the real server with saved credentials and failing loopback endpoints, without exposing secrets.")]
+	public async Task VerifyOAuthApp_ShouldReportFailure_WhenVerificationFails(string scenario, bool tokenAcquired, int status) {
+		// Arrange
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		CallToolResult callResult = await context.Session.CallToolAsync(VerifyOAuthAppTool.VerifyOAuthAppToolName,
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+				["environment-name"] = StubEnvironmentName,
+				["identity-server-url"] = _stub!.BaseUri + "/" + scenario
+			} }, context.CancellationTokenSource.Token);
+		VerifyOAuthAppResponse response = EntitySchemaStructuredResultParser.Extract<VerifyOAuthAppResponse>(callResult);
+
+		// Assert
+		Allure.Net.Commons.AllureApi.Step("Verify failed check results", () => {
+			response.Result.Should().NotBeNull(because: "a completed check reports its verification result");
+			response.Result!.Ok.Should().BeFalse(because: "token acquisition alone is not proof of CRM acceptance");
+			response.Result.TokenAcquired.Should().Be(tokenAcquired, because: "the result identifies whether token acquisition succeeded");
+			response.Result.DataServiceStatus.Should().Be(status, because: "the CRM status is retained without permission interpretation");
+		});
+		Allure.Net.Commons.AllureApi.Step("Verify secrets are absent", () => {
+			JsonSerializer.Serialize(callResult).Should().NotContain("client-secret", because: "verification never returns stored secrets");
+		});
 	}
 
 	[OneTimeTearDown]
@@ -241,6 +273,9 @@ public sealed class OAuthConfigurationToolsE2ETests : McpContractFixtureBase
 			      "Uri": "{{_stub.BaseUri}}",
 			      "Login": "Supervisor",
 			      "Password": "Supervisor",
+			      "ClientId": "client-id",
+			      "ClientSecret": "client-secret",
+			      "AuthAppUri": "{{_stub.BaseUri}}/connect/token",
 			      "IsNetCore": true
 			    }
 			  }
@@ -330,6 +365,10 @@ public sealed class OAuthConfigurationToolsE2ETests : McpContractFixtureBase
 					|| !TokenRequestBody.Contains("client_secret=client-secret", StringComparison.Ordinal)) {
 					context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
 					bytes = Encoding.UTF8.GetBytes("{\"error\":\"invalid_client\"}");
+				} else if (path.StartsWith("/invalid-token/", StringComparison.Ordinal)) {
+					bytes = Encoding.UTF8.GetBytes("{}");
+				} else if (path.StartsWith("/rejected-token/", StringComparison.Ordinal)) {
+					bytes = Encoding.UTF8.GetBytes("{\"access_token\":\"rejected\",\"token_type\":\"Bearer\"}");
 				} else {
 					bytes = Encoding.UTF8.GetBytes("{\"access_token\":\"stub-access-token\",\"token_type\":\"Bearer\"}");
 				}

--- a/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
+++ b/clio.tests/Command/IdentityServiceDeployment/IdentityServiceDeploymentServiceTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command.IdentityServiceDeployment;
+using Clio.Command.OAuthAppConfiguration;
 using Clio.Common;
 using Clio.Common.IIS;
 using Clio.UserEnvironment;
@@ -22,10 +23,13 @@ namespace Clio.Tests.Command.IdentityServiceDeployment;
 [Property("Module", "Command")]
 public sealed class IdentityServiceDeploymentServiceTests
 {
-	[Test]
-	[Description("Deploy uses the persisted registered environment so EnvironmentPath survives option filling and ConnectionStrings.config can be read.")]
+	[TestCase(true, 200)]
+	[TestCase(true, 401)]
+	[TestCase(true, 403)]
+	[TestCase(false, 0)]
+	[Description("Deploy verifies the newly issued token against the persisted environment before saving OAuth credentials.")]
 	[Platform("Win", Reason = "deploy-identity performs Windows-only IIS deployment (DeploymentStrategyFactory throws PlatformNotSupportedException off-Windows); skipped on non-Windows")]
-	public void Deploy_Should_Use_Persisted_Environment_When_Resolving_Identity_Path_And_Db_Connection()
+	public void Deploy_ShouldPersistCredentialsOnlyWhenVerified_WhenTokenAndCrmChecksComplete(bool tokenAcquired, int crmStatus)
 	{
 		// Arrange
 		string environmentPath = CreateCreatioEnvironmentPath();
@@ -64,11 +68,16 @@ public sealed class IdentityServiceDeploymentServiceTests
 		IAvailableIisPortService availableIisPortService = Substitute.For<IAvailableIisPortService>();
 		IIdentityServiceRoleGrantService roleGrantService = Substitute.For<IIdentityServiceRoleGrantService>();
 		IDeploymentTargetReservation targetReservation = CreateTargetReservation();
+		IIdentityServerProbe probe = CreateProbe();
+		probe.AcquireClientCredentialsToken(Arg.Any<string>(), "client-id", "client-secret")
+			.Returns(tokenAcquired ? "test-token" : string.Empty);
+		probe.RunBearerDataServiceSmokeTest(persistedEnvironment, Arg.Any<string>(), "test-token").Returns(crmStatus);
 		IdentityServiceDeploymentService service = new(
 			settingsRepository,
 			archiveResolver,
 			creatioClient,
-			new StubHttpClientFactory(HttpStatusCode.OK),
+			probe,
+			Substitute.For<IServiceUrlBuilder>(),
 			sysSettingsManager,
 			processExecutor,
 			availableIisPortService,
@@ -86,11 +95,23 @@ public sealed class IdentityServiceDeploymentServiceTests
 		settingsRepository.ClearReceivedCalls();
 
 		// Act
+		if (!tokenAcquired || crmStatus != 200) {
+			Action act = () => service.Deploy(options);
+
+			// Assert
+			act.Should().Throw<InvalidOperationException>(because: "failed OAuth verification must stop deployment success");
+			settingsRepository.DidNotReceive().ConfigureEnvironment(Arg.Any<string>(), Arg.Any<EnvironmentSettings>());
+			if (!tokenAcquired) {
+				probe.DidNotReceive().RunBearerDataServiceSmokeTest(Arg.Any<EnvironmentSettings>(), Arg.Any<string>(), Arg.Any<string>());
+			}
+			return;
+		}
 		IdentityServiceDeploymentResult result = service.Deploy(options);
 
 		// Assert
 		result.Success.Should().BeTrue(
 			because: "a persisted EnvironmentPath should let deploy-identity read ConnectionStrings.config and complete");
+		probe.Received(1).RunBearerDataServiceSmokeTest(persistedEnvironment, Arg.Any<string>(), "test-token");
 		settingsRepository.DidNotReceive().GetEnvironment(Arg.Any<DeployIdentityOptions>());
 		settingsRepository.Received(1).ConfigureEnvironment(
 			"bank",
@@ -148,7 +169,8 @@ public sealed class IdentityServiceDeploymentServiceTests
 			settingsRepository,
 			archiveResolver,
 			creatioClient,
-			new StubHttpClientFactory(HttpStatusCode.OK),
+			CreateProbe(),
+			Substitute.For<IServiceUrlBuilder>(),
 			sysSettingsManager,
 			processExecutor,
 			availableIisPortService,
@@ -604,7 +626,8 @@ public sealed class IdentityServiceDeploymentServiceTests
 			settingsRepository ?? CreateSettingsRepository(),
 			archiveResolver ?? Substitute.For<IIdentityServiceArchiveResolver>(),
 			creatioClient ?? Substitute.For<IIdentityServiceCreatioClient>(),
-			new StubHttpClientFactory(HttpStatusCode.OK),
+			CreateProbe(),
+			Substitute.For<IServiceUrlBuilder>(),
 			sysSettingsManager,
 			processExecutor,
 			availableIisPortService,
@@ -625,30 +648,11 @@ public sealed class IdentityServiceDeploymentServiceTests
 	private static string CreateIdentityTargetPath() =>
 		Path.Combine(Path.GetTempPath(), $"identity-target-{Guid.NewGuid():N}");
 
-	private sealed class StubHttpClientFactory : IHttpClientFactory
-	{
-		private readonly HttpStatusCode _statusCode;
-
-		public StubHttpClientFactory(HttpStatusCode statusCode) {
-			_statusCode = statusCode;
-		}
-
-		public HttpClient CreateClient(string name) => new(new StubHandler(_statusCode));
-	}
-
-	private sealed class StubHandler : HttpMessageHandler
-	{
-		private readonly HttpStatusCode _statusCode;
-
-		public StubHandler(HttpStatusCode statusCode) {
-			_statusCode = statusCode;
-		}
-
-		protected override Task<HttpResponseMessage> SendAsync(
-			HttpRequestMessage request,
-			CancellationToken cancellationToken) =>
-			Task.FromResult(new HttpResponseMessage(_statusCode) {
-				Content = new StringContent("{}")
-			});
+	private static IIdentityServerProbe CreateProbe() {
+		IIdentityServerProbe probe = Substitute.For<IIdentityServerProbe>();
+		probe.IsDiscoveryReachable(Arg.Any<string>()).Returns(true);
+		probe.AcquireClientCredentialsToken(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns("test-token");
+		probe.RunBearerDataServiceSmokeTest(Arg.Any<EnvironmentSettings>(), Arg.Any<string>(), "test-token").Returns(200);
+		return probe;
 	}
 }

--- a/clio.tests/Command/McpServer/OAuthConfigurationToolsTests.cs
+++ b/clio.tests/Command/McpServer/OAuthConfigurationToolsTests.cs
@@ -156,8 +156,10 @@ public sealed class OAuthConfigurationToolsTests
 
 	[Test]
 	[Category("Unit")]
-	[Description("verify-oauth-app advertises its stable name and returns a success envelope with the verification result.")]
-	public void VerifyOAuthApp_ShouldAdvertiseNameAndReturnSuccess_WhenCommandResolves() {
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("verify-oauth-app resolves the selected environment and preserves optional credential overrides.")]
+	public void VerifyOAuthApp_ShouldAdvertiseNameAndReturnSuccess_WhenCommandResolves(bool explicitCredentials) {
 		// Arrange
 		GetToolName<VerifyOAuthAppTool>(nameof(VerifyOAuthAppTool.VerifyOAuthApp))
 			.Should().Be(VerifyOAuthAppTool.VerifyOAuthAppToolName,
@@ -173,10 +175,13 @@ public sealed class OAuthConfigurationToolsTests
 		VerifyOAuthAppTool tool = new(command, ConsoleLogger.Instance, resolver);
 
 		// Act
-		VerifyOAuthAppResponse response = tool.VerifyOAuthApp(new VerifyOAuthAppArgs("dev", "cid", "secret"));
+		VerifyOAuthAppResponse response = tool.VerifyOAuthApp(new VerifyOAuthAppArgs("dev", explicitCredentials ? "cid" : null, explicitCredentials ? "secret" : null));
 
 		// Assert
 		response.Success.Should().BeTrue(because: "a completed verification is a success envelope");
 		response.Result.Should().Be(expected, because: "the tool surfaces the command's verification result");
+		command.Received(1).Verify(Arg.Is<VerifyOAuthAppOptions>(options => options.Environment == "dev"
+			&& options.ClientId == (explicitCredentials ? "cid" : null)
+			&& options.ClientSecret == (explicitCredentials ? "secret" : null)));
 	}
 }

--- a/clio.tests/Command/OAuthAppConfiguration/IdentityServerProbeTests.cs
+++ b/clio.tests/Command/OAuthAppConfiguration/IdentityServerProbeTests.cs
@@ -18,14 +18,15 @@ internal sealed class IdentityServerProbeTests : BaseClioModuleTests {
 	private IApplicationClientFactory _applicationClientFactory;
 	private IOwnedApplicationClient _applicationClient;
 	private IIdentityServerProbe _sut;
+	private IHttpClientFactory _httpClientFactory;
 
 	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {
 		base.AdditionalRegistrations(containerBuilder);
 		_applicationClientFactory = Substitute.For<IApplicationClientFactory>();
 		_applicationClient = Substitute.For<IOwnedApplicationClient>();
-		IHttpClientFactory httpClientFactory = Substitute.For<IHttpClientFactory>();
+		_httpClientFactory = Substitute.For<IHttpClientFactory>();
 		containerBuilder.AddSingleton(_applicationClientFactory);
-		containerBuilder.AddSingleton(httpClientFactory);
+		containerBuilder.AddSingleton(_httpClientFactory);
 	}
 
 	public override void Setup() {
@@ -38,7 +39,85 @@ internal sealed class IdentityServerProbeTests : BaseClioModuleTests {
 
 	public override void TearDown() {
 		_applicationClient?.Dispose();
+		_applicationClient.ClearReceivedCalls();
+		_applicationClientFactory.ClearReceivedCalls();
+		_httpClientFactory.ClearReceivedCalls();
 		base.TearDown();
+	}
+
+	[TestCase("{}")]
+	[TestCase("[]")]
+	[TestCase("not json")]
+	[TestCase("{\"access_token\":\"secret-token\"}")]
+	[TestCase("{\"access_token\":\"\",\"token_type\":\"Bearer\"}")]
+	[TestCase("{\"access_token\":\"secret token\",\"token_type\":\"Bearer\"}")]
+	[TestCase("{\"access_token\":\"secret-token\",\"token_type\":\"Basic\"}")]
+	[Description("HTTP 200 cannot make an empty, malformed, or non-bearer token response pass verification.")]
+	public void AcquireClientCredentialsToken_ShouldReturnEmpty_WhenResponseIsInvalid(string body) {
+		// Arrange
+		_httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new ResponseHandler(body)));
+
+		// Act
+		string token = _sut.AcquireClientCredentialsToken("https://identity.example", "client", "secret");
+
+		// Assert
+		token.Should().BeEmpty(because: "only a usable bearer token can be tested against CRM");
+	}
+
+	[Test]
+	[Description("Token validation accepts a nonempty bearer token without decoding or reimplementing its permissions.")]
+	public void AcquireClientCredentialsToken_ShouldReturnToken_WhenBearerResponseIsValid() {
+		// Arrange
+		_httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(
+			new ResponseHandler("{\"access_token\":\"opaque-token\",\"token_type\":\"bearer\"}")));
+
+		// Act
+		string token = _sut.AcquireClientCredentialsToken("https://identity.example", "client", "secret");
+
+		// Assert
+		token.Should().Be("opaque-token", because: "CRM owns validation of the issued token");
+	}
+
+	[TestCase("{}", false)]
+	[TestCase("[]", false)]
+	[TestCase("invalid", false)]
+	[TestCase("{\"issuer\":\"https://identity.example\"}", false)]
+	[TestCase("{\"issuer\":\"https://identity.example\",\"token_endpoint\":\"https://identity.example/connect/token\",\"jwks_uri\":\"https://identity.example/keys\",\"authorization_endpoint\":\"https://identity.example/connect/authorize\"}", true)]
+	[TestCase("{\"issuer\":\"creatio.com\",\"token_endpoint\":\"https://identity.example/connect/token\",\"jwks_uri\":\"https://identity.example/keys\",\"authorization_endpoint\":\"https://identity.example/connect/authorize\"}", true)]
+	[Description("Discovery validates the issuer and required endpoint metadata instead of trusting HTTP 200.")]
+	public void IsDiscoveryReachable_ShouldValidateMetadata_WhenHttpStatusIsSuccessful(string body, bool expected) {
+		// Arrange
+		_httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new ResponseHandler(body)));
+
+		// Act
+		bool result = _sut.IsDiscoveryReachable("https://identity.example");
+
+		// Assert
+		result.Should().Be(expected, because: "a discovery response must contain usable issuer and endpoint URLs");
+	}
+
+	[TestCase("<html>login</html>")]
+	[TestCase("{}")]
+	[TestCase("{\"success\":false}")]
+	[Description("A login page or failed DataService response must not count as CRM accepting the token.")]
+	public void RunBearerDataServiceSmokeTest_ShouldFail_WhenHttp200BodyIsNotSuccessful(string body) {
+		// Arrange
+		_applicationClient.ExecutePostRequestAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+			.Returns(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }));
+
+		// Act
+		Action act = () => _sut.RunBearerDataServiceSmokeTest(new EnvironmentSettings { Uri = "https://crm.example" },
+			"https://crm.example/select", "opaque-token");
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(because: "HTTP success alone does not prove CRM authentication")
+			.WithMessage("CRM OAuth smoke request*", because: "the sanitized error identifies the failing check");
+	}
+
+	private sealed class ResponseHandler(string body) : HttpMessageHandler {
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) });
 	}
 
 	[Test]

--- a/clio.tests/Command/OAuthAppConfiguration/VerifyOAuthAppCommandTests.cs
+++ b/clio.tests/Command/OAuthAppConfiguration/VerifyOAuthAppCommandTests.cs
@@ -18,10 +18,59 @@ internal sealed class VerifyOAuthAppCommandTests : BaseCommandTests<VerifyOAuthA
 	private IIdentityServerProbe _identityServerProbe;
 	private IServiceUrlBuilder _serviceUrlBuilder;
 	private ILogger _logger;
+	private EnvironmentSettings _environment;
 
 	public override void Setup() {
 		base.Setup();
 		_command = Container.GetRequiredService<VerifyOAuthAppCommand>();
+		_environment = Container.GetRequiredService<EnvironmentSettings>();
+	}
+
+	public override void TearDown() {
+		_environment.ClientId = null;
+		_environment.ClientSecret = null;
+		_environment.AuthAppUri = null;
+		_identityServerProbe.ClearReceivedCalls();
+		_sysSettingsManager.ClearReceivedCalls();
+		_logger.ClearReceivedCalls();
+		base.TearDown();
+	}
+
+	[TestCase("")]
+	[TestCase("/connect/token")]
+	[Description("An environment-only invocation uses saved OAuth credentials and URL without querying CRM settings or mutating options.")]
+	public void Verify_ShouldUseRegisteredCredentials_WhenOverridesAreOmitted(string endpointPath) {
+		// Arrange
+		_environment.ClientId = "saved-client";
+		_environment.ClientSecret = "saved-secret";
+		_environment.AuthAppUri = "https://saved-identity.example" + endpointPath;
+		_identityServerProbe.AcquireClientCredentialsToken("https://saved-identity.example", "saved-client", "saved-secret").Returns(Token);
+		_identityServerProbe.RunBearerDataServiceSmokeTest(_environment, SelectUrl, Token).Returns(200);
+		VerifyOAuthAppOptions options = new() { Environment = "DEV" };
+
+		// Act
+		VerifyOAuthAppResult result = _command.Verify(options);
+
+		// Assert
+		result.Ok.Should().BeTrue(because: "saved credentials should support an environment-only invocation");
+		options.ClientSecret.Should().BeNull(because: "verification must not copy stored secrets into command options");
+		_sysSettingsManager.DidNotReceive().GetSysSettingValueByCode(Arg.Any<string>());
+	}
+
+	[TestCase(401)]
+	[TestCase(403)]
+	[TestCase(500)]
+	[Description("Verification fails when CRM does not accept the bearer smoke request, without interpreting permissions.")]
+	public void Execute_ShouldReturnFailure_WhenCrmRequestFails(int status) {
+		// Arrange
+		_identityServerProbe.AcquireClientCredentialsToken(Arg.Any<string>(), "cid", "secret").Returns(Token);
+		_identityServerProbe.RunBearerDataServiceSmokeTest(Arg.Any<EnvironmentSettings>(), SelectUrl, Token).Returns(status);
+
+		// Act
+		int exitCode = _command.Execute(new VerifyOAuthAppOptions { ClientId = "cid", ClientSecret = "secret" });
+
+		// Assert
+		exitCode.Should().Be(1, because: "token issuance alone cannot pass OAuth verification");
 	}
 
 	protected override void AdditionalRegistrations(IServiceCollection containerBuilder) {

--- a/clio/Command/IdentityServiceDeployment/IdentityServiceDeploymentService.cs
+++ b/clio/Command/IdentityServiceDeployment/IdentityServiceDeploymentService.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
@@ -13,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Clio.Common;
+using Clio.Command.OAuthAppConfiguration;
 using Clio.Common.IIS;
 using Clio.UserEnvironment;
 using Microsoft.Data.SqlClient;
@@ -348,7 +347,8 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 	private readonly IAvailableIisPortService _availableIisPortService;
 	private readonly IIdentityServiceCreatioClient _creatioClient;
 	private readonly IDeploymentTargetReservation _deploymentTargetReservation;
-	private readonly IHttpClientFactory _httpClientFactory;
+	private readonly IIdentityServerProbe _identityServerProbe;
+	private readonly IServiceUrlBuilder _serviceUrlBuilder;
 	private readonly ILogger _logger;
 	private readonly IProcessExecutor _processExecutor;
 	private readonly IIdentityServiceRoleGrantService _roleGrantService;
@@ -363,7 +363,8 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		ISettingsRepository settingsRepository,
 		IIdentityServiceArchiveResolver archiveResolver,
 		IIdentityServiceCreatioClient creatioClient,
-		IHttpClientFactory httpClientFactory,
+		IIdentityServerProbe identityServerProbe,
+		IServiceUrlBuilder serviceUrlBuilder,
 		ISysSettingsManager sysSettingsManager,
 		IProcessExecutor processExecutor,
 		IAvailableIisPortService availableIisPortService,
@@ -374,7 +375,8 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		_settingsRepository = settingsRepository ?? throw new ArgumentNullException(nameof(settingsRepository));
 		_archiveResolver = archiveResolver ?? throw new ArgumentNullException(nameof(archiveResolver));
 		_creatioClient = creatioClient ?? throw new ArgumentNullException(nameof(creatioClient));
-		_httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+		_identityServerProbe = identityServerProbe ?? throw new ArgumentNullException(nameof(identityServerProbe));
+		_serviceUrlBuilder = serviceUrlBuilder ?? throw new ArgumentNullException(nameof(serviceUrlBuilder));
 		_sysSettingsManager = sysSettingsManager ?? throw new ArgumentNullException(nameof(sysSettingsManager));
 		_processExecutor = processExecutor ?? throw new ArgumentNullException(nameof(processExecutor));
 		_availableIisPortService = availableIisPortService
@@ -422,7 +424,7 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		if (options.NoApp) {
 			return new IdentityServiceDeploymentResult(
 				true,
-				"IdentityService deployed and connected to Creatio. OAuth app creation skipped by --no-app; no clio client credentials were persisted and token verification was skipped.",
+				"IdentityService deployed and connected to Creatio. OAuth app creation skipped by --no-app; no clio client credentials were persisted and token verification was skipped. CRM OAuth verification was skipped.",
 				identityUrl,
 				string.Empty);
 		}
@@ -435,7 +437,7 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 			systemUserId = _systemUserResolver.ResolveSystemUserId(environment, systemUserName);
 		}
 		OAuthClientCredentials credentials = _creatioClient.CreateClioClient(options, systemUserId);
-		VerifyClientCredentials(identityUrl, credentials);
+		VerifyClientCredentials(identityUrl, credentials, environment);
 		PersistClioEnvironment(environmentName, environment, identityUrl, credentials);
 
 		return new IdentityServiceDeploymentResult(
@@ -793,14 +795,9 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 	}
 
 	private void VerifyIdentityDiscovery(string identityUrl) {
-		HttpClient client = _httpClientFactory.CreateClient();
-		HttpResponseMessage response = Task.Run(() =>
-				client.GetAsync($"{identityUrl.TrimEnd('/')}/.well-known/openid-configuration"))
-			.GetAwaiter()
-			.GetResult();
-		if (!response.IsSuccessStatusCode) {
+		if (!_identityServerProbe.IsDiscoveryReachable(identityUrl)) {
 			throw new InvalidOperationException(
-				$"IdentityService discovery check failed with HTTP {(int)response.StatusCode}.");
+				"IdentityService discovery check failed. Check connectivity and the discovery issuer and endpoint metadata.");
 		}
 	}
 
@@ -823,21 +820,18 @@ public sealed class IdentityServiceDeploymentService : IIdentityServiceDeploymen
 		}
 	}
 
-	private void VerifyClientCredentials(string identityUrl, OAuthClientCredentials credentials) {
-		HttpClient client = _httpClientFactory.CreateClient();
-		using FormUrlEncodedContent content = new(new Dictionary<string, string> {
-			["grant_type"] = "client_credentials",
-			["client_id"] = credentials.ClientId,
-			["client_secret"] = credentials.ClientSecret
-		});
-		content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
-		HttpResponseMessage response = Task.Run(() =>
-				client.PostAsync($"{identityUrl.TrimEnd('/')}/connect/token", content))
-			.GetAwaiter()
-			.GetResult();
-		if (!response.IsSuccessStatusCode) {
+	private void VerifyClientCredentials(string identityUrl, OAuthClientCredentials credentials,
+		EnvironmentSettings environment) {
+		string token = _identityServerProbe.AcquireClientCredentialsToken(identityUrl,
+			credentials.ClientId, credentials.ClientSecret);
+		if (string.IsNullOrWhiteSpace(token)) {
 			throw new InvalidOperationException(
-				$"IdentityService client_credentials token check failed with HTTP {(int)response.StatusCode}.");
+				"IdentityService did not return a usable bearer token. Check the OAuth client credentials.");
+		}
+		int status = _identityServerProbe.RunBearerDataServiceSmokeTest(environment,
+			_serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.Select), token);
+		if (status != 200) {
+			throw new InvalidOperationException($"CRM OAuth verification failed with HTTP {status}.");
 		}
 	}
 

--- a/clio/Command/McpServer/Tools/DeployIdentityTool.cs
+++ b/clio/Command/McpServer/Tools/DeployIdentityTool.cs
@@ -38,13 +38,13 @@ public sealed class DeployIdentityTool(
 	[Description("""
 				 Deploys IdentityService to IIS, connects the target Creatio environment, creates a fresh clio OAuth
 				 client bound to an existing Creatio user, and stores the returned client credentials in the local
-				 clio appsettings environment.
+				 clio appsettings environment after validating discovery, token issuance, and a read-only CRM bearer request.
 
 				 When zipFile is omitted, the command finds IdentityService.zip under the registered environment
 				 EnvironmentPath. When identitySitePort is omitted, the command selects the first free IIS port
 				 in range 40001-40100. Explicit zipFile and identitySitePort values still win.
 				 Set noApp to deploy and connect IdentityService without creating an OAuth app or verifying
-				 client_credentials. Set createTechUser to create a new technical user instead of binding the
+				 client_credentials or CRM OAuth access. Set createTechUser to create a new technical user instead of binding the
 				 fresh OAuth app to the existing Supervisor user.
 				 Secret values are written only to clio settings and are not returned in the tool response.
 				 """)]

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -5858,7 +5858,7 @@ internal static class ToolContractCatalog {
 	private static ToolContractDefinition BuildDeployIdentity() {
 		return new ToolContractDefinition(
 			DeployIdentityTool.DeployIdentityToolName,
-			"Deploys IdentityService to IIS for a registered local Creatio environment, connects Creatio through the platform sys-settings/REST path, creates a fresh clio OAuth client bound to an existing user by default, and stores the returned client credentials in local clio appsettings. Never echo the generated client secret in logs or public messages.",
+			"Deploys IdentityService to IIS for a registered local Creatio environment, connects Creatio through the platform sys-settings/REST path, creates a fresh clio OAuth client bound to an existing user by default, and stores the returned client credentials in local clio appsettings only after discovery, token issuance, and a read-only CRM bearer request succeed. With noApp, token and CRM checks are skipped. Never echo the generated client secret in logs or public messages.",
 			new ToolInputSchemaContract(
 				[EnvironmentNameFieldName],
 				[

--- a/clio/Command/McpServer/Tools/VerifyOAuthAppTool.cs
+++ b/clio/Command/McpServer/Tools/VerifyOAuthAppTool.cs
@@ -41,11 +41,13 @@ public sealed class VerifyOAuthAppTool(
 				 Verifies a server-to-server OAuth app end to end over REST: acquires a client_credentials access token from the
 				 IdentityService token endpoint, then runs a minimal bearer-authenticated Creatio DataService smoke request with that
 				 token. Returns tokenAcquired, dataServiceStatus (HTTP status of the smoke request), and ok (token acquired AND
-				 dataServiceStatus 200). The access token text is never returned or logged. Supply identity-server-url to override the
-				 IdentityService URL otherwise read from the OAuth20IdentityServerUrl system setting or derived from the Creatio host.
+				 dataServiceStatus 200 with a successful DataService response). The access token text is never returned or logged.
+				 Defaults to the registered environment OAuth credentials and AuthAppUri. Supply both client-id and client-secret
+				 to override credentials, and identity-server-url to override the IdentityService URL. Without AuthAppUri, the URL
+				 is read from OAuth20IdentityServerUrl or derived from the Creatio host. No configuration or credentials are changed.
 				 """)]
 	public VerifyOAuthAppResponse VerifyOAuthApp(
-		[Description("Parameters: environment-name (required); client-id (required); client-secret (required); identity-server-url (optional override).")]
+		[Description("Parameters: environment-name (required); client-id and client-secret (optional pair); identity-server-url (optional override).")]
 		[Required]
 		VerifyOAuthAppArgs args) {
 		try {
@@ -59,8 +61,8 @@ public sealed class VerifyOAuthAppTool(
 			VerifyOAuthAppResult result = resolvedCommand.Verify(options);
 			return new VerifyOAuthAppResponse(true, result, null);
 		}
-		catch (Exception exception) {
-			return new VerifyOAuthAppResponse(false, null, exception.Message);
+		catch (Exception) {
+			return new VerifyOAuthAppResponse(false, null, VerifyOAuthAppCommand.VerificationFailureMessage);
 		}
 	}
 }
@@ -75,17 +77,15 @@ public sealed record VerifyOAuthAppArgs(
 	string EnvironmentName,
 
 	[property: JsonPropertyName("client-id")]
-	[property: Description("OAuth client id to verify")]
-	[property: Required]
-	string ClientId,
+	[property: Description("OAuth client id override. Omit both credentials to use the registered environment.")]
+	string? ClientId = null,
 
 	[property: JsonPropertyName("client-secret")]
 	[property: Description("OAuth client secret to verify. Never returned or logged.")]
-	[property: Required]
-	string ClientSecret,
+	string? ClientSecret = null,
 
 	[property: JsonPropertyName("identity-server-url")]
-	[property: Description("Explicit IdentityService base URL. Defaults to the OAuth20IdentityServerUrl system setting, then a derived -is host.")]
+	[property: Description("Explicit IdentityService base URL. Defaults to registered AuthAppUri, then OAuth20IdentityServerUrl, then a derived -is host.")]
 	string? IdentityServerUrl = null);
 
 /// <summary>

--- a/clio/Command/OAuthAppConfiguration/IdentityServerProbe.cs
+++ b/clio/Command/OAuthAppConfiguration/IdentityServerProbe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -19,7 +20,7 @@ namespace Clio.Command.OAuthAppConfiguration;
 public interface IIdentityServerProbe
 {
 	/// <summary>
-	/// Issues a GET against the OpenID discovery document and reports whether it returns a success status.
+	/// Checks that OpenID discovery succeeds and contains an issuer and valid endpoint URLs.
 	/// </summary>
 	/// <param name="identityServerBaseUrl">IdentityService base URL.</param>
 	/// <returns><see langword="true"/> when the discovery document is reachable.</returns>
@@ -85,12 +86,28 @@ public sealed class IdentityServerProbe : IIdentityServerProbe
 			return false;
 		}
 		try {
-			HttpClient client = _httpClientFactory.CreateClient();
-			HttpResponseMessage response = Task.Run(() =>
+			using HttpClient client = _httpClientFactory.CreateClient();
+			using HttpResponseMessage response = Task.Run(() =>
 					client.GetAsync($"{identityServerBaseUrl.TrimEnd('/')}/.well-known/openid-configuration"))
 				.GetAwaiter()
 				.GetResult();
-			return response.IsSuccessStatusCode;
+			if (!response.IsSuccessStatusCode) {
+				return false;
+			}
+			using JsonDocument document = JsonDocument.Parse(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+			return document.RootElement.ValueKind == JsonValueKind.Object
+				&& document.RootElement.TryGetProperty("issuer", out JsonElement issuer)
+				&& issuer.ValueKind == JsonValueKind.String
+				&& !string.IsNullOrWhiteSpace(issuer.GetString())
+				&& new[] { "token_endpoint", "jwks_uri", "authorization_endpoint" }.All(name =>
+					document.RootElement.TryGetProperty(name, out JsonElement value)
+					&& value.ValueKind == JsonValueKind.String
+					&& Uri.TryCreate(value.GetString(), UriKind.Absolute, out Uri uri)
+					&& uri.Scheme is "http" or "https"
+					&& string.IsNullOrEmpty(uri.UserInfo));
+		}
+		catch (JsonException) {
+			return false;
 		}
 		catch (HttpRequestException) {
 			return false;
@@ -107,22 +124,30 @@ public sealed class IdentityServerProbe : IIdentityServerProbe
 			|| string.IsNullOrWhiteSpace(clientSecret)) {
 			return string.Empty;
 		}
-		HttpClient client = _httpClientFactory.CreateClient();
-		using FormUrlEncodedContent content = new(new Dictionary<string, string> {
-			["grant_type"] = "client_credentials",
-			["client_id"] = clientId,
-			["client_secret"] = clientSecret
-		});
-		content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
-		HttpResponseMessage response = Task.Run(() =>
-				client.PostAsync($"{identityServerBaseUrl.TrimEnd('/')}/connect/token", content))
-			.GetAwaiter()
-			.GetResult();
-		if (!response.IsSuccessStatusCode) {
-			return string.Empty;
+		try {
+			using HttpClient client = _httpClientFactory.CreateClient();
+			using FormUrlEncodedContent content = new(new Dictionary<string, string> {
+				["grant_type"] = "client_credentials",
+				["client_id"] = clientId,
+				["client_secret"] = clientSecret
+			});
+			content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+			using HttpResponseMessage response = Task.Run(() =>
+					client.PostAsync($"{identityServerBaseUrl.TrimEnd('/')}/connect/token", content))
+				.GetAwaiter()
+				.GetResult();
+			if (!response.IsSuccessStatusCode) {
+				return string.Empty;
+			}
+			string body = Task.Run(() => response.Content.ReadAsStringAsync()).GetAwaiter().GetResult();
+			return ExtractAccessToken(body);
 		}
-		string body = Task.Run(() => response.Content.ReadAsStringAsync()).GetAwaiter().GetResult();
-		return ExtractAccessToken(body);
+		catch (HttpRequestException) {
+			throw new InvalidOperationException("OAuth token request failed. Check the IdentityService URL and connectivity.");
+		}
+		catch (TaskCanceledException) {
+			throw new InvalidOperationException("OAuth token request timed out. Check IdentityService connectivity.");
+		}
 	}
 
 	/// <inheritdoc />
@@ -142,21 +167,51 @@ public sealed class IdentityServerProbe : IIdentityServerProbe
 			return 0;
 		}
 		ArgumentNullException.ThrowIfNull(environmentSettings);
-		using IOwnedApplicationClient client = _applicationClientFactory.CreateBearerEnvironmentClient(
-			environmentSettings, accessToken);
-		using HttpResponseMessage response = client.ExecutePostRequestAsync(
-			selectQueryUrl, ContactTop1SelectQuery).GetAwaiter().GetResult();
-		return (int)response.StatusCode;
+		try {
+			using IOwnedApplicationClient client = _applicationClientFactory.CreateBearerEnvironmentClient(
+				environmentSettings, accessToken);
+			using HttpResponseMessage response = client.ExecutePostRequestAsync(
+				selectQueryUrl, ContactTop1SelectQuery).GetAwaiter().GetResult();
+			if (response.StatusCode == System.Net.HttpStatusCode.OK) {
+				using JsonDocument document = JsonDocument.Parse(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+				if (document.RootElement.ValueKind != JsonValueKind.Object
+					|| !document.RootElement.TryGetProperty("success", out JsonElement success)
+					|| success.ValueKind != JsonValueKind.True) {
+					throw new InvalidOperationException("CRM OAuth smoke request did not return a successful DataService response.");
+				}
+			}
+			return (int)response.StatusCode;
+		}
+		catch (JsonException) {
+			throw new InvalidOperationException("CRM OAuth smoke request returned invalid JSON.");
+		}
+		catch (HttpRequestException) {
+			throw new InvalidOperationException("CRM OAuth smoke request failed. Check the target URL and connectivity.");
+		}
+		catch (TaskCanceledException) {
+			throw new InvalidOperationException("CRM OAuth smoke request timed out. Check target connectivity.");
+		}
 	}
 
 	private static string ExtractAccessToken(string tokenResponseJson) {
 		if (string.IsNullOrWhiteSpace(tokenResponseJson)) {
 			return string.Empty;
 		}
-		using JsonDocument document = JsonDocument.Parse(tokenResponseJson);
-		return document.RootElement.TryGetProperty("access_token", out JsonElement tokenElement)
-			&& tokenElement.ValueKind == JsonValueKind.String
-				? tokenElement.GetString() ?? string.Empty
-				: string.Empty;
+		try {
+			using JsonDocument document = JsonDocument.Parse(tokenResponseJson);
+			if (document.RootElement.ValueKind != JsonValueKind.Object
+				|| !document.RootElement.TryGetProperty("token_type", out JsonElement type)
+				|| type.ValueKind != JsonValueKind.String
+				|| !string.Equals(type.GetString(), "Bearer", StringComparison.OrdinalIgnoreCase)
+				|| !document.RootElement.TryGetProperty("access_token", out JsonElement token)
+				|| token.ValueKind != JsonValueKind.String) {
+				return string.Empty;
+			}
+			string value = token.GetString();
+			return string.IsNullOrWhiteSpace(value) || value.Any(c => char.IsWhiteSpace(c) || char.IsControl(c)) ? string.Empty : value;
+		}
+		catch (JsonException) {
+			return string.Empty;
+		}
 	}
 }

--- a/clio/Command/OAuthAppConfiguration/VerifyOAuthAppCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/VerifyOAuthAppCommand.cs
@@ -18,13 +18,13 @@ public sealed class VerifyOAuthAppOptions : RemoteCommandOptions
 	/// <summary>
 	/// Gets or sets the OAuth client identifier to verify.
 	/// </summary>
-	[Option("client-id", Required = true, HelpText = "OAuth client id to verify")]
+	[Option("client-id", Required = false, HelpText = "OAuth client id to verify. Defaults to the registered environment credentials")]
 	public string ClientId { get; set; }
 
 	/// <summary>
 	/// Gets or sets the OAuth client secret to verify.
 	/// </summary>
-	[Option("client-secret", Required = true, HelpText = "OAuth client secret to verify")]
+	[Option("client-secret", Required = false, HelpText = "OAuth client secret to verify. Supply together with --client-id to override registered credentials")]
 	public string ClientSecret { get; set; }
 
 	/// <summary>
@@ -32,7 +32,7 @@ public sealed class VerifyOAuthAppOptions : RemoteCommandOptions
 	/// <c>OAuth20IdentityServerUrl</c> system setting, then derived from the Creatio host.
 	/// </summary>
 	[Option("identity-server-url", Required = false,
-		HelpText = "Explicit IdentityService base URL. Defaults to the OAuth20IdentityServerUrl system setting, then a derived -is host")]
+		HelpText = "Explicit IdentityService base URL. Defaults to registered AuthAppUri, then OAuth20IdentityServerUrl, then a derived -is host")]
 	public string IdentityServerUrl { get; set; }
 }
 
@@ -57,6 +57,7 @@ public sealed record VerifyOAuthAppResult(
 /// </summary>
 public class VerifyOAuthAppCommand : Command<VerifyOAuthAppOptions>
 {
+	internal const string VerificationFailureMessage = "OAuth verification failed. Check the IdentityService URL and CRM connectivity; configure OAuth credentials or supply both --client-id and --client-secret.";
 	private const string IdentityServerUrlSettingCode = "OAuth20IdentityServerUrl";
 	private const int HttpOk = 200;
 
@@ -97,8 +98,8 @@ public class VerifyOAuthAppCommand : Command<VerifyOAuthAppOptions>
 			_logger.WriteInfo(JsonSerializer.Serialize(result, WriteIndentedOptions));
 			return result.Ok ? 0 : 1;
 		}
-		catch (Exception exception) {
-			_logger.WriteError(exception.Message);
+		catch (Exception) {
+			_logger.WriteError(VerificationFailureMessage);
 			return 1;
 		}
 	}
@@ -111,18 +112,25 @@ public class VerifyOAuthAppCommand : Command<VerifyOAuthAppOptions>
 	/// <returns>The structured verification result. The access token text is never surfaced.</returns>
 	public virtual VerifyOAuthAppResult Verify(VerifyOAuthAppOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
-		if (string.IsNullOrWhiteSpace(options.ClientId) || string.IsNullOrWhiteSpace(options.ClientSecret)) {
-			throw new ArgumentException("Both --client-id and --client-secret are required.");
+		bool explicitCredentials = options.ClientId is not null || options.ClientSecret is not null;
+		string clientId = explicitCredentials ? options.ClientId : _environmentSettings.ClientId;
+		string clientSecret = explicitCredentials ? options.ClientSecret : _environmentSettings.ClientSecret;
+		if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret)) {
+			throw new ArgumentException("OAuth credentials are missing. Configure the environment or supply both --client-id and --client-secret.");
 		}
 
 		string identityServerUrl = ResolveIdentityServerUrl(options);
-		if (string.IsNullOrWhiteSpace(identityServerUrl)) {
+		if (!Uri.TryCreate(identityServerUrl, UriKind.Absolute, out Uri identityUri)
+			|| identityUri.Scheme is not ("http" or "https")
+			|| !string.IsNullOrEmpty(identityUri.UserInfo)
+			|| !string.IsNullOrEmpty(identityUri.Query)
+			|| !string.IsNullOrEmpty(identityUri.Fragment)) {
 			throw new InvalidOperationException(
-				"Could not determine the IdentityService URL. Pass --identity-server-url explicitly.");
+				"A valid IdentityService base URL is required. Pass --identity-server-url explicitly.");
 		}
 
 		string accessToken = _identityServerProbe.AcquireClientCredentialsToken(
-			identityServerUrl, options.ClientId, options.ClientSecret);
+			identityServerUrl, clientId, clientSecret);
 		bool tokenAcquired = !string.IsNullOrWhiteSpace(accessToken);
 
 		int dataServiceStatus = 0;
@@ -143,6 +151,14 @@ public class VerifyOAuthAppCommand : Command<VerifyOAuthAppOptions>
 		if (!string.IsNullOrWhiteSpace(options.IdentityServerUrl)) {
 			return options.IdentityServerUrl.TrimEnd('/');
 		}
+		if (!string.IsNullOrWhiteSpace(_environmentSettings.AuthAppUri)) {
+			// Registered OAuth settings store the token endpoint, while the probe accepts the base URL.
+			const string tokenPath = "/connect/token";
+			string savedUrl = _environmentSettings.AuthAppUri.TrimEnd('/');
+			return savedUrl.EndsWith(tokenPath, StringComparison.OrdinalIgnoreCase)
+				? savedUrl[..^tokenPath.Length]
+				: savedUrl;
+		}
 		string settingUrl = TryReadSetting(IdentityServerUrlSettingCode);
 		if (!string.IsNullOrWhiteSpace(settingUrl)) {
 			return settingUrl.TrimEnd('/');
@@ -154,8 +170,8 @@ public class VerifyOAuthAppCommand : Command<VerifyOAuthAppOptions>
 		try {
 			return _sysSettingsManager.GetSysSettingValueByCode(code);
 		}
-		catch (Exception ex) {
-			_logger.WriteWarning($"Could not read system setting '{code}': {ex.Message}");
+		catch (Exception) {
+			_logger.WriteWarning($"Could not read system setting '{code}'.");
 			return string.Empty;
 		}
 	}

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -539,7 +539,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="create-server-to-server-oauth-app"></a>
 - [`create-server-to-server-oauth-app`](docs/commands/create-server-to-server-oauth-app.md) - Create a server-to-server (client_credentials) OAuth app in Creatio via OAuthConfigService REST
 <a id="verify-oauth-app"></a>
-- [`verify-oauth-app`](docs/commands/verify-oauth-app.md) - Verify a server-to-server OAuth app: acquire a client_credentials token and run a bearer DataService smoke test
+- [`verify-oauth-app`](docs/commands/verify-oauth-app.md) - Verify registered or explicit OAuth credentials by obtaining a bearer token and testing CRM access
 <a id="deploy-infrastructure"></a>
 <a id="di"></a>
 - [`deploy-infrastructure`](docs/commands/deploy-infrastructure.md) - Deploy Kubernetes infrastructure for Creatio (namespace, storage, redis, postgres, pgadmin), `di`

--- a/clio/docs/commands/deploy-identity.md
+++ b/clio/docs/commands/deploy-identity.md
@@ -154,3 +154,6 @@ clio OAuth credential updates, and `connect/token` verification because no clien
 The `db-first` mode is the default contract requested for the command, but direct DB
 seeding is not used until it is fully proven. The command falls back to the supported
 REST/sys-settings path and refuses explicit `--configuration-mode db`.
+
+Deployment validates discovery issuer and endpoint metadata, obtains a usable bearer token, and checks it with a read-only CRM DataService request before saving client credentials. Failed verification returns a nonzero exit code.
+With --no-app, token and CRM OAuth verification are explicitly skipped.

--- a/clio/docs/commands/get-identity-service-config.md
+++ b/clio/docs/commands/get-identity-service-config.md
@@ -25,7 +25,7 @@ It reports:
 - `clientId` - the `OAuth20IdentityServerClientId` value
 - `tokenEndpoint` - `{base}/connect/token`
 - `discoveryEndpoint` - `{base}/.well-known/openid-configuration`
-- `reachable` - whether the discovery document responded with a success status
+- `reachable` - whether discovery succeeded with an issuer and valid endpoint URLs
 
 Use it first when configuring server-to-server OAuth on a remote Creatio.
 

--- a/clio/docs/commands/verify-oauth-app.md
+++ b/clio/docs/commands/verify-oauth-app.md
@@ -18,7 +18,7 @@ It reports:
 
 - `tokenAcquired` - whether a `client_credentials` access token was acquired
 - `dataServiceStatus` - the HTTP status of the bearer DataService smoke request (`0` when skipped)
-- `ok` - whether the token was acquired **and** `dataServiceStatus` is `200`
+- `ok` - whether the token was acquired and the CRM returned HTTP `200` with a successful DataService JSON response
 - `identityServerUrl` - the IdentityService base URL used for the token request
 
 The access token text is never returned or logged.

--- a/clio/docs/commands/verify-oauth-app.md
+++ b/clio/docs/commands/verify-oauth-app.md
@@ -26,7 +26,7 @@ The access token text is never returned or logged.
 ## Synopsis
 
 ```
-clio verify-oauth-app -e ENVIRONMENT --client-id ID --client-secret SECRET [OPTIONS]
+clio verify-oauth-app -e ENVIRONMENT [OPTIONS]
 ```
 
 ## Options
@@ -34,13 +34,14 @@ clio verify-oauth-app -e ENVIRONMENT --client-id ID --client-secret SECRET [OPTI
 | Option | Required | Description |
 |---|---|---|
 | `-e, --environment` | Yes | Registered Creatio environment. |
-| `--client-id` | Yes | OAuth client id to verify. |
-| `--client-secret` | Yes | OAuth client secret to verify. Never returned or logged. |
-| `--identity-server-url` | No | Explicit IdentityService base URL. Defaults to the `OAuth20IdentityServerUrl` setting, then a derived `-is` host. |
+| `--client-id` | No | OAuth client id override; supply together with `--client-secret`. Defaults to registered credentials. |
+| `--client-secret` | No | OAuth client secret override; supply together with `--client-id`. Never returned or logged. |
+| `--identity-server-url` | No | Explicit IdentityService base URL. Defaults to registered `AuthAppUri`, then the `OAuth20IdentityServerUrl` setting, then a derived `-is` host. |
 
 ## Examples
 
 ```
+clio verify-oauth-app -e DEV
 clio verify-oauth-app -e c-dev --client-id my-client --client-secret my-secret
 clio verify-oauth-app -e c-dev --client-id my-client --client-secret my-secret \
     --identity-server-url https://c-dev-is.creatio.com
@@ -55,3 +56,7 @@ clio experimental --name deploy-identity --enable
 ```
 
 This command is read-only; it does not modify Creatio. The access token is never logged.
+
+Verification reads existing credentials and does not change settings or create an OAuth app.
+A nonempty bearer token and a successful DataService JSON response are required; HTTP 200 alone is insufficient.
+The CRM request uses only the newly issued token, without falling back to username/password. Exit code is 0 on success and 1 on failure.

--- a/clio/help/en/deploy-identity.txt
+++ b/clio/help/en/deploy-identity.txt
@@ -121,3 +121,6 @@ NOTES
     With --no-app, deployment still verifies IdentityService discovery and writes the
     Creatio IdentityService sys-settings. It intentionally skips OAuth app creation, local
     clio OAuth credential updates, and connect/token verification because no client exists.
+
+    Deployment validates discovery issuer and endpoint metadata, obtains a usable bearer token, and checks it with a read-only CRM DataService request before saving client credentials. Failed verification returns a nonzero exit code.
+    With --no-app, token and CRM OAuth verification are explicitly skipped.

--- a/clio/help/en/get-identity-service-config.txt
+++ b/clio/help/en/get-identity-service-config.txt
@@ -14,7 +14,7 @@ DESCRIPTION
 
     It reports identityServerUrl, source (setting, derived, or none), the token endpoint
     ({base}/connect/token), the discovery endpoint ({base}/.well-known/openid-configuration), and
-    whether the discovery document is reachable. Use it first when configuring server-to-server
+    whether discovery succeeds with an issuer and valid endpoint URLs. Use it first when configuring server-to-server
     OAuth on a remote Creatio.
 
 SYNOPSIS

--- a/clio/help/en/verify-oauth-app.txt
+++ b/clio/help/en/verify-oauth-app.txt
@@ -10,27 +10,28 @@ DESCRIPTION
     Creatio DataService smoke request with that token.
 
     It reports tokenAcquired, dataServiceStatus (the HTTP status of the smoke request), and ok
-    (token acquired AND dataServiceStatus 200). The access token text is never returned or logged.
+    (token acquired, HTTP 200, and successful DataService JSON response). The access token text is never returned or logged.
 
 SYNOPSIS
-    clio verify-oauth-app -e ENVIRONMENT --client-id ID --client-secret SECRET [OPTIONS]
+    clio verify-oauth-app -e ENVIRONMENT [OPTIONS]
 
 OPTIONS
     -e, --environment NAME
         Required. Registered Creatio environment.
 
     --client-id ID
-        Required. OAuth client id to verify.
+        Optional. OAuth client id override; supply together with --client-secret. Defaults to registered credentials.
 
     --client-secret SECRET
-        Required. OAuth client secret to verify. Never returned or logged.
+        Optional. OAuth client secret override; supply together with --client-id. Never returned or logged.
 
     --identity-server-url URL
-        Explicit IdentityService base URL. When omitted, it is read from the
+        Explicit IdentityService base URL. Defaults to registered AuthAppUri, then the
         OAuth20IdentityServerUrl system setting, then derived from the Creatio host.
 
 EXAMPLES
     # Verify an OAuth app, deriving the IdentityService URL.
+    clio verify-oauth-app -e DEV
     clio verify-oauth-app -e c-dev --client-id my-client --client-secret my-secret
 
     # Verify against an explicit IdentityService URL.
@@ -42,3 +43,7 @@ NOTES
         clio experimental --name deploy-identity --enable
 
     This command is read-only; it does not modify Creatio. The access token is never logged.
+
+    Verification reads existing credentials and does not change settings or create an OAuth app.
+    A nonempty bearer token and a successful DataService JSON response are required; HTTP 200 alone is insufficient.
+    The CRM request uses only the newly issued token, without falling back to username/password. Exit code is 0 on success and 1 on failure.

--- a/docs/knowledge/Command/identityservice-issuer-can-be-an-opaque-name.md
+++ b/docs/knowledge/Command/identityservice-issuer-can-be-an-opaque-name.md
@@ -1,0 +1,13 @@
+---
+description: Creatio IdentityService can publish creatio.com as its issuer rather than an absolute URL
+applies-to:
+  - clio/Command/OAuthAppConfiguration/IdentityServerProbe.cs
+ticket: clio-1432
+date: 2026-09-10
+---
+
+**What is true** — The IdentityService bundled with Creatio 10.1.585 publishes `issuer: "creatio.com"` with absolute discovery endpoint URLs. This was observed on the isolated issue-1432 local deployment.
+
+**Why it is this way** — The issuer is a configured token identifier, independent of the host address used to reach IdentityService. Clio checks that it is present; CRM remains responsible for accepting the issued token.
+
+**What breaks if you ignore it** — Requiring the issuer to be an absolute HTTP URL rejects this real deployment before token verification. Do not equate the issuer identifier with the discovery host or implement a second token-validation policy in Clio.


### PR DESCRIPTION
`verify-oauth-app -e DEV` now reads the registered OAuth credentials and token URL, obtains a bearer token, and uses that exact token for the existing read-only CRM DataService request. Explicit credential pairs still override the saved pair. No permission analysis, additional command, or AI Studio integration is introduced.

`deploy-identity` reuses the probe and saves credentials only after CRM accepts the token. Malformed discovery/token/CRM responses fail verification; `--no-app` explicitly skips token and CRM checks. Discovery accepts the opaque issuer used by the real bundled IdentityService. Errors and results do not expose tokens or secrets.

Fixes #1432 (scope narrowed by the reporter).

Validation:
- Affected Command/McpServer unit tests: `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=McpServer)&FullyQualifiedName!~RunStartupUpdateCheck_ShouldStartExistingCommands_WhenSchedulesAreDue" --no-build` with `CLIO_NO_UPDATE_CHECK=1`; the update-check test runs separately without that override.
- Real MCP process tests: `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~OAuthConfigurationToolsE2ETests|FullyQualifiedName~DeployIdentityToolE2ETests" --no-build`; repeated on net8.0. Ten passed per framework.
- Isolated Creatio 10.1.585/.NET 8/PostgreSQL lab `issue-1432`: deployment verification succeeded; standalone `verify-oauth-app -e issue-1432` returned tokenAcquired=true, dataServiceStatus=200, ok=true, exit 0. The settings file hash was unchanged by standalone verification. The repaired instance was not touched.
- Comprehensive parallel pre-PR and final review covered quality, correctness/testing/performance, security, intent, and KISS; no blockers.

Docs and MCP arguments/descriptions/curated deployment contract updated; existing prompts, resources, templates, and Wiki anchors reviewed. Published server-to-server-oauth and deploy-lifecycle guidance remains accurate; no library update required. ClioRing compatibility reviewed, no Ring-consumed contract changed (inspected clio-ring/ClioRing.Ipc, clio-ring/ClioRing, and clio-ring/ClioRing.Desktop/actions.json).

Claude review: no blocking findings. The suggested CRM settings-cache concern was ruled out by the successful fresh deployment without a CRM restart. Safe generic errors retained; help-text formatting corrected. Unit results: 9,252 passed and 15 skipped, plus the update-check test passed separately.
