### PR TITLE
fix: clarify workspace roots for local data bindings

### DIFF
--- a/clio.mcp.e2e/DataBindingToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingToolE2ETests.cs
@@ -203,6 +203,49 @@ public sealed class DataBindingToolE2ETests : McpContractFixtureBase {
 			because: "the failure should explain why offline generation is unavailable for the requested schema");
 	}
 
+	[TestCase(CreateToolName)]
+	[TestCase(AddRowToolName)]
+	[TestCase(RemoveRowToolName)]
+	[Description("Rejects a package directory passed as workspace-path through the real MCP process, with actionable diagnostics and no binding output.")]
+	[AllureTag(CreateToolName, AddRowToolName, RemoveRowToolName)]
+	[AllureName("Local binding commands require the workspace root")]
+	[AllureDescription("Passes a real local package directory to each binding tool and verifies the missing root marker diagnostic, error log, failure exit code, and absence of output.")]
+	public async Task DataBinding_ShouldExplainWorkspaceRoot_WhenPackageDirectoryIsSupplied(string toolName) {
+		// Arrange
+		await using DataBindingArrangeContext context = await ArrangeWorkspaceAsync(requireEnvironment: false);
+		string packagePath = Path.Combine(context.WorkspacePath, "packages", context.PackageName);
+		Dictionary<string, object?> args = new() {
+			["package-name"] = context.PackageName,
+			["workspace-path"] = packagePath
+		};
+		if (toolName == CreateToolName) {
+			args["schema-name"] = "SysSettings";
+		} else {
+			args["binding-name"] = "SysSettings";
+			args[toolName == AddRowToolName ? "values" : "key-value"] =
+				toolName == AddRowToolName ? "{}" : Guid.NewGuid().ToString();
+		}
+
+		// Act
+		CommandExecutionActResult result = await ActCommandAsync(context, toolName, args);
+
+		// Assert
+		Allure.Net.Commons.AllureApi.Step("Verify failure envelope and root guidance", () => {
+			result.CallResult.IsError.Should().NotBeTrue(because: "path validation returns a command execution envelope");
+			AssertCommandExitCode(result, 1, "a package directory does not contain the workspace marker");
+			result.Execution.Output.Should().Contain(message => message.MessageType == LogDecoratorType.Error,
+				because: "invalid workspace input must emit an Error diagnostic");
+			DescribeExecution(result.Execution).Should()
+				.Contain(Path.Combine(packagePath, ".clio", "workspaceSettings.json"), because: "the diagnostic identifies the missing marker")
+				.And.Contain("not the package directory", because: "the correction must name the expected root")
+				.And.Contain("packages/<package-name>", because: "the package resolution rule must be explicit");
+		});
+		Allure.Net.Commons.AllureApi.Step("Verify no binding artifacts were written", () => {
+			Directory.Exists(Path.Combine(packagePath, "Data", "SysSettings")).Should().BeFalse(
+				because: "invalid workspace input must be rejected before local binding writes");
+		});
+	}
+
 	private async Task<DataBindingArrangeContext> ArrangeWorkspaceAsync(bool requireEnvironment = true) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();

--- a/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
+++ b/clio.mcp.e2e/ToolContractGetToolE2ETests.cs
@@ -678,6 +678,14 @@ public sealed class ToolContractGetToolE2ETests : McpContractFixtureBase {
 			},
 			because: "the response should preserve the requested local binding tool order");
 
+		foreach (ToolContractDefinition contract in response.Tools) {
+			contract.InputSchema.Properties.Single(field => field.Name == "workspace-path").Description.Should()
+				.Contain(".clio/workspaceSettings.json", because: "the MCP contract must identify the workspace root")
+				.And.Contain("packages/<package-name>", because: "the contract must explain package resolution");
+			contract.Examples.Should().OnlyContain(example => example.Arguments["workspace-path"]!.ToString() == "<workspace-root>",
+				because: "serialized local binding examples must not suggest a package directory");
+		}
+
 		ToolContractDefinition createContract = response.Tools.Single(tool => tool.Name == CreateDataBindingTool.CreateDataBindingToolName);
 		createContract.InputSchema.Properties.Should().Contain(field =>
 				field.Name == "environment-name" &&

--- a/clio.tests/Command/DataBindingCommandTests.cs
+++ b/clio.tests/Command/DataBindingCommandTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text.Json;
 using Clio.Command;
@@ -76,6 +77,30 @@ internal sealed class CreateDataBindingCommandTests : BaseCommandTests<CreateDat
 		containerBuilder.AddTransient(_ => _logger);
 		containerBuilder.AddTransient(_ => _workspacePathBuilder);
 		containerBuilder.AddTransient(_ => serviceUrlBuilder);
+	}
+
+	[Test]
+	[Description("Rejects an explicitly supplied package directory with the missing workspace marker and root-path guidance before writing binding files.")]
+	public void Execute_ShouldExplainWorkspaceRoot_WhenPackageDirectoryIsSupplied() {
+		// Arrange
+		CreateDataBindingOptions options = new() {
+			PackageName = PackageName,
+			SchemaName = "SysSettings",
+			WorkspacePath = WorkspacePath("packages", PackageName)
+		};
+
+		// Act
+		int result = _command.Execute(options);
+
+		// Assert
+		result.Should().Be(1, because: "the package directory is not a workspace root");
+		_logger.ReceivedCalls().Where(call => call.GetMethodInfo().Name == nameof(ILogger.WriteError))
+			.Select(call => call.GetArguments()[0]?.ToString()).Should().Contain(message =>
+				message != null && message.Contains(WorkspacePath("packages", PackageName, ".clio", "workspaceSettings.json"))
+				&& message.Contains("not the package directory") && message.Contains("packages/<package-name>"),
+				because: "the diagnostic must identify the missing marker and explain the correct argument");
+		FileSystem.Directory.Exists(WorkspacePath("packages", PackageName, "Data")).Should().BeFalse(
+			because: "invalid workspace input must fail before any binding output is created");
 	}
 
 	[Test]

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +21,29 @@ namespace Clio.Tests.Command.McpServer;
 [Property("Module", "McpServer")]
 public sealed class ToolContractGetToolTests {
 	private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+	[Test]
+	[Category("Unit")]
+	[TestCase(CreateDataBindingTool.CreateDataBindingToolName)]
+	[TestCase(AddDataBindingRowTool.AddDataBindingRowToolName)]
+	[TestCase(RemoveDataBindingRowTool.RemoveDataBindingRowToolName)]
+	[Description("Local binding contracts consistently describe and illustrate the workspace root rather than a package directory.")]
+	public void GetToolContracts_ShouldIdentifyWorkspaceRoot_WhenLocalBindingIsRequested(string toolName) {
+		// Arrange
+		ToolContractGetTool tool = BuildToolWithRegistry();
+
+		// Act
+		ToolContractDefinition contract = tool.GetToolContracts(new ToolContractGetArgs([toolName])).Tools!.Single();
+
+		// Assert
+		contract.InputSchema.Properties.Single(field => field.Name == "workspace-path").Description.Should()
+			.Contain(".clio/workspaceSettings.json", because: "callers need the marker that identifies the root")
+			.And.Contain("packages/<package-name>", because: "the package path is resolved beneath the root")
+			.And.Contain("not the package directory", because: "the reported ambiguity must be removed");
+		contract.Examples.Should().NotBeEmpty(because: "binding callers need a working example");
+		contract.Examples.Should().OnlyContain(example => Equals(example.Arguments["workspace-path"], "<workspace-root>"),
+			because: "every local binding example must use the same unambiguous root placeholder");
+	}
 
 	[Test]
 	[Category("Unit")]
@@ -1871,7 +1894,7 @@ public sealed class ToolContractGetToolTests {
 			because: "create-data-binding should advertise that runtime schemas require environment-name on the MCP surface");
 		createContract.InputSchema.Properties.Should().Contain(field =>
 				field.Name == "workspace-path" &&
-				field.Description.Contains("Absolute local workspace path", StringComparison.Ordinal),
+				field.Description.Contains("Absolute local workspace root containing .clio/workspaceSettings.json", StringComparison.Ordinal),
 			because: "create-data-binding should canonically describe the local workspace requirement");
 		createContract.InputSchema.Validators.Should().Contain(validator =>
 				validator.Name == "require-environment-name-for-runtime-schema"

--- a/clio/Command/DataBindingCommand.cs
+++ b/clio/Command/DataBindingCommand.cs
@@ -37,7 +37,8 @@ public class CreateDataBindingOptions : EnvironmentOptions {
 	[Option("localizations", Required = false, HelpText = "Localized values as JSON object keyed by culture and column name")]
 	public string? LocalizationsJson { get; set; }
 
-	[Option("workspace-path", Required = false, HelpText = "Workspace root path. Defaults to the current workspace")]
+	/// <summary>Gets or sets the workspace root containing the .clio/workspaceSettings.json marker.</summary>
+	[Option("workspace-path", Required = false, HelpText = "Workspace root containing .clio/workspaceSettings.json, not the package directory. Defaults to the current workspace")]
 	public string? WorkspacePath { get; set; }
 }
 
@@ -58,7 +59,8 @@ public class AddDataBindingRowOptions {
 	[Option("localizations", Required = false, HelpText = "Localized values as JSON object keyed by culture and column name")]
 	public string? LocalizationsJson { get; set; }
 
-	[Option("workspace-path", Required = false, HelpText = "Workspace root path. Defaults to the current workspace")]
+	/// <summary>Gets or sets the workspace root containing the .clio/workspaceSettings.json marker.</summary>
+	[Option("workspace-path", Required = false, HelpText = "Workspace root containing .clio/workspaceSettings.json, not the package directory. Defaults to the current workspace")]
 	public string? WorkspacePath { get; set; }
 }
 
@@ -76,7 +78,8 @@ public class RemoveDataBindingRowOptions {
 	[Option("key-value", Required = true, HelpText = "Primary-key value of the row to delete")]
 	public string KeyValue { get; set; } = string.Empty;
 
-	[Option("workspace-path", Required = false, HelpText = "Workspace root path. Defaults to the current workspace")]
+	/// <summary>Gets or sets the workspace root containing the .clio/workspaceSettings.json marker.</summary>
+	[Option("workspace-path", Required = false, HelpText = "Workspace root containing .clio/workspaceSettings.json, not the package directory. Defaults to the current workspace")]
 	public string? WorkspacePath { get; set; }
 }
 
@@ -398,7 +401,9 @@ internal sealed class DataBindingService(
 		string workspaceSettingsPath = fileSystem.Combine(rootPath, ".clio", "workspaceSettings.json");
 		if (!fileSystem.ExistsFile(workspaceSettingsPath)) {
 			throw new InvalidOperationException(
-				$"Workspace root was not detected at '{rootPath}'. Run the command from a workspace or supply --workspace-path.");
+				$"Workspace root was not detected at '{rootPath}': missing '{workspaceSettingsPath}'. " +
+				"Supply --workspace-path with the workspace root containing .clio/workspaceSettings.json, not the package directory. " +
+				"The package is resolved under packages/<package-name> beneath that root.");
 		}
 
 		return rootPath;

--- a/clio/Command/McpServer/Prompts/DataBindingPrompt.cs
+++ b/clio/Command/McpServer/Prompts/DataBindingPrompt.cs
@@ -17,7 +17,7 @@ public static class DataBindingPrompt {
 	public static string CreateDataBinding(
 		[Required] [Description("Target package name")] string packageName,
 		[Required] [Description("Entity schema name")] string schemaName,
-		[Required] [Description("Absolute workspace path")] string workspacePath,
+		[Required] [Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory")] string workspacePath,
 		[Description("Optional binding folder name")] string? bindingName = null,
 		[Description("Optional descriptor install type")] int installType = 0,
 		[Description("Optional values JSON")] string? values = null,
@@ -28,6 +28,7 @@ public static class DataBindingPrompt {
 		 for schema `{schemaName}` in package `{packageName}`.
 		 For canonical workflow selection, call `{GuidanceGetTool.ToolName}` with `name` set to `data-bindings`
 		 before choosing this local artifact path.
+		 The workspace root must contain `.clio/workspaceSettings.json`; the package is resolved under `packages/{packageName}` beneath it.
 		 Pass `workspace-path` `{workspacePath}` exactly as provided.
 		 If `{schemaName}` is covered by the built-in offline template `SysSettings`, omit `environment-name`.
 		 Otherwise pass `environment-name` `{environmentName ?? "<required for non-templated schema>"}` exactly as provided.
@@ -48,7 +49,7 @@ public static class DataBindingPrompt {
 	public static string AddDataBindingRow(
 		[Required] [Description("Target package name")] string packageName,
 		[Required] [Description("Binding folder name")] string bindingName,
-		[Required] [Description("Absolute workspace path")] string workspacePath,
+		[Required] [Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory")] string workspacePath,
 		[Required] [Description("Row values JSON")] string values,
 		[Description("Optional localizations JSON")] string? localizations = null) =>
 		$"""
@@ -56,6 +57,7 @@ public static class DataBindingPrompt {
 		 `{bindingName}` under package `{packageName}`.
 		 For canonical workflow selection and verification discipline, call `{GuidanceGetTool.ToolName}` with `name`
 		 set to `data-bindings` when the overall binding path is not already fixed.
+		 The workspace root must contain `.clio/workspaceSettings.json`; the package is resolved under `packages/{packageName}` beneath it.
 		 Pass `workspace-path` `{workspacePath}` exactly as provided and use `values` `{values}`.
 		 If that payload omits the GUID primary key column or sets it to null, the tool generates it automatically.
 		 For non-null lookup and image-reference columns, `values` should use an object like
@@ -72,13 +74,14 @@ public static class DataBindingPrompt {
 	public static string RemoveDataBindingRow(
 		[Required] [Description("Target package name")] string packageName,
 		[Required] [Description("Binding folder name")] string bindingName,
-		[Required] [Description("Absolute workspace path")] string workspacePath,
+		[Required] [Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory")] string workspacePath,
 		[Required] [Description("Primary-key value")] string keyValue) =>
 		$"""
 		 Use clio mcp server `{RemoveDataBindingRowTool.RemoveDataBindingRowToolName}` to remove the row with primary key
 		 `{keyValue}` from binding `{bindingName}` under package `{packageName}`.
 		 For canonical workflow selection and verification discipline, call `{GuidanceGetTool.ToolName}` with `name`
 		 set to `data-bindings` when the overall binding path is not already fixed.
+		 The workspace root must contain `.clio/workspaceSettings.json`; the package is resolved under `packages/{packageName}` beneath it.
 		 Pass `workspace-path` `{workspacePath}` exactly as provided.
 		 """;
 }

--- a/clio/Command/McpServer/Tools/DataBindingTool.cs
+++ b/clio/Command/McpServer/Tools/DataBindingTool.cs
@@ -169,7 +169,7 @@ public sealed record CreateDataBindingArgs(
 	string SchemaName,
 
 	[property: JsonPropertyName("workspace-path")]
-	[property: Description("Absolute path to the local workspace")]
+	[property: Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory. The package is resolved under packages/<package-name> beneath that root.")]
 	[property: Required]
 	string WorkspacePath,
 
@@ -205,7 +205,7 @@ public sealed record AddDataBindingRowArgs(
 	string BindingName,
 
 	[property: JsonPropertyName("workspace-path")]
-	[property: Description("Absolute path to the local workspace")]
+	[property: Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory. The package is resolved under packages/<package-name> beneath that root.")]
 	[property: Required]
 	string WorkspacePath,
 
@@ -234,7 +234,7 @@ public sealed record RemoveDataBindingRowArgs(
 	string BindingName,
 
 	[property: JsonPropertyName("workspace-path")]
-	[property: Description("Absolute path to the local workspace")]
+	[property: Description("Absolute workspace root containing .clio/workspaceSettings.json, not the package directory. The package is resolved under packages/<package-name> beneath that root.")]
 	[property: Required]
 	string WorkspacePath,
 

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -654,7 +654,7 @@ internal static class ToolContractCatalog {
 	private const string EventNameFieldName = "event_name";
 	private const string TelemetryConsentFieldName = "telemetry_consent";
 	private const string ExampleOrderPageSchemaName = "UsrOrder_FormPage";
-	private const string ExampleWorkspacePath = "<workspace>/UsrTaskApp";
+	private const string ExampleWorkspacePath = "<workspace-root>";
 	private const string MakeReadOnlyActionTypeName = "make-read-only";
 	private const string MakeRequiredActionTypeName = "make-required";
 	private const string RuleNamesFieldName = "rule-names";
@@ -671,6 +671,7 @@ internal static class ToolContractCatalog {
 	private const string VerifyFieldName = "verify";
 	private const string BindingNameDescription = "Binding name.";
 	private const string WorkspacePathDescription = "Absolute local workspace path. Network-share paths are not supported.";
+	private const string DataBindingWorkspacePathDescription = "Absolute local workspace root containing .clio/workspaceSettings.json, not the package directory. The package is resolved under packages/<package-name> beneath that root. Network-share paths are not supported.";
 	private const string WorkspacePathFieldName = "workspace-path";
 	private const string DataForgePlatformRequirementDescription =
 		"Requires Creatio platform version 10.0.0 or later; CrtDataForge is included in supported platform versions.";
@@ -4543,7 +4544,7 @@ internal static class ToolContractCatalog {
 					Field(EnvironmentNameFieldName, StringType, "Registered clio environment name. Required when schema-name is not SysSettings because the MCP tool does not expose a uri fallback."),
 						Field(PackageNameFieldName, StringType, PackageNameDescription),
 						Field(SchemaNameFieldName, StringType, "Entity schema name for the binding. The built-in offline template currently includes SysSettings."),
-						Field(WorkspacePathFieldName, StringType, WorkspacePathDescription),
+						Field(WorkspacePathFieldName, StringType, DataBindingWorkspacePathDescription),
 						Field(BindingNameFieldName, StringType, "Optional binding name; defaults to the schema name."),
 						Field("install-type", NumberType, "Optional descriptor install type; defaults to 0."),
 						Field(ValuesFieldName, StringType, "Optional JSON object keyed by column name for the initial row."),
@@ -4617,7 +4618,7 @@ internal static class ToolContractCatalog {
 					[
 						Field(PackageNameFieldName, StringType, PackageNameDescription),
 						Field(BindingNameFieldName, StringType, BindingNameDescription),
-						Field(WorkspacePathFieldName, StringType, WorkspacePathDescription),
+						Field(WorkspacePathFieldName, StringType, DataBindingWorkspacePathDescription),
 						Field(ValuesFieldName, StringType, "JSON object keyed by column name for the row to add or replace."),
 						Field("localizations", StringType, "Optional JSON object keyed by culture then column name.")
 					]),
@@ -4656,7 +4657,7 @@ internal static class ToolContractCatalog {
 				[
 						Field(PackageNameFieldName, StringType, PackageNameDescription),
 						Field(BindingNameFieldName, StringType, BindingNameDescription),
-						Field(WorkspacePathFieldName, StringType, WorkspacePathDescription),
+						Field(WorkspacePathFieldName, StringType, DataBindingWorkspacePathDescription),
 						Field(KeyValueFieldName, StringType, "Primary-key value of the row to remove.")
 					]),
 			CommandExecutionOutput(),

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -242,7 +242,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 ## Workspace
 
 <a id="add-data-binding-row"></a>
-- [`add-data-binding-row`](docs/commands/add-data-binding-row.md) - Add or replace a row in a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
+- [`add-data-binding-row`](docs/commands/add-data-binding-row.md) - Add or replace a row in a package data binding
 <a id="build-workspace"></a>
 <a id="build"></a>
 <a id="compile"></a>
@@ -254,7 +254,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="configure-workspace"></a>
 - [`cfg-worspace`](docs/commands/cfg-worspace.md) - Configure workspace package selection, `cfgw`
 <a id="create-data-binding"></a>
-- [`create-data-binding`](docs/commands/create-data-binding.md) - Create or regenerate a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
+- [`create-data-binding`](docs/commands/create-data-binding.md) - Create or regenerate a package data binding
 <a id="create-data-binding-db"></a>
 - [`create-data-binding-db`](docs/commands/create-data-binding-db.md) - Create a DB-first package data binding by saving data directly to the remote Creatio database
 <a id="create-workspace"></a>
@@ -294,7 +294,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="pushw"></a>
 - [`push-workspace`](docs/commands/push-workspace.md) - Push workspace to selected environment, `pushw`
 <a id="remove-data-binding-row"></a>
-- [`remove-data-binding-row`](docs/commands/remove-data-binding-row.md) - Remove a row from a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
+- [`remove-data-binding-row`](docs/commands/remove-data-binding-row.md) - Remove a row from a package data binding
 <a id="remove-data-binding-row-db"></a>
 - [`remove-data-binding-row-db`](docs/commands/remove-data-binding-row-db.md) - Remove a row from a DB-first package data binding
 <a id="restore-workspace"></a>

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -242,7 +242,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 ## Workspace
 
 <a id="add-data-binding-row"></a>
-- [`add-data-binding-row`](docs/commands/add-data-binding-row.md) - Add or replace a row in a package data binding
+- [`add-data-binding-row`](docs/commands/add-data-binding-row.md) - Add or replace a row in a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
 <a id="build-workspace"></a>
 <a id="build"></a>
 <a id="compile"></a>
@@ -254,7 +254,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="configure-workspace"></a>
 - [`cfg-worspace`](docs/commands/cfg-worspace.md) - Configure workspace package selection, `cfgw`
 <a id="create-data-binding"></a>
-- [`create-data-binding`](docs/commands/create-data-binding.md) - Create or regenerate a package data binding
+- [`create-data-binding`](docs/commands/create-data-binding.md) - Create or regenerate a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
 <a id="create-data-binding-db"></a>
 - [`create-data-binding-db`](docs/commands/create-data-binding-db.md) - Create a DB-first package data binding by saving data directly to the remote Creatio database
 <a id="create-workspace"></a>
@@ -294,7 +294,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="pushw"></a>
 - [`push-workspace`](docs/commands/push-workspace.md) - Push workspace to selected environment, `pushw`
 <a id="remove-data-binding-row"></a>
-- [`remove-data-binding-row`](docs/commands/remove-data-binding-row.md) - Remove a row from a package data binding
+- [`remove-data-binding-row`](docs/commands/remove-data-binding-row.md) - Remove a row from a package data binding. Pass the workspace root containing `.clio/workspaceSettings.json`, not the package directory.
 <a id="remove-data-binding-row-db"></a>
 - [`remove-data-binding-row-db`](docs/commands/remove-data-binding-row-db.md) - Remove a row from a DB-first package data binding
 <a id="restore-workspace"></a>

--- a/clio/docs/commands/add-data-binding-row.md
+++ b/clio/docs/commands/add-data-binding-row.md
@@ -60,6 +60,8 @@ clio add-data-binding-row --package Custom --binding-name UsrLookupBinding --val
 
 ## Notes
 
+- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
+
 - The binding must already exist locally
 - The row key is the primary column marked in descriptor.json
 - If that primary key is Guid-based and omitted or null in --values, add-data-binding-row generates it automatically

--- a/clio/docs/commands/add-data-binding-row.md
+++ b/clio/docs/commands/add-data-binding-row.md
@@ -31,7 +31,8 @@ built-in offline templates.
 ```bash
 --package              Target package name
 --binding-name         Binding folder name under package Data
---workspace-path       Workspace root path. Defaults to the current workspace
+--workspace-path       Workspace root containing .clio/workspaceSettings.json,
+not the package directory. Defaults to the current workspace
 --values               JSON object keyed by column name for the row payload.
 If the GUID primary key column is omitted or null,
 it is generated automatically. For image-content
@@ -60,8 +61,8 @@ clio add-data-binding-row --package Custom --binding-name UsrLookupBinding --val
 
 ## Notes
 
-- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
-
+- --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+not the package directory. Clio resolves packages/{package-name} beneath that root.
 - The binding must already exist locally
 - The row key is the primary column marked in descriptor.json
 - If that primary key is Guid-based and omitted or null in --values, add-data-binding-row generates it automatically

--- a/clio/docs/commands/create-data-binding.md
+++ b/clio/docs/commands/create-data-binding.md
@@ -89,6 +89,8 @@ clio create-data-binding -e dev --package Custom --schema UsrLookupBinding --val
 
 ## Notes
 
+- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
+
 - This command writes LOCAL workspace artifact files (descriptor.json, data.json) under packages/<package>/Data/<binding-name>; it does not persist data to a remote Creatio database. To persist row data directly to the remote database instead, use create-data-binding-db
 - For the templated schema SysSettings, --environment and --uri are optional
 - For non-templated schemas, the command requires either --environment or --uri

--- a/clio/docs/commands/create-data-binding.md
+++ b/clio/docs/commands/create-data-binding.md
@@ -44,7 +44,8 @@ schema columns and empty placeholder values.
 ```bash
 --package              Target package name
 --schema               Entity schema name used to fetch template or runtime metadata
---workspace-path       Workspace root path. Defaults to the current workspace
+--workspace-path       Workspace root containing .clio/workspaceSettings.json,
+not the package directory. Defaults to the current workspace
 --binding-name         Binding folder name. Defaults to <schema>
 --install-type         Descriptor install type. Allowed values: 0, 1, 2, 3.
 Default: 0
@@ -89,8 +90,8 @@ clio create-data-binding -e dev --package Custom --schema UsrLookupBinding --val
 
 ## Notes
 
-- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
-
+- --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+not the package directory. Clio resolves packages/{package-name} beneath that root.
 - This command writes LOCAL workspace artifact files (descriptor.json, data.json) under packages/<package>/Data/<binding-name>; it does not persist data to a remote Creatio database. To persist row data directly to the remote database instead, use create-data-binding-db
 - For the templated schema SysSettings, --environment and --uri are optional
 - For non-templated schemas, the command requires either --environment or --uri

--- a/clio/docs/commands/remove-data-binding-row.md
+++ b/clio/docs/commands/remove-data-binding-row.md
@@ -43,6 +43,8 @@ clio remove-data-binding-row --package Custom --binding-name SysSettings --works
 
 ## Notes
 
+- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
+
 - The binding must already exist locally
 - The command fails if the supplied key does not exist
 - Localization rows that share the same primary key are removed together

--- a/clio/docs/commands/remove-data-binding-row.md
+++ b/clio/docs/commands/remove-data-binding-row.md
@@ -27,7 +27,8 @@ including bindings that were created from built-in offline templates.
 ```bash
 --package              Target package name
 --binding-name         Binding folder name under package Data
---workspace-path       Workspace root path. Defaults to the current workspace
+--workspace-path       Workspace root containing .clio/workspaceSettings.json,
+not the package directory. Defaults to the current workspace
 --key-value            Primary-key value of the row to remove
 ```
 
@@ -43,8 +44,8 @@ clio remove-data-binding-row --package Custom --binding-name SysSettings --works
 
 ## Notes
 
-- `--workspace-path` is the workspace root containing `.clio/workspaceSettings.json`, not the package directory. Clio resolves `packages/<package-name>` beneath that root.
-
+- --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+not the package directory. Clio resolves packages/{package-name} beneath that root.
 - The binding must already exist locally
 - The command fails if the supplied key does not exist
 - Localization rows that share the same primary key are removed together

--- a/clio/help/en/add-data-binding-row.txt
+++ b/clio/help/en/add-data-binding-row.txt
@@ -21,7 +21,8 @@ DESCRIPTION
 OPTIONS
     --package              Target package name
     --binding-name         Binding folder name under package Data
-    --workspace-path       Workspace root path. Defaults to the current workspace
+    --workspace-path       Workspace root containing .clio/workspaceSettings.json,
+                           not the package directory. Defaults to the current workspace
     --values               JSON object keyed by column name for the row payload.
                            If the GUID primary key column is omitted or null,
                            it is generated automatically. For image-content
@@ -46,7 +47,7 @@ EXAMPLES
 
 NOTES
     - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
-      not the package directory. Clio resolves packages/<package-name> beneath that root.
+      not the package directory. Clio resolves packages/{package-name} beneath that root.
     - The binding must already exist locally
     - The row key is the primary column marked in descriptor.json
     - If that primary key is Guid-based and omitted or null in --values, add-data-binding-row generates it automatically

--- a/clio/help/en/add-data-binding-row.txt
+++ b/clio/help/en/add-data-binding-row.txt
@@ -45,6 +45,8 @@ EXAMPLES
     clio add-data-binding-row --package Custom --binding-name UsrLookupBinding --values "{\"Code\":\"UsrLookupBinding\",\"UsrStatus\":{\"value\":\"b659d704-3955-e011-981f-00155d043204\",\"displayValue\":\"In Progress\"}}"
 
 NOTES
+    - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+      not the package directory. Clio resolves packages/<package-name> beneath that root.
     - The binding must already exist locally
     - The row key is the primary column marked in descriptor.json
     - If that primary key is Guid-based and omitted or null in --values, add-data-binding-row generates it automatically

--- a/clio/help/en/create-data-binding.txt
+++ b/clio/help/en/create-data-binding.txt
@@ -74,6 +74,8 @@ EXAMPLES
     clio create-data-binding -e dev --package Custom --schema UsrLookupBinding --values "{\"Code\":\"UsrLookupBinding\",\"UsrStatus\":{\"value\":\"b659d704-3955-e011-981f-00155d043204\",\"displayValue\":\"In Progress\"}}"
 
 NOTES
+    - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+      not the package directory. Clio resolves packages/<package-name> beneath that root.
     - This command writes LOCAL workspace artifact files (descriptor.json, data.json) under packages/<package>/Data/<binding-name>; it does not persist data to a remote Creatio database. To persist row data directly to the remote database instead, use create-data-binding-db
     - For the templated schema SysSettings, --environment and --uri are optional
     - For non-templated schemas, the command requires either --environment or --uri

--- a/clio/help/en/create-data-binding.txt
+++ b/clio/help/en/create-data-binding.txt
@@ -34,7 +34,8 @@ DESCRIPTION
 OPTIONS
     --package              Target package name
     --schema               Entity schema name used to fetch template or runtime metadata
-    --workspace-path       Workspace root path. Defaults to the current workspace
+    --workspace-path       Workspace root containing .clio/workspaceSettings.json,
+                           not the package directory. Defaults to the current workspace
     --binding-name         Binding folder name. Defaults to <schema>
     --install-type         Descriptor install type. Allowed values: 0, 1, 2, 3.
                            Default: 0
@@ -75,7 +76,7 @@ EXAMPLES
 
 NOTES
     - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
-      not the package directory. Clio resolves packages/<package-name> beneath that root.
+      not the package directory. Clio resolves packages/{package-name} beneath that root.
     - This command writes LOCAL workspace artifact files (descriptor.json, data.json) under packages/<package>/Data/<binding-name>; it does not persist data to a remote Creatio database. To persist row data directly to the remote database instead, use create-data-binding-db
     - For the templated schema SysSettings, --environment and --uri are optional
     - For non-templated schemas, the command requires either --environment or --uri

--- a/clio/help/en/remove-data-binding-row.txt
+++ b/clio/help/en/remove-data-binding-row.txt
@@ -28,6 +28,8 @@ EXAMPLES
     clio remove-data-binding-row --package Custom --binding-name SysSettings --workspace-path C:\Work\MyWorkspace --key-value 4f41bcc2-7ed0-45e8-a1fd-474918966d15
 
 NOTES
+    - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
+      not the package directory. Clio resolves packages/<package-name> beneath that root.
     - The binding must already exist locally
     - The command fails if the supplied key does not exist
     - Localization rows that share the same primary key are removed together

--- a/clio/help/en/remove-data-binding-row.txt
+++ b/clio/help/en/remove-data-binding-row.txt
@@ -17,7 +17,8 @@ DESCRIPTION
 OPTIONS
     --package              Target package name
     --binding-name         Binding folder name under package Data
-    --workspace-path       Workspace root path. Defaults to the current workspace
+    --workspace-path       Workspace root containing .clio/workspaceSettings.json,
+                           not the package directory. Defaults to the current workspace
     --key-value            Primary-key value of the row to remove
 
 EXAMPLES
@@ -29,7 +30,7 @@ EXAMPLES
 
 NOTES
     - --workspace-path is the workspace root containing .clio/workspaceSettings.json,
-      not the package directory. Clio resolves packages/<package-name> beneath that root.
+      not the package directory. Clio resolves packages/{package-name} beneath that root.
     - The binding must already exist locally
     - The command fails if the supplied key does not exist
     - Localization rows that share the same primary key are removed together


### PR DESCRIPTION
Local data-binding examples implied that `workspace-path` could name the package directory, which the command rejects. The create/add/remove contracts, prompts and command docs now identify the workspace root containing `.clio/workspaceSettings.json` and explain resolution of `packages/<package-name>` beneath it. An invalid root reports the missing marker and the expected argument.

Accepted paths and binding generation behavior are unchanged. Localization projection and output preservation were delivered separately in #1475 for #1187; this branch integrates that change and preserves its regression tests.

Fixes #950.

Validation:

- Command/McpServer unit modules: `dotnet test clio.tests/clio.tests.csproj -c Release --filter 'Category=Unit&(Module=Command|Module=McpServer)'` — 9,511 passed, 15 existing skips, zero failures.
- Real MCP process: 6 passed (create happy path, contract serialization, package-directory rejection for create/add/remove, and localization validation preserving existing artifacts), zero skipped.
- ClioRing compatibility reviewed: `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 157 passed; `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` — passed; published NativeAOT `clio-ring.exe --ipc-proof --clio-dll <this-worktree>/clio/bin/Release/net10.0/clio.dll --env issue-647 --out <report>` — PASS (handshake, contract catalog, transport recovery). Ring consumes get-tool-contract, so its consumer gate was run even though only contract prose/examples changed.
- `git diff --check` passed; affected knowledge facts, command anchors and shipped templates reviewed, no changes needed. Existing unit skips remain explicit unrelated fixtures.

Docs updated in canonical CLI help and regenerated detailed command pages; generated command index reviewed, no change required. MCP updated in full contracts, argument descriptions and prompts; unit and E2E coverage added. The data-bindings guidance and its existing tool trigger remain accurate; no separate knowledge-library change is required.

Review: comprehensive parallel review covering quality/testing, correctness/performance, security, intent and KISS found no blocking findings. Final comprehensive review passed after documentation corrections. Claude review rev_5ee45e639f5b47b8 found no runtime blockers; both documentation findings were verified and fixed. The docs-only follow-up needs no incremental code review. The implementation retains the existing root check and adds no new path inference or runtime machinery.

After merging current master, full dotnet test clio.tests/clio.tests.csproj -c Release --no-build --filter Category=Unit passed: 12,350 tests, 25 existing skips, zero failures. The five MCP E2E tests and published NativeAOT Ring IPC harness also passed again against the merged source. Full integration review found no findings.

After integrating #1475, the affected unit modules passed again (9,511 passed, 15 skips), all six focused MCP E2E tests passed, and comprehensive parallel review confirmed both fixes and regression sets remain intact.

