### PR TITLE
Fix test scaffold solution registration and require Clio test projects

### DIFF
--- a/clio.mcp.e2e/CreateIntegrationTestProjectToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateIntegrationTestProjectToolE2ETests.cs
@@ -1,3 +1,5 @@
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Mcp.E2E.Support.Configuration;
@@ -9,7 +11,7 @@ using ModelContextProtocol.Protocol;
 namespace Clio.Mcp.E2E;
 
 [TestFixture, Category("McpE2E.NoEnvironment"), AllureNUnit]
-[AllureFeature("new-integration-test-project")]
+[AllureFeature(CreateIntegrationTestProjectTool.ToolName)]
 [NonParallelizable]
 public sealed class CreateIntegrationTestProjectToolE2ETests {
 	[Test]
@@ -29,7 +31,7 @@ public sealed class CreateIntegrationTestProjectToolE2ETests {
 
 			// Act
 			CallToolResult callResult = await session.CallToolAsync(
-				"new-integration-test-project",
+				CreateIntegrationTestProjectTool.ToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["package-name"] = "Acme",
@@ -40,6 +42,8 @@ public sealed class CreateIntegrationTestProjectToolE2ETests {
 			CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
 
 			// Assert
+			callResult.IsError.Should().NotBe(true, because: "valid scaffolding must not produce an MCP error");
+			execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Info, because: "the caller needs a visible success message");
 			execution.ExitCode.Should().Be(0, "because the real MCP tool should generate a valid local scaffold");
 			string projectDirectory = Path.Combine(workspace, "tests", "Acme.IntegrationTests");
 			File.Exists(Path.Combine(projectDirectory, "Acme.IntegrationTests.csproj")).Should().BeTrue(

--- a/clio.mcp.e2e/CreateTestProjectToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateTestProjectToolE2ETests.cs
@@ -17,17 +17,20 @@ namespace Clio.Mcp.E2E;
 public sealed class CreateTestProjectToolE2ETests {
 	[TestCase(false)]
 	[TestCase(true)]
+	[TestCase(null)]
 	[Description("Creates or preserves unit-test projects through real MCP and verifies both solutions across multiple packages and reruns.")]
 	[AllureName("Unit-test scaffolding registers every project and preserves reruns")]
-	public async Task Tool_ShouldRegisterProjects_WhenScaffoldingOrRepairing(bool existingProject) {
+	public async Task Tool_ShouldRegisterProjects_WhenScaffoldingOrRepairing(bool? existingProject) {
 		// Arrange
 		string workspace = Path.Combine(Path.GetTempPath(), $"clio unit e2e {Guid.NewGuid():N}");
 		Directory.CreateDirectory(Path.Combine(workspace, ".clio"));
 		Directory.CreateDirectory(Path.Combine(workspace, "tests", "Acme"));
 		await File.WriteAllTextAsync(Path.Combine(workspace, ".clio", "workspaceSettings.json"),
 			"{\"Packages\":[\"Acme\",\"Other\"],\"ApplicationVersion\":\"8.1.0\"}");
-		await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"), "<Solution />");
-		await File.WriteAllTextAsync(Path.Combine(workspace, "MainSolution.slnx"), "<Solution />");
+		if (existingProject.HasValue) {
+			await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"), "<Solution />");
+			await File.WriteAllTextAsync(Path.Combine(workspace, "MainSolution.slnx"), "<Solution />");
+		}
 		foreach (string package in new[] { "Acme", "Other" }) {
 			string directory = Path.Combine(workspace, "packages", package, "Files");
 			Directory.CreateDirectory(directory);
@@ -37,7 +40,7 @@ public sealed class CreateTestProjectToolE2ETests {
 		string projectPath = Path.Combine(workspace, "tests", "Acme", "Acme.Tests.csproj");
 		string fixturePath = Path.Combine(workspace, "tests", "Acme", "BaseComposableAppTestFixture.cs");
 		const string customizedProject = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework><Description>Keep customizations</Description></PropertyGroup></Project>";
-		if (existingProject) {
+		if (existingProject == true) {
 			await File.WriteAllTextAsync(projectPath, customizedProject);
 			await File.WriteAllTextAsync(fixturePath, "// existing custom fixture");
 			await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"),
@@ -81,7 +84,7 @@ public sealed class CreateTestProjectToolE2ETests {
 					AssertProject(Path.Combine(workspace, "MainSolution.slnx"), Path.Combine(workspace, "tests", package, package + ".Tests.csproj"));
 				}
 			});
-			if (existingProject) {
+			if (existingProject == true) {
 				File.ReadAllText(projectPath).Should().Be(customizedProject, because: "solution repair must preserve the user's project");
 				File.ReadAllText(fixturePath).Should().Be("// existing custom fixture", because: "reruns must preserve custom fixture code");
 			}

--- a/clio.mcp.e2e/CreateTestProjectToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateTestProjectToolE2ETests.cs
@@ -1,0 +1,117 @@
+using System.Xml.Linq;
+using Allure.Net.Commons;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+[TestFixture, Category("McpE2E.NoEnvironment"), AllureNUnit, NonParallelizable]
+[AllureFeature(CreateTestProjectTool.ToolName)]
+public sealed class CreateTestProjectToolE2ETests {
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Creates or preserves unit-test projects through real MCP and verifies both solutions across multiple packages and reruns.")]
+	[AllureName("Unit-test scaffolding registers every project and preserves reruns")]
+	public async Task Tool_ShouldRegisterProjects_WhenScaffoldingOrRepairing(bool existingProject) {
+		// Arrange
+		string workspace = Path.Combine(Path.GetTempPath(), $"clio unit e2e {Guid.NewGuid():N}");
+		Directory.CreateDirectory(Path.Combine(workspace, ".clio"));
+		Directory.CreateDirectory(Path.Combine(workspace, "tests", "Acme"));
+		await File.WriteAllTextAsync(Path.Combine(workspace, ".clio", "workspaceSettings.json"),
+			"{\"Packages\":[\"Acme\",\"Other\"],\"ApplicationVersion\":\"8.1.0\"}");
+		await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"), "<Solution />");
+		await File.WriteAllTextAsync(Path.Combine(workspace, "MainSolution.slnx"), "<Solution />");
+		foreach (string package in new[] { "Acme", "Other" }) {
+			string directory = Path.Combine(workspace, "packages", package, "Files");
+			Directory.CreateDirectory(directory);
+			await File.WriteAllTextAsync(Path.Combine(directory, package + ".csproj"),
+				"<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>");
+		}
+		string projectPath = Path.Combine(workspace, "tests", "Acme", "Acme.Tests.csproj");
+		string fixturePath = Path.Combine(workspace, "tests", "Acme", "BaseComposableAppTestFixture.cs");
+		const string customizedProject = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework><Description>Keep customizations</Description></PropertyGroup></Project>";
+		if (existingProject) {
+			await File.WriteAllTextAsync(projectPath, customizedProject);
+			await File.WriteAllTextAsync(fixturePath, "// existing custom fixture");
+			await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"),
+				"<Solution><Folder Name=\"/Tests/\"><Project Path=\"Acme/Acme.Tests.csproj\" /></Folder></Solution>");
+		}
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		string clioHome = Path.Combine(workspace, "clio-home");
+		Directory.CreateDirectory(clioHome);
+		await File.WriteAllTextAsync(Path.Combine(clioHome, "appsettings.json"),
+			"{\"ActiveEnvironmentKey\":\"scaffold\",\"Autoupdate\":false,\"Environments\":{\"scaffold\":{\"Uri\":\"http://127.0.0.1:1\",\"IsNetCore\":true}}}");
+		settings.ProcessEnvironmentVariables["CLIO_HOME"] = clioHome;
+		using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(3));
+		try {
+			await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellation.Token);
+			IReadOnlyCollection<string> names = await session.ListReachableToolNamesAsync(cancellation.Token);
+			names.Should().Contain(CreateTestProjectTool.ToolName, because: "agents must discover the existing scaffold through MCP");
+			Dictionary<string, object?> args = new() {
+				["args"] = new Dictionary<string, object?> {
+					["package-name"] = "Acme,Other", ["workspace-path"] = workspace, ["environment-name"] = "scaffold"
+				}
+			};
+
+			// Act
+			for (int attempt = 0; attempt < 2; attempt++) {
+				CallToolResult result = await session.CallToolAsync(CreateTestProjectTool.ToolName, args, cancellation.Token);
+				CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(result);
+
+				// Assert
+				AllureApi.Step("Scaffolding succeeds with an Info message", () => {
+					result.IsError.Should().NotBe(true, because: "valid scaffolding must not produce an MCP error");
+					execution.ExitCode.Should().Be(0, because: "both packages must be registered before success");
+					execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Info,
+						because: "success must be visible to the calling agent");
+				});
+			}
+			AllureApi.Step("Both slnx files contain each generated project exactly once", () => {
+				foreach (string package in new[] { "Acme", "Other" }) {
+					AssertProject(Path.Combine(workspace, "tests", "UnitTests.slnx"), Path.Combine(workspace, "tests", package, package + ".Tests.csproj"));
+					AssertProject(Path.Combine(workspace, "tests", "UnitTests.slnx"), Path.Combine(workspace, "packages", package, "Files", package + ".csproj"));
+					AssertProject(Path.Combine(workspace, "MainSolution.slnx"), Path.Combine(workspace, "tests", package, package + ".Tests.csproj"));
+				}
+			});
+			if (existingProject) {
+				File.ReadAllText(projectPath).Should().Be(customizedProject, because: "solution repair must preserve the user's project");
+				File.ReadAllText(fixturePath).Should().Be("// existing custom fixture", because: "reruns must preserve custom fixture code");
+			}
+
+			// Arrange / Act: a malformed existing solution must not produce another successful scaffold.
+			await File.WriteAllTextAsync(Path.Combine(workspace, "tests", "UnitTests.slnx"), "<WrongRoot />", cancellation.Token);
+			CallToolResult failure = await session.CallToolAsync(CreateTestProjectTool.ToolName, args, cancellation.Token);
+			CommandExecutionEnvelope failedExecution = McpCommandExecutionParser.Extract(failure);
+
+			// Assert
+			AllureApi.Step("Invalid solution reports failure with actionable Error output", () => {
+				failure.IsError.Should().NotBe(true, because: "handled command failures use the execution envelope");
+				failedExecution.ExitCode.Should().Be(1, because: "missing solution membership cannot be reported as success");
+				failedExecution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error && message.Value!.Contains("Repair the solution"),
+					because: "the agent needs an actionable solution diagnostic");
+				File.ReadAllText(Path.Combine(workspace, "tests", "UnitTests.slnx")).Should().Be("<WrongRoot />",
+					because: "the failed update must preserve the malformed file for repair");
+			});
+		}
+		finally {
+			Directory.Delete(workspace, true);
+		}
+	}
+
+	private static void AssertProject(string solution, string expectedProject) {
+		XDocument document = XDocument.Load(solution);
+		string[] projects = document.Descendants("Project").Select(element => Path.GetFullPath(
+			Path.Combine(Path.GetDirectoryName(solution)!, element.Attribute("Path")!.Value.Replace('\\', Path.DirectorySeparatorChar)))).ToArray();
+		projects.Should().ContainSingle(path => path == expectedProject,
+			because: "each project must resolve from its solution and appear exactly once");
+		File.Exists(expectedProject).Should().BeTrue(because: "solution entries must point to actual generated files");
+	}
+}

--- a/clio.tests/Command/CreateTestProjectCommandTests.cs
+++ b/clio.tests/Command/CreateTestProjectCommandTests.cs
@@ -1,63 +1,163 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Xml;
 using Clio.Command;
 using Clio.Common;
 using Clio.Workspace;
+using Clio.Workspaces;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
 
-[TestFixture]
-[Category("Unit")]
-[Property("Module", "Command")]
-public class CreateTestProjectCommandTests {
+[TestFixture, Property("Module", "Command")]
+public class CreateTestProjectCommandTests : BaseCommandTests<CreateTestProjectOptions> {
+	private ICreateTestProjectContext _context = Substitute.For<ICreateTestProjectContext>();
+	private ICreateTestProjectInfrastructure _infrastructure = Substitute.For<ICreateTestProjectInfrastructure>();
+	private ITemplateProvider _templates = Substitute.For<ITemplateProvider>();
+	private ISolutionCreator _solutions = Substitute.For<ISolutionCreator>();
+	private IValidator<CreateTestProjectOptions> _validator = Substitute.For<IValidator<CreateTestProjectOptions>>();
+	private CreateTestProjectCommand _command;
+
+	protected override void AdditionalRegistrations(IServiceCollection services) {
+		_context = Substitute.For<ICreateTestProjectContext>();
+		_infrastructure = Substitute.For<ICreateTestProjectInfrastructure>();
+		_templates = Substitute.For<ITemplateProvider>();
+		_solutions = Substitute.For<ISolutionCreator>();
+		_validator = Substitute.For<IValidator<CreateTestProjectOptions>>();
+		services.AddSingleton(_context);
+		services.AddSingleton(_infrastructure);
+		services.AddSingleton(_templates);
+		services.AddSingleton(_solutions);
+		services.AddSingleton(_validator);
+		ILogger logger = Substitute.For<ILogger>();
+		logger.When(value => value.WriteError(Arg.Any<string>())).Do(call => TestContext.WriteLine(call.Arg<string>()));
+		services.AddSingleton(logger);
+	}
+
+	[SetUp]
+	public void ConfigureCommand() {
+		_command = Container.GetRequiredService<CreateTestProjectCommand>();
+		_context.IsWorkspace.Returns(true);
+		string workspace = Path.GetFullPath("workspace");
+		_context.RootPath = workspace;
+		_context.ProjectsTestsFolderPath.Returns(Path.Combine(workspace, "tests"));
+		_context.TasksFolderPath.Returns(Path.Combine(workspace, "tasks"));
+		_context.BuildPackageProjectPath(Arg.Any<string>()).Returns(call =>
+			Path.Combine(_context.RootPath, "packages", call.Arg<string>(), "Files", call.Arg<string>() + ".csproj"));
+		_infrastructure.Combine(Arg.Any<string[]>()).Returns(call => Path.Combine(call.Arg<string[]>()));
+		_infrastructure.GetRelativePath(Arg.Any<string>(), Arg.Any<string>()).Returns(call =>
+			Path.GetRelativePath(call.ArgAt<string>(0), call.ArgAt<string>(1)));
+		_infrastructure.ExistsFile(Arg.Any<string>()).Returns(call => call.Arg<string>().Contains(Path.DirectorySeparatorChar + "packages" + Path.DirectorySeparatorChar));
+		_infrastructure.ReadAllText(Arg.Any<string>()).Returns("{{packageUnderTest}}");
+		_validator.Validate(Arg.Any<CreateTestProjectOptions>()).Returns(new ValidationResult());
+	}
+
+	[TearDown]
+	public void ClearCalls() {
+		_context.ClearReceivedCalls();
+		_infrastructure.ClearReceivedCalls();
+		_templates.ClearReceivedCalls();
+		_solutions.ClearReceivedCalls();
+		_validator.ClearReceivedCalls();
+	}
+
+	[TestCase("Acme")]
+	[TestCase("Acme,Other")]
+	[Description("Registers every package test and production project directly in the test solution, and every test project in the main solution.")]
+	public void Execute_ShouldRegisterAllProjects_WhenScaffoldingPackages(string packages) {
+		// Arrange
+		CreateTestProjectOptions options = new() { PackageName = packages };
+
+		// Act
+		int result = _command.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "all requested projects should be registered before success");
+		foreach (string package in packages.Split(',')) {
+			string testPath = Path.Combine(package, package + ".Tests.csproj");
+			_solutions.ReceivedCalls().Should().Contain(call =>
+				(string)call.GetArguments()[0] == Path.Combine(_context.ProjectsTestsFolderPath, "UnitTests.slnx") &&
+				((IEnumerable<SolutionProject>)call.GetArguments()[1]).Any(project => project.Path == testPath),
+				because: "each package must be included in the actual slnx file");
+			_solutions.ReceivedCalls().Should().Contain(call =>
+				(string)call.GetArguments()[0] == Path.Combine(_context.RootPath, "MainSolution.slnx") &&
+				((IEnumerable<SolutionProject>)call.GetArguments()[1]).Single().Path == Path.Combine("tests", testPath),
+				because: "the main workspace solution must include each test project");
+		}
+		_infrastructure.ReceivedCalls().Should().NotContain(call => call.GetMethodInfo().Name == "ExecuteDotnetCommand",
+			because: "solution registration must not depend on SDK-specific sln defaults or ignored process exit codes");
+	}
 
 	[Test]
-	[Description("Uses the explicit workspace path for new-test-project execution when MCP supplies one.")]
-	public void Execute_Should_Use_Explicit_Workspace_Path_When_Provided() {
-		string workspacePath = Path.Combine(Path.GetTempPath(), "clio-tests", Guid.NewGuid().ToString("N"));
+	[Description("Repairs solution registrations without overwriting customized project or fixture files on a rerun.")]
+	public void Execute_ShouldPreserveExistingFiles_WhenRepairingRegistrations() {
+		// Arrange
+		_infrastructure.ExistsFile(Arg.Any<string>()).Returns(true);
+
+		// Act
+		int result = _command.Execute(new CreateTestProjectOptions { PackageName = "Acme" });
+
+		// Assert
+		result.Should().Be(0, because: "an existing project still needs solution registration");
+		_infrastructure.ReceivedCalls().Should().NotContain(call => call.GetMethodInfo().Name == "WriteAllText",
+			because: "repairing solution membership must preserve customized source and project files");
+		_solutions.ReceivedCalls().Should().HaveCount(2, because: "both solutions must be repaired on a rerun");
+	}
+
+	[Test]
+	[Description("Applies the MCP workspace path before rejecting a non-workspace without writing files.")]
+	public void Execute_ShouldRejectInvalidWorkspace_WhenExplicitPathProvided() {
+		// Arrange
+		_context.IsWorkspace.Returns(false);
+		string workspace = Path.GetFullPath("missing-workspace");
+
+		// Act
+		int result = _command.Execute(new CreateTestProjectOptions { PackageName = "Acme", WorkspacePath = workspace });
+
+		// Assert
+		result.Should().Be(1, because: "generation must remain inside a verified workspace");
+		_context.RootPath.Should().Be(workspace, because: "MCP must select the supplied workspace");
+		_infrastructure.ReceivedCalls().Should().BeEmpty(because: "invalid workspaces must fail before file writes");
+	}
+
+	[Test]
+	[Description("Rejects a missing package project before writing test scaffolds or dangling solution entries.")]
+	public void Execute_ShouldFailBeforeWrites_WhenPackageProjectIsMissing() {
+		// Arrange
+		_infrastructure.ExistsFile(Arg.Any<string>()).Returns(false);
+
+		// Act
+		int result = _command.Execute(new CreateTestProjectOptions { PackageName = "Missing" });
+
+		// Assert
+		result.Should().Be(1, because: "a solution must not contain a nonexistent package project");
+		_solutions.ReceivedCalls().Should().BeEmpty(because: "missing packages must fail before solution changes");
+		_infrastructure.ReceivedCalls().Should().NotContain(call => call.GetMethodInfo().Name == "WriteAllText",
+			because: "missing packages must fail before scaffold writes");
+	}
+
+	[Test]
+	[Description("Reports failure if solution registration throws, instead of reporting Done.")]
+	public void Execute_ShouldFail_WhenSolutionCannotBeUpdated() {
+		// Arrange
+		_solutions.When(service => service.AddProjectToSolution(Arg.Any<string>(), Arg.Any<IEnumerable<SolutionProject>>()))
+			.Do(_ => throw new XmlException("Repair the solution"));
 		try {
-			// Arrange
-			IValidator<CreateTestProjectOptions> validator = Substitute.For<IValidator<CreateTestProjectOptions>>();
-			ICreateTestProjectContext context = Substitute.For<ICreateTestProjectContext>();
-			ITemplateProvider templateProvider = Substitute.For<ITemplateProvider>();
-			ICreateTestProjectInfrastructure infrastructure = Substitute.For<ICreateTestProjectInfrastructure>();
-			ILogger logger = Substitute.For<ILogger>();
-			ISolutionCreator solutionCreator = Substitute.For<ISolutionCreator>();
-			CreateTestProjectCommand command = new(
-				validator,
-				context,
-				templateProvider,
-				infrastructure,
-				logger,
-				solutionCreator);
-
-			CreateTestProjectOptions options = new() {
-				PackageName = "MyPackage",
-				WorkspacePath = workspacePath
-			};
-			if (!Directory.Exists(options.WorkspacePath)) {
-				Directory.CreateDirectory(options.WorkspacePath);
-			}
-
-			ValidationResult validationResult = new([new ValidationFailure("PackageName", "Project name is required.")]);
-			validator.Validate(options).Returns(validationResult);
-
 			// Act
-			int result = command.Execute(options);
+			int result = _command.Execute(new CreateTestProjectOptions { PackageName = "Acme" });
 
 			// Assert
-			result.Should().Be(1, "because validation failure should stop execution after the explicit workspace path is applied");
-			context.Received().RootPath = workspacePath;
+			result.Should().Be(1, because: "a generated project without solution registration is not a successful scaffold");
 		}
 		finally {
-			if (Directory.Exists(workspacePath)) {
-				Directory.Delete(workspacePath, true);
-			}
+			_solutions.ClearReceivedCalls();
 		}
 	}
 }

--- a/clio.tests/Command/McpServer/CreateTestProjectToolTests.cs
+++ b/clio.tests/Command/McpServer/CreateTestProjectToolTests.cs
@@ -11,6 +11,22 @@ namespace Clio.Tests.Command.McpServer;
 [TestFixture]
 [Property("Module", "McpServer")]
 public class CreateTestProjectToolTests {
+	[TestCase(typeof(CreateTestProjectTool), nameof(CreateTestProjectTool.CreateTestProject), CreateTestProjectTool.ToolName)]
+	[TestCase(typeof(CreateIntegrationTestProjectTool), nameof(CreateIntegrationTestProjectTool.Create), CreateIntegrationTestProjectTool.ToolName)]
+	[Category("Unit")]
+	[Description("Keeps both package-test MCP tool names discoverable through their production constants.")]
+	public void Scaffold_ShouldExposeStableName_WhenInspectingToolContract(System.Type toolType, string methodName, string toolName) {
+		// Arrange
+		System.Reflection.MethodInfo method = toolType.GetMethod(methodName)!;
+
+		// Act
+		object[] attributes = method.GetCustomAttributes(typeof(ModelContextProtocol.Server.McpServerToolAttribute), false);
+
+		// Assert
+		attributes.Should().ContainSingle(because: "each scaffold must expose one MCP tool contract");
+		((ModelContextProtocol.Server.McpServerToolAttribute)attributes[0]).Name.Should().Be(toolName,
+			because: "discovery and E2E callers must share the production tool-name constant");
+	}
 
 	[Test]
 	[Description("Resolves the new-test-project command for the requested environment and maps structured MCP arguments into command options.")]

--- a/clio.tests/Workspace/SolutionCreatorTests.cs
+++ b/clio.tests/Workspace/SolutionCreatorTests.cs
@@ -103,10 +103,46 @@ public class SolutionCreatorTests {
 
 	#region Methods: Private
 
+	[Test]
+	[Description("Rejects a well-formed XML file with the wrong root instead of silently skipping solution registration.")]
+	public void AddProjectToSolution_ShouldFail_WhenSolutionRootIsMissing() {
+		// Arrange
+		string solutionPath = Path.Combine(_tempDir, "Invalid.slnx");
+		File.WriteAllText(solutionPath, "<NotASolution />");
+
+		// Act
+		Action addProject = () => _solutionCreator.AddProjectToSolution(solutionPath,
+			[new SolutionProject("Acme", "Acme.csproj")]);
+
+		// Assert
+		addProject.Should().Throw<XmlException>(because: "a scaffold cannot succeed without registering its project")
+			.WithMessage("*Repair the solution*", because: "the caller needs an actionable diagnostic");
+		File.ReadAllText(solutionPath).Should().Be("<NotASolution />", because: "invalid input must be preserved for repair");
+	}
+
 	private static XmlNode LoadProjectNode(string solutionPath, string projectPath) {
 		XmlDocument doc = new();
 		doc.Load(solutionPath);
 		return doc.SelectSingleNode($"Solution/Project[@Path='{projectPath}']");
+	}
+
+	[Test]
+	[Description("Preserves solution folders and recognizes an existing project with alternate path separators on reruns.")]
+	public void AddProjectToSolution_ShouldReuseNestedProject_WhenPathSeparatorsDiffer() {
+		// Arrange
+		string solutionPath = Path.Combine(_tempDir, "UnitTests.slnx");
+		File.WriteAllText(solutionPath, "<Solution><Folder Name=\"/Tests/\"><Project Path=\"Acme/Acme.Tests.csproj\" /></Folder></Solution>");
+
+		// Act
+		_solutionCreator.AddProjectToSolution(solutionPath,
+			[new SolutionProject("Acme", @"Acme\Acme.Tests.csproj") { ForceBuild = true }]);
+
+		// Assert
+		XmlDocument document = new();
+		document.Load(solutionPath);
+		document.SelectNodes("//Project").Count.Should().Be(1, because: "an existing nested registration must not be duplicated");
+		document.SelectSingleNode("Solution/Folder/Project/Build").Should().NotBeNull(
+			because: "the existing project must retain its folder and receive requested build settings");
 	}
 
 	#endregion

--- a/clio/Command/CreateIntegrationTestProjectCommand.cs
+++ b/clio/Command/CreateIntegrationTestProjectCommand.cs
@@ -80,7 +80,7 @@ public class CreateIntegrationTestProjectCommand(
 			solutionCreator.AddProjectToSolution(
 				infrastructure.Combine(context.RootPath, "MainSolution.slnx"),
 				[new SolutionProject(projectFileName, relativeToRoot)]);
-			logger.WriteLine($"Created {projectPath}");
+			logger.WriteInfo($"Created {projectPath}");
 			return 0;
 		}
 		catch (Exception exception) {

--- a/clio/Command/CreateTestProjectCommand.cs
+++ b/clio/Command/CreateTestProjectCommand.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using System;
 using System.Collections.Generic;
@@ -90,7 +90,6 @@ public interface ICreateTestProjectInfrastructure {
 
 	void DeleteFileIfExists(string path);
 
-	void ExecuteDotnetCommand(string command, string workingDirectoryPath);
 }
 
 #endregion
@@ -98,15 +97,13 @@ public interface ICreateTestProjectInfrastructure {
 #region Class: CreateTestProjectInfrastructure
 
 public class CreateTestProjectInfrastructure : ICreateTestProjectInfrastructure {
-	private readonly IDotnetExecutor _dotnetExecutor;
 	private readonly IFileSystem _fileSystem;
 	private readonly IAbstractionsFileSystem _pathFileSystem;
 
-	public CreateTestProjectInfrastructure(IFileSystem fileSystem, IAbstractionsFileSystem pathFileSystem,
-		IDotnetExecutor dotnetExecutor) {
+	/// <summary>Creates the local filesystem adapter used by test-project scaffolds.</summary>
+	public CreateTestProjectInfrastructure(IFileSystem fileSystem, IAbstractionsFileSystem pathFileSystem) {
 		_fileSystem = fileSystem;
 		_pathFileSystem = pathFileSystem;
-		_dotnetExecutor = dotnetExecutor;
 	}
 
 	public string Combine(params string[] paths) {
@@ -141,9 +138,6 @@ public class CreateTestProjectInfrastructure : ICreateTestProjectInfrastructure 
 		_fileSystem.DeleteFileIfExists(path);
 	}
 
-	public void ExecuteDotnetCommand(string command, string workingDirectoryPath) {
-		_dotnetExecutor.Execute(command, true, workingDirectoryPath);
-	}
 }
 
 #endregion
@@ -177,12 +171,6 @@ public class CreateTestProjectOptions : EnvironmentOptions{
 /// Creates test project scaffolding for workspace packages.
 /// </summary>
 public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
-	#region Constants: Private
-
-	private const string TestsDirectoryName = "tests";
-
-	#endregion
-
 	#region Fields: Private
 
 	private readonly ICreateTestProjectContext _context;
@@ -196,6 +184,7 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 
 	#region Constructors: Public
 
+	/// <summary>Creates the command using the workspace, template, and solution services.</summary>
 	public CreateTestProjectCommand(IValidator<CreateTestProjectOptions> optionsValidator,
 		ICreateTestProjectContext context, ITemplateProvider templateProvider,
 		ICreateTestProjectInfrastructure infrastructure, ILogger logger,
@@ -212,10 +201,7 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 
 	#region Properties: Private
 
-	private string TestsPath =>
-		_context.IsWorkspace
-			? _context.ProjectsTestsFolderPath
-			: _infrastructure.Combine(_context.CurrentDirectory, TestsDirectoryName);
+	private string TestsPath => _context.ProjectsTestsFolderPath;
 
 	#endregion
 
@@ -223,6 +209,7 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 
 	private void EnsureTestSolutionScriptsExist() {
 		string tasksDir = _context.TasksFolderPath;
+		_infrastructure.EnsureDirectoryExists(tasksDir);
 		string[] scripts = {
 			"open-test-solution-framework.cmd", "open-test-solution-netcore.cmd"
 		};
@@ -234,10 +221,6 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 				_infrastructure.WriteAllText(targetPath, tplContent);
 			}
 		}
-	}
-
-	private void ExecuteDotnetCommand(string command, string workingDirectoryPath) {
-		_infrastructure.ExecuteDotnetCommand(command, workingDirectoryPath);
 	}
 
 	private void UpdateCsProj(string csprojPath, string packageName) {
@@ -257,8 +240,13 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 
 	#region Methods: Public
 
+	/// <inheritdoc />
 	public override int Execute(CreateTestProjectOptions options) {
 		ApplyWorkspacePath(options);
+		if (!_context.IsWorkspace) {
+			_logger.WriteError("Current directory is not a clio workspace. Run the command from a workspace or pass a valid workspace path.");
+			return 1;
+		}
 		
 		ValidationResult validationResult = _optionsValidator.Validate(options);
 		if (validationResult.Errors.Count != 0) {
@@ -272,9 +260,15 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 				: options.PackageName.Split(",", StringSplitOptions.RemoveEmptyEntries);
 			const string solutionName = "UnitTests";
 			const string mainSolutionName = "MainSolution";
+			foreach (string packageName in packages) {
+				string packageProjectPath = _context.BuildPackageProjectPath(packageName);
+				if (!_infrastructure.ExistsFile(packageProjectPath)) {
+					_logger.WriteError($"Package project not found: {packageProjectPath}. Generate the package project with clio before creating unit tests.");
+					return 1;
+				}
+			}
 
 			_infrastructure.EnsureDirectoryExists(TestsPath);
-			ExecuteDotnetCommand($"new sln -n {solutionName}", TestsPath);
 
 			string tplContent = _templateProvider.GetTemplate("UnitTest.csproj");
 			string fixtureContent = _templateProvider.GetTemplate("BaseComposableAppTestFixture.cs");
@@ -284,19 +278,25 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 				string csprojFilePath = _infrastructure.Combine(unitTestDirectoryName, unitTestProjFileName);
 				string fixtureFilePath = _infrastructure.Combine(unitTestDirectoryName, "BaseComposableAppTestFixture.cs");
 				_infrastructure.EnsureDirectoryExists(unitTestDirectoryName);
-				_infrastructure.WriteAllText(csprojFilePath, tplContent);
-				_infrastructure.WriteAllText(fixtureFilePath, fixtureContent);
-				
-				_templateProvider.CopyTemplateFolder(
-					"UnitTestLibs",
-					_infrastructure.Combine(unitTestDirectoryName, "Libs"));
-				UpdateCsProj(csprojFilePath, packageName);
-				UpdateBaseFixture(fixtureFilePath, packageName);
+				if (!_infrastructure.ExistsFile(csprojFilePath)) {
+					_infrastructure.WriteAllText(csprojFilePath, tplContent);
+					UpdateCsProj(csprojFilePath, packageName);
+					_templateProvider.CopyTemplateFolder(
+						"UnitTestLibs",
+						_infrastructure.Combine(unitTestDirectoryName, "Libs"));
+				}
+				if (!_infrastructure.ExistsFile(fixtureFilePath)) {
+					_infrastructure.WriteAllText(fixtureFilePath, fixtureContent);
+					UpdateBaseFixture(fixtureFilePath, packageName);
+				}
 				string relativeTestProjectPath = _infrastructure.Combine(packageName, unitTestProjFileName);
-				ExecuteDotnetCommand($"sln {solutionName}.sln add {relativeTestProjectPath}", TestsPath);
 
 				string underTestProjectPath = _context.BuildPackageProjectPath(packageName);
-				ExecuteDotnetCommand($"sln {solutionName}.sln add {underTestProjectPath}", TestsPath);
+				string relativePackageProjectPath = _infrastructure.GetRelativePath(TestsPath, underTestProjectPath);
+				_solutionCreator.AddProjectToSolution(
+					_infrastructure.Combine(TestsPath, $"{solutionName}.slnx"),
+					[new SolutionProject(unitTestProjFileName, relativeTestProjectPath),
+					 new SolutionProject($"{packageName}.csproj", relativePackageProjectPath)]);
 
 				string testProjectRelativePath = _infrastructure.GetRelativePath(_context.RootPath, csprojFilePath);
 				string mainSolutionPath = _infrastructure.Combine(_context.RootPath, $"{mainSolutionName}.slnx");
@@ -304,13 +304,11 @@ public class CreateTestProjectCommand : Command<CreateTestProjectOptions>{
 				SolutionProject mainSolutionProject = new (unitTestProjFileName, testProjectRelativePath);
 				_solutionCreator.AddProjectToSolution(mainSolutionPath, [mainSolutionProject]);
 				
-				ExecuteDotnetCommand("sln migrate", TestsPath);
-				_infrastructure.DeleteFileIfExists(_infrastructure.Combine(TestsPath, "UnitTests.sln"));
 			}
 
 			// Ensure test solution scripts exist in the tasks directory
 			EnsureTestSolutionScriptsExist();
-			_logger.WriteLine("Done");
+			_logger.WriteInfo("Done");
 			return 0;
 		}
 		catch (Exception e) {

--- a/clio/Command/McpServer/Prompts/WorkspacePackagePrompt.cs
+++ b/clio/Command/McpServer/Prompts/WorkspacePackagePrompt.cs
@@ -66,10 +66,12 @@ public static class WorkspacePackagePrompt {
 		[Description("Creatio environment name")]
 		string environmentName) =>
 		$"""
-		 Use clio mcp server `new-test-project` tool to create a test project for workspace package
+		 Use clio-run with command `new-test-project` to create a test project for workspace package
 		 `{packageName}` in the workspace at `{workspacePath}`.
 		 Pass `workspace-path` exactly as provided and use `environment-name` `{environmentName}`.
 		 Operate on the specified workspace package only.
+		 Use only the clio scaffold for test projects; write test cases inside the generated project.
+		 Verify the project appears in tests/UnitTests.slnx and MainSolution.slnx before running tests.
 		""";
 
 	/// <summary>Builds a prompt for portable integration-test project creation.</summary>
@@ -79,9 +81,11 @@ public static class WorkspacePackagePrompt {
 		[Required, Description("Absolute path to the local workspace")] string workspacePath,
 		[Description("Target framework")] string targetFramework = "net10.0") =>
 		$"""
-		 Read get-guidance name=integration-testing, then use the `new-integration-test-project` tool
+		 Read get-guidance name=integration-testing, then use clio-run with command `new-integration-test-project`
 		 to create a portable integration-test project for `{packageName}` in `{workspacePath}` with
 		 target framework `{targetFramework}`. Do not embed credentials or assume a local clio environment.
+		 Use only the clio scaffold for test projects; write test cases inside the generated project.
+		 Verify the project appears in tests/IntegrationTests.slnx and MainSolution.slnx before running tests.
 		 """;
 
 	/// <summary>

--- a/clio/Command/McpServer/Tools/WorkspacePackageTool.cs
+++ b/clio/Command/McpServer/Tools/WorkspacePackageTool.cs
@@ -66,14 +66,15 @@ public class CreateTestProjectTool(
 	ILogger logger,
 	IToolCommandResolver commandResolver)
 	: BaseTool<CreateTestProjectOptions>(createTestProjectCommand, logger, commandResolver) {
+	internal const string ToolName = "new-test-project";
 
 	/// <summary>
 	/// Creates a new test project for a package in the specified workspace.
 	/// </summary>
-	[McpServerTool(Name = "new-test-project", ReadOnly = false, Destructive = false, Idempotent = false,
+	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = false, Idempotent = false,
 		OpenWorld = false)]
 	// InProcess (the inventory's file-level heuristic said worker, and §4 pre-flagged this row):
-	// CreateTestProjectCommand.Execute only writes templates and drives the local dotnet CLI. The
+	// CreateTestProjectCommand.Execute only writes templates and solution files. The
 	// environment-name argument exists because the options inherit EnvironmentOptions; nothing on the path
 	// holds an IApplicationClient, so the call can never block on Creatio.
 	[McpToolExecution(
@@ -87,7 +88,9 @@ public class CreateTestProjectTool(
 				 Creates a new unit test project for a package in the specified local workspace.
 				 
 				 The workspace path is required because the command generates files under that workspace and
-				 updates the workspace solution structure.
+				 registers the test project in tests/UnitTests.slnx and MainSolution.slnx.
+				 Existing project and fixture files are preserved; rerun to repair missing solution entries.
+				 Use this scaffold before writing test cases; do not create a separate test project or harness.
 				 """)]
 	public CommandExecutionResult CreateTestProject(
 		[Description("new-test-project parameters")] [Required] CreateTestProjectArgs args
@@ -106,9 +109,10 @@ public class CreateIntegrationTestProjectTool(
 	CreateIntegrationTestProjectCommand command,
 	ILogger logger)
 	: BaseTool<CreateIntegrationTestProjectOptions>(command, logger) {
+	internal const string ToolName = "new-integration-test-project";
 
 	/// <summary>Creates a scenario-neutral integration-test project in a local clio workspace.</summary>
-	[McpServerTool(Name = "new-integration-test-project", ReadOnly = false, Destructive = false,
+	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = false,
 		Idempotent = false, OpenWorld = false)]
 	// InProcess (the inventory's file-level heuristic said worker): CreateIntegrationTestProjectOptions does
 	// not inherit EnvironmentOptions, the tool takes no IToolCommandResolver and the generated project is
@@ -125,6 +129,8 @@ public class CreateIntegrationTestProjectTool(
 		Read get-guidance name=integration-testing before adding scenario-specific tests. The generated
 		project accepts Creatio URL, runtime, and password or access-token authentication from NUnit
 		parameters or environment variables and does not depend on a local clio environment registry.
+		Registers the project in tests/IntegrationTests.slnx and MainSolution.slnx.
+		Use this scaffold before writing test cases; do not create a separate test project or harness.
 		""")]
 	public CommandExecutionResult Create(
 		[Description("new-integration-test-project parameters")] [Required] CreateIntegrationTestProjectArgs args) {

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -1,4 +1,4 @@
-# Clio Command Reference
+﻿# Clio Command Reference
 
 Use `clio help` for the terminal overview and `clio <command> --help` for command details.
 
@@ -424,11 +424,11 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="new-test-project"></a>
 <a id="create-test-project"></a>
 <a id="unit-test"></a>
-- [`new-test-project`](docs/commands/new-test-project.md) - Create package unit-test projects and register them in UnitTests.slnx and MainSolution.slnx, `create-test-project`, `unit-test`
+- [`new-test-project`](docs/commands/new-test-project.md) - Create a new test project, `create-test-project`, `unit-test`
 
 <a id="new-integration-test-project"></a>
 <a id="integration-test"></a>
-- [`new-integration-test-project`](docs/commands/new-integration-test-project.md) - Create a portable Creatio integration-test project and register it in IntegrationTests.slnx and MainSolution.slnx, `integration-test`
+- [`new-integration-test-project`](docs/commands/new-integration-test-project.md) - Create a portable Creatio integration-test project, `integration-test`
 <a id="new-ui-project"></a>
 <a id="create-ui-project"></a>
 <a id="createup"></a>

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -1,4 +1,4 @@
-﻿# Clio Command Reference
+# Clio Command Reference
 
 Use `clio help` for the terminal overview and `clio <command> --help` for command details.
 
@@ -424,11 +424,11 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="new-test-project"></a>
 <a id="create-test-project"></a>
 <a id="unit-test"></a>
-- [`new-test-project`](docs/commands/new-test-project.md) - Create a new test project, `create-test-project`, `unit-test`
+- [`new-test-project`](docs/commands/new-test-project.md) - Create package unit-test projects and register them in UnitTests.slnx and MainSolution.slnx, `create-test-project`, `unit-test`
 
 <a id="new-integration-test-project"></a>
 <a id="integration-test"></a>
-- [`new-integration-test-project`](docs/commands/new-integration-test-project.md) - Create a portable Creatio integration-test project, `integration-test`
+- [`new-integration-test-project`](docs/commands/new-integration-test-project.md) - Create a portable Creatio integration-test project and register it in IntegrationTests.slnx and MainSolution.slnx, `integration-test`
 <a id="new-ui-project"></a>
 <a id="create-ui-project"></a>
 <a id="createup"></a>

--- a/clio/Workspace/SolutionCreator.cs
+++ b/clio/Workspace/SolutionCreator.cs
@@ -1,13 +1,18 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Xml;
 using Clio.Common;
 using Clio.Workspaces;
 
 namespace Clio.Workspace;
 
+/// <summary>Creates and updates XML solution project registrations.</summary>
 public interface ISolutionCreator{
 	#region Methods: Public
+	/// <summary>Adds missing projects, preserving existing registrations and solution folders.</summary>
+	/// <param name="solutionPath">Path to the XML solution to create or update.</param>
+	/// <param name="solutionProjects">Projects with paths relative to the solution directory.</param>
+	/// <exception cref="XmlException">The existing file is not a valid XML solution.</exception>
 	void AddProjectToSolution(string solutionPath, IEnumerable<SolutionProject> solutionProjects);
 
 	#endregion
@@ -37,6 +42,7 @@ public class SolutionCreator : ISolutionCreator{
 
 	#region Methods: Public
 	
+	/// <inheritdoc />
 	public void AddProjectToSolution(string solutionPath, IEnumerable<SolutionProject> solutionProjects) {
 
 		if (!_fileSystem.ExistsFile(solutionPath)) {
@@ -49,28 +55,14 @@ public class SolutionCreator : ISolutionCreator{
 
 		XmlNode solutionNode = doc.SelectSingleNode("Solution");
 		if (solutionNode == null) {
-			_logger.WriteWarning($"[WARNING] Solution file {solutionPath} does not contain a root <Solution> node.");
-			return;
-		}
-		XmlNodeList existingProjects = solutionNode.SelectNodes("Project");
-		List<string> paths = [];
-		if (existingProjects != null) {
-			foreach (XmlNode existingProject in existingProjects) {
-				if (existingProject.Attributes != null) {
-					string path = existingProject.Attributes["Path"].Value;
-					paths.Add(path);
-				}
-			}
+			throw new XmlException($"Solution file {solutionPath} does not contain a root <Solution> node. Repair the solution and rerun the command.");
 		}
 		foreach (SolutionProject sp in solutionProjects) {
-			XmlElement projectNode;
-			if (!paths.Contains(sp.Path)) {
+			XmlElement projectNode = FindProjectNode(solutionNode, sp.Path);
+			if (projectNode == null) {
 				projectNode = doc.CreateElement("Project");
 				projectNode.SetAttribute("Path", sp.Path);
 				solutionNode.AppendChild(projectNode);
-				paths.Add(sp.Path);
-			} else {
-				projectNode = FindProjectNode(solutionNode, sp.Path);
 			}
 			if (sp.ForceBuild && projectNode != null && projectNode.SelectSingleNode("Build") == null) {
 				projectNode.AppendChild(doc.CreateElement("Build"));
@@ -81,13 +73,14 @@ public class SolutionCreator : ISolutionCreator{
 	}
 
 	private static XmlElement FindProjectNode(XmlNode solutionNode, string path) {
-		XmlNodeList existingProjects = solutionNode.SelectNodes("Project");
+		XmlNodeList existingProjects = solutionNode.SelectNodes(".//Project");
 		if (existingProjects == null) {
 			return null;
 		}
 		foreach (XmlNode existingProject in existingProjects) {
 			if (existingProject is XmlElement element
-				&& element.Attributes?["Path"]?.Value == path) {
+				&& string.Equals(element.Attributes?["Path"]?.Value.Replace('\\', '/'), path.Replace('\\', '/'),
+					OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal)) {
 				return element;
 			}
 		}

--- a/clio/Workspace/SolutionCreator.cs
+++ b/clio/Workspace/SolutionCreator.cs
@@ -64,7 +64,7 @@ public class SolutionCreator : ISolutionCreator{
 				projectNode.SetAttribute("Path", sp.Path);
 				solutionNode.AppendChild(projectNode);
 			}
-			if (sp.ForceBuild && projectNode != null && projectNode.SelectSingleNode("Build") == null) {
+			if (sp.ForceBuild && projectNode.SelectSingleNode("Build") == null) {
 				projectNode.AppendChild(doc.CreateElement("Build"));
 			}
 		}

--- a/clio/Workspace/SolutionCreator.cs
+++ b/clio/Workspace/SolutionCreator.cs
@@ -90,7 +90,7 @@ public class SolutionCreator : ISolutionCreator{
 	private void CreateNewMainSolution(string solutionPath) {
 		string solutionContent = _templateProvider.GetTemplate("workspace/MainSolution.slnx");
 		_fileSystem.WriteAllTextToFile(solutionPath, solutionContent);
-		_logger.WriteWarning($"[WARNING] Solution file {solutionPath} does not exist, created new MainSolution.slnx");
+		_logger.WriteInfo($"Created solution file {solutionPath}");
 	}
 
 	#endregion

--- a/clio/docs/commands/new-integration-test-project.md
+++ b/clio/docs/commands/new-integration-test-project.md
@@ -38,3 +38,12 @@ clio integration-test --package UsrFinancialApplicatio --target-framework net8.0
 ```
 
 - [Clio Command Reference](../../Commands.md#new-integration-test-project)
+
+Creates `tests/<Package>.IntegrationTests/<Package>.IntegrationTests.csproj` and registers it
+in `tests/IntegrationTests.slnx` and `MainSolution.slnx`. An existing project directory is
+refused to preserve customizations. Solution-write errors return a nonzero exit code;
+success emits an Info message. Verify both solution entries before running tests.
+
+Use only the Clio scaffold for package integration-test projects, then write test cases in
+the generated project. For MCP, call `clio-run` with command `new-integration-test-project`,
+`package-name`, absolute `workspace-path`, and optional `target-framework`.

--- a/clio/docs/commands/new-integration-test-project.md
+++ b/clio/docs/commands/new-integration-test-project.md
@@ -1,49 +1,41 @@
 # new-integration-test-project
 
-Create a portable, scenario-neutral Creatio integration-test project.
+## Name
 
-## Usage
+new-integration-test-project (alias: integration-test) - Create a portable Creatio integration-test project
+
+## Synopsis
 
 ```bash
 clio new-integration-test-project --package <NAME> [--target-framework <TFM>]
 ```
 
-Alias: `integration-test`.
-
-The project uses NUnit, FluentAssertions, ATF.Repository, and Allure. It contains only
-configuration and a base fixture; process models, entity models, business assertions, and
-Playwright are added when a scenario requires them.
-
 ## Options
 
-- `--package` — required workspace package name.
-- `--target-framework` — generated target framework; defaults to `net10.0`.
+```bash
+--package <NAME>
+Required workspace package name.
 
-## Runtime configuration
-
-NUnit parameters take precedence over environment variables. Supply `CREATIO_URL`,
-`CREATIO_IS_NETCORE`, and exactly one authentication mode:
-
-- `CREATIO_ACCESS_TOKEN`; or
-- `CREATIO_USERNAME` and `CREATIO_PASSWORD`.
-
-Keep credentials in CI secret storage. The generated project does not depend on clio's local
-environment registry.
+--target-framework <TFM>
+Generated project target framework. Default: net10.0.
+```
 
 ## Examples
 
 ```bash
 clio new-integration-test-project --package UsrFinancialApplicatio
-clio integration-test --package UsrFinancialApplicatio --target-framework net8.0
+clio new-integration-test-project --package UsrFinancialApplicatio --target-framework net8.0
 ```
 
+## Notes
+
+The generated project reads CREATIO_URL, CREATIO_IS_NETCORE, and either
+CREATIO_ACCESS_TOKEN or CREATIO_USERNAME plus CREATIO_PASSWORD from NUnit parameters
+or environment variables. It does not require a registered clio environment.
+Registers the generated project in tests/IntegrationTests.slnx and MainSolution.slnx.
+An existing project directory is refused to preserve customizations.
+Solution-write errors return a nonzero exit code. Success emits an Info message.
+MCP: clio-run command=new-integration-test-project with package-name, absolute
+workspace-path, and optional target-framework. Write test cases in the generated project.
+
 - [Clio Command Reference](../../Commands.md#new-integration-test-project)
-
-Creates `tests/<Package>.IntegrationTests/<Package>.IntegrationTests.csproj` and registers it
-in `tests/IntegrationTests.slnx` and `MainSolution.slnx`. An existing project directory is
-refused to preserve customizations. Solution-write errors return a nonzero exit code;
-success emits an Info message. Verify both solution entries before running tests.
-
-Use only the Clio scaffold for package integration-test projects, then write test cases in
-the generated project. For MCP, call `clio-run` with command `new-integration-test-project`,
-`package-name`, absolute `workspace-path`, and optional `target-framework`.

--- a/clio/docs/commands/new-test-project.md
+++ b/clio/docs/commands/new-test-project.md
@@ -1,6 +1,6 @@
 # new-test-project
 
-Create a new test project.
+Create package unit-test projects from a clio workspace root. Registers each test project and package project in `tests/UnitTests.slnx`, and the test project in `MainSolution.slnx`.
 
 
 ## Usage
@@ -11,7 +11,7 @@ clio new-test-project [options]
 
 ## Description
 
-Create a new test project.
+Create package unit-test projects from a clio workspace root. Registers each test project and package project in `tests/UnitTests.slnx`, and the test project in `MainSolution.slnx`.
 
 ## Aliases
 
@@ -20,14 +20,14 @@ Create a new test project.
 ## Examples
 
 ```bash
-clio new-test-project -e dev
+clio new-test-project --package UsrOrders
 ```
 
 ## Options
 
 ```bash
 --package <VALUE>
-Package name
+Required package name or comma-separated package names
 ```
 
 ## Environment Options
@@ -82,3 +82,10 @@ Path to the application root folder
 ```
 
 - [Clio Command Reference](../../Commands.md#new-test-project)
+
+Existing project and fixture files are preserved. Rerun to repair missing solution entries. Legacy .sln files are left untouched. Solution-write failures return a nonzero exit code.
+
+Use only the Clio scaffold for package test projects, then write test cases inside the generated project. MCP callers use clio-run with command new-test-project and package-name, absolute workspace-path, and environment-name. Scaffolding needs no ClioGate installation.
+
+
+The package project packages/<NAME>/Files/<NAME>.csproj must exist before unit-test scaffolding. A missing package project fails before any files are written.

--- a/clio/docs/commands/new-test-project.md
+++ b/clio/docs/commands/new-test-project.md
@@ -1,91 +1,45 @@
 # new-test-project
 
-Create package unit-test projects from a clio workspace root. Registers each test project and package project in `tests/UnitTests.slnx`, and the test project in `MainSolution.slnx`.
+## Name
 
+new-test-project (aliases: unit-test, create-test-project) - Create package unit-test projects
 
-## Usage
+## Synopsis
 
 ```bash
-clio new-test-project [options]
+clio new-test-project --package <NAME[,NAME...]>
 ```
 
 ## Description
 
-Create package unit-test projects from a clio workspace root. Registers each test project and package project in `tests/UnitTests.slnx`, and the test project in `MainSolution.slnx`.
+Run from a clio workspace root. Creates tests/<NAME>/<NAME>.Tests.csproj and
+its base fixture. Registers test and package projects in tests/UnitTests.slnx,
+and the test project in MainSolution.slnx using Clio's solution writer.
 
-## Aliases
+## Options
 
-`create-test-project`, `unit-test`
+```bash
+--package <NAME[,NAME...]>
+Required package name or comma-separated package names.
+```
 
 ## Examples
 
 ```bash
 clio new-test-project --package UsrOrders
+clio new-test-project --package UsrOrders,UsrInvoices
 ```
 
-## Options
+## Notes
 
-```bash
---package <VALUE>
-Required package name or comma-separated package names
-```
+Existing project and fixture files are preserved. Rerun to repair missing
+solution registrations. Existing legacy .sln files are left untouched.
+A solution-write failure returns a nonzero exit code; do not report success.
+Use the Clio scaffold before writing test cases; do not create a separate harness.
+MCP: clio-run command=new-test-project with package-name, absolute workspace-path,
+and environment-name. No ClioGate installation is needed for scaffolding.
 
-## Environment Options
-
-```bash
--u, --uri <VALUE>
-Application uri
--p, --Password <VALUE>
-User password
--l, --Login <VALUE>
-User login (administrator permission required)
--i, --IsNetCore
-Use NetCore application
--e, --Environment <VALUE>
-Environment name
--m, --Maintainer <VALUE>
-Maintainer name
--c, --dev <VALUE>
-Developer mode state for environment
---WorkspacePathes <VALUE>
-Workspace path
--s, --Safe <VALUE>
-Safe action in this environment
---clientId <VALUE>
-OAuth client id
---clientSecret <VALUE>
-OAuth client secret
---authAppUri <VALUE>
-OAuth app URI
---silent
-Use default behavior without user interaction
---restart-environment
-Restart environment after execute command
---db-server-uri <VALUE>
-Db server uri
---db-user <VALUE>
-Database user
---db-password <VALUE>
-Database password
---backup-file <VALUE>
-Full path to backup file
---db-working-folder <VALUE>
-Folder visible to db server
---db-name <VALUE>
-Desired database name
---force
-Force restore
---callback-process <VALUE>
-Callback process name
---ep <VALUE>
-Path to the application root folder
-```
+The package project packages/<NAME>/Files/<NAME>.csproj must exist first.
+A missing package project fails before any files are written.
 
 - [Clio Command Reference](../../Commands.md#new-test-project)
-
-Existing project and fixture files are preserved. Rerun to repair missing solution entries. Legacy .sln files are left untouched. Solution-write failures return a nonzero exit code.
-
-Use only the Clio scaffold for package test projects, then write test cases inside the generated project. MCP callers use clio-run with command new-test-project and package-name, absolute workspace-path, and environment-name. Scaffolding needs no ClioGate installation.
-
-
-The package project packages/<NAME>/Files/<NAME>.csproj must exist before unit-test scaffolding. A missing package project fails before any files are written.

--- a/clio/help/en/new-integration-test-project.txt
+++ b/clio/help/en/new-integration-test-project.txt
@@ -19,3 +19,8 @@ NOTES
     The generated project reads CREATIO_URL, CREATIO_IS_NETCORE, and either
     CREATIO_ACCESS_TOKEN or CREATIO_USERNAME plus CREATIO_PASSWORD from NUnit parameters
     or environment variables. It does not require a registered clio environment.
+    Registers the generated project in tests/IntegrationTests.slnx and MainSolution.slnx.
+    An existing project directory is refused to preserve customizations.
+    Solution-write errors return a nonzero exit code. Success emits an Info message.
+    MCP: clio-run command=new-integration-test-project with package-name, absolute
+    workspace-path, and optional target-framework. Write test cases in the generated project.

--- a/clio/help/en/new-test-project.txt
+++ b/clio/help/en/new-test-project.txt
@@ -1,0 +1,28 @@
+NAME
+    new-test-project (aliases: unit-test, create-test-project) - Create package unit-test projects
+
+SYNOPSIS
+    clio new-test-project --package <NAME[,NAME...]>
+
+DESCRIPTION
+    Run from a clio workspace root. Creates tests/<NAME>/<NAME>.Tests.csproj and
+    its base fixture. Registers test and package projects in tests/UnitTests.slnx,
+    and the test project in MainSolution.slnx using Clio's solution writer.
+
+OPTIONS
+    --package <NAME[,NAME...]>
+        Required package name or comma-separated package names.
+
+EXAMPLES
+    clio new-test-project --package UsrOrders
+    clio new-test-project --package UsrOrders,UsrInvoices
+
+NOTES
+    Existing project and fixture files are preserved. Rerun to repair missing
+    solution registrations. Existing legacy .sln files are left untouched.
+    A solution-write failure returns a nonzero exit code; do not report success.
+    Use the Clio scaffold before writing test cases; do not create a separate harness.
+    MCP: clio-run command=new-test-project with package-name, absolute workspace-path,
+    and environment-name. No ClioGate installation is needed for scaffolding.
+
+The package project packages/<NAME>/Files/<NAME>.csproj must exist before unit-test scaffolding. A missing package project fails before any files are written.

--- a/clio/help/en/new-test-project.txt
+++ b/clio/help/en/new-test-project.txt
@@ -25,4 +25,5 @@ NOTES
     MCP: clio-run command=new-test-project with package-name, absolute workspace-path,
     and environment-name. No ClioGate installation is needed for scaffolding.
 
-The package project packages/<NAME>/Files/<NAME>.csproj must exist before unit-test scaffolding. A missing package project fails before any files are written.
+    The package project packages/<NAME>/Files/<NAME>.csproj must exist first.
+    A missing package project fails before any files are written.

--- a/clio/tpl/ui-project-Empty/AGENTS.md
+++ b/clio/tpl/ui-project-Empty/AGENTS.md
@@ -4,3 +4,52 @@
 
 Runtime components: node_modules\@creatio-devkit\common\AI_GUIDES_INDEX.md
 Design-time components (if relevant): node_modules\@creatio\interface-designer\AI_GUIDES_INDEX.md
+
+## Creating package test projects (required)
+
+Clio is the only approved way to scaffold package unit-test and integration-test projects.
+Do not hand-create test `.csproj`, `.sln`, or `.slnx` files, run `dotnet new` test templates,
+or invent a separate test harness. Write scenario-specific test cases inside the Clio-generated
+projects, using their existing frameworks, base fixtures, and configuration conventions.
+This rule concerns package C# tests; retain the existing Angular test tooling for UI tests.
+
+Run these commands from the Clio workspace root (the directory containing `.clio`):
+
+```shell
+clio unit-test --package <Package_Name>
+clio integration-test --package <Package_Name>
+```
+
+For example, for package `UsrOrders`:
+
+```shell
+clio unit-test --package UsrOrders
+clio integration-test --package UsrOrders --target-framework net8.0
+```
+
+Integration tests default to `net10.0`; select `--target-framework` to match the intended test runtime.
+Before adding integration scenarios, read `get-guidance name=integration-testing`.
+For MCP, discover contracts with `get-tool-contract`, then invoke the existing tools through `clio-run`:
+
+```json
+{"command":"new-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","environment-name":"<registered-environment>"}}
+```
+
+```json
+{"command":"new-integration-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","target-framework":"net8.0"}}
+```
+
+Use the workspace root even when working inside a nested UI project. Unit-test MCP scaffolding
+requires a registered environment name; integration-test scaffolding does not.
+Verify the command's exit code and the resulting solution membership before reporting success:
+
+| Scaffold | Generated test project | Test solution | Workspace solution |
+|---|---|---|---|
+| Unit | `tests/UsrOrders/UsrOrders.Tests.csproj` | `tests/UnitTests.slnx` | `MainSolution.slnx` |
+| Integration | `tests/UsrOrders.IntegrationTests/UsrOrders.IntegrationTests.csproj` | `tests/IntegrationTests.slnx` | `MainSolution.slnx` |
+
+Both solutions must contain the generated test project. UnitTests.slnx also contains the package
+project under test. Rerunning the unit scaffold repairs missing registrations and preserves existing
+project/fixture files. The integration scaffold refuses an existing project directory to protect
+customizations. If Clio reports an error, report the diagnostic and fix the Clio workflow; do not
+bypass it by inventing another test project. Scaffolding alone does not prove the tests pass.

--- a/clio/tpl/ui-project/AGENTS.md
+++ b/clio/tpl/ui-project/AGENTS.md
@@ -4,3 +4,52 @@
 
 Runtime components: node_modules\@creatio-devkit\common\AI_GUIDES_INDEX.md
 Design-time components (if relevant): node_modules\@creatio\interface-designer\AI_GUIDES_INDEX.md
+
+## Creating package test projects (required)
+
+Clio is the only approved way to scaffold package unit-test and integration-test projects.
+Do not hand-create test `.csproj`, `.sln`, or `.slnx` files, run `dotnet new` test templates,
+or invent a separate test harness. Write scenario-specific test cases inside the Clio-generated
+projects, using their existing frameworks, base fixtures, and configuration conventions.
+This rule concerns package C# tests; retain the existing Angular test tooling for UI tests.
+
+Run these commands from the Clio workspace root (the directory containing `.clio`):
+
+```shell
+clio unit-test --package <Package_Name>
+clio integration-test --package <Package_Name>
+```
+
+For example, for package `UsrOrders`:
+
+```shell
+clio unit-test --package UsrOrders
+clio integration-test --package UsrOrders --target-framework net8.0
+```
+
+Integration tests default to `net10.0`; select `--target-framework` to match the intended test runtime.
+Before adding integration scenarios, read `get-guidance name=integration-testing`.
+For MCP, discover contracts with `get-tool-contract`, then invoke the existing tools through `clio-run`:
+
+```json
+{"command":"new-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","environment-name":"<registered-environment>"}}
+```
+
+```json
+{"command":"new-integration-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","target-framework":"net8.0"}}
+```
+
+Use the workspace root even when working inside a nested UI project. Unit-test MCP scaffolding
+requires a registered environment name; integration-test scaffolding does not.
+Verify the command's exit code and the resulting solution membership before reporting success:
+
+| Scaffold | Generated test project | Test solution | Workspace solution |
+|---|---|---|---|
+| Unit | `tests/UsrOrders/UsrOrders.Tests.csproj` | `tests/UnitTests.slnx` | `MainSolution.slnx` |
+| Integration | `tests/UsrOrders.IntegrationTests/UsrOrders.IntegrationTests.csproj` | `tests/IntegrationTests.slnx` | `MainSolution.slnx` |
+
+Both solutions must contain the generated test project. UnitTests.slnx also contains the package
+project under test. Rerunning the unit scaffold repairs missing registrations and preserves existing
+project/fixture files. The integration scaffold refuses an existing project directory to protect
+customizations. If Clio reports an error, report the diagnostic and fix the Clio workflow; do not
+bypass it by inventing another test project. Scaffolding alone does not prove the tests pass.

--- a/clio/tpl/workspace/AGENTS.md
+++ b/clio/tpl/workspace/AGENTS.md
@@ -33,7 +33,7 @@ and the solution is C#-only. Setup details (esproj + `global.json` + `<Build/>` 
 
 ### /tests
 
-Unit/integration tests live under `./tests/<PACKAGE_NAME>/`.
+Unit tests live under `./tests/<PACKAGE_NAME>/`; integration tests live under `./tests/<PACKAGE_NAME>.IntegrationTests/`.
 
 ### /.application
 
@@ -161,3 +161,52 @@ Discovery: <important behavior/constraint learned>
 Files: <path1>, <path2>
 Impact: <how this helps future tasks>
 ```
+
+## Creating package test projects (required)
+
+Clio is the only approved way to scaffold package unit-test and integration-test projects.
+Do not hand-create test `.csproj`, `.sln`, or `.slnx` files, run `dotnet new` test templates,
+or invent a separate test harness. Write scenario-specific test cases inside the Clio-generated
+projects, using their existing frameworks, base fixtures, and configuration conventions.
+This rule concerns package C# tests; retain the existing Angular test tooling for UI tests.
+
+Run these commands from the Clio workspace root (the directory containing `.clio`):
+
+```shell
+clio unit-test --package <Package_Name>
+clio integration-test --package <Package_Name>
+```
+
+For example, for package `UsrOrders`:
+
+```shell
+clio unit-test --package UsrOrders
+clio integration-test --package UsrOrders --target-framework net8.0
+```
+
+Integration tests default to `net10.0`; select `--target-framework` to match the intended test runtime.
+Before adding integration scenarios, read `get-guidance name=integration-testing`.
+For MCP, discover contracts with `get-tool-contract`, then invoke the existing tools through `clio-run`:
+
+```json
+{"command":"new-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","environment-name":"<registered-environment>"}}
+```
+
+```json
+{"command":"new-integration-test-project","args":{"package-name":"UsrOrders","workspace-path":"<absolute-workspace-path>","target-framework":"net8.0"}}
+```
+
+Use the workspace root even when working inside a nested UI project. Unit-test MCP scaffolding
+requires a registered environment name; integration-test scaffolding does not.
+Verify the command's exit code and the resulting solution membership before reporting success:
+
+| Scaffold | Generated test project | Test solution | Workspace solution |
+|---|---|---|---|
+| Unit | `tests/UsrOrders/UsrOrders.Tests.csproj` | `tests/UnitTests.slnx` | `MainSolution.slnx` |
+| Integration | `tests/UsrOrders.IntegrationTests/UsrOrders.IntegrationTests.csproj` | `tests/IntegrationTests.slnx` | `MainSolution.slnx` |
+
+Both solutions must contain the generated test project. UnitTests.slnx also contains the package
+project under test. Rerunning the unit scaffold repairs missing registrations and preserves existing
+project/fixture files. The integration scaffold refuses an existing project directory to protect
+customizations. If Clio reports an error, report the diagnostic and fix the Clio workflow; do not
+bypass it by inventing another test project. Scaffolding alone does not prove the tests pass.


### PR DESCRIPTION
Fixes #1186.

`clio unit-test --package UsrOrders` could report Done after the SDK created UnitTests.slnx while Clio tried to add projects to UnitTests.sln. The command now uses the existing solution writer to register each test/package project in UnitTests.slnx and each test project in MainSolution.slnx. Reruns preserve customized project and fixture files; nested solution entries and alternate path separators are recognized. Missing package projects and invalid solution roots produce errors.

The workspace and both UI-project AGENTS.md templates now require Clio scaffolding for package test projects and include `unit-test`, `integration-test`, and MCP `clio-run` examples. Agents write test cases inside the generated projects. Existing unit/integration MCP tools remain the supported path, emit Info on success, and have real-process solution-registration coverage.

Validation:
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=Workspace|Module=McpServer)"`: 9,464 passed, 15 existing skips.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj --no-build -f net10.0 --filter "FullyQualifiedName~CreateTestProjectToolE2ETests|FullyQualifiedName~CreateIntegrationTestProjectToolE2ETests"`: 4 passed. Covers fresh and empty solutions, customized reruns, multiple packages, nested entries, and invalid solutions.
- Real CLI aliases executed in an isolated workspace; `dotnet sln ... list` verified all three solution files.
- Docs, CLI help, command index, alias anchors, MCP tools/prompts and shipped templates reviewed and aligned. Published integration-testing guidance remains accurate; no clio-knowledge change needed.
- ClioRing compatibility reviewed, no Ring-consumed contract changed. Inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`; no test-scaffold consumers. Ring validation is not required for this change.
- Comprehensive parallel review ran before PR publication and against the final complete diff (correctness/performance/testing, security, independent intent and KISS); no findings remain. Claude review rev_aa3e52444cc74dbe found no Blocker/High defects. Accepted the normal-creation logging and regeneratable-help suggestions; retained explicit malformed-solution failure. The follow-up commit received scoped combined review, and the final full parallel gate is clear.

Scaffolding and solution registration are verified here; executing customer test cases still requires their package build dependencies and, for integration scenarios, the intended Creatio environment.



Follow-up validation: Workspace plus help/export regressions: 64 passed. Re-ran real MCP tests on final source: 4 passed. Canonical help text now generates both command documents; the existing index descriptions and alias anchors remain valid. No new CLIO diagnostics in modified files.

