### PR TITLE
Default clio and toolkit automatic updates to off

### DIFF
--- a/clio.tests/Command/SettingsBootstrapServiceTests.cs
+++ b/clio.tests/Command/SettingsBootstrapServiceTests.cs
@@ -178,8 +178,8 @@ public sealed class SettingsBootstrapServiceTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Clears a legacy Autoupdate=false artifact (serialized when the field was a non-nullable bool) and stamps the settings version, restoring the enabled opt-out default.")]
-	public void GetResult_Should_Reset_Legacy_Autoupdate_False_And_Stamp_Version() {
+	[Description("Preserves legacy Autoupdate=false while stamping the settings version.")]
+	public void GetResult_ShouldPreserveLegacyAutoupdateFalse_WhenMigratingSettings() {
 		// Arrange
 		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
 		fileSystem.AddFile(SettingsRepository.AppSettingsFile, new MockFileData("""
@@ -196,12 +196,12 @@ public sealed class SettingsBootstrapServiceTests {
 		Settings persisted = JsonConvert.DeserializeObject<Settings>(persistedContent);
 
 		// Assert
-		result.Settings.Autoupdate.Clio.Enabled.Should().BeTrue(
-			because: "the legacy false must be cleared so the enabled opt-out default applies");
-		result.Report.RepairsApplied.Should().ContainSingle(repair => repair.Code == "autoupdate-legacy-default-reset",
-			because: "the migration must surface that auto-update was re-enabled so the user is informed");
-		persisted.Autoupdate.Clio.Enabled.Should().BeTrue(
-			because: "the repaired clio policy must be persisted as enabled");
+		result.Settings.Autoupdate.Clio.Enabled.Should().BeFalse(
+			because: "legacy false must remain disabled with opt-in updates");
+		result.Report.RepairsApplied.Should().NotContain(repair => repair.Code == "autoupdate-legacy-default-reset",
+			because: "migration must never re-enable auto-update");
+		persisted.Autoupdate.Clio.Enabled.Should().BeFalse(
+			because: "the clio policy must remain disabled");
 		persisted.SettingsVersion.Should().Be(3,
 			because: "the settings version must be stamped so the one-time migration never runs again");
 		persistedContent.Should().Contain("\"autoupdate\"",
@@ -283,8 +283,8 @@ public sealed class SettingsBootstrapServiceTests {
 		// Assert
 		persisted.SettingsVersion.Should().Be(3,
 			because: "new installs must be born at the current settings version so the legacy migration never runs for them");
-		result.Settings.Autoupdate.Clio.Enabled.Should().BeTrue(
-			because: "a fresh file has no autoupdate key, so the enabled opt-out default applies");
+		result.Settings.Autoupdate.Clio.Enabled.Should().BeFalse(
+			because: "a fresh file must default to disabled clio updates");
 		persisted.DeployCreatioDefaults.Should().NotBeNull(
 			because: "fresh installations must visibly persist deploy-creatio-defaults in appsettings.json");
 		persisted.DeployCreatioDefaults.SitePortRange.Should().Equal(new[] { 40100, 40199 },

--- a/clio.tests/Command/SettingsRepositoryFeatureTests.cs
+++ b/clio.tests/Command/SettingsRepositoryFeatureTests.cs
@@ -348,6 +348,60 @@ public sealed class SettingsRepositoryFeatureTests {
 	}
 
 	[Test]
+	[Description("Keeps settings editor completion aligned with the per-component automatic-update defaults.")]
+	public void AppSettingsSchema_ShouldUseComponentDefaults_WhenCompletingAutoUpdatePolicies() {
+		// Arrange
+		string templatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tpl", "jsonschema", "schema.json.tpl");
+		JsonObject definitions = JsonNode.Parse(File.ReadAllText(templatePath))!["definitions"]!.AsObject();
+
+		// Act
+		JsonNode policies = definitions["autoupdatesettings"]!["properties"]!;
+		JsonNode sharedEnabled = definitions["autoupdatepolicy"]!["properties"]!["enabled"]!;
+
+		// Assert
+		policies["clio"]!["default"]!["enabled"]!.GetValue<bool>().Should().BeFalse(
+			because: "editor completion must not opt users into clio updates");
+		policies["knowledge"]!["default"]!["enabled"]!.GetValue<bool>().Should().BeTrue(
+			because: "knowledge updates remain enabled by default");
+		policies["toolkit"]!["default"]!["enabled"]!.GetValue<bool>().Should().BeFalse(
+			because: "editor completion must not opt users into toolkit updates");
+		sharedEnabled["default"].Should().BeNull(
+			because: "there is no single enabled default shared by all components");
+	}
+
+	[TestCase("{}", false, true, false)]
+	[TestCase("{\"autoupdate\":null}", false, true, false)]
+	[TestCase("{\"autoupdate\":{}}", false, true, false)]
+	[TestCase("{\"autoupdate\":{\"clio\":{},\"knowledge\":{},\"toolkit\":{}}}", false, true, false)]
+	[TestCase("{\"autoupdate\":{\"clio\":null,\"knowledge\":null,\"toolkit\":null}}", false, true, false)]
+	[TestCase("{\"autoupdate\":true}", true, true, false)]
+	[TestCase("{\"autoupdate\":false}", false, true, false)]
+	[TestCase("{\"autoupdate\":{\"clio\":{\"enabled\":true},\"knowledge\":{\"enabled\":false},\"toolkit\":{\"enabled\":true}}}", true, false, true)]
+	[Description("Defaults absent policies correctly and preserves explicit preferences through bootstrap, scheduling, and reload.")]
+	public void TryScheduleAutoupdate_ShouldRespectDefaultsAndPreferences_WhenSettingsAreLoaded(
+		string json, bool clioEnabled, bool knowledgeEnabled, bool toolkitEnabled) {
+		// Arrange
+		_fileSystem.File.WriteAllText(SettingsRepository.AppSettingsFile, json);
+		SettingsRepository sut = new(_fileSystem);
+		DateTimeOffset now = new(2026, 9, 10, 12, 0, 0, TimeSpan.Zero);
+
+		// Act
+		bool clio = sut.TryScheduleAutoupdate(AutoUpdateTarget.Clio, now);
+		bool knowledge = sut.TryScheduleAutoupdate(AutoUpdateTarget.Knowledge, now);
+		bool toolkit = sut.TryScheduleAutoupdate(AutoUpdateTarget.Toolkit, now);
+		Settings persisted = JsonConvert.DeserializeObject<Settings>(
+			_fileSystem.File.ReadAllText(SettingsRepository.AppSettingsFile));
+
+		// Assert
+		clio.Should().Be(clioEnabled, because: "clio updates require an opt-in");
+		knowledge.Should().Be(knowledgeEnabled, because: "knowledge updates default on but respect an opt-out");
+		toolkit.Should().Be(toolkitEnabled, because: "toolkit updates require an opt-in");
+		persisted.Autoupdate.Clio.Enabled.Should().Be(clioEnabled, because: "persistence must retain the clio preference");
+		persisted.Autoupdate.Knowledge.Enabled.Should().Be(knowledgeEnabled, because: "persistence must retain the knowledge preference");
+		persisted.Autoupdate.Toolkit.Enabled.Should().Be(toolkitEnabled, because: "persistence must retain the toolkit preference");
+	}
+
+	[Test]
 	[Description("Claims each due automatic update once and advances its independent next-run timestamp by the configured frequency.")]
 	public void TryScheduleAutoupdate_ShouldAdvanceIndependentTimestamp_WhenPolicyIsDue() {
 		// Arrange
@@ -366,11 +420,11 @@ public sealed class SettingsRepositoryFeatureTests {
 		// Assert
 		first.Should().BeTrue(because: "a missing next-run timestamp makes the enabled policy due immediately");
 		repeated.Should().BeFalse(because: "the same policy must wait for its configured frequency");
-		toolkit.Should().BeTrue(because: "the toolkit schedule is independent from knowledge");
+		toolkit.Should().BeFalse(because: "toolkit updates are opt-in");
 		persisted.Autoupdate.Knowledge.NextRun.Should().Be(now.AddMinutes(60),
 			because: "knowledge uses its one-hour default frequency");
-		persisted.Autoupdate.Toolkit.NextRun.Should().Be(now.AddMinutes(60),
-			because: "toolkit uses its own one-hour default frequency");
+		persisted.Autoupdate.Toolkit.NextRun.Should().Be(default(DateTimeOffset),
+			because: "disabled toolkit updates must not advance their schedule");
 	}
 
 	[Test]
@@ -407,8 +461,8 @@ public sealed class SettingsRepositoryFeatureTests {
 	}
 
 	[Test]
-	[Description("Preserves the existing pre-version migration when startup schedules content before normal repairs run.")]
-	public void TryScheduleAutoupdate_ShouldResetHistoricalFalse_WhenBootstrapRepairsAreDeferred() {
+	[Description("Preserves legacy false when startup schedules knowledge before normal repairs run.")]
+	public void TryScheduleAutoupdate_ShouldPreserveHistoricalFalse_WhenBootstrapRepairsAreDeferred() {
 		// Arrange
 		const string json = """
 			{
@@ -425,7 +479,7 @@ public sealed class SettingsRepositoryFeatureTests {
 		SettingsRepository reloaded = new(_fileSystem);
 
 		// Assert
-		reloaded.GetAutoupdate().Should().BeTrue(
-			because: "the historical serialized false default must not become a deliberate clio opt-out");
+		reloaded.GetAutoupdate().Should().BeFalse(
+			because: "knowledge scheduling must not enable clio updates");
 	}
 }

--- a/clio/Command/Update/SetAutoupdateCommand.cs
+++ b/clio/Command/Update/SetAutoupdateCommand.cs
@@ -4,13 +4,16 @@ using CommandLine;
 
 namespace Clio.Command.Update;
 
+/// <summary>Options for inspecting or changing automatic clio updates.</summary>
 [Verb("autoupdate", HelpText = "Enable or disable automatic clio updates on startup")]
 public class SetAutoupdateOptions {
 
-	[Option("enable", SetName = "enable", HelpText = "Enable automatic updates on startup (default behavior)")]
+	/// <summary>Gets or sets whether to opt in to automatic clio updates.</summary>
+	[Option("enable", SetName = "enable", HelpText = "Enable automatic updates on startup")]
 	public bool Enable { get; set; }
 
-	[Option("disable", SetName = "disable", HelpText = "Disable automatic updates on startup")]
+	/// <summary>Gets or sets whether to disable automatic clio updates.</summary>
+	[Option("disable", SetName = "disable", HelpText = "Disable automatic updates on startup (default behavior)")]
 	public bool Disable { get; set; }
 
 }

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -227,7 +227,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="up"></a>
 - [`unlock-package`](docs/commands/unlock-package.md) - Unlock a package in Creatio, `up`
 <a id="autoupdate"></a>
-- [`autoupdate`](docs/commands/autoupdate.md) - Enable or disable automatic clio updates on startup
+- [`autoupdate`](docs/commands/autoupdate.md) - Enable or disable automatic clio updates on startup (disabled by default; knowledge enabled, toolkit disabled)
 <a id="experimental"></a>
 <a id="exp"></a>
 - [`experimental`](docs/commands/experimental.md) - List and toggle clio experimental feature flags, `exp`

--- a/clio/Common/AutoUpdateSettings.cs
+++ b/clio/Common/AutoUpdateSettings.cs
@@ -34,7 +34,7 @@ public sealed class AutoUpdatePolicy {
 public sealed class AutoUpdateSettings {
 	/// <summary>Gets or sets the clio update schedule.</summary>
 	[JsonProperty("clio")]
-	public AutoUpdatePolicy Clio { get; set; } = CreatePolicy(480);
+	public AutoUpdatePolicy Clio { get; set; } = CreatePolicy(480, false);
 
 	/// <summary>Gets or sets the knowledge update schedule.</summary>
 	[JsonProperty("knowledge")]
@@ -42,12 +42,10 @@ public sealed class AutoUpdateSettings {
 
 	/// <summary>Gets or sets the toolkit update schedule.</summary>
 	[JsonProperty("toolkit")]
-	public AutoUpdatePolicy Toolkit { get; set; } = CreatePolicy(60);
+	public AutoUpdatePolicy Toolkit { get; set; } = CreatePolicy(60, false);
 
-	[JsonIgnore]
-	internal bool WasLegacyScalar { get; set; }
-
-	private static AutoUpdatePolicy CreatePolicy(int frequencyMinutes) => new() {
+	private static AutoUpdatePolicy CreatePolicy(int frequencyMinutes, bool enabled = true) => new() {
+		Enabled = enabled,
 		FrequencyMinutes = frequencyMinutes
 	};
 }
@@ -61,7 +59,6 @@ internal sealed class AutoUpdateSettingsConverter : JsonConverter<AutoUpdateSett
 		AutoUpdateSettings settings = new();
 		if (token.Type == JTokenType.Boolean) {
 			settings.Clio.Enabled = token.Value<bool>();
-			settings.WasLegacyScalar = true;
 		}
 		else if (token.Type == JTokenType.Object) {
 			serializer.Populate(token.CreateReader(), settings);

--- a/clio/Environment/ConfigurationOptions.cs
+++ b/clio/Environment/ConfigurationOptions.cs
@@ -1021,9 +1021,9 @@ namespace Clio
 			result.Knowledge ??= new KnowledgeConfiguration();
 			result.KnowledgeFeedback ??= new KnowledgeFeedbackSettings();
 			result.Autoupdate ??= new AutoUpdateSettings();
-			result.Autoupdate.Clio ??= new AutoUpdatePolicy { FrequencyMinutes = 480 };
+			result.Autoupdate.Clio ??= new AutoUpdatePolicy { Enabled = false, FrequencyMinutes = 480 };
 			result.Autoupdate.Knowledge ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
-			result.Autoupdate.Toolkit ??= new AutoUpdatePolicy { FrequencyMinutes = 60 };
+			result.Autoupdate.Toolkit ??= new AutoUpdatePolicy { Enabled = false, FrequencyMinutes = 60 };
 			if (result.Autoupdate.Clio.FrequencyMinutes <= 0) result.Autoupdate.Clio.FrequencyMinutes = 480;
 			if (result.Autoupdate.Knowledge.FrequencyMinutes <= 0) result.Autoupdate.Knowledge.FrequencyMinutes = 60;
 			if (result.Autoupdate.Toolkit.FrequencyMinutes <= 0) result.Autoupdate.Toolkit.FrequencyMinutes = 60;
@@ -1353,10 +1353,6 @@ namespace Clio
 		public bool TryScheduleAutoupdate(AutoUpdateTarget target, DateTimeOffset now) {
 			bool due = false;
 			UpdateSettingsIfChanged(settings => {
-				if ((settings.SettingsVersion ?? 0) < 1
-					&& settings.Autoupdate is { WasLegacyScalar: true, Clio.Enabled: false }) {
-					settings.Autoupdate.Clio.Enabled = true;
-				}
 				AutoUpdatePolicy policy = GetPolicy(settings.Autoupdate, target);
 				due = policy.Enabled && now > policy.NextRun;
 				if (due) {

--- a/clio/Environment/ISettingsRepository.cs
+++ b/clio/Environment/ISettingsRepository.cs
@@ -368,7 +368,7 @@ namespace Clio.UserEnvironment
 		string GetActualEnvironmentName(string environmentName);
 
 		/// <summary>
-		/// Gets the AutoUpdate setting. Returns true when not explicitly configured (opt-out model).
+		/// Gets the AutoUpdate setting. Returns false when not explicitly configured (opt-in model).
 		/// </summary>
 		bool GetAutoupdate();
 

--- a/clio/Environment/SettingsBootstrapService.cs
+++ b/clio/Environment/SettingsBootstrapService.cs
@@ -181,19 +181,7 @@ public sealed class SettingsBootstrapService : ISettingsBootstrapService {
 		if ((settings.SettingsVersion ?? 0) >= CurrentSettingsVersion) {
 			return false;
 		}
-		// Migration 1: before #576 Autoupdate was a non-nullable bool, so the C# default
-		// 'false' was serialized into appsettings.json for every user who never opted in,
-		// silently disabling auto-update. Clear that legacy artifact so the opt-out default
-		// (enabled) applies again. Guarded by SettingsVersion, this runs once — a deliberate
-		// 'clio autoupdate --disable' made afterwards is preserved.
-		if ((settings.SettingsVersion ?? 0) < 1
-			&& settings.Autoupdate is { WasLegacyScalar: true, Clio.Enabled: false }) {
-			settings.Autoupdate.Clio.Enabled = true;
-			repairs.Add(new SettingsRepair(
-				"autoupdate-legacy-default-reset",
-				"auto-update was disabled by a legacy default and has been re-enabled "
-				+ "(run 'clio autoupdate --disable' to opt out)"));
-		}
+		// Preserve legacy auto-update choices now that clio updates are opt-in.
 		// Migration 2 makes automatic IIS port selection visible and immediately usable after an upgrade.
 		// Preserve a user-configured range; only materialize the built-in range when the setting was absent.
 		if ((settings.SettingsVersion ?? 0) < 2

--- a/clio/appsettings.json
+++ b/clio/appsettings.json
@@ -9,7 +9,11 @@
       "authAppUri": "http://localhost:81/connect/token",
       "clientid": "",
       "clientSecret": ""
-    },
-    "autoupdate": true
+    }
+  },
+  "autoupdate": {
+    "clio": { "enabled": false, "frequency-minutes": 480 },
+    "knowledge": { "enabled": true, "frequency-minutes": 60 },
+    "toolkit": { "enabled": false, "frequency-minutes": 60 }
   }
 }

--- a/clio/docs/commands/autoupdate.md
+++ b/clio/docs/commands/autoupdate.md
@@ -19,15 +19,18 @@ autoupdate [--enable | --disable]
 Controls the `clio` policy in the automatic-update settings. Running the
 command without arguments displays whether automatic clio updates are enabled.
 
+By default, automatic clio and toolkit updates are disabled; knowledge updates are enabled.
+Existing explicitly configured values, including legacy scalar values, are preserved.
+
 Clio also has independent knowledge and toolkit policies. On an eligible
 command startup, each due enabled policy advances its `next-run` timestamp and
 calls the existing updater on a best-effort basis.
 
 ```json
 "autoupdate": {
-  "clio":      { "enabled": true, "frequency-minutes": 480, "next-run": "2026-09-04T08:00:00Z" },
+  "clio":      { "enabled": false, "frequency-minutes": 480, "next-run": "2026-09-04T08:00:00Z" },
   "knowledge": { "enabled": true, "frequency-minutes": 60,  "next-run": "2026-09-04T01:00:00Z" },
-  "toolkit":   { "enabled": true, "frequency-minutes": 60,  "next-run": "2026-09-04T01:00:00Z" }
+  "toolkit":   { "enabled": false, "frequency-minutes": 60,  "next-run": "2026-09-04T01:00:00Z" }
 }
 ```
 
@@ -37,9 +40,9 @@ is accepted and applied only to the clio policy.
 ## Options
 
 ```bash
---enable    Enable automatic clio updates (default behavior)
+--enable    Enable automatic clio updates
 
---disable   Disable automatic clio updates
+--disable   Disable automatic clio updates (default behavior)
 ```
 
 ## Examples

--- a/clio/help/en/autoupdate.txt
+++ b/clio/help/en/autoupdate.txt
@@ -13,8 +13,8 @@ DESCRIPTION
     reuse the existing update behavior on a best-effort basis.
 
 OPTIONS
-    --enable     Enable automatic clio updates (default behavior)
-    --disable    Disable automatic clio updates
+    --enable     Enable automatic clio updates
+    --disable    Disable automatic clio updates (default behavior)
 
 EXAMPLES
     autoupdate
@@ -26,3 +26,7 @@ EXIT CODES
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio
+
+DEFAULTS
+    Clio updates: disabled. Knowledge updates: enabled. Toolkit updates: disabled.
+    Existing explicitly configured preferences are preserved.

--- a/clio/tpl/jsonschema/schema.json.tpl
+++ b/clio/tpl/jsonschema/schema.json.tpl
@@ -121,7 +121,7 @@
 			"additionalProperties": false,
 			"required": ["enabled", "frequency-minutes"],
 			"properties": {
-				"enabled": { "type": "boolean", "default": true },
+				"enabled": { "type": "boolean" },
 				"frequency-minutes": { "type": "integer", "minimum": 1 },
 				"next-run": { "type": "string", "format": "date-time" }
 			}
@@ -133,7 +133,7 @@
 			"properties": {
 				"clio": {
 					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
-					"default": { "enabled": true, "frequency-minutes": 480 }
+					"default": { "enabled": false, "frequency-minutes": 480 }
 				},
 				"knowledge": {
 					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
@@ -141,7 +141,7 @@
 				},
 				"toolkit": {
 					"allOf": [{ "$ref": "#/definitions/autoupdatepolicy" }],
-					"default": { "enabled": true, "frequency-minutes": 60 }
+					"default": { "enabled": false, "frequency-minutes": 60 }
 				}
 			}
 		},

--- a/docs/knowledge/process/background-self-update-replaces-a-branch-install.md
+++ b/docs/knowledge/process/background-self-update-replaces-a-branch-install.md
@@ -1,5 +1,5 @@
 ---
-description: a globally installed clio self-updates at startup (RunStartupUpdateCheck), so a branch build installed as the global tool is silently replaced mid-measurement - disable it with clio autoupdate --disable or CLIO_NO_UPDATE_CHECK
+description: an opted-in globally installed clio self-updates at startup (RunStartupUpdateCheck), so a branch build installed as the global tool is silently replaced mid-measurement - disable it with clio autoupdate --disable or CLIO_NO_UPDATE_CHECK
 applies-to:
   - clio/Program.cs
   - clio/Command/Update/SetAutoupdateCommand.cs
@@ -7,15 +7,14 @@ ticket: ENG-88474
 date: 2026-08-19
 ---
 
-**What is true** — every clio invocation runs `Program.RunStartupUpdateCheck` before the command,
-which upgrades the installed tool in the background (`Updating clio X -> Y in background...`). If you
+**What is true** — eligible clio invocations run `Program.RunStartupUpdateCheck` before the command.
+When automatic clio updates are enabled and due, this upgrades the installed tool in the background (`Updating clio X -> Y in background...`). If you
 installed your branch build as the global tool in order to measure its behaviour, a later invocation
 can quietly restore the released package underneath you. Turn it off for the duration of the
 measurement with `clio autoupdate --disable`, or set `CLIO_NO_UPDATE_CHECK` for a spawned process
 tree.
 
-**Why it is this way** — the check exists for ordinary users, who should not have to think about
-updating. `ShouldSkipUpdateCheck` exempts only the update verbs themselves, `mcp-server`, `mcp-http`,
+**Why it is this way** — clio updates are disabled by default, but explicit opt-ins are preserved. `ShouldSkipUpdateCheck` exempts only the update verbs themselves, `mcp-server`, `mcp-http`,
 `--version` and the help flags, because those are the paths where an update would be actively
 harmful. Nothing exempts "the operator is deliberately running a non-released build" — the tool has
 no way to know that.

--- a/spec/autoupdate-defaults/autoupdate-defaults-adr.md
+++ b/spec/autoupdate-defaults/autoupdate-defaults-adr.md
@@ -1,0 +1,9 @@
+# Automatic update defaults
+
+Issue: #1443
+
+Users repeatedly ask to disable automatic tool replacement. Default clio and toolkit updates to disabled and keep knowledge enabled. Preserve all explicit current and legacy preferences.
+
+Use the existing policy initializers and null normalization; remove the two obsolete migrations that re-enable legacy false. Align shipped settings, schema completion and CLI help. Reuse existing scheduling and manual commands. No new state, migration version, service, or protocol is needed.
+
+Validate fresh, missing, empty, null, legacy scalar and explicit object settings through bootstrap and scheduling. Run affected Command/Common tests and the full unit suite because shared settings changed. No Creatio deployment or MCP contract change is involved.

--- a/spec/autoupdate-defaults/autoupdate-defaults-story.md
+++ b/spec/autoupdate-defaults/autoupdate-defaults-story.md
@@ -1,0 +1,7 @@
+# Default automatic updates by component
+
+Issue: #1443
+
+Acceptance: unset clio/toolkit policies are off and knowledge is on; explicit booleans survive bootstrap and scheduling; schemas/help agree with runtime; independent schedules and manual updates are unchanged.
+
+Implementation and validation are tracked in the linked GitHub issue and PR.


### PR DESCRIPTION
Clio and toolkit now require opting in to automatic updates; knowledge updates remain enabled by default. Missing and partial settings use these defaults, while existing explicit preferences (including legacy booleans) are preserved. Removed the legacy migration paths that re-enabled false and aligned shipped settings, schema completion, and help.

Fixes #1443.

Validation:
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=Common)" -m:2 -v:q`: 5,650 passed, 16 skipped (final diff).
- `dotnet test clio.tests/clio.tests.csproj --no-build --filter "Category=Unit" -v:q`: 12,004 passed, 25 skipped; followed by the final affected-module run after adding schema coverage.
- Built CLI with isolated `CLIO_HOME`: fresh policies false/true/false; `autoupdate --enable` and `--disable` verified.
- No new CLIO diagnostics in changed files; `git diff --check` passed.

Docs and JSON schema updated. Wiki anchors reviewed, unchanged. MCP reviewed, no update required: this local settings command has no dedicated MCP tool, and no new tool is needed. Shipped guidance reviewed, no relevant rule requires a change. ClioRing compatibility reviewed, no Ring-consumed contract changed (searched `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`). Creatio deployment not required.

Comprehensive parallel review covered correctness, performance, testing, code quality, security, intent, and KISS. The stale schema-default finding was fixed and regression-tested; no remaining actionable findings. The implementation reuses existing policy initialization and scheduling without new services or state.

Final Claude review rev_b2d468a9dbbf4f8f: no blockers. Accepted and corrected a stale XML comment; comment-only follow-up, incremental review skipped: documentation only. Focused settings/bootstrap tests rerun: 40 passed. No behavior changed after the comprehensive review.
