### PR TITLE
Fix misleading MCP tool-name suggestions

### DIFF
--- a/clio.mcp.e2e/ClioRunToolE2ETests.cs
+++ b/clio.mcp.e2e/ClioRunToolE2ETests.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
 using Clio.Mcp.E2E.Support.Mcp;
 using FluentAssertions;
 using ModelContextProtocol.Protocol;
@@ -26,6 +28,62 @@ namespace Clio.Mcp.E2E;
 public sealed class ClioRunToolE2ETests : McpContractFixtureBase {
 
 	private const string SyntheticMissingName = "synthetic-missing-guide";
+
+	private protected override void ConfigureMcpServerSettings(McpE2ESettings settings) {
+		settings.ProcessEnvironmentVariables["CLIO_HOME"] = CreateIsolatedClioHome("{}", "clio-run-suggestions");
+	}
+
+	[Test]
+	[Category("E2E")]
+	[Description("A disabled identity tool is not echoed back in the unknown-name shortlist over stdio.")]
+	[AllureTag(ClioRunTool.ToolName)]
+	[AllureName("clio-run excludes disabled identity tool suggestions")]
+	[AllureDescription("Uses isolated settings with all experimental flags off to reproduce reflection-only self-suggestions.")]
+	public async Task ClioRun_ShouldExcludeRequestedName_WhenIdentityToolIsDisabled() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+		const string requestedName = DeployIdentityTool.DeployIdentityToolName;
+
+		// Act
+		CallToolResult result = await context.Session.CallToolAsync(ClioRunTool.ToolName,
+			new Dictionary<string, object?> { ["command"] = requestedName },
+			context.CancellationTokenSource.Token);
+
+		// Assert
+		AllureApi.Step("Assert disabled tool remains unavailable", () =>
+			result.IsError.Should().BeTrue(because: "experimental tools must remain unavailable with flags off"));
+		string text = string.Join(" ", result.Content.OfType<TextContentBlock>().Select(block => block.Text));
+		AllureApi.Step("Assert rejected name occurs only in the diagnostic", () =>
+			text.Split(requestedName).Length.Should().Be(2,
+				because: "the rejected name must appear once in the error and never again in suggestions"));
+	}
+
+	[Test]
+	[Category("E2E")]
+	[Description("Unknown executor targets suggest update for set without dispatching the suggestion.")]
+	[AllureTag(ClioRunTool.ToolName)]
+	[AllureName("clio-run suggests update for set")]
+	[AllureDescription("Calls an unregistered name over stdio and verifies the failure shortlist and discovery hint.")]
+	public async Task ClioRun_ShouldSuggestUpdateFirst_WhenSetVerbIsRequested() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		CallToolResult result = await context.Session.CallToolAsync(ClioRunTool.ToolName,
+			new Dictionary<string, object?> { ["command"] = "set-sys-setting" },
+			context.CancellationTokenSource.Token);
+
+		// Assert
+		AllureApi.Step("Assert unknown tool is an error", () =>
+			result.IsError.Should().BeTrue(because: "a suggestion must never execute a write tool"));
+		string text = string.Join(" ", result.Content.OfType<TextContentBlock>().Select(block => block.Text));
+		AllureApi.Step("Assert update ranks first", () =>
+			text.Should().Contain("Did you mean: " + SysSettingUpdateTool.UpdateSysSettingToolName + ",",
+				because: "write intent must precede lexical read matches"));
+		AllureApi.Step("Assert discovery remains available", () =>
+			text.Should().Contain(ToolContractGetTool.DiscoveryHint,
+				because: "the full catalog remains the recovery path if the suggestions miss"));
+	}
 
 	// Either typed outcome proves the dispatch reached get-guidance with the forwarded name:
 	// "guidance-not-found" when a knowledge bundle is active and the synthetic name is absent from

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -18,6 +18,28 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 	[Test]
+	[Description("An unknown set-system-setting name suggests the update tool first over real stdio.")]
+	[AllureTag(ToolContractGetTool.ToolName)]
+	[AllureName("get-tool-contract suggests update for set")]
+	[AllureDescription("Checks the serialized shortlist without executing any system-setting operation.")]
+	public async Task GetToolContracts_ShouldSuggestUpdateFirst_WhenSetVerbIsRequested() {
+		// Arrange
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		ToolContractGetResponse response = await CallAsync(context.Session,
+			context.CancellationTokenSource.Token,
+			new Dictionary<string, object?> { ["tool-names"] = new[] { "set-sys-setting" } });
+
+		// Assert
+		AllureApi.Step("Assert lookup remains a failure", () =>
+			response.Success.Should().BeFalse(because: "suggestions must not execute or alias the unknown tool"));
+		AllureApi.Step("Assert update ranks first", () =>
+			response.Error!.Suggestions!.First().Should().Be(SysSettingUpdateTool.UpdateSysSettingToolName,
+				because: "the matching write intent must survive the real wire path"));
+	}
+
+	[Test]
 	[TestCase(false)]
 	[TestCase(true)]
 	[Description("Returns valid contracts and individual misses through the real MCP server in either request order.")]

--- a/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
+++ b/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
@@ -396,17 +396,44 @@ public sealed class ClioRunDispatchTests {
 			because: "the hint must follow with exactly one space (no double space) after the suggestions segment");
 	}
 
-	// The executor's suggestion source unions the (mockable) registry with the static reflection catalog
-	// of every clio MCP tool, which is always non-empty — so a real ClioRunExecutor cannot emit a literally
-	// empty 'did you mean' segment. The append is unconditional (outside the suggestions ternary), so this
-	// pins the invariant that matters regardless of the shortlist: the hint is the trailing sentence and is
-	// appended with correct single-space punctuation, with no empty-fragment double punctuation.
+	[Test]
+	[Category("Unit")]
+	[TestCase("get-identity-service-config")]
+	[TestCase("GET-IDENTITY-SERVICE-CONFIG")]
+	[Description("Unknown-name suggestions exclude the requested name and tools absent from the live registry.")]
+	public async Task RunAsync_ShouldExcludeUnavailableAndRequestedNames_WhenToolIsUnknown(string requestedName) {
+		// Arrange
+		_registry.ToolNames.Returns(new[] { requestedName.ToLowerInvariant(), "get-identity-assertion" });
+
+		// Act
+		CallToolResult result = await _sut.RunAsync(requestedName, null, false, CallContext(), CancellationToken.None);
+
+		// Assert
+		ErrorText(result).Should().Contain("Did you mean: get-identity-assertion?",
+			because: "only the other live registry name may be suggested, without reflection-only candidates");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A set-system-setting guess suggests the update operation before lexical read matches.")]
+	public async Task RunAsync_ShouldSuggestUpdateFirst_WhenSetVerbIsRequested() {
+		// Arrange
+		_registry.ToolNames.Returns(new[] { "get-sys-setting", "create-sys-setting", "list-sys-settings",
+			SysSettingUpdateTool.UpdateSysSettingToolName });
+
+		// Act
+		CallToolResult result = await _sut.RunAsync("set-sys-setting", null, false, CallContext(), CancellationToken.None);
+
+		// Assert
+		ErrorText(result).Should().Contain("Did you mean: " + SysSettingUpdateTool.UpdateSysSettingToolName + ",",
+			because: "set and update describe the same intent for this exact subject");
+	}
+
 	[Test]
 	[Category("Unit")]
 	[Description("The get-tool-contract compact-index discovery hint is always the trailing sentence of the unknown-tool error and is appended with single-space punctuation (no double space) — independent of the 'did you mean' shortlist.")]
 	public async Task RunAsync_ShouldEndWithDiscoveryHint_WhenToolIsUnknown() {
-		// Arrange — registry advertises ONLY the executor names (BuildSuggestions strips them), so any
-		// shortlist here can only come from the reflection catalog, exercising the hint append path.
+		// Arrange — registry advertises only executor names, so no alternative remains.
 		_registry.ToolNames.Returns(new[] { ClioRunTool.ToolName, ClioRunDestructiveTool.ToolName });
 		_registry.TryGetTool("zzzzzzzzzzzzzzzz", out Arg.Any<McpServerTool>()).Returns(false);
 
@@ -424,6 +451,8 @@ public sealed class ClioRunDispatchTests {
 			because: "the hint must always be the trailing sentence regardless of whether suggestions exist");
 		text.Should().NotContain(". .",
 			because: "an empty 'did you mean' fragment must not double-punctuate before the hint");
+		text.Should().NotContain("Did you mean",
+			because: "reflection-only tools must not fill an empty live candidate pool");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/McpToolArgumentSupportTests.cs
+++ b/clio.tests/Command/McpServer/McpToolArgumentSupportTests.cs
@@ -18,6 +18,51 @@ namespace Clio.Tests.Command.McpServer;
 [Property("Module", "McpServer")]
 public sealed class McpToolArgumentSupportTests
 {
+	[TestCase("set-widget", "update-widget")]
+	[TestCase("UPDATE-widget", "set-widget")]
+	[Category("Unit")]
+	[Description("Equivalent set/update verbs lead only when the complete subject matches.")]
+	public void SuggestToolNames_ShouldPreferEquivalentVerb_WhenSubjectMatches(string requested, string expected) {
+		// Arrange
+		string[] candidates = ["get-widget", "set-other", "update-other", expected];
+
+		// Act
+		IReadOnlyList<string> result = McpToolArgumentSupport.SuggestToolNames(requested, candidates);
+
+		// Assert
+		result[0].Should().Be(expected, because: "synonymous intent applies only to the same subject");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Ordinary typo suggestions remain distinct, bounded, and ordered by edit distance then name.")]
+	public void SuggestToolNames_ShouldKeepLexicalRanking_WhenNoSynonymMatches() {
+		// Arrange
+		string[] candidates = ["cat", "bat", "BAT", "hat", "mat", "AT", "", " "];
+
+		// Act
+		IReadOnlyList<string> result = McpToolArgumentSupport.SuggestToolNames("at", candidates);
+
+		// Assert
+		result.Should().Equal(["bat", "cat", "hat"],
+			because: "self-matches, blank names, duplicates and fourth-place candidates must not enter the shortlist");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Oversized input retains full-name exclusion while bounding edit-distance work.")]
+	public void SuggestToolNames_ShouldExcludeFullInput_WhenNameExceedsRankingLimit() {
+		// Arrange
+		string requested = new('a', 10000);
+		string shorter = new('a', 64);
+
+		// Act
+		IReadOnlyList<string> result = McpToolArgumentSupport.SuggestToolNames(requested, [requested, shorter]);
+
+		// Assert
+		result.Should().Equal([shorter], because: "the cap must bound ranking without weakening full-input self-exclusion");
+	}
+
 	private static IReadOnlyDictionary<string, JsonElement> Overflow(params string[] keys) {
 		Dictionary<string, JsonElement> bag = new(System.StringComparer.Ordinal);
 		foreach (string key in keys) {

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -24,6 +24,26 @@ public sealed class ToolContractGetToolTests {
 
 	[Test]
 	[Category("Unit")]
+	[TestCase("set-sys-setting")]
+	[TestCase("SET-SYS-SETTING")]
+	[Description("A set-system-setting miss ranks the registered update tool before read/create lexical matches.")]
+	public void GetToolContracts_ShouldSuggestUpdateFirst_WhenSetVerbIsRequested(string requestedName) {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+
+		// Act
+		ToolContractGetResponse result = tool.GetToolContracts(new ToolContractGetArgs([requestedName]));
+
+		// Assert
+		result.Success.Should().BeFalse(because: "suggesting a tool must not turn a miss into a successful lookup");
+		result.Error!.Suggestions!.First().Should().Be(SysSettingUpdateTool.UpdateSysSettingToolName,
+			because: "the exact subject with synonymous update intent should precede a read tool");
+		result.Error.Suggestions.Should().NotContain(requestedName.ToLowerInvariant(),
+			because: "an unknown name must never suggest itself");
+	}
+
+	[Test]
+	[Category("Unit")]
 	[TestCase(false)]
 	[TestCase(true)]
 	[Description("Retains valid contracts regardless of where unknown names occur in a batch and deduplicates names.")]

--- a/clio/Command/McpServer/Tools/ClioRunTool.cs
+++ b/clio/Command/McpServer/Tools/ClioRunTool.cs
@@ -138,10 +138,9 @@ public sealed class ClioRunExecutor(
 		if (!toolRegistry.TryGetTool(toolName, out McpServerTool tool)) {
 			// The long tail clio-run targets is hidden from tools/list, so agents frequently GUESS the
 			// name and miss by a typo. Append a "did you mean" shortlist of the nearest REAL tool names so
-			// the agent can self-correct without an extra discovery round-trip. Only the RANKING (Levenshtein
-			// distance then ordinal) matches the BuildSuggestions helper in ToolContractGetTool. The candidate
-			// SOURCE SET is caller-specific and intentionally divergent — here it is the registry's invokable
-			// names + the reflection catalog (the hidden long tail clio-run targets), deduped case-insensitively.
+			// the agent can self-correct without an extra discovery round-trip. Ranking is shared with
+			// contract lookup: exact set/update subject matches, then edit distance and name. Candidates
+			// come only from the live invokable registry, which includes the enabled hidden long tail.
 			IReadOnlyList<string> suggestions = BuildSuggestions(toolName);
 			string didYouMean = suggestions.Count > 0
 				? $" Did you mean: {string.Join(", ", suggestions)}?"
@@ -580,42 +579,15 @@ public sealed class ClioRunExecutor(
 	private static bool IsBindableToolParameter(ParameterInfo parameter) =>
 		McpToolArgumentSupport.IsBindableToolParameter(parameter);
 
-	// Top-3 nearest real tool names for an unknown `command`, ordered by Levenshtein distance to the
-	// requested name then ordinally by name — the same ranking the BuildSuggestions helper in
-	// ToolContractGetTool uses. The candidate source set here is caller-specific (intentionally divergent):
-	// it is the FULL invokable name
-	// set — the registry's invokable names (the hidden long tail clio-run targets) unioned with the
-	// reflection catalog — deduped case-insensitively. The executor names themselves are excluded so a
-	// near-miss never suggests re-entering clio-run / clio-run-destructive.
+	// Use only the live invokable registry: reflection also includes feature-disabled tools.
 	private IReadOnlyList<string> BuildSuggestions(string requestedName) =>
 		BuildSuggestions(requestedName, toolRegistry);
 
-	// Upper bound on the requested-name length fed into the O(n·m) Levenshtein ranking. This is a cold
-	// error path (only reached on an unknown tool), but the requested name is caller-supplied and could be
-	// arbitrarily long, so it is capped before ranking — mirroring the same 64-char cap the durable handler
-	// applies when sanitizing the name for prose reflection.
-	private const int MaxRequestedNameLengthForRanking = 64;
-
-	// Static form shared with the durable (forgiving) call-tool handler, so both callers rank the same
-	// candidate set with the same algorithm and never drift apart.
-	internal static IReadOnlyList<string> BuildSuggestions(string requestedName, IMcpToolInvokerRegistry registry) {
-		// Cap the caller-supplied name before it drives the per-candidate Levenshtein computation, so an
-		// oversized name cannot inflate the cost of the ranking on this cold error path.
-		string rankingName = requestedName is { Length: > MaxRequestedNameLengthForRanking }
-			? requestedName[..MaxRequestedNameLengthForRanking]
-			: requestedName;
-		return registry.ToolNames
-			.Concat(McpToolSchemaCatalog.RegisteredToolNames)
-			.Where(name => !string.IsNullOrWhiteSpace(name)
-				&& !string.Equals(name, ClioRunTool.ToolName, StringComparison.OrdinalIgnoreCase)
-				&& !string.Equals(name, ClioRunDestructiveTool.ToolName, StringComparison.OrdinalIgnoreCase))
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.OrderBy(name => McpToolArgumentSupport.LevenshteinDistance(rankingName, name))
-			.ThenBy(name => name, StringComparer.OrdinalIgnoreCase)
-			.Take(3)
-			.ToArray();
-	}
-
+	// Shared with the durable handler; never suggest re-entering either executor.
+	internal static IReadOnlyList<string> BuildSuggestions(string requestedName, IMcpToolInvokerRegistry registry) =>
+		McpToolArgumentSupport.SuggestToolNames(requestedName, registry.ToolNames.Where(name =>
+			!string.Equals(name, ClioRunTool.ToolName, StringComparison.OrdinalIgnoreCase)
+			&& !string.Equals(name, ClioRunDestructiveTool.ToolName, StringComparison.OrdinalIgnoreCase)));
 
 	private static CallToolResult Error(string message) =>
 		new() {

--- a/clio/Command/McpServer/Tools/McpToolArgumentSupport.cs
+++ b/clio/Command/McpServer/Tools/McpToolArgumentSupport.cs
@@ -198,6 +198,30 @@ internal static class McpToolArgumentSupport {
 	}
 
 	/// <summary>
+	/// Ranks distinct alternative tool names, preferring an exact subject match for set/update synonyms.
+	/// </summary>
+	/// <param name="requestedName">The unresolved tool name.</param>
+	/// <param name="candidates">Tool names available to the calling surface.</param>
+	/// <returns>At most three alternatives, excluding the requested name regardless of casing.</returns>
+	public static IReadOnlyList<string> SuggestToolNames(string requestedName, IEnumerable<string> candidates) {
+		string rankingName = requestedName.Length > 64 ? requestedName[..64] : requestedName;
+		string? synonym = rankingName.StartsWith("set-", StringComparison.OrdinalIgnoreCase)
+			? "update-" + rankingName[4..]
+			: rankingName.StartsWith("update-", StringComparison.OrdinalIgnoreCase)
+				? "set-" + rankingName[7..]
+				: null;
+		return candidates
+			.Where(name => !string.IsNullOrWhiteSpace(name)
+				&& !string.Equals(name, requestedName, StringComparison.OrdinalIgnoreCase))
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(name => string.Equals(name, synonym, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+			.ThenBy(name => LevenshteinDistance(rankingName, name))
+			.ThenBy(name => name, StringComparer.OrdinalIgnoreCase)
+			.Take(3)
+			.ToArray();
+	}
+
+	/// <summary>
 	/// Case-insensitive Levenshtein edit distance between two identifiers. Drives the "closest
 	/// match" ranking for unknown tool names and unknown component types. Equal strings score 0.
 	/// </summary>

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -959,13 +959,7 @@ internal static class ToolContractCatalog {
 		IMcpToolInvokerRegistry? toolInvokerRegistry) {
 		IEnumerable<string> derivedNames = toolInvokerRegistry?.ToolNames
 			?? McpToolSchemaCatalog.RegisteredToolNames;
-		return Contracts.Keys
-			.Concat(derivedNames)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.OrderBy(name => McpToolArgumentSupport.LevenshteinDistance(requestedName, name))
-			.ThenBy(name => name, StringComparer.OrdinalIgnoreCase)
-			.Take(3)
-			.ToArray();
+		return McpToolArgumentSupport.SuggestToolNames(requestedName, Contracts.Keys.Concat(derivedNames));
 	}
 
 	/// <summary>

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -55,7 +55,7 @@ server registers an unmatched-name handler (`McpDurableCallToolHandler` via the 
   CLI hidden-alias policy; e.g. `restart-by-environmentName` → `restart-by-environment-name`). Catalog
   collisions fail at startup.
 - **Unresolvable name** → a structured, machine-readable outcome instead of an opaque error:
-  `unknown-tool` (with Levenshtein did-you-mean candidates and the `get-tool-contract` discovery hint),
+  `unknown-tool` (with did-you-mean alternatives from the live tool registry and the `get-tool-contract` discovery hint),
   `feature-disabled`, `cli-verb-not-mcp-tool`, `deprecated-tool-alias`, or `foreign-command` — every
   outcome carrying a `correlation-id`.
 


### PR DESCRIPTION
Fixes #1405.

Unknown-tool suggestions now exclude the requested name case-insensitively. `clio-run` and the durable handler use only the live invokable registry, so reflection-only disabled tools cannot send callers into retry loops. Both dispatch and contract lookup share a bounded shortlist helper that prefers exact-subject `set`/`update` synonyms: `set-sys-setting` suggests `update-sys-setting` first. Ordinary typos retain edit-distance/name ordering. Suggestions never alias or execute a call.

Validation:
- `dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit&Module=McpServer"`: 5,001 passed, 2 skipped. After refreshing from master and simplifying the conditional: `dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit&(Module=McpServer|Module=Command)"`: 9,325 passed, 15 skipped; the same 33 E2E tests passed again.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~ClioRunToolE2ETests|FullyQualifiedName~ToolContractGetToolE2ETests"`: 33 passed over real stdio. Original identity-config name is now registered, so the live disabled-tool regression uses gated `deploy-identity`; the reported name remains covered in unit tests.
- ClioRing compatibility reviewed: `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release`: 157 passed.
- `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true`: passed, no trim/AOT warnings.
- Published NativeAOT `clio-ring.exe --ipc-proof --clio-dll <changed clio.dll> --env issue-1405-no-environment --out <report>`: PASS with isolated CLIO_HOME; handshake, 201-tool catalog, restart, and shutdown verified. No Creatio environment required.

MCP implementation and unit/E2E coverage updated together. Capability-map wording updated; CLI docs reviewed, no update required (MCP-only error ranking). Prompts, resources, shipped templates, and current clio-knowledge routing remain accurate; no guidance generation change. Knowledge applicability checked; existing recorded facts remain unchanged.

Comprehensive parallel pre-PR and final review covered quality, security, performance, testing, bugs, independent intent and KISS: no remaining findings. One stale comment corrected. Focused Claude review completed with no material findings (rev_415c594867a046eb). The complete flow remains caller-owned candidates -> shared bounded ranking -> advisory error response.
Sonar S3358 corrected with ordinary conditionals. Post-open incremental review used one combined lens for the small behavior-preserving rewrite; the refreshed complete diff also passed the comprehensive final parallel gate. Claude review was not repeated for this mechanical correction.
