### PR TITLE
fix: preserve MCP worker runtime roll-forward policy

### DIFF
--- a/clio.mcp.e2e/McpWorkerRuntimeE2ETests.cs
+++ b/clio.mcp.e2e/McpWorkerRuntimeE2ETests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Allure.Net.Commons;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Mcp;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>Exercises runtime selection through a real MCP parent and its worker.</summary>
+[TestFixture]
+[Category("McpE2E.NoEnvironment")]
+[AllureNUnit]
+[NonParallelizable]
+public sealed class McpWorkerRuntimeE2ETests {
+	[Test]
+	[Description("A real worker reaches the Creatio stub when both parent and worker require an explicit runtime roll-forward setting to start.")]
+	[AllureFeature(PageListTool.ToolName)]
+	[AllureTag(PageListTool.ToolName)]
+	[AllureName("Worker inherits the runtime roll-forward policy")]
+	public async Task Worker_ShouldReachCreatio_WhenParentRequiresRuntimeRollForward() {
+		// Arrange
+		string scratch = Path.Combine(Path.GetTempPath(), $"clio-runtime-e2e-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(scratch);
+		try {
+			string source = Path.GetDirectoryName(TestConfiguration.ResolveFreshClioProcessPath())!;
+			string install = Path.Combine(scratch, "clio");
+			CopyBuild(source, install);
+			string configPath = Path.Combine(install, "clio.runtimeconfig.json");
+			JsonNode config = JsonNode.Parse(await File.ReadAllTextAsync(configPath))!;
+			JsonNode runtime = config["runtimeOptions"]!;
+			// An unavailable minor in the previous major requires a major roll-forward on every
+			// machine. Disable in the file makes losing the environment override fail deterministically.
+			string requested = $"{Environment.Version.Major - 1}.999.0";
+			foreach (JsonNode? framework in runtime["frameworks"]!.AsArray()) {
+				framework!["version"] = requested;
+			}
+			runtime["rollForward"] = "Disable";
+			await File.WriteAllTextAsync(configPath, config.ToJsonString());
+			string home = Path.Combine(scratch, "home");
+			Directory.CreateDirectory(home);
+			await using CreatioWedgeStubServer stub = CreatioWedgeStubServer.Start();
+			await File.WriteAllTextAsync(Path.Combine(home, "appsettings.json"), JsonSerializer.Serialize(new {
+				ActiveEnvironmentKey = "runtime-probe",
+				Environments = new Dictionary<string, object> {
+					["runtime-probe"] = new { Uri = stub.BaseUrl, Login = "fixture", Password = "fixture", IsNetCore = false }
+				}
+			}));
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = Path.Combine(install, "clio.dll");
+			settings.ProcessEnvironmentVariables["CLIO_HOME"] = home;
+			settings.ProcessEnvironmentVariables["DOTNET_ROLL_FORWARD"] = "LatestMajor";
+			using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(2));
+			await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellation.Token);
+
+			// Act
+			CallToolResult result = await session.CallToolAsync(PageListTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> { ["environment-name"] = "runtime-probe" }
+				}, cancellation.Token);
+
+			// Assert
+			await AllureApi.Step("The worker starts and executes the read against the stub", () => {
+				result.IsError.Should().NotBeTrue(because: "losing the runtime policy must not cause a worker relay failure");
+				string text = string.Join("\n", result.Content.OfType<TextContentBlock>().Select(block => block.Text));
+				using JsonDocument payload = JsonDocument.Parse(text);
+				payload.RootElement.GetProperty("success").GetBoolean().Should().BeTrue(
+					because: "a transport response alone does not establish successful tool execution");
+				stub.SelectCount.Should().BeGreaterThan(0,
+					because: "the worker must actually read from Creatio after its runtime starts");
+				return Task.CompletedTask;
+			});
+		} finally {
+			Directory.Delete(scratch, recursive: true);
+		}
+	}
+
+	private static void CopyBuild(string source, string destination) {
+		Directory.CreateDirectory(destination);
+		foreach (string file in Directory.EnumerateFiles(source)) {
+			File.Copy(file, Path.Combine(destination, Path.GetFileName(file)));
+		}
+		foreach (string directory in Directory.EnumerateDirectories(source)) {
+			CopyBuild(directory, Path.Combine(destination, Path.GetFileName(directory)));
+		}
+	}
+}

--- a/clio.mcp.e2e/McpWorkerRuntimeE2ETests.cs
+++ b/clio.mcp.e2e/McpWorkerRuntimeE2ETests.cs
@@ -27,6 +27,7 @@ public sealed class McpWorkerRuntimeE2ETests {
 		// Arrange
 		string scratch = Path.Combine(Path.GetTempPath(), $"clio-runtime-e2e-{Guid.NewGuid():N}");
 		Directory.CreateDirectory(scratch);
+		bool testFailed = false;
 		try {
 			string source = Path.GetDirectoryName(TestConfiguration.ResolveFreshClioProcessPath())!;
 			string install = Path.Combine(scratch, "clio");
@@ -75,8 +76,33 @@ public sealed class McpWorkerRuntimeE2ETests {
 					because: "the worker must actually read from Creatio after its runtime starts");
 				return Task.CompletedTask;
 			});
+		} catch {
+			testFailed = true;
+			throw;
 		} finally {
-			Directory.Delete(scratch, recursive: true);
+			await DeleteScratchAsync(scratch, testFailed);
+		}
+	}
+
+	private static async Task DeleteScratchAsync(string scratch, bool testFailed) {
+		// Disposing the MCP transport can precede Windows releasing the copied assemblies.
+		// Bound the retry, but never replace a tool assertion with a cleanup exception.
+		for (int attempt = 0; attempt < 20; attempt++) {
+			try {
+				if (Directory.Exists(scratch)) {
+					Directory.Delete(scratch, recursive: true);
+				}
+				return;
+			} catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+				if (attempt == 19) {
+					if (!testFailed) {
+						throw;
+					}
+					TestContext.Error.WriteLine($"Cleanup failed for '{scratch}': {exception.Message}");
+					return;
+				}
+			}
+			await Task.Delay(250);
 		}
 	}
 

--- a/clio.tests/Command/McpServer/WorkerProcessSupervisorTests.cs
+++ b/clio.tests/Command/McpServer/WorkerProcessSupervisorTests.cs
@@ -604,6 +604,23 @@ public sealed class WorkerProcessSupervisorTests {
 			because: "the variable that tells an apphost where the shared runtime lives is architecture-specific — measured on arm64 macOS only DOTNET_ROOT_ARM64 was set — and a frozen environment missing it makes every worker die at startup with \"You must install or update .NET\"");
 	}
 
+	[TestCase("Major")]
+	[TestCase("LatestMajor")]
+	[TestCase("Disable")]
+	[Description("Workers preserve the parent's explicit runtime roll-forward policy instead of independently selecting a runtime or failing before the MCP handshake.")]
+	public void ComposeEffectiveEnvironment_ShouldPreserveRollForward_WhenConfigured(string policy) {
+		// Arrange
+		WorkerSpawnRequest request = new();
+
+		// Act
+		IReadOnlyDictionary<string, string> environment = WorkerProcessSupervisor.ComposeEffectiveEnvironment(
+			request, name => name == "DOTNET_ROLL_FORWARD" ? policy : null);
+
+		// Assert
+		environment.Should().Contain("DOTNET_ROLL_FORWARD", policy,
+			because: "a working parent and its workers must use the same operator-selected runtime policy");
+	}
+
 	[Test]
 	[Description("Every host-behaviour knob a worker can actually reach is inherited, because an operator tunes clio and not one process of it: a knob that lands in the parent only produces two clios that disagree, and the difference is invisible because the parent is the process an operator can watch.")]
 	public void DefaultInheritedEnvironmentVariableAllowlist_ShouldKeepEveryHostBehaviourVariableAWorkerCanReach() {

--- a/clio/Common/McpWorker/WorkerProcessSupervisor.cs
+++ b/clio/Common/McpWorker/WorkerProcessSupervisor.cs
@@ -159,6 +159,9 @@ public sealed class WorkerProcessSupervisor : IWorkerProcessSupervisor, IWorkerP
 		"DOTNET_ROOT_X86",
 		"DOTNET_ROOT(x86)",
 		"DOTNET_HOST_PATH",
+		// A parent running through a newer installed runtime must give its worker the same policy.
+		// Otherwise the parent starts, but the worker fails before its MCP handshake (GH-1409).
+		"DOTNET_ROLL_FORWARD",
 		"CLIO_HOME",
 		"CLIO_WORKING_DIRECTORY",
 		"LANG",

--- a/clio/docs/commands/mcp-server.md
+++ b/clio/docs/commands/mcp-server.md
@@ -18,6 +18,12 @@ that support the MCP protocol.
 The server runs until the stdin stream is closed or the process is
 terminated.
 
+Worker processes inherit `DOTNET_ROOT` (including architecture-specific variants) and
+`DOTNET_ROLL_FORWARD` from the server process. Configure these in your MCP client's
+server environment when using a non-default .NET installation or an explicit runtime
+roll-forward policy. Clio preserves that policy; it does not enable major-version
+roll-forward automatically.
+
 Available MCP tool categories:
 - application     Create, list, and inspect Creatio applications
 - entity          Create and update entity schemas (DB-first)

--- a/clio/help/en/mcp-server.txt
+++ b/clio/help/en/mcp-server.txt
@@ -13,6 +13,11 @@ DESCRIPTION
     The server runs until the stdin stream is closed or the process is
     terminated.
 
+    Workers inherit DOTNET_ROOT (including architecture-specific variants) and
+    DOTNET_ROLL_FORWARD from the server. Set these in your MCP client's server
+    environment for a non-default .NET installation or explicit roll-forward
+    policy. Clio does not enable major-version roll-forward automatically.
+
     Available MCP tool categories:
     - application     Create, list, and inspect Creatio applications
     - entity          Create and update entity schemas (DB-first)

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -21,6 +21,18 @@
 # 2026-07-06) is a separate Jira ticket stacked on the same branch; tracked as its own row.
 
 stories:
+  - id: story-worker-runtime-policy
+    title: "Preserve the MCP worker runtime roll-forward policy"
+    feature: "mcp-worker-execution-boundary"
+    repo: "clio"
+    size: S
+    status: review
+    file: spec/stories/story-worker-runtime-policy.md
+    adr: spec/adr/adr-mcp-worker-execution-boundary.md
+    note: "GH-1409: Windows/Linux reproduction and validation complete; merge requires Alexandr-Kravchuk's live Mac confirmation."
+    depends_on: []
+    blocks: []
+
   - id: story-knowledge-bundle-runtime-1
     title: "Install and hot-reload external knowledge"
     feature: "knowledge-bundle-runtime"

--- a/spec/sprint-status.yaml
+++ b/spec/sprint-status.yaml
@@ -29,7 +29,7 @@ stories:
     status: review
     file: spec/stories/story-worker-runtime-policy.md
     adr: spec/adr/adr-mcp-worker-execution-boundary.md
-    note: "GH-1409: Windows/Linux reproduction and validation complete; merge requires Alexandr-Kravchuk's live Mac confirmation."
+    note: "GH-1409: Alex independently verified Windows and reported a teardown race. User authorized proceeding without a Mac runtime; Mac validation remains unverified."
     depends_on: []
     blocks: []
 

--- a/spec/stories/story-worker-runtime-policy.md
+++ b/spec/stories/story-worker-runtime-policy.md
@@ -10,6 +10,8 @@ allowlist; do not discover/install runtimes or enable roll-forward by default.
 
 The Linux reproduction confirms a dropped roll-forward policy, not a dropped
 `DOTNET_ROOT`. The exact Mac launcher has not yet been verified.
+On 2026-09-11 the user authorized proceeding without a Mac runtime. Mac
+validation remains unavailable, rather than being reported as passed.
 
 Acceptance:
 - [x] Reproduce parent initialization followed by worker startup failure.
@@ -17,5 +19,6 @@ Acceptance:
 - [x] Prove a real MCP worker reaches a deterministic Creatio stub after the fix.
 - [x] Run Windows and Rancher Desktop Linux validation.
 - [x] Complete agentic review and Ring compatibility validation.
-- [ ] Request Alexandr-Kravchuk's review and live Mac tests against his environment.
-- [ ] Merge only after Alex confirms the fix on his Mac.
+- [x] Request Alexandr-Kravchuk's review; record his independent Windows verification.
+- [x] Address the reported Windows teardown race and verify repeated runs and mutation failure.
+- [x] Record unavailable Mac validation and the user's authorization to proceed without it.

--- a/spec/stories/story-worker-runtime-policy.md
+++ b/spec/stories/story-worker-runtime-policy.md
@@ -1,0 +1,21 @@
+# Worker runtime policy inheritance
+
+Issue: [#1409](https://github.com/Advance-Technologies-Foundation/clio/issues/1409)
+Status: review
+Architecture: existing [worker execution boundary ADR](../adr/adr-mcp-worker-execution-boundary.md), frozen environment rule.
+
+When a user explicitly configures `DOTNET_ROLL_FORWARD` for the MCP server,
+its workers must receive the same value. Reuse the supervisor's environment
+allowlist; do not discover/install runtimes or enable roll-forward by default.
+
+The Linux reproduction confirms a dropped roll-forward policy, not a dropped
+`DOTNET_ROOT`. The exact Mac launcher has not yet been verified.
+
+Acceptance:
+- [x] Reproduce parent initialization followed by worker startup failure.
+- [x] Preserve explicit roll-forward values, including restrictive `Disable`.
+- [x] Prove a real MCP worker reaches a deterministic Creatio stub after the fix.
+- [x] Run Windows and Rancher Desktop Linux validation.
+- [x] Complete agentic review and Ring compatibility validation.
+- [ ] Request Alexandr-Kravchuk's review and live Mac tests against his environment.
+- [ ] Merge only after Alex confirms the fix on his Mac.


### PR DESCRIPTION
When a .NET 8 MCP server starts on .NET 10 through `DOTNET_ROLL_FORWARD=Major`, Clio clears that setting from its workers. The parent initializes, but the worker exits before contacting Creatio with `clio-worker-relay-failure`. Preserve the configured value through the existing environment allowlist. No runtime discovery, installation, or automatic roll-forward is introduced.

Closes #1409. **The reported Mac launcher has not yet been verified.** Released 8.1.0.121 already preserves `DOTNET_ROOT` and architecture-specific variants. Linux controls using a private .NET 8 muxer or explicit root succeeded; the dropped roll-forward setting reproduced the exact reported failure. This PR repairs that confirmed case and records Mac equivalence as unverified; see the updated acceptance boundary below.

### Review disposition and validation boundary

Alexandr-Kravchuk independently confirmed the production fix on Windows and reported a reproducible test teardown race. That concern is accepted: the copied build can still have locked DLLs when immediate deletion runs, masking the original assertion and leaving temporary files.

The test now retries deletion up to 20 times with 250 ms between attempts. If cleanup exhausts its budget, an otherwise successful test fails; if the test already failed, cleanup logs the remaining path and preserves the original exception. It does not silently report leaked files as success.

The user subsequently authorized proceeding without a Mac runtime. **Mac validation remains unavailable and the original Mac launcher equivalence is unverified.** The earlier Mac-only merge gate is superseded by that instruction; delivery proceeds on the recorded Windows/Linux evidence and required repository checks.

### Validation

- Released .121 Linux reproduction in a Rancher Desktop container: default .NET/ASP.NET 10.0.12, private .NET/ASP.NET 8.0.31. `DOTNET_ROLL_FORWARD=Major` gives successful parent initialization, failed worker, and zero stub requests. Private muxer, `DOTNET_ROOT`, and `DOTNET_ROOT_X64` controls all perform the read successfully.
- Windows regression proved failing before the fix, passing after it. The test launches a real MCP parent and worker with an isolated runtime configuration requiring roll-forward and verifies a real SelectQuery reaches the existing deterministic Creatio stub.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter FullyQualifiedName~McpWorkerRuntimeE2ETests`: 1 passed.
- Same command with `-f net8.0`: 1 passed.
- Rancher Desktop Linux: `dotnet vstest /repo/clio.mcp.e2e/bin/Debug/net10.0/clio.mcp.e2e.dll --TestCaseFilter:FullyQualifiedName~McpWorkerRuntimeE2ETests`: 1 passed. The net8.0 target also passed under .NET 10 with explicit `DOTNET_ROLL_FORWARD=LatestMajor`. These are cross-platform managed build artifacts executed on Linux; live Mac remains untested.
- `dotnet test clio.tests/clio.tests.csproj --no-build --filter "Category=Unit&(Module=Common|Module=McpServer)"`: 6,317 passed, 5 skipped.
- Full `Category=Unit`: 12,008 passed, 25 skipped, zero failures. Existing skipped platform/explicit tests are not claimed as passes.
- `git diff --check`: passed. Knowledge applicability check reviewed; no recorded fact changed by this allowlist addition.

**ClioRing compatibility reviewed:** inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`. Tool schemas, error envelopes, and stage-event bytes are unchanged.
- `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release`: 157 passed.
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true`: exit 0, no IL2026/IL3050 diagnostics; native `clio-ring.exe` produced.
- Published `clio-ring.exe --ipc-proof --clio-dll <this-worktree>/clio/bin/Debug/net10.0/clio.dll --env unconfigured-1409 --out <report>` with an isolated empty `CLIO_HOME`: exit 0; initialization, 197-tool catalog, restart, and shutdown passed. Environment-detail probe skipped because no live environment was configured for this harness; worker read execution is covered by the separate stub E2E.

### Review and documentation

Comprehensive pre-PR parallel review covered quality/testing/bugs, security, performance, intent alignment, and KISS: no findings. Final read-only Claude review (`rev_19a982d924404c1f`) completed with no material findings. It confirmed policy precedence and the real worker execution path. Mac equivalence remains unconfirmed; other runtime policy variables are outside this reproduced repair.

Command documentation reviewed: updated `mcp-server` detailed docs and CLI help. Command index, aliases, shipped templates, and published guidance require no change. MCP reviewed, no update required to tool arguments, prompts, descriptions, or result contracts; external-process regression coverage added.

KISS check: the parent selects a runtime policy; the existing allowlist carries the same value to workers. One allowlist entry is the entire production behavior change.




