### PR TITLE
Fix lookup binding descriptors and report synchronization item errors

### DIFF
--- a/clio.mcp.e2e/DataBindingToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingToolE2ETests.cs
@@ -41,7 +41,7 @@ public sealed class DataBindingToolE2ETests : McpContractFixtureBase {
 				["package-name"] = arrangeContext.PackageName,
 				["schema-name"] = "SysSettings",
 				["workspace-path"] = arrangeContext.WorkspacePath,
-				["values"] = """{"Code":"UsrMcpSetting","Name":"Created by MCP"}"""
+				["values"] = """{"Code":"UsrMcpSetting","Name":"Created by MCP","ReferenceSchemaUId":"27aeadd6-d508-4572-8061-5b55b667c902"}"""
 			});
 
 		// Assert
@@ -65,6 +65,8 @@ public sealed class DataBindingToolE2ETests : McpContractFixtureBase {
 			because: "explicit-value mode should retain the requested business columns from the template");
 		dataJson.Should().Contain("UsrMcpSetting",
 			because: "the created row should preserve the user-provided payload columns");
+		descriptorJson.Should().NotContain("ReferenceSchemaName", because: "the platform rejects generator-only descriptor properties");
+		dataJson.Should().Contain("\"Value\": \"27aeadd6-d508-4572-8061-5b55b667c902\"", because: "the referenced schema identity must remain in the row payload");
 		string? keyColumnUId = null;
 		foreach (JsonElement column in JsonDocument.Parse(descriptorJson).RootElement.GetProperty("Descriptor").GetProperty("Columns").EnumerateArray()) {
 			if (column.GetProperty("IsKey").GetBoolean()) {

--- a/clio.mcp.e2e/PackageSynchronizationErrorsE2ETests.cs
+++ b/clio.mcp.e2e/PackageSynchronizationErrorsE2ETests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Common;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>Proves synchronization item errors survive the external MCP process boundary.</summary>
+[TestFixture]
+[Category("McpE2E.NoEnvironment")]
+[AllureNUnit]
+[AllureFeature("package-synchronization")]
+[NonParallelizable]
+public sealed class PackageSynchronizationErrorsE2ETests {
+	[TestCase(LoadPackagesTool.LoadPackagesToDbToolName, true)]
+	[TestCase(LoadPackagesTool.LoadPackagesToDbToolName, false)]
+	[TestCase(LoadPackagesTool.LoadPackagesToFileSystemToolName, true)]
+	[TestCase(LoadPackagesTool.LoadPackagesToFileSystemToolName, false)]
+	[Description("A successful synchronization envelope with item errors fails through the real MCP server; a clean envelope succeeds.")]
+	[AllureTag(LoadPackagesTool.LoadPackagesToDbToolName, LoadPackagesTool.LoadPackagesToFileSystemToolName)]
+	[AllureName("Synchronization item errors override overall success")]
+	[AllureDescription("Uses an isolated configuration and local HTTP stub to verify the real clio MCP synchronization result and diagnostics.")]
+	public async Task LoadPackages_ShouldReportItemErrors_WhenPlatformReportsPartialSuccess(string toolName, bool hasErrors) {
+		// Arrange
+		string tempHome = Path.Combine(Path.GetTempPath(), $"clio-sync-errors-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempHome);
+		try {
+			McpE2ESettings settings = TestConfiguration.Load();
+			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+			settings.ProcessEnvironmentVariables["CLIO_HOME"] = tempHome;
+			await using RuntimeDetectionStubServer stub = RuntimeDetectionStubServer.Start(new(
+				NetCoreHealthEnabled: true, NetFrameworkHealthEnabled: false,
+				NetCoreServiceEnabled: true, NetFrameworkServiceEnabled: false,
+				PackageSynchronizationResponse: hasErrors
+					? """{"success":true,"errors":[{"workspaceItem":{"name":"LookupBinding"},"errorInfo":{"message":"ReferenceSchemaName is unsupported","errorCode":"InvalidDescriptor"}}]}"""
+					: """{"success":true,"errors":[]}"""));
+			using TemporaryClioSettingsOverride configuration = TemporaryClioSettingsOverride.ReplaceContent(
+				JsonSerializer.Serialize(new {
+					ActiveEnvironmentKey = "stub",
+					Environments = new { stub = new { Uri = stub.BaseUrl, Login = "Supervisor", Password = "Supervisor", IsNetCore = true } }
+				}), settings.ClioProcessPath, settings.ProcessEnvironmentVariables);
+			using CancellationTokenSource timeout = new(TimeSpan.FromMinutes(2));
+			await using McpServerSession session = await McpServerSession.StartAsync(settings, timeout.Token);
+
+			// Act
+			var call = await session.CallToolAsync(toolName,
+				new Dictionary<string, object?> { ["environmentName"] = "stub" }, timeout.Token);
+			CommandExecutionEnvelope result = McpCommandExecutionParser.Extract(call);
+
+			// Assert
+			call.IsError.Should().NotBeTrue(because: "command outcomes are carried by the execution envelope");
+			result.ExitCode.Should().Be(hasErrors ? 1 : 0,
+				because: "item errors must override the overall success flag");
+			result.Output.Should().NotBeNullOrEmpty(because: "the operation must explain its result");
+			if (hasErrors) {
+				result.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error
+					&& message.Value!.Contains("LookupBinding") && message.Value.Contains("ReferenceSchemaName"),
+					because: "the failure must name the rejected item and platform reason");
+				result.Output.Should().NotContain(message => message.Value!.Contains("completed"),
+					because: "partial synchronization must not claim completion");
+			} else {
+				result.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Info,
+					because: "successful synchronization must publish an informational completion message");
+				result.Output.Should().NotContain(message => message.MessageType == LogDecoratorType.Error,
+					because: "clean synchronization must remain successful");
+			}
+		} finally {
+			Directory.Delete(tempHome, recursive: true);
+		}
+	}
+}

--- a/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
+++ b/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
@@ -190,6 +190,14 @@ http.createServer((request, response) => {
       return;
     }
     recordedRequests.push({ method: request.method, url: url });
+    if (config.PackageSynchronizationResponse && url.endsWith("/WorkspaceExplorerService.svc/GetIsFileDesignMode")) {
+      sendJson(response, 200, { success: true, value: true });
+      return;
+    }
+    if (config.PackageSynchronizationResponse && (url.endsWith("/AppInstallerService.svc/LoadPackagesToDB") || url.endsWith("/AppInstallerService.svc/LoadPackagesToFileSystem"))) {
+      sendJson(response, 200, JSON.parse(config.PackageSynchronizationResponse));
+      return;
+    }
     if (request.method === "POST" && url === "/ServiceModel/AuthService.svc/Login") {
       sendJson(
         response,
@@ -371,7 +379,8 @@ internal sealed record RuntimeDetectionStubServerConfiguration(
 	string? ODataNonJsonEntity = null,
 	string? ODataEntity = null,
 	string? ODataPreWriteMode = null,
-	string? AuthRejectedSelectQuerySchemaName = null);
+	string? AuthRejectedSelectQuerySchemaName = null,
+	string? PackageSynchronizationResponse = null);
 
 /// <summary>
 /// One request served by <see cref="RuntimeDetectionStubServer"/>, as reported by

--- a/clio.tests/Command/DataBindingCommandTests.cs
+++ b/clio.tests/Command/DataBindingCommandTests.cs
@@ -237,6 +237,11 @@ internal sealed class CreateDataBindingCommandTests : BaseCommandTests<CreateDat
 		string dataJson = FileSystem.File.ReadAllText(WorkspacePath("packages", PackageName, "Data", "UsrLookupBinding", "data.json"));
 		dataJson.Should().Contain("\"DisplayValue\": \"Provided status\"",
 			because: "lookup columns should preserve the caller-supplied display value");
+		string descriptorJson = FileSystem.File.ReadAllText(WorkspacePath("packages", PackageName, "Data", "UsrLookupBinding", "descriptor.json"));
+		descriptorJson.Should().NotContain("ReferenceSchemaName",
+			because: "the platform descriptor reader rejects generator-only lookup hints");
+		dataJson.Should().Contain("b659d704-3955-e011-981f-00155d043204",
+			because: "excluding the lookup hint must preserve the referenced row identity");
 	}
 
 	[Test]

--- a/clio.tests/Package/FileDesignModePackagesTests.cs
+++ b/clio.tests/Package/FileDesignModePackagesTests.cs
@@ -58,8 +58,8 @@ public class FileDesignModePackagesTests {
 		_applicationClient
 			.ExecutePostRequest(endpointUrl, string.Empty, Timeout.Infinite, Arg.Any<int>(), Arg.Any<int>())
 			.Returns("load-response");
-		_jsonConverter.DeserializeObject<BaseResponse>("load-response")
-			.Returns(new BaseResponse {
+		_jsonConverter.DeserializeObject<PackageSynchronizationResponse>("load-response")
+			.Returns(new PackageSynchronizationResponse {
 				Success = success,
 				ErrorInfo = success
 					? null
@@ -73,6 +73,30 @@ public class FileDesignModePackagesTests {
 	#endregion
 
 	#region Methods: Public
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("Item errors override overall success for both package synchronization directions.")]
+	public void LoadPackages_ShouldReportFailure_WhenSuccessfulResponseContainsItemErrors(bool toDatabase) {
+		// Arrange
+		ArrangeFileDesignModeProbe(success: true, value: true);
+		string endpoint = toDatabase ? LoadPackagesToDbUrl : LoadPackagesToFileSystemUrl;
+		ArrangeLoadResponse(endpoint, success: true);
+		PackageSynchronizationResponse response = Newtonsoft.Json.JsonConvert.DeserializeObject<PackageSynchronizationResponse>(
+			"""{"success":true,"changes":[],"errors":[{"workspaceItem":{"name":"LookupBinding"},"errorInfo":{"message":"Unsupported descriptor property","errorCode":"InvalidDescriptor"}}]}""");
+		_jsonConverter.DeserializeObject<PackageSynchronizationResponse>("load-response").Returns(response);
+
+		// Act
+		FileDesignModeLoadResult result = toDatabase ? _sut.LoadPackagesToDb() : _sut.LoadPackagesToFileSystem();
+
+		// Assert
+		result.Should().Be(FileDesignModeLoadResult.LoadRefused,
+			because: "partial synchronization must not be reported as a completed import or export");
+		_logger.Received(1).WriteError(Arg.Is<string>(message =>
+			message.Contains("LookupBinding") && message.Contains("Unsupported descriptor property")));
+		_logger.DidNotReceive().WriteLine(Arg.Is<string>(message => message.Contains("completed")));
+		_logger.DidNotReceive().WriteInfo(Arg.Is<string>(message => message.Contains("completed")));
+	}
 
 	[SetUp]
 	public void SetUp() {
@@ -179,8 +203,8 @@ public class FileDesignModePackagesTests {
 		_applicationClient
 			.ExecutePostRequest(LoadPackagesToDbUrl, string.Empty, Timeout.Infinite, Arg.Any<int>(), Arg.Any<int>())
 			.Returns("load-response");
-		_jsonConverter.DeserializeObject<BaseResponse>("load-response")
-			.Returns(new BaseResponse { Success = false, ErrorInfo = null });
+		_jsonConverter.DeserializeObject<PackageSynchronizationResponse>("load-response")
+			.Returns(new PackageSynchronizationResponse { Success = false, ErrorInfo = null });
 
 		// Act
 		FileDesignModeLoadResult result = _sut.LoadPackagesToDb();

--- a/clio.tests/Package/FileDesignModePackagesTests.cs
+++ b/clio.tests/Package/FileDesignModePackagesTests.cs
@@ -98,6 +98,28 @@ public class FileDesignModePackagesTests {
 		_logger.DidNotReceive().WriteInfo(Arg.Is<string>(message => message.Contains("completed")));
 	}
 
+	[Test]
+	[Description("A failed synchronization retains both the overall error and item diagnostics.")]
+	public void LoadPackagesToDb_ShouldRetainOverallError_WhenItemErrorsAreAlsoPresent() {
+		// Arrange
+		ArrangeFileDesignModeProbe(success: true, value: true);
+		ArrangeLoadResponse(LoadPackagesToDbUrl, success: false);
+		_jsonConverter.DeserializeObject<PackageSynchronizationResponse>("load-response")
+			.Returns(new PackageSynchronizationResponse {
+				Success = false,
+				ErrorInfo = new ErrorInfo { Message = "overall failure" },
+				Errors = [new PackageSynchronizationError { ErrorInfo = new ErrorInfo { Message = "item failure" } }]
+			});
+
+		// Act
+		FileDesignModeLoadResult result = _sut.LoadPackagesToDb();
+
+		// Assert
+		result.Should().Be(FileDesignModeLoadResult.LoadRefused, because: "both diagnostics describe a failed synchronization");
+		_logger.Received().WriteError(Arg.Is<string>(message => message.Contains("overall failure")));
+		_logger.Received().WriteError(Arg.Is<string>(message => message.Contains("item failure")));
+	}
+
 	[SetUp]
 	public void SetUp() {
 		_applicationClient = Substitute.For<IApplicationClient>();

--- a/clio/Command/DataBindingCommand.cs
+++ b/clio/Command/DataBindingCommand.cs
@@ -1533,7 +1533,8 @@ internal sealed class DataBindingColumnDefinition {
 	[JsonPropertyName("DataTypeValueUId")]
 	public Guid DataTypeValueUId { get; set; }
 
-	[JsonPropertyName("ReferenceSchemaName")]
+	// Runtime lookup hint; Creatio's PackageSchemaDataColumnDescriptor reader rejects this property.
+	[JsonIgnore]
 	public string? ReferenceSchemaName { get; set; }
 }
 

--- a/clio/Command/McpServer/Tools/LoadPackagesTool.cs
+++ b/clio/Command/McpServer/Tools/LoadPackagesTool.cs
@@ -14,6 +14,12 @@ public class LoadPackagesTool(
 	IToolCommandResolver commandResolver)
 	: BaseTool<EnvironmentOptions>(loadPackagesToFileSystemCommand, logger, commandResolver) {
 
+	/// <summary>Name of the database import tool.</summary>
+	public const string LoadPackagesToDbToolName = "pkg-to-db";
+
+	/// <summary>Name of the file-system export tool.</summary>
+	public const string LoadPackagesToFileSystemToolName = "pkg-to-file-system";
+
 	/// <summary>
 	/// Loads package definitions from the configuration database into the file system for the selected
 	/// environment. Requires file system development mode (FSM) on the environment.
@@ -27,8 +33,8 @@ public class LoadPackagesTool(
 		BudgetPolicy = McpToolBudgetPolicy.ParentKillDefault,
 		RequiresClientRequests = McpToolClientRequests.None,
 		SharedFileResource = McpToolSharedFileResource.None)]
-	[McpServerTool(Name = "pkg-to-file-system", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
-	[Description("Loads package definitions from the configuration database into the file system on a Creatio web application. Requires file system development mode (FSM): the call fails when FSM is disabled on the environment.")]
+	[McpServerTool(Name = LoadPackagesToFileSystemToolName, ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
+	[Description("Loads package definitions from the configuration database into the file system on a Creatio web application. Requires file system development mode (FSM): the call fails when FSM is disabled or the platform reports per-item synchronization errors.")]
 	public CommandExecutionResult LoadPackagesToFileSystem(
 		[Description("Target environment name")] [Required] string environmentName
 	) {
@@ -52,8 +58,8 @@ public class LoadPackagesTool(
 		BudgetPolicy = McpToolBudgetPolicy.ParentKillDefault,
 		RequiresClientRequests = McpToolClientRequests.None,
 		SharedFileResource = McpToolSharedFileResource.None)]
-	[McpServerTool(Name = "pkg-to-db", ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
-	[Description("Loads package definitions (schemas, resources, descriptors) from the file system into the configuration database on a Creatio web application. It does not install package data: a Data/ binding folder is applied only by package installation (push-pkg, push-workspace) or by the DB-first tools create-data-binding-db / upsert-data-binding-row-db. Requires file system development mode (FSM): the call fails when FSM is disabled on the environment.")]
+	[McpServerTool(Name = LoadPackagesToDbToolName, ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
+	[Description("Loads package definitions (schemas, resources, descriptors) from the file system into the configuration database on a Creatio web application. It does not install package data: a Data/ binding folder is applied only by package installation (push-pkg, push-workspace) or by the DB-first tools create-data-binding-db / upsert-data-binding-row-db. Requires file system development mode (FSM): the call fails when FSM is disabled or the platform reports per-item synchronization errors.")]
 	public CommandExecutionResult LoadPackagesToDb(
 		[Description("Target environment name")] [Required] string environmentName
 	) {

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -279,11 +279,11 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="pkg-to-db"></a>
 <a id="2db"></a>
 <a id="todb"></a>
-- [`pkg-to-db`](docs/commands/pkg-to-db.md) - Load file-system package definitions into the configuration database (no package data), `2db`, `todb`
+- [`pkg-to-db`](docs/commands/pkg-to-db.md) - Load file-system package definitions into the configuration database (no package data; item errors fail), `2db`, `todb`
 <a id="pkg-to-file-system"></a>
 <a id="2fs"></a>
 <a id="tofs"></a>
-- [`pkg-to-file-system`](docs/commands/pkg-to-file-system.md) - Export configuration-database packages to the file system (no package data), `2fs`, `tofs`
+- [`pkg-to-file-system`](docs/commands/pkg-to-file-system.md) - Export configuration-database packages to the file system (no package data; item errors fail), `2fs`, `tofs`
 <a id="publish-app"></a>
 <a id="ph"></a>
 <a id="publish-hub"></a>

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -279,11 +279,11 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="pkg-to-db"></a>
 <a id="2db"></a>
 <a id="todb"></a>
-- [`pkg-to-db`](docs/commands/pkg-to-db.md) - Load file-system package definitions into the configuration database (no package data; item errors fail), `2db`, `todb`
+- [`pkg-to-db`](docs/commands/pkg-to-db.md) - Load file-system package definitions into the configuration database (no package data), `2db`, `todb`
 <a id="pkg-to-file-system"></a>
 <a id="2fs"></a>
 <a id="tofs"></a>
-- [`pkg-to-file-system`](docs/commands/pkg-to-file-system.md) - Export configuration-database packages to the file system (no package data; item errors fail), `2fs`, `tofs`
+- [`pkg-to-file-system`](docs/commands/pkg-to-file-system.md) - Export configuration-database packages to the file system (no package data), `2fs`, `tofs`
 <a id="publish-app"></a>
 <a id="ph"></a>
 <a id="publish-hub"></a>

--- a/clio/Package/FileDesignModePackages.cs
+++ b/clio/Package/FileDesignModePackages.cs
@@ -221,6 +221,9 @@ namespace Clio.Package
 			string responseFormServer = _applicationClient.ExecutePostRequest(endpoint, string.Empty,Timeout.Infinite, maxRequestAttempts, delayBetweenRetryAttemptsSec);
 			var response = _jsonConverter.DeserializeObject<PackageSynchronizationResponse>(responseFormServer);
 			if (response.Errors is { Length: > 0 }) {
+				if (!response.Success && response.ErrorInfo is not null) {
+					PrintErrorOperationMessage(storageName, GetErrorDetails(response.ErrorInfo));
+				}
 				foreach (PackageSynchronizationError error in response.Errors) {
 					PrintErrorOperationMessage(storageName,
 						$"Synchronization rejected item '{error?.WorkspaceItem?.Name ?? "unknown"}': " +

--- a/clio/Package/FileDesignModePackages.cs
+++ b/clio/Package/FileDesignModePackages.cs
@@ -219,9 +219,17 @@ namespace Clio.Package
 			}
 			_logger.WriteLine($"Start load packages to {storageName} on a web application");
 			string responseFormServer = _applicationClient.ExecutePostRequest(endpoint, string.Empty,Timeout.Infinite, maxRequestAttempts, delayBetweenRetryAttemptsSec);
-			var response = _jsonConverter.DeserializeObject<BaseResponse>(responseFormServer);
+			var response = _jsonConverter.DeserializeObject<PackageSynchronizationResponse>(responseFormServer);
+			if (response.Errors is { Length: > 0 }) {
+				foreach (PackageSynchronizationError error in response.Errors) {
+					PrintErrorOperationMessage(storageName,
+						$"Synchronization rejected item '{error?.WorkspaceItem?.Name ?? "unknown"}': " +
+						GetErrorDetails(error?.ErrorInfo));
+				}
+				return FileDesignModeLoadResult.LoadRefused;
+			}
 			if (response.Success) {
-				_logger.WriteLine($"Load packages to {storageName} on a web application completed");
+				_logger.WriteInfo($"Load packages to {storageName} on a web application completed");
 				return FileDesignModeLoadResult.Completed;
 			}
 			PrintErrorOperationMessage(storageName, GetErrorDetails(response.ErrorInfo));

--- a/clio/Package/PackageSynchronizationResponse.cs
+++ b/clio/Package/PackageSynchronizationResponse.cs
@@ -1,0 +1,27 @@
+using Clio.Common.Responses;
+using Newtonsoft.Json;
+
+namespace Clio.Package;
+
+// The platform can report success=true and still reject individual descriptors.
+internal sealed class PackageSynchronizationResponse : BaseResponse {
+	/// <summary>Items rejected during synchronization despite an overall successful request.</summary>
+	[JsonProperty("errors")]
+	public PackageSynchronizationError[] Errors { get; set; }
+}
+
+internal sealed record PackageSynchronizationError {
+	/// <summary>Identity of the rejected descriptor.</summary>
+	[JsonProperty("workspaceItem")]
+	public PackageSynchronizationItem WorkspaceItem { get; init; }
+
+	/// <summary>Platform diagnostic for the rejected item.</summary>
+	[JsonProperty("errorInfo")]
+	public ErrorInfo ErrorInfo { get; init; }
+}
+
+internal sealed record PackageSynchronizationItem {
+	/// <summary>Name of the rejected descriptor.</summary>
+	[JsonProperty("name")]
+	public string Name { get; init; }
+}

--- a/clio/docs/commands/create-data-binding.md
+++ b/clio/docs/commands/create-data-binding.md
@@ -101,6 +101,12 @@ clio create-data-binding -e dev --package Custom --schema UsrLookupBinding --val
 command fails instead of overwriting it
 - filter.json is always created as an empty file
 
+Lookup descriptor compatibility: ReferenceSchemaName is a generator-only hint and is
+not written to descriptor.json. Lookup Value and DisplayValue remain in data.json.
+For older affected bindings, remove only ReferenceSchemaName and advance ModifiedOnUtc,
+preserving existing rows and localizations. Regeneration requires supplying all intended
+rows and localizations again. Verify target rows after applying the binding.
+
 ## Reporting Bugs
 
     https://github.com/Advance-Technologies-Foundation/clio

--- a/clio/docs/commands/pkg-to-db.md
+++ b/clio/docs/commands/pkg-to-db.md
@@ -51,7 +51,7 @@ clio get-fsm-mode -e <ENVIRONMENT_NAME>
 
 - Aliases: 2db, todb
 - Exit code 0 means the platform reported the import as completed; any other
-outcome (FSM disabled, unreadable FSM state, platform error) exits with 1
+outcome (FSM disabled, unreadable FSM state, platform error, or per-item synchronization errors) exits with 1
 - Configuration changes may additionally require a compilation and a restart
 before they take full effect
 - A Data/ folder created by create-data-binding is a transferable source

--- a/clio/docs/commands/pkg-to-file-system.md
+++ b/clio/docs/commands/pkg-to-file-system.md
@@ -49,7 +49,7 @@ clio get-fsm-mode -e <ENVIRONMENT_NAME>
 
 - Aliases: 2fs, tofs
 - Exit code 0 means the platform reported the export as completed; any other
-outcome (FSM disabled, unreadable FSM state, platform error) exits with 1
+outcome (FSM disabled, unreadable FSM state, platform error, or per-item synchronization errors) exits with 1
 - turn-fsm on runs this export after it enables FSM, so a failure there leaves
 FSM enabled with the export unfinished; re-run this command once the web
 application has restarted

--- a/clio/help/en/create-data-binding.txt
+++ b/clio/help/en/create-data-binding.txt
@@ -86,6 +86,12 @@ NOTES
       command fails instead of overwriting it
     - filter.json is always created as an empty file
 
+Lookup descriptor compatibility: ReferenceSchemaName is a generator-only hint and is
+not written to descriptor.json. Lookup Value and DisplayValue remain in data.json.
+For older affected bindings, remove only ReferenceSchemaName and advance ModifiedOnUtc,
+preserving existing rows and localizations. Regeneration requires supplying all intended
+rows and localizations again. Verify target rows after applying the binding.
+
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio
 

--- a/clio/help/en/pkg-to-db.txt
+++ b/clio/help/en/pkg-to-db.txt
@@ -38,7 +38,7 @@ REQUIREMENTS
 NOTES
     - Aliases: 2db, todb
     - Exit code 0 means the platform reported the import as completed; any other
-      outcome (FSM disabled, unreadable FSM state, platform error) exits with 1
+      outcome (FSM disabled, unreadable FSM state, platform error, or per-item synchronization errors) exits with 1
     - Configuration changes may additionally require a compilation and a restart
       before they take full effect
     - A Data/ folder created by create-data-binding is a transferable source

--- a/clio/help/en/pkg-to-file-system.txt
+++ b/clio/help/en/pkg-to-file-system.txt
@@ -36,7 +36,7 @@ REQUIREMENTS
 NOTES
     - Aliases: 2fs, tofs
     - Exit code 0 means the platform reported the export as completed; any other
-      outcome (FSM disabled, unreadable FSM state, platform error) exits with 1
+      outcome (FSM disabled, unreadable FSM state, platform error, or per-item synchronization errors) exits with 1
     - turn-fsm on runs this export after it enables FSM, so a failure there leaves
       FSM enabled with the export unfinished; re-run this command once the web
       application has restarted

--- a/docs/knowledge/Command/load-packages-to-db-registers-definitions-not-package-data.md
+++ b/docs/knowledge/Command/load-packages-to-db-registers-definitions-not-package-data.md
@@ -12,7 +12,7 @@ date: 2026-09-06
 
 **What is true** — `pkg-to-db` posts `AppInstallerService.svc/LoadPackagesToDB`, which registers package
 CONTENT (schemas, resources, descriptors) in the configuration database. It never installs package DATA.
-The endpoint answers with a bare `BaseResponse` (`success` + `errorInfo`), so no row count exists for it to
+The endpoint returns `SynchronizationResultResponse` (`success`, `errorInfo`, `changes`, and `errors`). Item errors can coexist with `success: true`; inspect them before claiming completion. No data-row count exists for it to
 report. Data installation lives on a different service — `PackageInstaller` posts
 `PackageInstallerService.svc/InstallPackage` with `installPackageData`, surfaced as
 `push-pkg --install-package-data`. On an FSM environment, where the shipped workspace template forbids


### PR DESCRIPTION
Lookup bindings included a generator-only ReferenceSchemaName field that the tested Creatio FSM reader rejects. Package synchronization also discarded per-item errors and could report completion when descriptors were skipped.

Keep lookup hints in memory while excluding them from descriptor JSON, preserving row Value/DisplayValue. Read the platform synchronization errors array and return the existing failure result with item diagnostics even when success is true. Clean synchronization emits an Info completion message. Older binding repair guidance preserves rows and localizations.

Fixes #1416. Guidance delivered in Advance-Technologies-Foundation/clio-knowledge#147.

Validation:
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=Package|Module=McpServer)"` — 9,569 passed, 15 skipped after merging current master. Final diagnostic correction additionally passed all 245 Package module tests.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~PackageSynchronizationErrorsE2ETests|FullyQualifiedName~DataBindingToolE2ETests.CreateDataBinding_Should_Create_Files"` — 5 passed, no skips on net10.0 and again with `-f net8.0`; real MCP process with isolated HTTP stub plus generated-file verification.
- Platform descriptor/response source inspected; no live Creatio installation claim.
- Full parallel quality, correctness/performance, security, intent, and KISS reviews: no actionable findings. Claude final review rev_180494a78a9947b1: no high/medium defects; both low findings resolved (generated index drift and overall diagnostics). Scoped three-lens master-merge review and single combined-lens diagnostic-fix review passed.
- Docs reviewed and updated. MCP reviewed: descriptions and E2E updated; arguments and result envelope preserved. Prompts, resources, aliases, and workspace templates remain accurate.
- ClioRing compatibility reviewed, no Ring-consumed contract changed: inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json` for both synchronization commands and create-data-binding; no consumers found.
