### PR TITLE
fix(reg-web-app): register nothing when detection refuses, and name the real failure

### DIFF
--- a/clio.mcp.e2e/RegWebAppToolE2ETests.cs
+++ b/clio.mcp.e2e/RegWebAppToolE2ETests.cs
@@ -105,6 +105,73 @@ public sealed class RegWebAppToolE2ETests {
 		AssertSettingsPersistedFrameworkRuntime(context.SettingsFilePath, actResult.EnvironmentName);
 	}
 
+	[Test]
+	[AllureTag(ToolName)]
+	[AllureName("reg-web-app registers nothing when runtime auto-detection refuses")]
+	[AllureDescription("Issue #1435: a refused detection used to leave a registered environment behind, carrying an IsNetCore value nothing verified. The command must fail and persist nothing.")]
+	[Description("Leaves the clio settings untouched when auto-detection cannot name a runtime.")]
+	public async Task RegisterWebApp_Should_Not_Persist_The_Environment_When_Detection_Refuses() {
+		// Arrange
+		(McpE2ESettings settings, TemporaryClioSettingsOverride settingsOverride) = ArrangeIsolatedClio();
+		using TemporaryClioSettingsOverride _ = settingsOverride;
+		await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
+			new RuntimeDetectionStubServerConfiguration(
+				NetCoreHealthEnabled: true,
+				NetFrameworkHealthEnabled: true,
+				NetCoreServiceEnabled: false,
+				NetFrameworkServiceEnabled: false,
+				NetCoreUiMarkerMode: "notfound",
+				NetFrameworkUiMarkerMode: "notfound"));
+		await using ArrangeContext context = await ArrangeAsync(settings, stubServer);
+
+		// Act
+		RegWebAppActResult actResult = await ActAsync(context);
+
+		// Assert
+		actResult.Execution.ExitCode.Should().NotBe(0,
+			because: $"a runtime that could not be determined is a registration failure. Actual execution: {DescribeExecution(actResult.Execution)}");
+		AssertEnvironmentWasNotPersisted(context.SettingsFilePath, actResult.EnvironmentName);
+	}
+
+	[Test]
+	[AllureTag(ToolName)]
+	[AllureName("reg-web-app reports a stopped site instead of asking for a runtime")]
+	[AllureDescription("Issue #1435: when every probe route answers 503 the operator was told to pass --IsNetCore, which cannot fix a site that is down.")]
+	[Description("Reports that the site is not serving requests when every probe route answers an HTTP server error.")]
+	public async Task RegisterWebApp_Should_Report_An_Unavailable_Site_When_Every_Route_Answers_503() {
+		// Arrange
+		(McpE2ESettings settings, TemporaryClioSettingsOverride settingsOverride) = ArrangeIsolatedClio();
+		using TemporaryClioSettingsOverride _ = settingsOverride;
+		await using RuntimeDetectionStubServer stubServer = RuntimeDetectionStubServer.Start(
+			new RuntimeDetectionStubServerConfiguration(
+				NetCoreHealthEnabled: false,
+				NetFrameworkHealthEnabled: false,
+				NetCoreServiceEnabled: false,
+				NetFrameworkServiceEnabled: false,
+				AllRoutesUnavailable: true));
+		await using ArrangeContext context = await ArrangeAsync(settings, stubServer);
+
+		// Act
+		RegWebAppActResult actResult = await ActAsync(context);
+
+		// Assert
+		actResult.Execution.ExitCode.Should().NotBe(0,
+			because: $"a site that serves nothing cannot be registered. Actual execution: {DescribeExecution(actResult.Execution)}");
+		string reported = DescribeExecution(actResult.Execution);
+		reported.Should().Contain("is not serving requests",
+			because: "the operator has to be sent to the stopped application rather than to the --IsNetCore flag");
+		AssertEnvironmentWasNotPersisted(context.SettingsFilePath, actResult.EnvironmentName);
+	}
+
+	private static void AssertEnvironmentWasNotPersisted(string settingsFilePath, string environmentName) {
+		using JsonDocument document = JsonDocument.Parse(File.ReadAllText(settingsFilePath));
+		document.RootElement
+			.GetProperty("Environments")
+			.TryGetProperty(environmentName, out _)
+			.Should().BeFalse(
+				because: "a failed registration must not leave an environment whose runtime was never verified");
+	}
+
 	private static (McpE2ESettings Settings, TemporaryClioSettingsOverride Override) ArrangeIsolatedClio() {
 		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-reg-web-app-e2e-{Guid.NewGuid():N}");
 		Directory.CreateDirectory(tempHome);

--- a/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
+++ b/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
@@ -211,6 +211,11 @@ http.createServer((request, response) => {
       return;
     }
     recordedRequests.push({ method: request.method, url: url });
+    // A stopped or recycling application pool answers 503 on every route, including the auth endpoint.
+    if (config.AllRoutesUnavailable) {
+      sendText(response, 503, "Service Unavailable");
+      return;
+    }
     if (request.method === "POST" && url === "/ServiceModel/AuthService.svc/Login") {
       sendJson(
         response,
@@ -389,6 +394,7 @@ internal sealed record RuntimeDetectionStubServerConfiguration(
 	bool NetFrameworkUiMarkerEnabled = false,
 	string? NetCoreUiMarkerMode = null,
 	string? NetFrameworkUiMarkerMode = null,
+	bool AllRoutesUnavailable = false,
 	string? ODataRoutingErrorEntity = null,
 	string? HtmlSelectQuerySchemaName = null,
 	string? ODataNonJsonEntity = null,

--- a/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
+++ b/clio.tests/Command/EnvironmentRuntimeDetectionServiceTests.cs
@@ -509,6 +509,127 @@ public sealed class EnvironmentRuntimeDetectionServiceTests {
 			because: "/api/HealthCheck/Ping also answers on a .NET Framework site, so a single successful health probe must not outrank the login markers");
 	}
 
+	[Test]
+	[Description("Reports a wrong or removed application path, instead of asking for a runtime, when every probe route answers 404.")]
+	public void Detect_Should_Report_A_Missing_Application_When_Every_Probe_Answers_NotFound() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.NotFound,
+			[BuildHealthUrl(false)] = HttpStatusCode.NotFound,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.NotFound,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.NotFound
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceThrows(netCoreClient, true, new HttpRequestException("404 Not Found."));
+		ConfigureServiceThrows(netFrameworkClient, false, new HttpRequestException("404 Not Found."));
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(CreateEnvironment());
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "a URL where no Creatio route exists cannot be classified into a runtime")
+			.Which;
+		exception.Message.Should().Contain("serves a Creatio route",
+			because: "the operator has to check the application path, not pick a runtime for a URL with nothing behind it");
+		exception.Message.Should().NotContain("--IsNetCore true",
+			because: "registering a runtime for a dead URL would only move the failure to the next command");
+	}
+
+	[Test]
+	[Description("Reports that the site is not serving requests, instead of asking for a runtime, when every probe route answers an HTTP server error.")]
+	public void Detect_Should_Report_An_Unavailable_Site_When_Every_Probe_Answers_A_Server_Error() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.ServiceUnavailable,
+			[BuildHealthUrl(false)] = HttpStatusCode.ServiceUnavailable,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.ServiceUnavailable,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.ServiceUnavailable
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceThrows(netCoreClient, true, new HttpRequestException("503 Service Unavailable."));
+		ConfigureServiceThrows(netFrameworkClient, false, new HttpRequestException("503 Service Unavailable."));
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(CreateEnvironment());
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "a site that serves nothing cannot be classified, and it is not the caller's runtime choice that is missing")
+			.Which;
+		exception.Message.Should().Contain("is not serving requests",
+			because: "the operator has to be sent to the stopped application, not to the --IsNetCore flag");
+		exception.Message.Should().NotContain("--IsNetCore true",
+			because: "choosing a runtime cannot fix a site that is down, so offering it sends the operator to the wrong problem");
+	}
+
+	[Test]
+	[Description("Keeps asking for an explicit runtime when every probe route answers 401, because a gated site is still serving.")]
+	public void Detect_Should_Not_Report_An_Unavailable_Site_When_Every_Probe_Answers_Unauthorized() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateHttpClientFactory(new Dictionary<string, HttpStatusCode> {
+			[BuildHealthUrl(true)] = HttpStatusCode.Unauthorized,
+			[BuildHealthUrl(false)] = HttpStatusCode.Unauthorized,
+			[BuildUiMarkerUrl(true)] = HttpStatusCode.Unauthorized,
+			[BuildUiMarkerUrl(false)] = HttpStatusCode.Unauthorized
+		});
+		IOwnedApplicationClient netCoreClient = Substitute.For<IOwnedApplicationClient>();
+		IOwnedApplicationClient netFrameworkClient = Substitute.For<IOwnedApplicationClient>();
+		ConfigureFactory(applicationClientFactory, netCoreClient, netFrameworkClient);
+		ConfigureClientWarmup(netCoreClient, true);
+		ConfigureClientWarmup(netFrameworkClient, false);
+		ConfigureServiceFailure(netCoreClient, true, "NetCore SelectQuery failed.");
+		ConfigureServiceFailure(netFrameworkClient, false, "Framework SelectQuery failed.");
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(CreateEnvironment());
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "a gated site answers every route, so nothing distinguishes the runtimes")
+			.Which;
+		exception.Message.Should().Contain("--IsNetCore true",
+			because: "the site is serving, so an explicit override really is the way past it");
+		exception.Message.Should().NotContain("is not serving requests",
+			because: "a 401 proves the route was served, so calling the site unavailable would be false");
+	}
+
+	[Test]
+	[Description("Classifies a real HttpClient timeout as an unreachable host even though the unwrapped message says only that a task was canceled.")]
+	public void Detect_Should_Report_An_Unreachable_Host_When_Every_Probe_Times_Out() {
+		// Arrange
+		IApplicationClientFactory applicationClientFactory = Substitute.For<IApplicationClientFactory>();
+		IHttpClientFactory httpClientFactory = CreateFailingHttpClientFactory(
+			new TaskCanceledException("A task was canceled."));
+		EnvironmentRuntimeDetectionService sut = new(applicationClientFactory, httpClientFactory, new ServiceUrlBuilderFactory());
+
+		// Act
+		Action act = () => sut.Detect(new EnvironmentSettings {
+			Uri = "http://ts1-infr-web01:88/studioenu_14771250_0401"
+		});
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "a host that never answers cannot be classified")
+			.Which;
+		exception.Message.Should().Contain("could not be reached from this machine",
+			because: "no HTTP status came back at all, which is a connectivity problem regardless of how the exception text reads");
+	}
+
 	private static void ConfigureFactory(
 		IApplicationClientFactory applicationClientFactory,
 		IOwnedApplicationClient netCoreClient,

--- a/clio.tests/Command/RegAppCommandAutoDetectionTests.cs
+++ b/clio.tests/Command/RegAppCommandAutoDetectionTests.cs
@@ -1,9 +1,11 @@
+using System;
 using Clio.Command;
 using Clio.Common;
 using Clio.UserEnvironment;
 using Clio.Utilities;
 using FluentAssertions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -45,6 +47,67 @@ public sealed class RegAppCommandAutoDetectionTests {
 		settingsRepository.Received().ConfigureEnvironment("sandbox", Arg.Is<EnvironmentSettings>(settings =>
 			settings.Uri == "http://example.invalid"
 			&& settings.IsNetCore));
+	}
+
+	[Test]
+	[Description("Persists nothing and reports a failure when runtime auto-detection refuses to name a runtime.")]
+	public void Execute_Should_Not_Register_The_Environment_When_Runtime_Detection_Refuses() {
+		// Arrange
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		IEnvironmentRuntimeDetectionService runtimeDetectionService = Substitute.For<IEnvironmentRuntimeDetectionService>();
+		runtimeDetectionService.Detect(Arg.Any<EnvironmentSettings>())
+			.Throws(new InvalidOperationException("Unable to auto-detect the Creatio runtime."));
+		RegAppCommand sut = new(
+			settingsRepository,
+			Substitute.For<IApplicationClientFactory>(),
+			Substitute.For<IPowerShellFactory>(),
+			_logger,
+			runtimeDetectionService);
+		RegAppOptions options = new() {
+			EnvironmentName = "sandbox",
+			Uri = "http://example.invalid/",
+			Login = "Supervisor",
+			Password = "Supervisor"
+		};
+
+		// Act
+		int result = sut.Execute(options);
+
+		// Assert
+		result.Should().Be(1,
+			because: "a runtime that could not be determined is a registration failure, not a warning");
+		settingsRepository.DidNotReceiveWithAnyArgs().ConfigureEnvironment(default!, default!);
+		_logger.Received().WriteError(Arg.Is<string>(text => text.Contains("Unable to auto-detect the Creatio runtime")));
+	}
+
+	[Test]
+	[Description("Writes the environment exactly once, with the detected runtime, instead of persisting a guess first.")]
+	public void Execute_Should_Persist_The_Environment_Once_With_The_Detected_Runtime() {
+		// Arrange
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		IEnvironmentRuntimeDetectionService runtimeDetectionService = Substitute.For<IEnvironmentRuntimeDetectionService>();
+		runtimeDetectionService.Detect(Arg.Any<EnvironmentSettings>()).Returns(true);
+		RegAppCommand sut = new(
+			settingsRepository,
+			Substitute.For<IApplicationClientFactory>(),
+			Substitute.For<IPowerShellFactory>(),
+			_logger,
+			runtimeDetectionService);
+		RegAppOptions options = new() {
+			EnvironmentName = "sandbox",
+			Uri = "http://example.invalid/",
+			Login = "Supervisor",
+			Password = "Supervisor"
+		};
+
+		// Act
+		int result = sut.Execute(options);
+
+		// Assert
+		result.Should().Be(0,
+			because: "detection succeeded, so registration should complete normally");
+		settingsRepository.Received(1).ConfigureEnvironment("sandbox", Arg.Any<EnvironmentSettings>());
+		settingsRepository.DidNotReceive().ConfigureEnvironment("sandbox", Arg.Is<EnvironmentSettings>(settings => !settings.IsNetCore));
 	}
 
 	[Test]

--- a/clio/Command/EnvironmentRuntimeDetectionService.cs
+++ b/clio/Command/EnvironmentRuntimeDetectionService.cs
@@ -280,7 +280,7 @@ internal sealed class EnvironmentRuntimeDetectionService(
 	}
 
 	private static string BuildFailureMessage(string baseUri, RuntimeProbeResult netCoreProbe, RuntimeProbeResult netFrameworkProbe) =>
-		TryBuildReachabilityFailureMessage(baseUri, netCoreProbe, netFrameworkProbe, out string message)
+		TryBuildSiteUnavailableMessage(baseUri, netCoreProbe, netFrameworkProbe, out string message)
 			? message
 			: $"Unable to auto-detect the Creatio runtime. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)} Rerun reg-web-app with --IsNetCore true or --IsNetCore false to override detection.";
 
@@ -288,14 +288,26 @@ internal sealed class EnvironmentRuntimeDetectionService(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe) =>
-		TryBuildReachabilityFailureMessage(baseUri, netCoreProbe, netFrameworkProbe, out string message)
+		TryBuildSiteUnavailableMessage(baseUri, netCoreProbe, netFrameworkProbe, out string message)
 			? message
 			: $"Unable to auto-detect the Creatio runtime because no credentials were provided and the unauthenticated probes were inconclusive. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)} Provide -l/-p or OAuth settings to enable the authenticated SelectQuery probe, or rerun reg-web-app with --IsNetCore true or --IsNetCore false.";
 
 	private static string BuildAmbiguousMessage(RuntimeProbeResult netCoreProbe, RuntimeProbeResult netFrameworkProbe) =>
 		$"Unable to auto-detect the Creatio runtime because both .NET Core / NET8 and .NET Framework service probes succeeded. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)} Rerun reg-web-app with --IsNetCore true or --IsNetCore false to override detection.";
 
-	private static bool TryBuildReachabilityFailureMessage(
+	/// <summary>
+	/// Builds the diagnostic for a site that never served a single probe, so the caller does not tell the user
+	/// to choose a runtime for a site that is simply not up.
+	/// </summary>
+	/// <remarks>
+	/// Two distinct outcomes, and the difference matters to whoever reads the message: no HTTP response arrived
+	/// at all (DNS, refused, no route, timed out) points at connectivity, while an HTTP server error from every
+	/// route points at the application itself being stopped or recycling. Classification is by whether a status
+	/// code came back, never by matching words in the exception text - a real
+	/// <see cref="HttpClient"/> timeout surfaces as "A task was canceled." once
+	/// <see cref="Exception.GetBaseException"/> has unwrapped it, so text matching silently misses it.
+	/// </remarks>
+	private static bool TryBuildSiteUnavailableMessage(
 		string baseUri,
 		RuntimeProbeResult netCoreProbe,
 		RuntimeProbeResult netFrameworkProbe,
@@ -306,32 +318,31 @@ internal sealed class EnvironmentRuntimeDetectionService(
 			netFrameworkProbe.HealthProbe,
 			netFrameworkProbe.UiMarkerProbe
 		];
-		if (directAttempts.Any(attempt => attempt.Succeeded)
-			|| directAttempts.Any(attempt => !IsReachabilityFailure(attempt.ErrorMessage))) {
+		if (!directAttempts.All(WasNotServed)) {
 			message = string.Empty;
 			return false;
 		}
 		string authority = Uri.TryCreate(baseUri, UriKind.Absolute, out Uri? uri)
 			? uri.Authority
 			: baseUri;
-		message =
-			$"Unable to auto-detect the Creatio runtime because the host '{authority}' could not be reached from this machine. Verify the URL, DNS/VPN connectivity, and that the site is accessible, then rerun reg-web-app. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)}";
+		if (directAttempts.All(attempt => attempt.StatusCode is null)) {
+			message =
+				$"Unable to auto-detect the Creatio runtime because the host '{authority}' could not be reached from this machine. Verify the URL, DNS/VPN connectivity, and that the site is accessible, then rerun reg-web-app. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)}";
+			return true;
+		}
+		message = directAttempts.All(ProvesAbsence)
+			? $"Unable to auto-detect the Creatio runtime because nothing at '{baseUri}' serves a Creatio route: every probe answered 404. Verify the application path in the URL and that the application is still deployed, then rerun reg-web-app. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)}"
+			: $"Unable to auto-detect the Creatio runtime because the site at '{authority}' is not serving requests: every probe answered an HTTP server error. Verify that the Creatio application is started and finished warming up, then rerun reg-web-app. {BuildProbeSummary(netCoreProbe, netFrameworkProbe)}";
 		return true;
 	}
 
-	private static bool IsReachabilityFailure(string? errorMessage) {
-		if (string.IsNullOrWhiteSpace(errorMessage)) {
-			return false;
-		}
-		return errorMessage.Contains("could not resolve host", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("nodename nor servname", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("name or service not known", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("no such host is known", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("connection refused", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("actively refused", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("timed out", StringComparison.OrdinalIgnoreCase)
-			|| errorMessage.Contains("timeout", StringComparison.OrdinalIgnoreCase);
-	}
+	/// <summary>Reports whether a probe route failed without the site serving anything usable there: no HTTP
+	/// response at all, an HTTP server error, or a "not found" that proves the route does not exist.</summary>
+	/// <remarks>A 401 or 403 does NOT qualify - the site served the route and refused the request, which means it
+	/// is up and the diagnostic must not claim otherwise.</remarks>
+	private static bool WasNotServed(ProbeAttempt attempt) =>
+		!attempt.Succeeded
+		&& (attempt.StatusCode is null || (int)attempt.StatusCode >= 500 || ProvesAbsence(attempt));
 
 	private static string BuildProbeSummary(RuntimeProbeResult netCoreProbe, RuntimeProbeResult netFrameworkProbe) =>
 		$".NET Core / NET8: health {netCoreProbe.HealthUrl} => {Describe(netCoreProbe.HealthProbe)}, service {netCoreProbe.ServiceUrl} => {Describe(netCoreProbe.ServiceProbe)}, UI marker {netCoreProbe.UiMarkerUrl} => {Describe(netCoreProbe.UiMarkerProbe)}. .NET Framework: health {netFrameworkProbe.HealthUrl} => {Describe(netFrameworkProbe.HealthProbe)}, service {netFrameworkProbe.ServiceUrl} => {Describe(netFrameworkProbe.ServiceProbe)}, UI marker {netFrameworkProbe.UiMarkerUrl} => {Describe(netFrameworkProbe.UiMarkerProbe)}.";

--- a/clio/Command/RegAppCommand.cs
+++ b/clio/Command/RegAppCommand.cs
@@ -111,13 +111,17 @@ public class RegAppCommand : Command<RegAppOptions> {
 				? null
 				: _settingsRepository.FindEnvironment(options.EnvironmentName);
 			
+			// Resolve the runtime BEFORE anything is persisted. Detection is allowed to refuse, and a refusal
+			// that leaves a registered environment behind is worse than a plain failure: the stored IsNetCore
+			// was guessed, nothing verified it, and every later command builds its URLs from it (issue #1435).
+			bool resolvedIsNetCore = ResolveIsNetCore(options, existingEnvironment);
 			EnvironmentSettings environment = new() {
 				Login = options.Login,
 				Password = options.Password,
 				Uri = options.Uri?.TrimEnd('/'),
 				Maintainer = options.Maintainer,
 				Safe = options.SafeValue ?? false,
-				IsNetCore = options.IsNetCore ?? existingEnvironment?.IsNetCore ?? false,
+				IsNetCore = resolvedIsNetCore,
 				DeveloperModeEnabled = options.DeveloperModeEnabled,
 				ClientId = options.ClientId,
 				ClientSecret = options.ClientSecret,
@@ -126,12 +130,6 @@ public class RegAppCommand : Command<RegAppOptions> {
 				EnvironmentPath = options.EnvironmentPath
 			};
 			_settingsRepository.ConfigureEnvironment(options.EnvironmentName, environment);
-
-			bool resolvedIsNetCore = ResolveIsNetCore(options, existingEnvironment);
-			if (resolvedIsNetCore != environment.IsNetCore) {
-				environment.IsNetCore = resolvedIsNetCore;
-				_settingsRepository.ConfigureEnvironment(options.EnvironmentName, environment);
-			}
 
 			_logger.WriteInfo($"Environment {options.EnvironmentName} was configured...");
 			environment = _settingsRepository.GetEnvironment(options);

--- a/clio/docs/commands/reg-web-app.md
+++ b/clio/docs/commands/reg-web-app.md
@@ -23,8 +23,10 @@ Omit `--IsNetCore` and clio detects the runtime itself, in this order:
 3. **Health endpoints**, last and only as a tiebreaker: `/api/HealthCheck/Ping` answers
    on a .NET Framework site as well, so it cannot tell the runtimes apart on its own.
 
-When the probes stay inconclusive clio stops with a diagnostic naming every URL it tried,
-rather than guessing — pass `--IsNetCore` to skip detection entirely.
+When the probes stay inconclusive clio stops with a diagnostic naming every URL it tried, rather than guessing,
+and **registers nothing** — an environment whose runtime was guessed would misdirect every later command. Pass
+`--IsNetCore` to skip detection entirely. If no route was served at all, the diagnostic says the site is
+unreachable or not serving requests instead of asking for a runtime.
 
 ## Synopsis
 

--- a/clio/help/en/reg-web-app.txt
+++ b/clio/help/en/reg-web-app.txt
@@ -14,7 +14,9 @@ DESCRIPTION
     404 proves that runtime is absent. The health endpoints are only a last
     resort, because /api/HealthCheck/Ping answers on a .NET Framework site too.
     Detection stops with a diagnostic rather than guessing when the probes stay
-    inconclusive - pass --IsNetCore to skip it entirely.
+    inconclusive, and registers nothing in that case - pass --IsNetCore to skip
+    it entirely. When no route was served at all, the diagnostic says the site is
+    unreachable or not serving requests instead of asking for a runtime.
 
 SYNOPSIS
     clio reg-web-app <ENVIRONMENT_NAME> -u http://mysite.creatio.com -l administrator -p password

--- a/docs/knowledge/Common/httpclient-timeout-message-is-lost-by-getbaseexception.md
+++ b/docs/knowledge/Common/httpclient-timeout-message-is-lost-by-getbaseexception.md
@@ -1,0 +1,28 @@
+---
+description: GetBaseException unwraps an HttpClient timeout to "A task was canceled.", so classifying a transport failure by matching words in the message never matches a real timeout
+applies-to:
+  - clio/Command/EnvironmentRuntimeDetectionService.cs
+date: 2026-09-10
+---
+
+**What is true** — when `HttpClient` aborts a request on its own `Timeout`, the exception it throws is a
+`TaskCanceledException` whose own `Message` names the timeout ("The request was canceled due to the configured
+HttpClient.Timeout of 10 seconds elapsing"), but whose `InnerException` is a plain `TimeoutException` /
+`OperationCanceledException`. `exception.GetBaseException().Message` therefore yields `A task was canceled.` —
+the wording that identifies the timeout is on the outer exception and is gone by the time it is logged.
+
+The same holds for a Windows socket timeout: the useful text is "A connection attempt failed because the
+connected party did not properly respond after a period of time", which contains neither "timeout" nor
+"timed out".
+
+**Why it is this way** — `GetBaseException` is used to strip the wrapper layers that `HttpClient` and
+`CreatioClient` add, so the surfaced message names the real cause. For a timeout that heuristic works against
+itself: the cause is the wrapper.
+
+**What breaks if you ignore it** — any code that decides "was this a connectivity failure?" by searching the
+message for `timeout` / `timed out` silently answers no on every real timeout. In
+`EnvironmentRuntimeDetectionService` that meant a host that accepted the connection and then never answered was
+reported as an undecidable runtime, telling the operator to pass `--IsNetCore` for a site that was not
+responding. Classify by whether an HTTP status code came back (`ProbeAttempt.StatusCode is null` means no HTTP
+response at all) rather than by message text; the text is for the human reading the diagnostic, not for the
+decision.


### PR DESCRIPTION
🔗 **Issue:** [#1435](https://github.com/Advance-Technologies-Foundation/clio/issues/1435)

Closes #1435

> **Stacked on [#1429](https://github.com/Advance-Technologies-Foundation/clio/pull/1429)** — base is
> `fix/issue-1428-runtime-detection-cold-site`, because both touch the failure-message builders in
> `EnvironmentRuntimeDetectionService`. Review the diff of this branch against that base; GitHub retargets to
> `master` when #1429 merges.

## 1. A refused detection no longer leaves an environment behind

`RegAppCommand.Execute` persisted the environment **before** resolving the runtime, then wrote it a second
time if detection disagreed. A refusal therefore exited `1` with a red error *and* left a registered
environment carrying an `IsNetCore` value nothing had verified, along with the supplied credentials.

On a .NET Framework site the guess happens to be right, so nothing looks wrong. On a .NET Core site the user
is left registered on the wrong runtime after a visible error, and every later command builds `0/`-prefixed
URLs and fails for reasons that look nothing like a registration problem.

The runtime is now resolved first and the environment written once. The reordering is safe because
`BuildDetectionEnvironment` composes its settings from the options and from the `existingEnvironment` snapshot
taken before the write, so detection never depended on the write having happened. It also removes the double
write.

## 2. The diagnostic now names the real failure

It used to tell the user to pick a runtime for a site that was not answering. Classification is now by what
came back, not by matching words in the exception text:

| What every probe route did | What the user is told |
|---|---|
| no HTTP response at all | the host could not be reached — check URL, DNS/VPN *(unchanged wording)* |
| answered `5xx` | the site is not serving requests — check the application is started |
| answered `404` | nothing at this URL serves a Creatio route — check the application path |

A `401` or `403` deliberately does **not** qualify: the site served the route and refused the request, so
calling it unavailable would be false. There is a test pinning that.

**The `404` case was found live, not designed.** Hours after #1428 was reported, the same stand had stopped
serving the application entirely and answered `404` on all six probes — and the old message still offered
`--IsNetCore`, which would have registered a dead URL.

Classifying by status code also removes a trap the #1429 review surfaced: `GetBaseException()` unwraps an
`HttpClient` timeout to `A task was canceled.`, so the old word list (`timeout`, `timed out`, …) never matched
a real timeout. Recorded in
[`docs/knowledge/Common/httpclient-timeout-message-is-lost-by-getbaseexception.md`](docs/knowledge/Common/httpclient-timeout-message-is-lost-by-getbaseexception.md).

## Tests

Unit — five new cases (nothing persisted on refusal, a single write on success, and the three site-level
diagnostics) plus a guard proving an all-`401` site still gets the runtime message rather than being called
unavailable.

E2E — two new `RegWebAppToolE2ETests` cases, with a stub mode that answers `503` on every route: a refused
detection must leave the settings file untouched, and an all-`503` site must be reported as not serving.

Mutation-checked: against the parent commit, four of the five unit cases and both e2e cases fail.

Validated:
- `dotnet test --filter "Category=Unit&Module=Command"` — 4277 passed, 0 failed
- `RegWebAppToolE2ETests` on net8.0 and net10.0 — 5 passed each
- Live against the stand from #1428, which is currently answering `404` everywhere:
  `Unable to auto-detect the Creatio runtime because nothing at 'http://…' serves a Creatio route: every probe
  answered 404.` and `appsettings.json` was left untouched.

## Behaviour change worth calling out in review

A failed detection now means **no environment at all**, where before one was created with a guessed runtime.
The user re-runs with `--IsNetCore`, which is a single command. The alternative — what we have today — is a
registration that looks fine and misdirects every later command.

## Review notes

Docs updated — `help/en/reg-web-app.txt` and `docs/commands/reg-web-app.md` now state that a refused detection
registers nothing, and what the site-level diagnostics mean.

MCP reviewed — the `reg-web-app` tool's behaviour changed on the failure path, and the new `clio.mcp.e2e`
coverage is part of this PR. `RegWebAppPrompt` needs no change: it does not describe failure handling.

ClioRing compatibility reviewed, no Ring-consumed contract changed — Ring reads the `IsNetCore` value out of
the environment catalog (`clio-ring/ClioRing/Services/ClioAdapter.cs:208`,
`clio-ring/ClioRing/Services/ClioModels.cs:19`) and never invokes `reg-web-app` or the detection service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
