### PR TITLE
Keep descriptor members PackageDescriptor does not model

### DIFF
--- a/clio.tests/Command/PackageCommand/SetPackageVersionCommandTests.cs
+++ b/clio.tests/Command/PackageCommand/SetPackageVersionCommandTests.cs
@@ -209,6 +209,36 @@ public class SetPackageVersionCommandTests : BaseCommandTests<SetPackageVersionO
 	}
 
 	[Test]
+	[Description("Keeps every descriptor block the model does not name, because a version stamp that deletes InstallScripts ships a package whose after-install script never runs.")]
+	public void Execute_ShouldKeepDescriptorBlocksTheModelDoesNotName() {
+		// Arrange
+		const string installScripts = """
+			,
+			    "InstallScripts": {
+			      "AfterInstall": [
+			        {
+			          "Position": 1,
+			          "SchemaUId": "56d48938-b594-466b-a168-48e947eeca18"
+			        }
+			      ]
+			    }
+			""";
+		string descriptor = Descriptor.Replace("\"DependsOn\": []", "\"DependsOn\": []" + installScripts);
+		FileSystem.AddFile(DescriptorPath, new MockFileData(descriptor));
+
+		// Act
+		int result = _command.Execute(Options("1.0.1.0"));
+
+		// Assert
+		result.Should().Be(0, because: "the version parses and the descriptor exists");
+		string onDisk = DescriptorOnDisk();
+		onDisk.Should().Contain("\"PackageVersion\": \"1.0.1.0\"", because: "the stamp itself must still land");
+		onDisk.Should().Contain("\"AfterInstall\"", because: "the block the model does not name must survive the round-trip");
+		onDisk.Should().Contain("56d48938-b594-466b-a168-48e947eeca18",
+			because: "the script reference inside it is what the target executes after install");
+	}
+
+	[Test]
 	[Description("Refuses a version that does not parse at all, quoting the offending value so the operator can see what was rejected.")]
 	public void Execute_ShouldRefuse_WhenTheVersionDoesNotParse() {
 		// Arrange

--- a/clio/Package/PackageDescriptor.cs
+++ b/clio/Package/PackageDescriptor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Clio.Common;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Clio.Package;
 
@@ -21,6 +22,16 @@ public class PackageDescriptor{
 	[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
 	public int? InstallBehavior { get; set; }
 	public IList<PackageDependency> DependsOn { get; set; }
+
+	/// <summary>
+	/// Every descriptor member this model does not name, carried through a read-modify-write untouched.
+	/// </summary>
+	/// <remarks>
+	/// A Creatio descriptor can carry blocks clio never interprets — <c>InstallScripts</c> is one — and a
+	/// model that drops them turns <c>set-pkg-version</c> into a silent delete of package behaviour.
+	/// </remarks>
+	[JsonExtensionData]
+	public IDictionary<string, JToken> AdditionalData { get; set; }
 
 	#endregion
 


### PR DESCRIPTION
`clio set-pkg-version` deserialises `descriptor.json` into `PackageDescriptor`, sets two fields and serialises the model back. The model names nine members; every other block is silently deleted. Measured with `CrtDashboardsMigratorApp`: its `InstallScripts.AfterInstall` vanished on a version stamp, so the package installed and the after-install script never ran.

**Fix:** `[JsonExtensionData]` on `PackageDescriptor`, so unknown members round-trip. Every writer of the model is affected in the safe direction: writers that build a descriptor from scratch have empty extension data and emit the same JSON as before. Descriptors already stripped are not restored.

**Test:** `SetPackageVersionCommandTests.Execute_ShouldKeepDescriptorBlocksTheModelDoesNotName` — stamps a descriptor carrying an unknown block and asserts the block and its script reference survive.

Validated: `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=Package)"` (4560 passed).

Docs reviewed, no update required (the command's contract is unchanged; it now keeps what it never should have dropped). MCP reviewed, no update required. ClioRing compatibility reviewed, no Ring-consumed contract changed.

Found while working on https://creatio.atlassian.net/browse/ENG-95794; independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
