### PR TITLE
Fix missing CSV destination diagnostic for execute-sql-script

### DIFF
--- a/clio.tests/Command/SqlScriptCommandTests.cs
+++ b/clio.tests/Command/SqlScriptCommandTests.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using Clio.Command.SqlScriptCommand;
+using Clio.Common;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+[Property("Module", "Command")]
+public class SqlScriptCommandTests : BaseCommandTests<ExecuteSqlScriptOptions> {
+	private ISqlScriptExecutor _executor;
+	private ILogger _logger;
+	private SqlScriptCommand _sut;
+
+	protected override void AdditionalRegistrations(IServiceCollection services) {
+		_executor = Substitute.For<ISqlScriptExecutor>();
+		_logger = Substitute.For<ILogger>();
+		services.AddSingleton(_executor);
+		services.AddSingleton(_logger);
+	}
+
+	public override void Setup() {
+		base.Setup();
+		_sut = Container.GetRequiredService<SqlScriptCommand>();
+	}
+
+	public override void TearDown() {
+		_executor.ClearReceivedCalls();
+		_logger.ClearReceivedCalls();
+		base.TearDown();
+	}
+
+	[TestCase("csv", null, false)]
+	[TestCase("CSV", "", false)]
+	[TestCase("CsV", " \t", true)]
+	[Description("CSV without a usable destination reports the missing option before executing SQL, including in silent mode.")]
+	public void Execute_ShouldRejectBeforeSqlExecution_WhenCsvDestinationIsMissing(
+		string view, string destination, bool silent) {
+		// Arrange
+		var options = new ExecuteSqlScriptOptions {
+			Script = "SELECT 1 AS a", ViewType = view, DestPath = destination, IsSilent = silent
+		};
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		result.Should().Be(1, because: "missing CSV output is an invalid invocation");
+		_executor.ReceivedCalls().Should().BeEmpty(because: "invalid output options must not execute SQL");
+		_logger.ReceivedCalls().Select(call => call.GetArguments().FirstOrDefault()).Should()
+			.Equal(new object[] { "-d/--destination-path is required when -v csv is used." },
+				because: "the diagnostic must name both options without reporting success");
+	}
+
+	[TestCase("table", null)]
+	[TestCase("json", null)]
+	[TestCase("csv", "result.csv")]
+	[Description("Table and JSON still allow no destination, and CSV accepts a supplied destination.")]
+	public void Execute_ShouldExecuteSql_WhenOutputOptionsAreValid(string view, string destination) {
+		// Arrange
+		var options = new ExecuteSqlScriptOptions {
+			Script = "SELECT 1 AS a", ViewType = view, DestPath = destination, IsSilent = true
+		};
+		_executor.Execute(options.Script, Arg.Any<IApplicationClient>(), Arg.Any<EnvironmentSettings>())
+			.Returns("[]");
+
+		// Act
+		int result = _sut.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "valid output options must retain the successful execution path");
+		_executor.ReceivedCalls().Should().ContainSingle(because: "SQL must execute exactly once");
+		_logger.ReceivedCalls().Select(call => call.GetArguments().FirstOrDefault()).Should()
+			.Equal(new object[] { "Done" }, because: "silent successful execution retains its completion message");
+	}
+}

--- a/clio/Command/SqlScriptCommand.cs
+++ b/clio/Command/SqlScriptCommand.cs
@@ -43,6 +43,8 @@ namespace Clio.Command.SqlScriptCommand
 
 	public class SqlScriptCommand : RemoteCommand<ExecuteSqlScriptOptions>
 	{
+		private const string CsvDestinationRequired =
+			"-d/--destination-path is required when -v csv is used.";
 		private readonly ISqlScriptExecutor _sqlScriptExecutor;
 		private readonly ILogger _logger;
 
@@ -164,7 +166,17 @@ namespace Clio.Command.SqlScriptCommand
 			spreadsheetDocument.Close();
 		}
 
+		/// <summary>
+		/// Executes SQL and renders the result after validating the CSV destination.
+		/// </summary>
+		/// <param name="opts">SQL input, output format, and destination options.</param>
+		/// <returns>One when CSV has no destination; otherwise the command's execution result.</returns>
 		public override int Execute(ExecuteSqlScriptOptions opts) {
+			if (string.Equals(opts.ViewType, "csv", StringComparison.OrdinalIgnoreCase)
+				&& string.IsNullOrWhiteSpace(opts.DestPath)) {
+				_logger.WriteError(CsvDestinationRequired);
+				return 1;
+			}
 			try {
 				string result = string.Empty;
 				if (!string.IsNullOrEmpty(opts.Script)) {

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -363,7 +363,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 - [`download-configuration`](docs/commands/download-configuration.md) - Download configuration libraries from Creatio, `dconf`
 <a id="execute-sql-script"></a>
 <a id="sql"></a>
-- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio, `sql`
+- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio; CSV requires `-d/--destination-path`, `sql`
 <a id="export-component-registry"></a>
 <a id="export-registry"></a>
 - [`export-component-registry`](docs/commands/export-component-registry.md) - Write the full Freedom UI component registry for a resolved platform version to a file, `export-registry`

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -363,7 +363,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 - [`download-configuration`](docs/commands/download-configuration.md) - Download configuration libraries from Creatio, `dconf`
 <a id="execute-sql-script"></a>
 <a id="sql"></a>
-- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio; CSV requires `-d/--destination-path`, `sql`
+- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio, `sql`
 <a id="export-component-registry"></a>
 <a id="export-registry"></a>
 - [`export-component-registry`](docs/commands/export-component-registry.md) - Write the full Freedom UI component registry for a resolved platform version to a file, `export-registry`

--- a/clio/docs/commands/execute-sql-script.md
+++ b/clio/docs/commands/execute-sql-script.md
@@ -24,13 +24,13 @@ Install or update cliogate with `clio install-gate -e <ENVIRONMENT_NAME>`.
 Value (pos. 0)   Sql script to execute
 --File           -f          Path to the SQL script file
 --View           -v          Output format: table, csv, xlsx (default: table)
---DestinationPath -d         Path to save the result file
+--destination-path -d         Path to save the result file
 --silent                     Suppress console output
 --uri            -u          Application uri
---Password       -p          User password
---Login          -l          User login (administrator permission required)
---Environment    -e          Environment name
---Maintainer     -m          Maintainer name
+--password       -p          User password
+--login          -l          User login (administrator permission required)
+--environment    -e          Environment name
+--maintainer     -m          Maintainer name
 ```
 
 ## Examples
@@ -46,7 +46,8 @@ execute-sql-script -f c:\Path\to\file.sql -v xlsx -d result.xlsx
 
 If both Script and File are omitted, the command prompts for SQL input.
 Output is shown in the console unless --silent is specified.
-Results can be saved to a file in the chosen format.
+Results can be saved to a file in the chosen format. CSV requires -d/--destination-path.
+If the CSV destination is missing or blank, the command exits with code 1 before executing SQL.
 
 cliogate version 2.0.0.41 or higher must be installed on the target environment for this command to work.
 Install or update it with: clio install-gate -e <ENVIRONMENT_NAME>

--- a/clio/help/en/execute-sql-script.txt
+++ b/clio/help/en/execute-sql-script.txt
@@ -18,13 +18,13 @@ OPTIONS
     Value (pos. 0)   Sql script to execute
     --File           -f          Path to the SQL script file
     --View           -v          Output format: table, csv, xlsx (default: table)
-    --DestinationPath -d         Path to save the result file
+    --destination-path -d         Path to save the result file
     --silent                     Suppress console output
     --uri            -u          Application uri
-    --Password       -p          User password
-    --Login          -l          User login (administrator permission required)
-    --Environment    -e          Environment name
-    --Maintainer     -m          Maintainer name
+    --password       -p          User password
+    --login          -l          User login (administrator permission required)
+    --environment    -e          Environment name
+    --maintainer     -m          Maintainer name
 
 EXAMPLES
     execute-sql-script "SELECT Id FROM SysSettings WHERE Code = 'CustomPackageId'"
@@ -35,7 +35,8 @@ EXAMPLES
 NOTES
     If both Script and File are omitted, the command prompts for SQL input.
     Output is shown in the console unless --silent is specified.
-    Results can be saved to a file in the chosen format.
+    Results can be saved to a file in the chosen format. CSV requires -d/--destination-path.
+    If the CSV destination is missing or blank, the command exits with code 1 before executing SQL.
     
     cliogate version 2.0.0.41 or higher must be installed and compatible on the target
     environment for this command to work. Install or update it with:

--- a/docs/knowledge/platform/execute-sql-script-reads-can-be-denied-while-writes-still-work.md
+++ b/docs/knowledge/platform/execute-sql-script-reads-can-be-denied-while-writes-still-work.md
@@ -21,5 +21,5 @@ cliogate unit test has to flip the private static property by reflection to exer
 
 **What breaks if you ignore it** — a survey or diagnostic built on `execute-sql-script` SELECTs works on one stand
 and dies on the next, and because writes keep working the failure looks like a broken query or a stale cliogate
-rather than a policy. Do not spend a round on redeploying the gate. Get the data another way: DataService ESQ
+rather than a policy. This diagnosis applies to the server denial above, not to a local missing-CSV-destination error; those two failures require different remedies. Do not spend a round on redeploying the gate. Get the data another way: DataService ESQ
 (`execute-esq`), a per-record command, or the dedicated clio read commands.


### PR DESCRIPTION
CSV output without `-d` previously reached the file writer with a null path. The command now reports `-d/--destination-path is required when -v csv is used.` and returns 1 before executing SQL when the destination is missing or blank. Existing output behavior with a destination is preserved.

Fixes #1402.

Validation: `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Command"` — 4,324 passed, 13 skipped. Regression tests cover missing/blank destinations, case variants, silent mode, no SQL execution on rejection, and valid output options. No live Creatio environment was needed for this local argument-validation defect.

Help, detailed command reference, and relevant internal knowledge updated; generated index, aliases, and wiki anchor reviewed and unchanged. MCP reviewed, no update required: no dedicated SQL-script MCP tool exists; adding one is outside this validation fix. No matching command-specific article was found in clio-knowledge.

ClioRing compatibility reviewed, no Ring-consumed contract changed. Inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json` for direct and nested command calls.

Comprehensive pre-PR parallel review covered code quality/testing, security, bugs/performance, intent, and KISS; no findings. The flow remains one pre-execution guard using the existing logger, with no additional services or state. Final comprehensive parallel review also found no defects. Claude review rev_db51b36404bb460a found no blocking defects; its one low-severity generated-index drift finding was verified and fixed by dropping the manual index edit. The docs-only follow-up used the policy skip tier (generated Markdown only); executable code and validated tests are unchanged. Latest-head Sonar analysis and direct issue query passed with zero new issues. Required Unit Tests, Integration Tests, Detect changes, and Sonar gates passed; Analyzer Tests skipped as expected. Merged as f4091e2b340118bac1b53dc3b337b81e060cfff0, verified reachable from origin/master. GitHub Codex review bot reported quota exhaustion; local comprehensive parallel review and Claude review completed independently.
