### PR TITLE
Isolate deployment tests from release runner IIS paths

### DIFF
--- a/clio.tests/Common/CreatioUninstallerTestFixture.cs
+++ b/clio.tests/Common/CreatioUninstallerTestFixture.cs
@@ -27,7 +27,11 @@ public class CreatioUninstallerTestFixture : BaseClioModuleTests
 
 	private const string ConnectionStringsFileName = "ConnectionStrings.config";
 	private const string EnvironmentName = "work";
-	private const string InstalledCreatioPath = @"C:\inetpub\wwwroot\work";
+	// Native path identity checks bypass MockFileSystem, so use the current user's
+	// accessible temp ancestor rather than a machine-owned IIS directory.
+	private static readonly string InstalledCreatioPath = Path.Combine(
+		DirectoryPathIdentity.Normalize(Path.GetTempPath()),
+		nameof(CreatioUninstallerTestFixture), Guid.NewGuid().ToString("N"), "work");
 	private const string AppPoolName = "custom-work-pool";
 	private const string ProfileDirectoryPath = @"C:\Users\custom-work-pool";
 

--- a/clio.tests/CreatioInstallerServiceTests.cs
+++ b/clio.tests/CreatioInstallerServiceTests.cs
@@ -9,6 +9,8 @@ using Clio.Common;
 using Clio.Common.IIS;
 using Clio.Common.K8;
 using Clio.Tests.Command;
+using Clio.UserEnvironment;
+using Newtonsoft.Json;
 using FluentAssertions;
 using k8s;
 using NSubstitute;
@@ -42,6 +44,11 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 	private readonly string _remoteArtifactServerPath = Environment.OSVersion.Platform == PlatformID.Win32NT
 		? @"\\tscrm.com\dfs-ts\builds-7"
 		: "/mnt/tscrm.com/dfs-ts/builds-7";
+
+	// The native identity check reads the real ancestor even though deployment files are mocked.
+	private static readonly string IisRootPath = Path.Combine(
+		DirectoryPathIdentity.Normalize(Path.GetTempPath()),
+		nameof(CreatioInstallerServiceTests), Guid.NewGuid().ToString("N"));
 
 	private CreatioInstallerService _creatioInstallerService;
 	private IProcessExecutor _processExecutor;
@@ -77,6 +84,10 @@ internal class CreatioInstallerServiceTests : BaseClioModuleTests{
 
 	protected override MockFileSystem CreateFs() {
 		return new MockFileSystem(new Dictionary<string, MockFileData> {
+			{
+				SettingsRepository.AppSettingsFile,
+				new MockFileData(JsonConvert.SerializeObject(new Settings { IISClioRootPath = IisRootPath }))
+			},
 			{
 				Path.Combine(_remoteArtifactServerPath, "8.1.2", "8.1.2.3888",
 					"BankSales_BankCustomerJourney_Lending_Marketing_Softkey_ENU",

--- a/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
+++ b/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
@@ -1,15 +1,15 @@
----
-description: mocked deployment paths still use native Windows directory handles, so hardcoded IIS roots depend on the runner account and filesystem
-applies-to:
-  - clio.tests/Common/CreatioUninstallerTestFixture.cs
-  - clio.tests/CreatioInstallerServiceTests.cs
-  - clio/Common/IIS/DirectoryPathIdentity.cs
-ticket: gh-1445
-date: 2026-09-10
----
-
-**What is true** — `DirectoryPathIdentity.Normalize` resolves the real existing ancestor on Windows with directory handles, even when a caller's file operations use `MockFileSystem`. Deployment fixtures therefore use unique descendants of the current user's normalized temp directory, with deployment files kept in the mock.
-
-**Why it is this way** — production deployment/uninstall must resolve physical identity to defend against path aliases. That safety check deliberately does not trust a lexical mock path. Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 with unresolved physical identities under C:\inetpub; the same fixtures passed locally and in release 8.1.0.123 on TS1-CORE-DEV24. The logs establish resolution failure, not the specific native error or ACL responsible.
-
-**What breaks if you ignore it** — an apparently isolated unit test fails before reaching its mocked port reservation or uninstall cleanup. Do not relax the production guard or skip the test; give the fixture an accessible real ancestor instead of relying on a machine-owned IIS directory.
+---
+description: mocked deployment paths still use native Windows directory handles, so hardcoded IIS roots depend on the runner account and filesystem
+applies-to:
+  - clio.tests/Common/CreatioUninstallerTestFixture.cs
+  - clio.tests/CreatioInstallerServiceTests.cs
+  - clio/Common/IIS/DirectoryPathIdentity.cs
+ticket: gh-1445
+date: 2026-09-10
+---
+
+**What is true** â€” `DirectoryPathIdentity.Normalize` resolves the real existing ancestor on Windows with directory handles, even when a caller's file operations use `MockFileSystem`. Deployment fixtures therefore use unique descendants of the current user's normalized temp directory, with deployment files kept in the mock.
+
+**Why it is this way** â€” production deployment/uninstall must resolve physical identity to defend against path aliases. That safety check deliberately does not trust a lexical mock path. Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 with unresolved physical identities under C:\inetpub; the same fixtures passed locally and in release 8.1.0.123 on TS1-CORE-DEV24. The logs establish resolution failure, not the specific native error or ACL responsible.
+
+**What breaks if you ignore it** â€” an apparently isolated unit test fails before reaching its mocked port reservation or uninstall cleanup. Do not relax the production guard or skip the test; give the fixture an accessible real ancestor instead of relying on a machine-owned IIS directory.

--- a/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
+++ b/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
@@ -1,15 +1,15 @@
----
-description: mocked deployment paths still use native Windows directory handles, so hardcoded IIS roots depend on the runner account and filesystem
-applies-to:
-  - clio.tests/Common/CreatioUninstallerTestFixture.cs
-  - clio.tests/CreatioInstallerServiceTests.cs
-  - clio/Common/IIS/DirectoryPathIdentity.cs
-ticket: gh-1445
-date: 2026-09-10
----
-
-**What is true** — `DirectoryPathIdentity.Normalize` resolves the real existing ancestor on Windows with directory handles, even when a caller's file operations use `MockFileSystem`. Deployment fixtures therefore use unique descendants of the current user's normalized temp directory, with deployment files kept in the mock.
-
-**Why it is this way** — production deployment/uninstall must resolve physical identity to defend against path aliases. That safety check deliberately does not trust a lexical mock path. Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 with unresolved physical identities under C:\inetpub; the same fixtures passed locally and in release 8.1.0.123 on TS1-CORE-DEV24. The logs establish resolution failure, not the specific native error or ACL responsible.
-
-**What breaks if you ignore it** — an apparently isolated unit test fails before reaching its mocked port reservation or uninstall cleanup. Do not relax the production guard or skip the test; give the fixture an accessible real ancestor instead of relying on a machine-owned IIS directory.
+---
+description: mocked deployment paths still use native Windows directory handles, so hardcoded IIS roots depend on the runner account and filesystem
+applies-to:
+  - clio.tests/Common/CreatioUninstallerTestFixture.cs
+  - clio.tests/CreatioInstallerServiceTests.cs
+  - clio/Common/IIS/DirectoryPathIdentity.cs
+ticket: gh-1445
+date: 2026-09-10
+---
+
+**What is true** — `DirectoryPathIdentity.Normalize` resolves the real existing ancestor on Windows with directory handles, even when a caller's file operations use `MockFileSystem`. Deployment fixtures therefore use unique descendants of the current user's normalized temp directory, with deployment files kept in the mock.
+
+**Why it is this way** — production deployment/uninstall must resolve physical identity to defend against path aliases. That safety check deliberately does not trust a lexical mock path. Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 with unresolved physical identities under C:\inetpub; the same fixtures passed locally and in release 8.1.0.123 on TS1-CORE-DEV24. The logs establish resolution failure, not the specific native error or ACL responsible.
+
+**What breaks if you ignore it** — an apparently isolated unit test fails before reaching its mocked port reservation or uninstall cleanup. Do not relax the production guard or skip the test; give the fixture an accessible real ancestor instead of relying on a machine-owned IIS directory.

--- a/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
+++ b/docs/knowledge/Tests/mock-deployment-paths-still-use-native-directory-identity.md
@@ -1,0 +1,15 @@
+---
+description: mocked deployment paths still use native Windows directory handles, so hardcoded IIS roots depend on the runner account and filesystem
+applies-to:
+  - clio.tests/Common/CreatioUninstallerTestFixture.cs
+  - clio.tests/CreatioInstallerServiceTests.cs
+  - clio/Common/IIS/DirectoryPathIdentity.cs
+ticket: gh-1445
+date: 2026-09-10
+---
+
+**What is true** — `DirectoryPathIdentity.Normalize` resolves the real existing ancestor on Windows with directory handles, even when a caller's file operations use `MockFileSystem`. Deployment fixtures therefore use unique descendants of the current user's normalized temp directory, with deployment files kept in the mock.
+
+**Why it is this way** — production deployment/uninstall must resolve physical identity to defend against path aliases. That safety check deliberately does not trust a lexical mock path. Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 with unresolved physical identities under C:\inetpub; the same fixtures passed locally and in release 8.1.0.123 on TS1-CORE-DEV24. The logs establish resolution failure, not the specific native error or ACL responsible.
+
+**What breaks if you ignore it** — an apparently isolated unit test fails before reaching its mocked port reservation or uninstall cleanup. Do not relax the production guard or skip the test; give the fixture an accessible real ancestor instead of relying on a machine-owned IIS directory.


### PR DESCRIPTION
Release 8.1.0.124 failed 41 tests on TS1-MRKT-WEB01 because mocked deployment paths under C:\inetpub still enter native directory identity resolution. These fixture and identity-check sources were unchanged from 8.1.0.123, which ran successfully on TS1-CORE-DEV24. PR CI used fresh GitHub-hosted Windows runners.

Use unique descendants of the current user's normalized temp directory for the two fixtures, and set the installer's root in its mock settings. Production safety checks, assertions, test categories, and release gates are unchanged.

Fixes #1445.

Validation:
- Original code: focused fixtures 86 passed locally; unfiltered release-equivalent suite 12,093 passed, 26 skipped. The exact runner-native error/ACL is not established by the log, and no local failure reproduction is claimed.
- Repaired code: focused install/uninstall fixtures 86 passed.
- `dotnet test clio.tests/clio.tests.csproj --no-build --filter "Category=Unit&(Module=Common|Module=Core)" -v:q`: 1,635 passed, 3 skipped.
- `dotnet test clio.tests/clio.tests.csproj --framework net10.0 -m:2 -v:q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=../TestResults/coverage.opencover.xml /p:AssemblyVersion=8.1.0.125 /p:FileVersion=8.1.0.125 /p:Version=8.1.0.125`: 12,093 passed, 26 skipped.
- `git diff --check` passed. No new CLIO diagnostics in the edited files.

Comprehensive parallel review covered correctness, performance, tests, quality, security, intent, and KISS: no actionable findings. Docs reviewed, no command update required. MCP reviewed, no update required. ClioRing compatibility reviewed, no Ring-consumed contract changed. No Creatio deployment required.

Release-runner verification remains the final publication check after merge; successful local tests are not presented as proof of that host.

Final Claude review rev_28d51d94487e4fed: no fixture correctness/security defects. Accepted and fixed the new knowledge note UTF-8 encoding finding; verified the knowledge checker and whitespace check. Follow-up review skipped: documentation encoding/line endings only.

