### PR TITLE
ENG-91853: close out the flow-label story and record its counter-example

### DIFF
--- a/docs/knowledge/Common/a-version-floor-in-a-caller-facing-message-is-unreachable-advice.md
+++ b/docs/knowledge/Common/a-version-floor-in-a-caller-facing-message-is-unreachable-advice.md
@@ -55,3 +55,19 @@ install a number is advice and must not.
 The regression guard is an inverse test: `FlowLabelSurfaces_ShouldNameNoPackageVersion` in
 `clio.tests/Common/BundledProcessBuilderPackageTests.cs` asserts these surfaces match no four-part
 version at all, because a number removed on purpose is otherwise free to come back looking helpful.
+
+**The counter-example is real, not hypothetical, and it is measured.** A reviewer left this as the one
+open question on the change: does any archive numbered ABOVE the capability floor actually lack the
+member? It does. Counted over the tags in the CrtProcessBuilder repository on 2026-09-10:
+
+```
+crtprocessbuilder-1.6.1.2   a115cc75   [DataMember(Name = "label")] declarations: 0
+crtprocessbuilder-1.6.1.4   9c86d9b0   [DataMember(Name = "label")] declarations: 3
+```
+
+1.6.1.2 is higher than the 1.6.0.8 the member first shipped in, and carries none of it - the 1.6.1.x
+line was cut from a branch that did not have the label work. The package's own default branch has 0 as
+well. So a reader on 1.6.1.2 satisfies "1.6.0.8 or newer" by arithmetic and still has the field
+discarded silently: the qualitative wording is not a stylistic improvement, it is the only wording that
+is TRUE. (Tags 1.6.1.0, 1.6.1.1 and 1.6.1.3 do not exist - one was replaced, one was burned by an
+aborted rebundle - so 1.6.1.2 is the whole population below 1.6.1.4.)

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -3692,7 +3692,7 @@ stories:
     feature: "eng-91853-gateways-and-flows"
     repo: "clio + workspace/ProcessBuilder + clio-knowledge"
     size: M
-    status: review
+    status: done
     pr: https://github.com/Advance-Technologies-Foundation/clio/pull/1414
     prs:
       - https://github.com/Advance-Technologies-Foundation/clio/pull/1414


### PR DESCRIPTION
Two items belonging to the merged ENG-91853 flow-label change that missed its window.

**The story is done.** All three PRs are merged — clio #1414 (`3517ea011`), crt-process-builder #53 (`3b2f326`), clio-knowledge #138 (`d6efe7d`) — so `story-eng-91853-flow-labels-1` moves `review` → `done`, which the sprint-tracker rules ask for at merge time.

**The rule now carries its counter-example.** The merged change removed every version floor from the flow-label texts, arguing that a number cannot express a capability once two branches cut versions. A reviewer left the right question open: does an archive numbered *above* the floor actually exist that lacks the member, or is the argument theoretical? It exists:

```
crtprocessbuilder-1.6.1.2   a115cc75   [DataMember(Name = "label")]: 0
crtprocessbuilder-1.6.1.4   9c86d9b0   [DataMember(Name = "label")]: 3
```

`1.6.1.2` is higher than the `1.6.0.8` the member first shipped in and carries none of it — the 1.6.1.x line was cut from a branch without the label work. Tags `1.6.1.0`, `1.6.1.1` and `1.6.1.3` do not exist (one replaced, one burned by an aborted rebundle), so `1.6.1.2` is the entire population below `1.6.1.4` and the single data point is the adverse one. That makes the qualitative wording the only *true* wording rather than a preference — a stronger claim than the record held before.

It was measured after the branch's last push, which is why it arrives in a follow-up rather than in the PR that introduced the rule. The knowledge-base rule says same-PR; this is the repair rather than a silent late edit.

**Scope:** one spec file and one knowledge record. No code. `dotnet test --filter "Category=Unit"` on the merged tree: 11 941 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
