### PR TITLE
Fix localization-only data bindings and preserve files on validation failure

### DIFF
--- a/clio.mcp.e2e/DataBindingToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingToolE2ETests.cs
@@ -25,6 +25,69 @@ public sealed class DataBindingToolE2ETests : McpContractFixtureBase {
 	private const string RemoveRowToolName = RemoveDataBindingRowTool.RemoveDataBindingRowToolName;
 
 	[Test]
+	[Description("Creates localization-only columns over real MCP and verifies invalid localization input preserves existing artifacts and creates no partial new binding.")]
+	[AllureTag(CreateToolName)]
+	[AllureName("Local binding localization validation preserves files")]
+	[AllureDescription("Checks local-only SysSettings localization generation and failure preservation through the external MCP server.")]
+	public async Task CreateDataBinding_ShouldPreserveArtifacts_WhenLocalizationValidationFails() {
+		// Arrange
+		await using DataBindingArrangeContext context = await ArrangeWorkspaceAsync(requireEnvironment: false);
+		Dictionary<string, object?> args = new() {
+			["package-name"] = context.PackageName,
+			["schema-name"] = "SysSettings",
+			["workspace-path"] = context.WorkspacePath,
+			["values"] = """{"Code":"UsrLocalized"}""",
+			["localizations"] = """{"en-US":{"Name":"Localized name","Description":"Localized description"}}"""
+		};
+
+		// Act
+		CommandExecutionActResult created = await ActCommandAsync(context, CreateToolName, args);
+
+		// Assert
+		Allure.Net.Commons.AllureApi.Step("Verify successful localization-only generation", () => {
+			AssertToolCallSucceeded(created);
+			AssertCommandExitCode(created, 0, "localization-only columns must be accepted");
+			AssertIncludesInfoMessage(created, "successful creation must report progress");
+		});
+		string bindingPath = Path.Combine(context.WorkspacePath, "packages", context.PackageName, "Data", "SysSettings");
+		Allure.Net.Commons.AllureApi.Step("Verify culture content", () =>
+			File.ReadAllText(Path.Combine(bindingPath, "Localization", "data.en-US.json"))
+				.Should().Contain("Localized description", because: "Description must be generated without a duplicate base value"));
+
+		// Arrange
+		Dictionary<string, string> original = Directory.GetFiles(bindingPath, "*", SearchOption.AllDirectories)
+			.ToDictionary(path => path, File.ReadAllText);
+		args["values"] = """{"Code":"Changed"}""";
+		args["localizations"] = """{"en-US":{"Name":"Valid first culture"},"de-DE":{"Unknown":"Invalid"}}""";
+
+		// Act
+		CommandExecutionActResult failed = await ActCommandAsync(context, CreateToolName, args);
+
+		// Assert
+		Allure.Net.Commons.AllureApi.Step("Verify failure diagnostics", () => {
+			AssertCommandExitCode(failed, 1, "unknown localization columns must fail");
+			failed.Execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+				because: "validation failure must report an error");
+		});
+		Allure.Net.Commons.AllureApi.Step("Verify all existing content is unchanged", () =>
+			Directory.GetFiles(bindingPath, "*", SearchOption.AllDirectories).ToDictionary(path => path, File.ReadAllText)
+				.Should().BeEquivalentTo(original, because: "failed regeneration must preserve every binding artifact"));
+
+		// Arrange
+		args["binding-name"] = "InvalidNewBinding";
+
+		// Act
+		CommandExecutionActResult failedNew = await ActCommandAsync(context, CreateToolName, args);
+
+		// Assert
+		Allure.Net.Commons.AllureApi.Step("Verify invalid new binding leaves no folder", () => {
+			AssertCommandExitCode(failedNew, 1, "the same invalid localization must fail for a new binding");
+			Directory.Exists(Path.Combine(Path.GetDirectoryName(bindingPath)!, "InvalidNewBinding")).Should().BeFalse(
+				because: "validation must precede any new binding files");
+		});
+	}
+
+	[Test]
 	[Description("Creates a workspace and package with the real clio CLI, invokes create-data-binding through MCP for the built-in SysSettings template without a Creatio environment, and verifies the descriptor and data files are generated with an auto-created GUID primary key.")]
 	[AllureTag(CreateToolName)]
 	[AllureName("Create templated data binding offline auto-generates missing GUID primary key")]

--- a/clio.tests/Command/DataBindingCommandTests.cs
+++ b/clio.tests/Command/DataBindingCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
 using Clio.Command;
@@ -76,6 +77,76 @@ internal sealed class CreateDataBindingCommandTests : BaseCommandTests<CreateDat
 		containerBuilder.AddTransient(_ => _logger);
 		containerBuilder.AddTransient(_ => _workspacePathBuilder);
 		containerBuilder.AddTransient(_ => serviceUrlBuilder);
+	}
+
+	[Test]
+	[Description("Includes columns requested only by localizations without inventing base-row values, and shares the generated primary key across cultures.")]
+	public void Execute_ShouldIncludeLocalizationOnlyColumns_WhenValuesOmitThem() {
+		// Arrange
+		CreateDataBindingOptions options = new() {
+			PackageName = PackageName, SchemaName = BindingName,
+			ValuesJson = """{"Code":"UsrLocalizedSetting"}""",
+			LocalizationsJson = """{"en-US":{"Name":"Setting"},"de-DE":{"Description":"Beschreibung","name":"Einstellung"}}"""
+		};
+
+		// Act
+		int result = _command.Execute(options);
+
+		// Assert
+		result.Should().Be(0, because: "localization columns do not require duplicate base values");
+		string bindingPath = WorkspacePath("packages", PackageName, "Data", BindingName);
+		using JsonDocument descriptor = JsonDocument.Parse(FileSystem.File.ReadAllText(Path.Combine(bindingPath, "descriptor.json")));
+		JsonElement[] columns = descriptor.RootElement.GetProperty("Descriptor").GetProperty("Columns").EnumerateArray().ToArray();
+		columns.Select(column => column.GetProperty("ColumnName").GetString()).Should().BeEquivalentTo(
+			new[] { "Id", "Code", "Name", "Description" }, because: "the projection is the union of values and all cultures plus the key");
+		string keyUid = columns.Single(column => column.GetProperty("IsKey").GetBoolean()).GetProperty("ColumnUId").GetString()!;
+		using JsonDocument data = JsonDocument.Parse(FileSystem.File.ReadAllText(Path.Combine(bindingPath, "data.json")));
+		JsonElement[] baseRow = data.RootElement.GetProperty("PackageData")[0].GetProperty("Row").EnumerateArray().ToArray();
+		baseRow.Should().HaveCount(2, because: "localization-only columns must not introduce null or empty base values");
+		string key = baseRow.Single(value => value.GetProperty("SchemaColumnUId").GetString() == keyUid).GetProperty("Value").GetString()!;
+		foreach (string culture in new[] { "en-US", "de-DE" }) {
+			using JsonDocument localized = JsonDocument.Parse(FileSystem.File.ReadAllText(Path.Combine(bindingPath, "Localization", $"data.{culture}.json")));
+			localized.RootElement.GetProperty("PackageData")[0].GetProperty("Row")[0].GetProperty("Value").GetString()
+				.Should().Be(key, because: "each culture must reference the generated base-row identity");
+		}
+	}
+
+	[TestCase("{", "{}")]
+	[TestCase("{}", "{")]
+	[TestCase("{\"Unknown\":1}", "{}")]
+	[TestCase("{\"Code\":\"Changed\"}", "{\"en-US\":{\"Name\":\"Valid first culture\"},\"de-DE\":{\"Unknown\":\"Invalid\"}}")]
+	[TestCase("{\"Code\":\"Changed\"}", "{\"en-US\":{\"IsPersonal\":true}}")]
+	[Description("Rejects invalid values or localizations without creating a partial binding or modifying any existing binding files.")]
+	public void Execute_ShouldPreserveArtifacts_WhenInputValidationFails(string values, string localizations) {
+		// Arrange
+		CreateDataBindingOptions options = new() {
+			PackageName = PackageName, SchemaName = BindingName,
+			ValuesJson = values, LocalizationsJson = localizations
+		};
+		string bindingPath = WorkspacePath("packages", PackageName, "Data", BindingName);
+
+		// Act
+		int newResult = _command.Execute(options);
+
+		// Assert
+		newResult.Should().Be(1, because: "invalid input must be rejected");
+		FileSystem.Directory.Exists(bindingPath).Should().BeFalse(because: "validation must finish before creating the binding directory");
+
+		// Arrange
+		FileSystem.AddFile(Path.Combine(bindingPath, "descriptor.json"), new MockFileData("""{"Descriptor":{"UId":"dd30882b-d0c4-448c-a885-e19cd9d723de","Schema":{"Name":"SysSettings"}}}"""));
+		FileSystem.AddFile(Path.Combine(bindingPath, "data.json"), new MockFileData("original data"));
+		FileSystem.AddFile(Path.Combine(bindingPath, "filter.json"), new MockFileData("original filter"));
+		FileSystem.AddFile(Path.Combine(bindingPath, "Localization", "data.fr-FR.json"), new MockFileData("original localization"));
+		Dictionary<string, string> original = FileSystem.Directory.GetFiles(bindingPath, "*", SearchOption.AllDirectories)
+			.ToDictionary(path => path, path => FileSystem.File.ReadAllText(path));
+
+		// Act
+		int existingResult = _command.Execute(options);
+
+		// Assert
+		existingResult.Should().Be(1, because: "regeneration must reject the same invalid input");
+		FileSystem.Directory.GetFiles(bindingPath, "*", SearchOption.AllDirectories).ToDictionary(path => path, path => FileSystem.File.ReadAllText(path))
+			.Should().BeEquivalentTo(original, because: "failed regeneration must preserve every file and its exact content");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/DataBindingToolTests.cs
+++ b/clio.tests/Command/McpServer/DataBindingToolTests.cs
@@ -202,7 +202,8 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 			_packageName,
 			"SysSettings",
 			_workspaceRoot,
-			ValuesJson: """{"Name":"Tool row"}"""));
+			ValuesJson: """{"Code":"UsrToolRow"}""",
+			LocalizationsJson: """{"en-US":{"Name":"Tool row"}}"""));
 
 		// Assert
 		result.ExitCode.Should().Be(0,
@@ -210,6 +211,8 @@ public sealed class DataBindingToolTests : BaseClioModuleTests {
 		commandResolver.DidNotReceiveWithAnyArgs().Resolve<CreateDataBindingCommand>(default!);
 		_mockFileSystem.File.Exists(Path.Combine(_workspaceRoot, "packages", _packageName, "Data", "SysSettings", "data.json")).Should().BeTrue(
 			because: "the resolved create-data-binding command should create binding files in the requested workspace");
+		_mockFileSystem.File.ReadAllText(Path.Combine(_workspaceRoot, "packages", _packageName, "Data", "SysSettings", "Localization", "data.en-US.json"))
+			.Should().Contain("Tool row", because: "the MCP adapter must pass localization-only columns to the shared service");
 		string dataJson = _mockFileSystem.File.ReadAllText(Path.Combine(_workspaceRoot, "packages", _packageName, "Data", "SysSettings", "data.json"));
 		string? generatedId = null;
 		foreach (JsonElement rowValue in JsonDocument.Parse(dataJson).RootElement.GetProperty("PackageData")[0].GetProperty("Row").EnumerateArray()) {

--- a/clio/Command/DataBindingCommand.cs
+++ b/clio/Command/DataBindingCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -140,6 +140,7 @@ public class RemoveDataBindingRowCommand(IDataBindingService dataBindingService,
 public interface IDataBindingService {
 	/// <summary>
 	/// Creates or regenerates a binding folder from the requested schema.
+	/// Validates and serializes all content before modifying binding files; input validation failures preserve existing artifacts.
 	/// </summary>
 	void CreateBinding(CreateDataBindingOptions options);
 
@@ -235,17 +236,19 @@ internal sealed class DataBindingService(
 				$"Binding '{bindingName}' already exists for schema '{existingDescriptor.Descriptor.Schema.Name}'.");
 		}
 
-		fileSystem.CreateDirectoryIfNotExists(fileSystem.Combine(packagePath, DataFolderName));
-		fileSystem.CreateDirectoryIfNotExists(bindingDirectoryPath);
-
 		Dictionary<string, JsonNode?>? values = ParseColumnObject(options.ValuesJson, "values", required: false);
 		Dictionary<string, Dictionary<string, JsonNode?>>? localizations =
 			ParseLocalizations(options.LocalizationsJson);
 
+		HashSet<string>? selectedColumns = values?.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		if (selectedColumns is not null && localizations is not null) {
+			selectedColumns.UnionWith(localizations.Values.SelectMany(columns => columns.Keys));
+		}
+
 		bool isTemplate = values is null;
 		List<DataBindingColumnDefinition> descriptorColumns = BuildDescriptorColumns(
 			schema,
-			values?.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase),
+			selectedColumns,
 			includeAllColumns: isTemplate);
 		DataBindingDescriptorFile descriptor = BuildDescriptor(
 			existingDescriptor?.Descriptor.UId,
@@ -266,23 +269,24 @@ internal sealed class DataBindingService(
 				!string.IsNullOrWhiteSpace(options.Environment) || !string.IsNullOrWhiteSpace(options.Uri),
 				valueFileBasePath: workspaceRoot);
 
-		fileSystem.WriteAllTextToFile(fileSystem.Combine(bindingDirectoryPath, DescriptorFileName),
-			serializer.SerializeDescriptor(descriptor));
-		fileSystem.WriteAllTextToFile(fileSystem.Combine(bindingDirectoryPath, DataFileName),
-			serializer.SerializePackageData(dataFile));
+		string descriptorContent = serializer.SerializeDescriptor(descriptor);
+		string dataContent = serializer.SerializePackageData(dataFile);
+		Dictionary<string, string> localizationFiles = BuildLocalizationFiles(
+			schema, dataFile, localizations, createTemplateDefault: isTemplate,
+			descriptorColumns, valueFileBasePath: workspaceRoot);
+
+		fileSystem.CreateDirectoryIfNotExists(fileSystem.Combine(packagePath, DataFolderName));
+		fileSystem.CreateDirectoryIfNotExists(bindingDirectoryPath);
+		fileSystem.WriteAllTextToFile(fileSystem.Combine(bindingDirectoryPath, DescriptorFileName), descriptorContent);
+		fileSystem.WriteAllTextToFile(fileSystem.Combine(bindingDirectoryPath, DataFileName), dataContent);
 		fileSystem.WriteAllTextToFile(fileSystem.Combine(bindingDirectoryPath, FilterFileName), string.Empty);
 
 		string localizationDirectoryPath = fileSystem.Combine(bindingDirectoryPath, LocalizationFolderName);
 		fileSystem.DeleteDirectoryIfExists(localizationDirectoryPath);
 		fileSystem.CreateDirectoryIfNotExists(localizationDirectoryPath);
-		WriteLocalizationFiles(
-			localizationDirectoryPath,
-			schema,
-			dataFile,
-			localizations,
-			createTemplateDefault: isTemplate,
-			descriptorColumns,
-			valueFileBasePath: workspaceRoot);
+		foreach ((string fileName, string content) in localizationFiles) {
+			fileSystem.WriteAllTextToFile(fileSystem.Combine(localizationDirectoryPath, fileName), content);
+		}
 	}
 
 	public void AddOrUpdateRow(AddDataBindingRowOptions options) {
@@ -812,14 +816,14 @@ internal sealed class DataBindingService(
 			string.Equals(Convert.ToString(value, CultureInfo.InvariantCulture), "null", StringComparison.OrdinalIgnoreCase);
 	}
 
-	private void WriteLocalizationFiles(
-		string localizationDirectoryPath,
+	private Dictionary<string, string> BuildLocalizationFiles(
 		DataBindingSchema schema,
 		DataBindingPackageDataFile dataFile,
 		Dictionary<string, Dictionary<string, JsonNode?>>? localizations,
 		bool createTemplateDefault,
 		IReadOnlyCollection<DataBindingColumnDefinition> descriptorColumns,
 		string? valueFileBasePath = null) {
+		Dictionary<string, string> files = new(StringComparer.OrdinalIgnoreCase);
 		DataBindingRuntimeDescriptor descriptor =
 			DataBindingRuntimeDescriptor.FromSchema(schema, descriptorColumns, valueConverter);
 		DataBindingRow sourceRow = dataFile.PackageData.Single();
@@ -829,23 +833,20 @@ internal sealed class DataBindingService(
 
 		if (defaultTemplateRow is not null) {
 			DataBindingPackageDataFile defaultFile = new() { PackageData = [defaultTemplateRow] };
-			fileSystem.WriteAllTextToFile(
-				fileSystem.Combine(localizationDirectoryPath, "data.en-US.json"),
-				serializer.SerializePackageData(defaultFile));
+			files["data.en-US.json"] = serializer.SerializePackageData(defaultFile);
 		}
 
 		if (localizations is null) {
-			return;
+			return files;
 		}
 
 		string primaryKey = GetPrimaryKey(sourceRow, descriptor);
 		foreach ((string culture, Dictionary<string, JsonNode?> cultureValues) in localizations) {
 			DataBindingRow localizedRow = BuildLocalizationRow(descriptor, primaryKey, cultureValues, valueFileBasePath);
 			DataBindingPackageDataFile localizedFile = new() { PackageData = [localizedRow] };
-			fileSystem.WriteAllTextToFile(
-				fileSystem.Combine(localizationDirectoryPath, $"data.{culture}.json"),
-				serializer.SerializePackageData(localizedFile));
+			files[$"data.{culture}.json"] = serializer.SerializePackageData(localizedFile);
 		}
+		return files;
 	}
 
 	private void UpdateLocalizationFilesForRow(

--- a/clio/Command/McpServer/Tools/DataBindingTool.cs
+++ b/clio/Command/McpServer/Tools/DataBindingTool.cs
@@ -186,7 +186,7 @@ public sealed record CreateDataBindingArgs(
 	string? ValuesJson = null,
 
 	[property: JsonPropertyName("localizations")]
-	[property: Description("Optional JSON object keyed by culture then column name")]
+	[property: Description("Optional JSON object keyed by culture then column name. Columns may appear only here; they are included in the descriptor without inventing base values. Input validation failures preserve existing binding files.")]
 	string? LocalizationsJson = null
 );
 

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -4547,7 +4547,7 @@ internal static class ToolContractCatalog {
 						Field(BindingNameFieldName, StringType, "Optional binding name; defaults to the schema name."),
 						Field("install-type", NumberType, "Optional descriptor install type; defaults to 0."),
 						Field(ValuesFieldName, StringType, "Optional JSON object keyed by column name for the initial row."),
-						Field("localizations", StringType, "Optional JSON object keyed by culture then column name.")
+						Field("localizations", StringType, "Optional JSON object keyed by culture then column name. Localization-only columns are included in the descriptor without inventing base values. Input validation failures preserve existing binding files.")
 					],
 					Validators: [
 						new ToolContractValidator(

--- a/clio/docs/commands/create-data-binding.md
+++ b/clio/docs/commands/create-data-binding.md
@@ -93,6 +93,8 @@ clio create-data-binding -e dev --package Custom --schema UsrLookupBinding --val
 - For the templated schema SysSettings, --environment and --uri are optional
 - For non-templated schemas, the command requires either --environment or --uri
 - Unknown columns in --values or --localizations are rejected
+- Columns supplied only in --localizations are included in the descriptor; no base-row value is invented
+- Input validation finishes before any files change; failed validation creates no partial binding and preserves existing artifacts
 - If the primary key column is a Guid and is omitted or null in --values, create-data-binding generates it automatically
 - For lookup and image-reference columns, clio writes SchemaColumnUId, Value, and DisplayValue in data.json
 - For create-data-binding, lookup and image-reference values may use {"value":"...","displayValue":"..."}; if displayValue is omitted and Creatio runtime lookup data is available, clio resolves it automatically

--- a/clio/help/en/create-data-binding.txt
+++ b/clio/help/en/create-data-binding.txt
@@ -78,6 +78,8 @@ NOTES
     - For the templated schema SysSettings, --environment and --uri are optional
     - For non-templated schemas, the command requires either --environment or --uri
     - Unknown columns in --values or --localizations are rejected
+    - Columns supplied only in --localizations are included in the descriptor; no base-row value is invented
+    - Input validation finishes before any files change; failed validation creates no partial binding and preserves existing artifacts
     - If the primary key column is a Guid and is omitted or null in --values, create-data-binding generates it automatically
     - For lookup and image-reference columns, clio writes SchemaColumnUId, Value, and DisplayValue in data.json
     - For create-data-binding, lookup and image-reference values may use {"value":"...","displayValue":"..."}; if displayValue is omitted and Creatio runtime lookup data is available, clio resolves it automatically

--- a/docs/knowledge/Command/a-shipped-binding-column-set-cannot-be-repaired-by-reinstalling.md
+++ b/docs/knowledge/Command/a-shipped-binding-column-set-cannot-be-repaired-by-reinstalling.md
@@ -9,7 +9,9 @@ date: 2026-08-19
 ---
 
 **What is true** — `clio/help/en/read-data-binding-db.txt` already states the projection rule: a
-binding ships only the columns it was created with and install supplies no default for the rest. What
+binding ships only the columns it was created with and install supplies no default for the rest.
+For local creation, that includes columns requested only through localizations; this does not invent
+a base-row value or change the installer rules below. What
 it does not say is that the mistake is one-way. Every non-key column is written with
 `"IsForceUpdate": false` (spec/data-binding/data-binding.md:75, "Always use false"), and installing a
 package whose version has not changed applies no data rows at all. Correcting the binding and


### PR DESCRIPTION
Fixes #1187.

`create-data-binding` now includes columns supplied only through localizations, so SysSettings Name and Description no longer need duplicate base-row values. It builds and serializes all requested content before changing files. Invalid JSON, unknown columns, and incompatible localization types leave no partial new binding and preserve every existing artifact during failed regeneration.

Validation:
- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit&(Module=Command|Module=McpServer)"` — 9,507 passed, 15 skipped, 0 failed.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release -f net10.0 --no-build --filter "FullyQualifiedName~DataBindingToolE2ETests"` — 4 passed, 0 skipped. Real external MCP process, local workspace side effects; no remote writes or package-install claim.
- Comprehensive parallel review: quality/testing, security, correctness/performance, independent intent and KISS lenses; no actionable findings. Final Claude review rev_7b9e8262b56e4376 found no material findings. Final comprehensive gate confirmed the complete committed diff.

CLI help and detailed documentation updated. Command index, aliases, templates, and add/remove documentation reviewed; no update required. MCP argument and full-contract descriptions updated, adapter unit test and real MCP regression coverage added. Existing data-bindings guidance and routing reviewed; no downstream guidance change required.

ClioRing compatibility reviewed, no Ring-consumed contract changed. Inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`; none invokes the local data-binding commands.

The preservation guarantee covers input/content validation before writes. Existing filesystem-failure behavior is unchanged; this does not add a filesystem transaction. KISS: project the requested column union, prepare content, then write it using existing primitives.


Merged current master and preserved its optional trailing MCP environment argument. Both conflict resolutions received a single combined incremental review; no findings. Module and real MCP tests rerun successfully after integration.

