### PR TITLE
Fix OAuth workflow availability and partial tool contract discovery

### DIFF
--- a/clio.mcp.e2e/OAuthDefaultAvailabilityE2ETests.cs
+++ b/clio.mcp.e2e/OAuthDefaultAvailabilityE2ETests.cs
@@ -1,0 +1,59 @@
+using Allure.Net.Commons;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>Proves OAuth workflow discovery with the deployment feature absent or disabled.</summary>
+[TestFixture(false)]
+[TestFixture(true)]
+[Category("McpE2E.NoEnvironment")]
+[NonParallelizable]
+public sealed class OAuthDefaultAvailabilityE2ETests(bool explicitDisabled) : McpContractFixtureBase {
+	/// <inheritdoc />
+	private protected override void ConfigureMcpServerSettings(McpE2ESettings settings) {
+		settings.ProcessEnvironmentVariables["CLIO_HOME"] = CreateIsolatedClioHome(
+			explicitDisabled ? "{\"Autoupdate\":false,\"Features\":{\"deploy-identity\":false}}" : "{\"Autoupdate\":false}",
+			"oauth-defaults");
+	}
+
+	[Test]
+	[Description("Discovers all four OAuth workflow contracts without enabling IdentityService deployment.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("OAuth workflow is available by default")]
+	[AllureDescription("Starts an isolated real MCP server with the deployment flag absent or false and checks named contracts and catalog visibility.")]
+	public async Task GetToolContracts_ShouldExposeOAuthWorkflow_WhenDeploymentFeatureIsDisabled() {
+		// Arrange
+		await using var context = Arrange();
+		string[] names = [GetIdentityServiceConfigTool.GetIdentityServiceConfigToolName,
+			ResolveOAuthSystemUserTool.ResolveOAuthSystemUserToolName,
+			CreateServerToServerOAuthAppTool.CreateServerToServerOAuthAppToolName,
+			VerifyOAuthAppTool.VerifyOAuthAppToolName];
+
+		// Act
+		var call = await context.Session.CallToolAsync(ToolContractGetTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> { ["tool-names"] = names } },
+			context.CancellationTokenSource.Token);
+		var response = EntitySchemaStructuredResultParser.Extract<ToolContractGetResponse>(call);
+		var index = await context.Session.GetToolContractIndexAsync(context.CancellationTokenSource.Token);
+
+		// Assert
+		AllureApi.Step("Assert a normal MCP response", () =>
+			call.IsError.Should().NotBeTrue(because: "discovery must work without a feature opt-in"));
+		AllureApi.Step("Assert discovery succeeds", () =>
+			response.Success.Should().BeTrue(because: "the documented OAuth workflow is public"));
+		AllureApi.Step("Assert all four contracts resolve", () =>
+			response.Tools!.Select(tool => tool.Name).Should().Equal(names,
+				because: "every documented OAuth workflow step needs a contract"));
+		AllureApi.Step("Assert there are no misses", () =>
+			response.NotFound.Should().BeNull(because: "none of the four OAuth steps remains gated"));
+		AllureApi.Step("Assert technical-user creation stays hidden", () => {
+			index.Select(tool => tool.Name).Should().NotContain(CreateOAuthTechnicalUserTool.CreateOAuthTechnicalUserToolName,
+				because: "technical-user creation remains experimental");
+		});
+	}
+}

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -18,6 +18,40 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 	[Test]
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Returns valid contracts and individual misses through the real MCP server in either request order.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract preserves partial batch results")]
+	[AllureDescription("Requests one real tool and two unknown names over stdio and checks contracts plus per-name suggestions.")]
+	public async Task GetToolContracts_ShouldReturnPartialResults_WhenBatchContainsUnknownNames(bool unknownFirst) {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+		string known = SysSettingUpdateTool.UpdateSysSettingToolName;
+		string[] names = unknownFirst
+			? ["page-updte", known, "missing-tool-two"]
+			: [known, "page-updte", "missing-tool-two"];
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> { ["tool-names"] = names });
+
+		// Assert
+		AllureApi.Step("Assert partial lookup succeeds", () =>
+			response.Success.Should().BeTrue(because: "the valid contract remains usable"));
+		AllureApi.Step("Assert the valid contract survives", () =>
+			response.Tools!.Select(item => item.Name).Should().Equal([known],
+				because: "unknown names must not discard the registered tool contract"));
+		AllureApi.Step("Assert every miss is identified", () =>
+			response.NotFound!.Select(item => item.Name).Should().Equal(["page-updte", "missing-tool-two"],
+				because: "both unknown names need separate diagnostics"));
+		AllureApi.Step("Assert suggestions survive serialization", () =>
+			response.NotFound![0].Error.Suggestions.Should().Contain(PageUpdateTool.ToolName,
+				because: "the misspelled page tool must suggest its registered name"));
+	}
+
+	[Test]
 	[Description("Returns the list-packages paging inputs, defaults, and completeness fields through the real MCP contract endpoint.")]
 	[AllureTag(ToolContractGetTool.ToolName)]
 	[AllureName("get-tool-contract advertises list-packages paging")]

--- a/clio.tests/Command/McpServer/OAuthConfigurationToolsTests.cs
+++ b/clio.tests/Command/McpServer/OAuthConfigurationToolsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Clio.Command;
 using Clio.Command.IdentityServiceDeployment;
 using Clio.Command.McpServer.Tools;
 using Clio.Command.OAuthAppConfiguration;
@@ -16,6 +17,32 @@ namespace Clio.Tests.Command.McpServer;
 [NonParallelizable]
 public sealed class OAuthConfigurationToolsTests
 {
+	[Test]
+	[Category("Unit")]
+	[TestCase(typeof(GetIdentityServiceConfigOptions), true)]
+	[TestCase(typeof(GetIdentityServiceConfigTool), true)]
+	[TestCase(typeof(ResolveOAuthSystemUserOptions), true)]
+	[TestCase(typeof(ResolveOAuthSystemUserTool), true)]
+	[TestCase(typeof(CreateServerToServerOAuthAppOptions), true)]
+	[TestCase(typeof(CreateServerToServerOAuthAppTool), true)]
+	[TestCase(typeof(VerifyOAuthAppOptions), true)]
+	[TestCase(typeof(VerifyOAuthAppTool), true)]
+	[TestCase(typeof(DeployIdentityOptions), false)]
+	[TestCase(typeof(DeployIdentityTool), false)]
+	[TestCase(typeof(CreateOAuthTechnicalUserOptions), false)]
+	[TestCase(typeof(CreateOAuthTechnicalUserTool), false)]
+	[Description("Makes only the four remote OAuth workflow commands and tools available when every feature is disabled.")]
+	public void IsEnabled_ShouldRespectOAuthPublicationScope_WhenFeaturesAreDisabled(Type type, bool expected) {
+		// Arrange
+		Func<string, bool> disabledFeature = _ => false;
+
+		// Act
+		bool enabled = FeatureToggleReflection.IsEnabled(type, disabledFeature);
+
+		// Assert
+		enabled.Should().Be(expected, because: "the four remote workflow steps are public while deployment and technical-user creation remain gated");
+	}
+
 	private static string GetToolName<TTool>(string methodName) =>
 		((McpServerToolAttribute)typeof(TTool)
 			.GetMethod(methodName)!

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -22,6 +22,83 @@ namespace Clio.Tests.Command.McpServer;
 public sealed class ToolContractGetToolTests {
 	private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
+	[Test]
+	[Category("Unit")]
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Retains valid contracts regardless of where unknown names occur in a batch and deduplicates names.")]
+	public void GetToolContracts_ShouldRetainResolvedContracts_WhenBatchContainsUnknownNames(bool unknownFirst) {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+		string known = SysSettingUpdateTool.UpdateSysSettingToolName;
+		string[] names = unknownFirst
+			? ["page-updte", known, "missing-tool-two", " PAGE-UPDTE ", known.ToUpperInvariant()]
+			: [known, "page-updte", "missing-tool-two", " PAGE-UPDTE ", known.ToUpperInvariant()];
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs(names));
+
+		// Assert
+		result.Success.Should().BeTrue(because: "a resolved contract makes a mixed lookup useful");
+		result.Tools!.Select(item => item.Name).Should().Equal([known],
+			because: "unknown guesses must not discard valid contracts or introduce duplicates");
+		result.Error.Should().BeNull(because: "individual misses belong in not-found for a partial success");
+		result.NotFound!.Select(item => item.Name).Should().Equal(["page-updte", "missing-tool-two"],
+			because: "each distinct miss must be reported in request order");
+		result.NotFound[0].Error.Suggestions.Should().Contain(PageUpdateTool.ToolName,
+			because: "suggestions must correspond to the individual miss");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Returns every unresolved name while preserving the original top-level error when all names miss.")]
+	public void GetToolContracts_ShouldReturnAllMisses_WhenNoNamesResolve() {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs(["page-updte", "missing-tool-two"]));
+
+		// Assert
+		result.Success.Should().BeFalse(because: "no requested contract resolved");
+		result.Tools.Should().BeNull(because: "the existing all-miss contract has no tools payload");
+		result.NotFound.Should().HaveCount(2, because: "both misses need independent diagnostics");
+		result.Error.Should().Be(result.NotFound![0].Error,
+			because: "existing clients must retain the first tool-not-found error");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Rejects malformed names before resolving any contracts, even in a mixed batch.")]
+	public void GetToolContracts_ShouldRejectWholeRequest_WhenBatchContainsBlankName() {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs([PageUpdateTool.ToolName, " "]));
+
+		// Assert
+		result.Success.Should().BeFalse(because: "blank names remain invalid input rather than lookup misses");
+		result.Tools.Should().BeNull(because: "input validation must precede lookup");
+		result.NotFound.Should().BeNull(because: "invalid input must not be reported as an unknown tool");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Omits the additive not-found field from successful responses without misses.")]
+	public void GetToolContracts_ShouldOmitNotFound_WhenAllNamesResolve() {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+
+		// Act
+		string json = JsonSerializer.Serialize(tool.GetToolContracts(new ToolContractGetArgs([PageUpdateTool.ToolName])));
+		using JsonDocument document = JsonDocument.Parse(json);
+
+		// Assert
+		document.RootElement.TryGetProperty("not-found", out _).Should().BeFalse(
+			because: "existing successful response shapes must remain unchanged");
+	}
+
 	// Builds the same REAL invoker registry BuildToolWithRegistry wraps in a tool, so contracts for
 	// uncurated tools derive from the same MCP tool input schema clio-run dispatches against (Codex
 	// review #1, story-6). Exposed separately so ENG-93885 tests can call ToolContractCatalog.GetContracts

--- a/clio/Command/McpServer/Tools/CreateServerToServerOAuthAppTool.cs
+++ b/clio/Command/McpServer/Tools/CreateServerToServerOAuthAppTool.cs
@@ -13,7 +13,6 @@ namespace Clio.Command.McpServer.Tools;
 /// MCP tool surface for the <c>create-server-to-server-oauth-app</c> command.
 /// </summary>
 [McpServerToolType]
-[FeatureToggle("deploy-identity")]
 public sealed class CreateServerToServerOAuthAppTool(
 	CreateServerToServerOAuthAppCommand command,
 	ILogger logger,

--- a/clio/Command/McpServer/Tools/CreateServerToServerOAuthAppTool.cs
+++ b/clio/Command/McpServer/Tools/CreateServerToServerOAuthAppTool.cs
@@ -38,7 +38,7 @@ public sealed class CreateServerToServerOAuthAppTool(
 		SharedFileResource = McpToolSharedFileResource.None)]
 	[Description("""
 				 Creates a server-to-server (client_credentials) OAuth app in Creatio via OAuthConfigService/AddClient over REST,
-				 binding it to a system user. Supply systemUserId (from resolve-oauth-system-user or create-oauth-technical-user)
+				 binding it to a system user. Supply systemUserId (from resolve-oauth-system-user)
 				 or systemUser by name (defaults to Supervisor). Returns clientId and clientSecret in the structured result ONLY:
 				 the secret is never written to logs and is NOT persisted to clio settings by this tool. Capture the secret from
 				 the response immediately - it cannot be retrieved again.
@@ -78,7 +78,7 @@ public sealed record CreateServerToServerOAuthAppArgs(
 	string EnvironmentName,
 
 	[property: JsonPropertyName("system-user-id")]
-	[property: Description("System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user or create-oauth-technical-user.")]
+	[property: Description("System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user.")]
 	string? SystemUserId = null,
 
 	[property: JsonPropertyName("system-user")]

--- a/clio/Command/McpServer/Tools/GetIdentityServiceConfigTool.cs
+++ b/clio/Command/McpServer/Tools/GetIdentityServiceConfigTool.cs
@@ -13,7 +13,6 @@ namespace Clio.Command.McpServer.Tools;
 /// MCP tool surface for the <c>get-identity-service-config</c> command.
 /// </summary>
 [McpServerToolType]
-[FeatureToggle("deploy-identity")]
 public sealed class GetIdentityServiceConfigTool(
 	GetIdentityServiceConfigCommand command,
 	ILogger logger,

--- a/clio/Command/McpServer/Tools/ResolveOAuthSystemUserTool.cs
+++ b/clio/Command/McpServer/Tools/ResolveOAuthSystemUserTool.cs
@@ -13,7 +13,6 @@ namespace Clio.Command.McpServer.Tools;
 /// MCP tool surface for the <c>resolve-oauth-system-user</c> command.
 /// </summary>
 [McpServerToolType]
-[FeatureToggle("deploy-identity")]
 public sealed class ResolveOAuthSystemUserTool(
 	ResolveOAuthSystemUserCommand command,
 	ILogger logger,

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -85,7 +85,7 @@ public sealed class ToolContractGetTool {
 	// Before ENG-95885 the flat call bound `args` to null, fell through to the no-tool-names branch, and
 	// handed the agent the entire index back as a plausible success.
 	[McpRecoversUnknownArguments]
-	[Description("Returns clio MCP tool contracts. Omit tool-names for a compact index of ALL tools (names + one-line purpose + safety flags) — cheap discovery without full schemas; pass tool-names to expand those tools' full contracts (parameter schema, aliases, defaults, examples, and preferred or fallback workflow hints); pass detail=full (with no tool-names) to expand every tool's full contract at once.")]
+	[Description("Returns clio MCP tool contracts. Omit tool-names for a compact index of ALL tools (names, purpose, safety flags); pass tool-names for full contracts (schemas, defaults, examples, workflows). Mixed batches retain valid contracts and report misses with suggestions in not-found. Pass detail=full without tool-names for every full contract.")]
 	public ToolContractGetResponse GetToolContracts(
 		[Description("Parameters: tool-names (optional array of tool names) and detail (optional 'index' | 'full'). Omit entirely for a compact index of all tools; pass tool-names for full contracts; pass detail=full to expand all full contracts.")]
 		ToolContractGetArgs? args = null,
@@ -324,11 +324,27 @@ public sealed record ToolContractGetArgs(
 	public Dictionary<string, JsonElement>? ExtensionData { get; init; }
 }
 
+/// <summary>Contract discovery results, including independently unresolved names for named lookups.</summary>
+/// <param name="Success">Whether discovery succeeded or at least one requested name resolved.</param>
+/// <param name="Tools">Resolved full contracts, or null when none resolved.</param>
+/// <param name="Error">Request failure, including the first miss when no requested names resolved.</param>
+/// <param name="Index">Compact discovery index for requests without names.</param>
+/// <param name="NotFound">Unresolved normalized names with individual suggestions; omitted when there are no misses.</param>
 public sealed record ToolContractGetResponse(
 	[property: JsonPropertyName("success")] bool Success,
 	[property: JsonPropertyName("tools")] IReadOnlyList<ToolContractDefinition>? Tools = null,
 	[property: JsonPropertyName("error")] ToolContractError? Error = null,
-	[property: JsonPropertyName("index")] IReadOnlyList<ToolContractIndexEntry>? Index = null
+	[property: JsonPropertyName("index")] IReadOnlyList<ToolContractIndexEntry>? Index = null,
+	[property: JsonPropertyName("not-found"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	IReadOnlyList<ToolContractNotFound>? NotFound = null
+);
+
+/// <summary>One requested tool name that could not be resolved.</summary>
+/// <param name="Name">Trimmed requested name, deduplicated without regard to case.</param>
+/// <param name="Error">Lookup diagnostic and suggestions for this name.</param>
+public sealed record ToolContractNotFound(
+	[property: JsonPropertyName("name")] string Name,
+	[property: JsonPropertyName("error")] ToolContractError Error
 );
 
 /// <summary>
@@ -860,8 +876,7 @@ internal static class ToolContractCatalog {
 	}
 
 	/// <summary>
-	/// Resolves the explicit tool-names branch of <see cref="GetContracts"/> — extracted purely to keep
-	/// <see cref="GetContracts"/>'s cognitive complexity low (Sonar S3776), no behavior change.
+	/// Resolves every distinct requested name, retaining successful contracts alongside individual misses.
 	/// </summary>
 	private static ToolContractGetResponse ResolveNamedContracts(
 		IReadOnlyList<string> toolNames,
@@ -883,19 +898,24 @@ internal static class ToolContractCatalog {
 			normalizedNames.Add(name.Trim());
 		}
 		List<ToolContractDefinition> results = [];
+		List<ToolContractNotFound> notFound = [];
 		foreach (string normalizedName in normalizedNames.Distinct(StringComparer.OrdinalIgnoreCase)) {
 			if (TryResolveFullContract(normalizedName, toolInvokerRegistry, out ToolContractDefinition contract)) {
 				results.Add(contract);
 				continue;
 			}
-			return new ToolContractGetResponse(
-				false,
-				Error: new ToolContractError(
+			notFound.Add(new ToolContractNotFound(
+				normalizedName,
+				new ToolContractError(
 					"tool-not-found",
 					$"Tool '{normalizedName}' is not registered by clio MCP. {ToolContractGetTool.DiscoveryHint}",
-					BuildSuggestions(normalizedName, toolInvokerRegistry)));
+					BuildSuggestions(normalizedName, toolInvokerRegistry))));
 		}
-		return new ToolContractGetResponse(true, results);
+		return new ToolContractGetResponse(
+			results.Count > 0,
+			Tools: results.Count > 0 ? results : null,
+			Error: results.Count == 0 ? notFound[0].Error : null,
+			NotFound: notFound.Count > 0 ? notFound : null);
 	}
 
 	/// <summary>
@@ -1123,8 +1143,9 @@ internal static class ToolContractCatalog {
 				[
 					SuccessFalseSignal
 				],
-				Field(SuccessFieldName, BooleanType, "Whether the contract lookup succeeded."),
+				Field(SuccessFieldName, BooleanType, "Whether discovery succeeded or at least one requested name resolved. Check not-found for partial results."),
 				Field("tools", ArrayType, "Full tool contract definitions; populated when tool-names are passed or detail=full."),
+				Field("not-found", ArrayType, "Unresolved names with per-name error codes, messages and suggestions. Valid contracts remain in tools; omitted when all names resolve. If no names resolve, success=false and error retains the first tool-not-found diagnostic."),
 				Field("index", ArrayType, "Compact tool index (name, purpose, contract-available, resident, destructive); populated for a no-names request unless detail=full. resident=true tools are present in tools/list and are called natively; resident=false tools are reachable only via clio-run/clio-run-destructive — never wrap a resident tool in clio-run."),
 				Field(ErrorFieldName, ObjectType, "Structured error payload when lookup fails.")
 			),

--- a/clio/Command/McpServer/Tools/VerifyOAuthAppTool.cs
+++ b/clio/Command/McpServer/Tools/VerifyOAuthAppTool.cs
@@ -13,7 +13,6 @@ namespace Clio.Command.McpServer.Tools;
 /// MCP tool surface for the <c>verify-oauth-app</c> command.
 /// </summary>
 [McpServerToolType]
-[FeatureToggle("deploy-identity")]
 public sealed class VerifyOAuthAppTool(
 	VerifyOAuthAppCommand command,
 	ILogger logger,

--- a/clio/Command/OAuthAppConfiguration/CreateServerToServerOAuthAppCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/CreateServerToServerOAuthAppCommand.cs
@@ -20,7 +20,7 @@ public sealed class CreateServerToServerOAuthAppOptions : RemoteCommandOptions
 	/// the system user resolved from <c>--system-user</c> (defaulting to <c>Supervisor</c>).
 	/// </summary>
 	[Option("system-user-id", Required = false,
-		HelpText = "System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user or create-oauth-technical-user")]
+		HelpText = "System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user")]
 	public string SystemUserId { get; set; }
 
 	/// <summary>
@@ -198,7 +198,7 @@ public class CreateServerToServerOAuthAppCommand : Command<CreateServerToServerO
 			});
 		if (!resolved.Found || string.IsNullOrWhiteSpace(resolved.SystemUserId)) {
 			throw new InvalidOperationException(
-				$"System user '{userName}' was not found. Pass --system-user-id explicitly or create one with create-oauth-technical-user.");
+				$"System user '{userName}' was not found. Pass --system-user-id explicitly or resolve an existing user with resolve-oauth-system-user.");
 		}
 		return resolved.SystemUserId;
 	}

--- a/clio/Command/OAuthAppConfiguration/CreateServerToServerOAuthAppCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/CreateServerToServerOAuthAppCommand.cs
@@ -13,7 +13,6 @@ namespace Clio.Command.OAuthAppConfiguration;
 /// </summary>
 [Verb("create-server-to-server-oauth-app",
 	HelpText = "Create a server-to-server (client_credentials) OAuth app in Creatio via OAuthConfigService REST")]
-[FeatureToggle("deploy-identity")]
 public sealed class CreateServerToServerOAuthAppOptions : RemoteCommandOptions
 {
 	/// <summary>

--- a/clio/Command/OAuthAppConfiguration/GetIdentityServiceConfigCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/GetIdentityServiceConfigCommand.cs
@@ -12,7 +12,6 @@ namespace Clio.Command.OAuthAppConfiguration;
 /// </summary>
 [Verb("get-identity-service-config",
 	HelpText = "Read (or derive) the OAuth IdentityService configuration of a Creatio environment over REST")]
-[FeatureToggle("deploy-identity")]
 public sealed class GetIdentityServiceConfigOptions : RemoteCommandOptions
 {
 }

--- a/clio/Command/OAuthAppConfiguration/ResolveOAuthSystemUserCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/ResolveOAuthSystemUserCommand.cs
@@ -16,7 +16,6 @@ namespace Clio.Command.OAuthAppConfiguration;
 /// </summary>
 [Verb("resolve-oauth-system-user",
 	HelpText = "Resolve a Creatio system user (SysAdminUnit) by name or id over DataService REST")]
-[FeatureToggle("deploy-identity")]
 public sealed class ResolveOAuthSystemUserOptions : RemoteCommandOptions
 {
 	/// <summary>

--- a/clio/Command/OAuthAppConfiguration/VerifyOAuthAppCommand.cs
+++ b/clio/Command/OAuthAppConfiguration/VerifyOAuthAppCommand.cs
@@ -12,7 +12,6 @@ namespace Clio.Command.OAuthAppConfiguration;
 /// </summary>
 [Verb("verify-oauth-app",
 	HelpText = "Verify a server-to-server OAuth app: acquire a client_credentials token and run a bearer DataService smoke test")]
-[FeatureToggle("deploy-identity")]
 public sealed class VerifyOAuthAppOptions : RemoteCommandOptions
 {
 	/// <summary>

--- a/clio/docs/commands/create-server-to-server-oauth-app.md
+++ b/clio/docs/commands/create-server-to-server-oauth-app.md
@@ -12,8 +12,7 @@ create-server-to-server-oauth-app - Create a server-to-server (client_credential
 
 Creates a server-to-server (`client_credentials`) OAuth app in Creatio through the platform
 `OAuthConfigService/AddClient` endpoint over REST, binding it to a system user. Supply
-`--system-user-id` (from [`resolve-oauth-system-user`](resolve-oauth-system-user.md) or
-[`create-oauth-technical-user`](create-oauth-technical-user.md)) or `--system-user` by name
+`--system-user-id` (from [`resolve-oauth-system-user`](resolve-oauth-system-user.md)) or `--system-user` by name
 (defaults to `Supervisor`).
 
 The returned client id and client secret are surfaced **only** in the structured command result. On

--- a/clio/docs/commands/create-server-to-server-oauth-app.md
+++ b/clio/docs/commands/create-server-to-server-oauth-app.md
@@ -50,11 +50,7 @@ clio create-server-to-server-oauth-app -e c-dev --system-user-id 410006e1-ca4e-4
 
 ## Notes
 
-This command is experimental and hidden by default. Enable it before use:
-
-```
-clio experimental --name deploy-identity --enable
-```
+This command is available by default in both CLI and MCP. It operates through remote APIs and does not require access to the Creatio server filesystem or database.
 
 This command mutates Creatio (creates an OAuth client). The generated client secret is returned only
 in the structured result and is never logged.

--- a/clio/docs/commands/get-identity-service-config.md
+++ b/clio/docs/commands/get-identity-service-config.md
@@ -49,10 +49,6 @@ clio get-identity-service-config -e c-dev
 
 ## Notes
 
-This command is experimental and hidden by default. Enable it before use:
-
-```
-clio experimental --name deploy-identity --enable
-```
+This command is available by default in both CLI and MCP. It operates through remote APIs and does not require access to the Creatio server filesystem or database.
 
 This command is read-only; it does not modify Creatio or clio settings.

--- a/clio/docs/commands/resolve-oauth-system-user.md
+++ b/clio/docs/commands/resolve-oauth-system-user.md
@@ -43,10 +43,6 @@ clio resolve-oauth-system-user -e c-dev --id 410006e1-ca4e-4502-a9ec-e54d922d2c0
 
 ## Notes
 
-This command is experimental and hidden by default. Enable it before use:
-
-```
-clio experimental --name deploy-identity --enable
-```
+This command is available by default in both CLI and MCP. It operates through remote APIs and does not require access to the Creatio server filesystem or database.
 
 This command is read-only; it does not modify Creatio.

--- a/clio/docs/commands/verify-oauth-app.md
+++ b/clio/docs/commands/verify-oauth-app.md
@@ -49,11 +49,7 @@ clio verify-oauth-app -e c-dev --client-id my-client --client-secret my-secret \
 
 ## Notes
 
-This command is experimental and hidden by default. Enable it before use:
-
-```
-clio experimental --name deploy-identity --enable
-```
+This command is available by default in both CLI and MCP. It operates through remote APIs and does not require access to the Creatio server filesystem or database.
 
 This command is read-only; it does not modify Creatio. The access token is never logged.
 

--- a/clio/help/en/create-server-to-server-oauth-app.txt
+++ b/clio/help/en/create-server-to-server-oauth-app.txt
@@ -7,7 +7,7 @@ NAME
 DESCRIPTION
     Creates a server-to-server (client_credentials) OAuth app in Creatio through the platform
     OAuthConfigService/AddClient endpoint over REST, binding it to a system user. Supply
-    --system-user-id (from resolve-oauth-system-user or create-oauth-technical-user) or
+    --system-user-id (from resolve-oauth-system-user) or
     --system-user by name (defaults to Supervisor).
 
     The returned client id and client secret are surfaced ONLY in the structured command result.
@@ -25,8 +25,7 @@ OPTIONS
         Required. Registered Creatio environment.
 
     --system-user-id ID
-        System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user
-        or create-oauth-technical-user.
+        System user id to bind the OAuth app to. Resolve it first with resolve-oauth-system-user.
 
     --system-user NAME
         System user name to bind the OAuth app to when --system-user-id is omitted.

--- a/clio/help/en/create-server-to-server-oauth-app.txt
+++ b/clio/help/en/create-server-to-server-oauth-app.txt
@@ -52,8 +52,7 @@ EXAMPLES
     clio create-server-to-server-oauth-app -e c-dev --system-user-id 410006e1-ca4e-4502-a9ec-e54d922d2c00
 
 NOTES
-    This command is experimental and hidden by default. Enable it before use:
-        clio experimental --name deploy-identity --enable
+    Available by default in CLI and MCP. No Creatio server filesystem or database access is required.
 
     This command mutates Creatio (creates an OAuth client). The generated client secret is
     returned only in the structured result and is never logged.

--- a/clio/help/en/get-identity-service-config.txt
+++ b/clio/help/en/get-identity-service-config.txt
@@ -29,7 +29,6 @@ EXAMPLES
     clio get-identity-service-config -e c-dev
 
 NOTES
-    This command is experimental and hidden by default. Enable it before use:
-        clio experimental --name deploy-identity --enable
+    Available by default in CLI and MCP. No Creatio server filesystem or database access is required.
 
     This command is read-only; it does not modify Creatio or clio settings.

--- a/clio/help/en/resolve-oauth-system-user.txt
+++ b/clio/help/en/resolve-oauth-system-user.txt
@@ -38,7 +38,6 @@ EXAMPLES
     clio resolve-oauth-system-user -e c-dev --id 410006e1-ca4e-4502-a9ec-e54d922d2c00
 
 NOTES
-    This command is experimental and hidden by default. Enable it before use:
-        clio experimental --name deploy-identity --enable
+    Available by default in CLI and MCP. No Creatio server filesystem or database access is required.
 
     This command is read-only; it does not modify Creatio.

--- a/clio/help/en/verify-oauth-app.txt
+++ b/clio/help/en/verify-oauth-app.txt
@@ -39,8 +39,7 @@ EXAMPLES
         --identity-server-url https://c-dev-is.creatio.com
 
 NOTES
-    This command is experimental and hidden by default. Enable it before use:
-        clio experimental --name deploy-identity --enable
+    Available by default in CLI and MCP. No Creatio server filesystem or database access is required.
 
     This command is read-only; it does not modify Creatio. The access token is never logged.
 

--- a/spec/adr/adr-tool-contract-partial-results.md
+++ b/spec/adr/adr-tool-contract-partial-results.md
@@ -1,0 +1,30 @@
+# Partial results for named tool contracts
+
+Issue: https://github.com/Advance-Technologies-Foundation/clio/issues/1408
+
+Related issue: https://github.com/Advance-Technologies-Foundation/clio/issues/1406
+
+The named lookup currently exits on its first unknown name. Resolve every distinct,
+trimmed name and retain successful contracts in request order. Add an optional
+`not-found` array containing each missing `name` and its existing structured `error`
+(including suggestions). `success` means at least one named contract resolved.
+
+When every name misses, preserve `success: false`, null `tools`, and the first
+top-level `tool-not-found` error for existing clients, while reporting all misses.
+Omit `not-found` when there are no misses so successful single-name and catalog
+responses keep their existing shape. Blank names remain whole-request validation
+errors. No stop-on-error option or new resolution service is needed.
+
+The reported missing OAuth tool already exists but is gated by `deploy-identity`.
+Publish the four documented remote workflow commands and their MCP adapters by
+removing that attribute: get-identity-service-config, resolve-oauth-system-user,
+create-server-to-server-oauth-app, and verify-oauth-app. The user approved this
+publication scope. Keep deploy-identity and create-oauth-technical-user gated.
+Preserve existing authentication, destructive flags, and secret handling. No
+server filesystem or database access is introduced; these commands use HTTP APIs.
+The existing external OAuth guide becomes usable without changing its workflow.
+
+ClioRing requests the unnamed catalog and individual named contracts. Preserve
+these paths and verify its tests and Windows NativeAOT publish. Unit tests cover
+ordering, deduplication, all misses, and invalid names; stdio E2E covers mixed
+batches and serialization. The full executable contract documents the new field.

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -21,6 +21,11 @@
 # 2026-07-06) is a separate Jira ticket stacked on the same branch; tracked as its own row.
 
 stories:
+  - id: story-tool-contract-partial-results-1
+    title: Publish remote OAuth workflow and keep partial tool contracts
+    status: review
+    file: spec/stories/story-tool-contract-partial-results-1.md
+    issue: https://github.com/Advance-Technologies-Foundation/clio/issues/1408
   - id: story-knowledge-bundle-runtime-1
     title: "Install and hot-reload external knowledge"
     feature: "knowledge-bundle-runtime"

--- a/spec/stories/story-tool-contract-partial-results-1.md
+++ b/spec/stories/story-tool-contract-partial-results-1.md
@@ -1,0 +1,19 @@
+# Keep valid contracts in mixed batches
+
+Status: review
+Issue: https://github.com/Advance-Technologies-Foundation/clio/issues/1408
+Related issue: https://github.com/Advance-Technologies-Foundation/clio/issues/1406
+Design: [Partial results](../adr/adr-tool-contract-partial-results.md)
+
+As an MCP caller, I can request several plausible tool names and receive every
+resolved contract with diagnostics for each missing name in the same response.
+
+Acceptance:
+- Valid contracts survive unknown names before or after them.
+- Each distinct miss includes its own suggestions.
+- Existing all-miss errors, catalog discovery, and malformed-name validation remain.
+- Successful responses without misses omit the additive field.
+- The four documented OAuth workflow commands and MCP tools are available without opt-in.
+- IdentityService deployment and technical-user creation retain their feature gate.
+- Focused unit and real stdio tests pass; Ring compatibility checks pass.
+- Mandatory agentic review and delivery checks complete.


### PR DESCRIPTION
The OAuth setup guide referenced four tools hidden behind the deploy-identity feature flag, and an unknown name in get-tool-contract discarded valid contracts from the same request.

Make get-identity-service-config, resolve-oauth-system-user, create-server-to-server-oauth-app, and verify-oauth-app available by default in CLI and MCP. Deployment and technical-user creation remain experimental; existing authentication, destructive classifications, and secret handling are unchanged. Mixed contract batches retain resolved tools and return a not-found array with per-name suggestions. All-miss requests preserve the first existing top-level error.

Closes #1406
Closes #1408

Validation:
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=McpServer|Module=Command)"`: 9302 passed, 15 existing skips.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~OAuthDefaultAvailabilityE2ETests|FullyQualifiedName~OAuthConfigurationToolsE2ETests|FullyQualifiedName~ToolContractGetToolE2ETests"`: 37 passed, no skips. Real stdio with isolated settings; OAuth verification uses loopback HTTP fixtures, not a live cloud instance.
- HelpArtifactConsistencyTests: 7 passed.
- ClioRing compatibility reviewed: `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release`: 157 passed. `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true`: passed, no IL2026/IL3050 warnings. Published executable `--ipc-proof --clio-dll <changed clio.dll>`: PASS for handshake, catalog and restart. Consumer paths inspected: ClioRing.Ipc/ClioIpcClient.cs, ClioRing and actions.json.

Docs reviewed: updated all four command guides and CLI help; Commands.md, WikiAnchors.txt and workspace templates remain accurate. MCP response DTO, executable contract and tests updated; no additional prompt/resource is needed. The clio-knowledge server-to-server-oauth guide already names this exact four-tool workflow and requires no content change after publication.

Comprehensive parallel agentic review covered quality/testing, security, correctness/performance, intent and KISS: no blocking findings; minor test-reporting feedback addressed. Final comprehensive agentic review passed. Claude review rev_ee9f32392d804b08 found no Blocker/High defects; its P3 hidden-tool recommendation was corrected and verified by incremental combined review and the same passing module/E2E suites. CI is checked on the final head.
