### PR TITLE
Give up compilation polling on a time window with backoff (#1376)

### DIFF
--- a/clio.tests/Command/CompileConfigurationCommand.Tests.cs
+++ b/clio.tests/Command/CompileConfigurationCommand.Tests.cs
@@ -218,7 +218,7 @@ public class CompileConfigurationCommandTestCase : BaseCommandTests<CompileConfi
 		poller.GetBaseline().Returns(new CompilationHistory { CreatedOn = DateTime.UtcNow.AddMinutes(-1) });
 		poller.When(value => value.Poll(Arg.Any<DateTime>(), Arg.Any<CancellationToken>(),
 				Arg.Any<Action<CompilationHistory>>()))
-			.Do(_ => throw new InvalidOperationException("Compilation history is unreachable after 10 rounds."));
+			.Do(_ => throw new InvalidOperationException("Compilation polling gave up after 93 s of rounds that all failed (give-up window 90 s, 21 failed rounds)"));
 		CompileConfigurationCommand command = CreateCommandWith(poller);
 
 		// Act
@@ -229,7 +229,7 @@ public class CompileConfigurationCommandTestCase : BaseCommandTests<CompileConfi
 			because: "losing the progress monitor is not a compile failure - the server keeps compiling and the command must still report its own verdict");
 		_logger.Received().WriteWarning(Arg.Is<string>(message =>
 			message.Contains("could not be monitored", StringComparison.Ordinal)
-			&& message.Contains("unreachable after 10 rounds", StringComparison.Ordinal)));
+			&& message.Contains("give-up window 90 s", StringComparison.Ordinal)));
 	}
 
 	[Test]

--- a/clio.tests/Common/CompilationHistoryPollerResilienceTests.cs
+++ b/clio.tests/Common/CompilationHistoryPollerResilienceTests.cs
@@ -1,11 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using ATF.Repository;
 using ATF.Repository.Providers;
 using Clio.Common;
 using Clio.CreatioModel;
 using FluentAssertions;
+using NSubstitute;
+using NSubstitute.Core;
 using NUnit.Framework;
 
 namespace Clio.Tests.Common;
@@ -18,45 +21,9 @@ public class CompilationHistoryPollerResilienceTests {
 	#region Helpers
 
 	/// <summary>
-	/// A provider whose <c>GetItems</c> fails the first <c>failuresBeforeSuccess</c> calls the way
-	/// <see cref="ClassifyingDataProvider"/> now surfaces a failed round, then succeeds.
-	/// </summary>
-	private sealed class FailThenSucceedDataProvider : IDataProvider {
-
-		private readonly int _failuresBeforeSuccess;
-		private int _calls;
-
-		internal FailThenSucceedDataProvider(int failuresBeforeSuccess) =>
-			_failuresBeforeSuccess = failuresBeforeSuccess;
-
-		internal int Calls => _calls;
-
-		public IItemsResponse GetItems(ISelectQuery selectQuery) {
-			int call = Interlocked.Increment(ref _calls);
-			return call <= _failuresBeforeSuccess
-				? throw new InvalidOperationException(
-					"Failed reading records from entity schema 'VwCompilationHistory': timeout")
-				: new SucceedingDataProvider().GetItems(selectQuery);
-		}
-
-		public IDefaultValuesResponse GetDefaultValues(string schemaName) =>
-			new SucceedingDataProvider().GetDefaultValues(schemaName);
-
-		public IExecuteResponse BatchExecute(List<IBaseQuery> queries) =>
-			new SucceedingDataProvider().BatchExecute(queries);
-
-		public T GetSysSettingValue<T>(string sysSettingCode) => default;
-
-		public bool GetFeatureEnabled(string featureCode) => true;
-
-		public IExecuteProcessResponse ExecuteProcess(IExecuteProcessRequest request) =>
-			new SucceedingDataProvider().ExecuteProcess(request);
-	}
-
-	/// <summary>
 	/// A provider that fails or succeeds per round according to <c>shouldFail</c>, which receives the
-	/// 1-based round number. Lets a test describe an exact failure PATTERN - nine then one, or alternating -
-	/// rather than only the two extremes.
+	/// 1-based round number. Lets a test describe an exact failure PATTERN - a fixed run then a success,
+	/// or alternating - rather than only the two extremes.
 	/// </summary>
 	private sealed class ScriptedDataProvider : IDataProvider {
 
@@ -65,14 +32,22 @@ public class CompilationHistoryPollerResilienceTests {
 
 		internal ScriptedDataProvider(Func<int, bool> shouldFail) => _shouldFail = shouldFail;
 
-		internal int Calls => Volatile.Read(ref _calls);
+		internal int Calls => _calls;
+
+		/// <summary>Raised on a failing round, the way <see cref="ClassifyingDataProvider"/> surfaces one.</summary>
+		internal string FailureMessage { get; set; } =
+			"Failed reading records from entity schema 'VwCompilationHistory': timeout";
+
+		/// <summary>Overrides what a failing round throws, for a test about the exception SHAPE.</summary>
+		internal Func<Exception> FailWith { get; set; }
 
 		public IItemsResponse GetItems(ISelectQuery selectQuery) {
-			int call = Interlocked.Increment(ref _calls);
-			return _shouldFail(call)
-				? throw new InvalidOperationException(
-					$"Failed reading records from entity schema 'VwCompilationHistory' on round {call}: timeout")
-				: new SucceedingDataProvider().GetItems(selectQuery);
+			int call = ++_calls;
+			if (!_shouldFail(call)) {
+				return new SucceedingDataProvider().GetItems(selectQuery);
+			}
+			throw FailWith?.Invoke()
+				?? new InvalidOperationException($"{FailureMessage} (round {call})");
 		}
 
 		public IDefaultValuesResponse GetDefaultValues(string schemaName) =>
@@ -89,31 +64,66 @@ public class CompilationHistoryPollerResilienceTests {
 			new SucceedingDataProvider().ExecuteProcess(request);
 	}
 
-	// Rounds run back to back so a test that has to exhaust the ten-round budget does not spend ten real
-	// seconds asleep. The interval is not what any of these tests is about.
-	private const int TestPollIntervalMilliseconds = 1;
+	/// <summary>A clock that only moves when a test (or the fake wait below) moves it.</summary>
+	private sealed class FakeTimeProvider : TimeProvider {
+
+		private long _ticks = TimeSpan.TicksPerHour;
+
+		public override long GetTimestamp() => _ticks;
+
+		public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+		public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(_ticks);
+
+		internal void Advance(TimeSpan by) => _ticks += by.Ticks;
+	}
 
 	/// <summary>
-	/// Runs <see cref="CompilationHistoryPoller.Poll"/> on its own thread until <paramref name="until"/>
-	/// holds (or the thread ends on its own), then cancels and joins, returning whatever escaped.
+	/// The wait seam, recorded rather than performed: each requested gap is remembered and the fake clock
+	/// is moved by it, so the poll's real 90-second budget is exercised in microseconds. Optionally
+	/// cancels after a given number of waits, which is how a test ends a poll that would otherwise run
+	/// forever.
 	/// </summary>
-	private static Exception RunPollUntil(IDataProvider provider, Func<bool> until) {
-		CompilationHistoryPoller sut = new(provider, TestPollIntervalMilliseconds);
-		using CancellationTokenSource cts = new();
-		Exception thrown = null;
-		Thread pollThread = new(() => {
-			try {
-				sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
-			} catch (Exception exception) {
-				thrown = exception;
+	private sealed class RecordingDelay : ICancellableDelay {
+
+		private readonly FakeTimeProvider _timeProvider;
+		private readonly CancellationTokenSource _cancelAfterWaits;
+		private readonly int _waitsBeforeCancel;
+
+		internal RecordingDelay(FakeTimeProvider timeProvider, CancellationTokenSource cancelAfterWaits = null,
+			int waitsBeforeCancel = int.MaxValue) {
+			_timeProvider = timeProvider;
+			_cancelAfterWaits = cancelAfterWaits;
+			_waitsBeforeCancel = waitsBeforeCancel;
+		}
+
+		internal List<TimeSpan> Waits { get; } = [];
+
+		/// <summary>Set to cancel DURING a wait rather than after it, to model a wait cut short.</summary>
+		internal bool CancelDuringWait { get; set; }
+
+		public bool WaitOrCancelled(TimeSpan duration, CancellationToken ct) {
+			Waits.Add(duration);
+			if (CancelDuringWait) {
+				//A FRACTION of the gap, not all of it: the point of this mode is a wait cut short, and
+				//advancing the full duration would model a wait that completed and then happened to be
+				//cancelled - which is a different thing and would hide a poll that ignores the token.
+				_timeProvider.Advance(duration / 4);
+				_cancelAfterWaits?.Cancel();
+				return true;
 			}
-		});
-		pollThread.Start();
-		SpinWait.SpinUntil(() => until() || !pollThread.IsAlive, TimeSpan.FromSeconds(30));
-		cts.Cancel();
-		pollThread.Join(TimeSpan.FromSeconds(10));
-		return thrown;
+			_timeProvider.Advance(duration);
+			if (Waits.Count >= _waitsBeforeCancel) {
+				_cancelAfterWaits?.Cancel();
+			}
+			return ct.IsCancellationRequested;
+		}
 	}
+
+	private static CompilationHistoryPoller CreatePoller(IDataProvider provider, ILogger logger,
+		FakeTimeProvider timeProvider, ICancellableDelay delay,
+		CompilationPollingOptions options = null) =>
+		new(provider, logger, timeProvider, delay, options);
 
 	#endregion
 
@@ -121,38 +131,30 @@ public class CompilationHistoryPollerResilienceTests {
 	[Description("A single failed round must not end the poll: before the classifying decorator an unreachable round came back as an empty list and the loop simply retried, and a compile that runs for minutes cannot be abandoned because one read timed out.")]
 	public void Poll_ShouldContinue_AfterOneFailedRound() {
 		// Arrange
-		FailThenSucceedDataProvider provider = new(failuresBeforeSuccess: 1);
-		CompilationHistoryPoller sut = new(provider);
+		ScriptedDataProvider provider = new(round => round == 1);
+		FakeTimeProvider clock = new();
 		using CancellationTokenSource cts = new();
-		List<CompilationHistory> observed = [];
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: 2);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
 
 		// Act
-		Exception thrown = null;
-		Thread pollThread = new(() => {
-			try {
-				sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, observed.Add);
-			} catch (Exception exception) {
-				thrown = exception;
-			}
-		});
-		pollThread.Start();
-		SpinWait.SpinUntil(() => provider.Calls >= 2, TimeSpan.FromSeconds(10));
-		cts.Cancel();
-		pollThread.Join(TimeSpan.FromSeconds(10));
+		Action act = () => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
 
 		// Assert
-		thrown.Should().BeNull(
-			because: "one transient failure is not a reason to stop watching a compile, and an escaping exception on this thread would terminate the whole clio process");
+		act.Should().NotThrow(
+			because: "one transient failure is not a reason to stop watching a compile, and an escaping exception on the poll thread would terminate the whole clio process");
 		provider.Calls.Should().BeGreaterThanOrEqualTo(2,
 			because: "the loop has to reach a second round for the tolerance to mean anything");
 	}
 
 	[Test]
-	[Description("A SUSTAINED run of failures does give up, and it does so by throwing so the caller can report the fault instead of polling silently until its own timeout.")]
-	public void Poll_ShouldThrow_AfterTooManyConsecutiveFailedRounds() {
-		// Arrange - never succeeds, so the consecutive-failure budget is exhausted.
-		CompilationHistoryPoller sut = new(new FailThenSucceedDataProvider(failuresBeforeSuccess: int.MaxValue),
-			TestPollIntervalMilliseconds);
+	[Description("A run of failures that outlasts the give-up window does give up, and it does so by throwing so the caller can report the fault instead of polling silently until its own timeout.")]
+	public void Poll_ShouldThrow_WhenRoundsKeepFailingPastTheGiveUpWindow() {
+		// Arrange - never succeeds, so the window is the only thing that can end the poll.
+		ScriptedDataProvider provider = new(_ => true);
+		FakeTimeProvider clock = new();
+		RecordingDelay delay = new(clock);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
 		using CancellationTokenSource cts = new();
 
 		// Act
@@ -161,17 +163,29 @@ public class CompilationHistoryPollerResilienceTests {
 		// Assert
 		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
 			because: "an environment that cannot answer at all must be reported, not waited on until the compile timeout expires").Which;
-		exception.Message.Should().Contain("consecutive failed",
-			because: "the operator has to be told the poll gave up rather than that the compile itself failed");
+		exception.Message.Should().Contain("give-up window 90 s",
+			because: "the operator has to be told how long the poll waited before it gave up, not just that it did");
+		provider.Calls.Should().Be(21,
+			because: "the 20th failure is observed at 88 s and is still inside the window, so the 21st - at 93 s - is the one that must throw; an earlier round means the comparison drifted and a compile is abandoned too soon");
+		exception.Message.Should().Contain("21 failed rounds",
+			because: "the round count is what tells an outage of a few slow rounds apart from a stand that answered nothing at all");
 		exception.InnerException.Should().NotBeNull(
 			because: "the last underlying failure is the only diagnosable detail available");
+		exception.Message.Should().NotContain(exception.InnerException!.Message,
+			because: "the last failure must be CHAINED, not interpolated: the CLI renderer drops a wrapper message that already quotes the text below it, which on a live stand deleted the elapsed time, the window and the round count from the only line the operator sees");
+		exception.GetReadableMessageException().Should().Contain("gave up after",
+			because: "this inner is an ordinary InvalidOperationException with no server detail of its own - the shape ClassifyingDataProvider produces when it rethrows a transport fault unchanged - and that arm of the renderer used to return the inner message alone, silently dropping the window and the round count");
+		delay.Waits.Sum(wait => wait.TotalSeconds).Should().BeGreaterThanOrEqualTo(90,
+			because: "the give-up is a DURATION: the poll must actually have spent the configured window failing, which a fixed round count could not guarantee once the gaps between rounds stopped being equal");
 	}
 
 	[Test]
 	[Description("Cancellation still ends the poll promptly and without a fault, so the normal end-of-compile path is unaffected by the failure tolerance.")]
 	public void Poll_ShouldReturnQuietly_WhenCancelled() {
 		// Arrange
-		CompilationHistoryPoller sut = new(new SucceedingDataProvider());
+		FakeTimeProvider clock = new();
+		CompilationHistoryPoller sut = CreatePoller(new SucceedingDataProvider(), Substitute.For<ILogger>(),
+			clock, new RecordingDelay(clock));
 		using CancellationTokenSource cts = new();
 		cts.Cancel();
 
@@ -184,56 +198,225 @@ public class CompilationHistoryPollerResilienceTests {
 	}
 
 	[Test]
-	[Description("The budget boundary itself: one round short of MaxConsecutiveFailures is still tolerated, and the poll goes on to succeed. Without this, the >= comparison could become off-by-one and every other test would stay green.")]
-	public void Poll_ShouldTolerate_OneRoundShortOfTheFailureBudget() {
-		// Arrange - fails MaxConsecutiveFailures - 1 times in a row, then answers normally.
-		int toleratedFailures = CompilationHistoryPoller.MaxConsecutiveFailures - 1;
+	[Description("A run of failures shorter than the window is tolerated even when it spans many rounds: 80 seconds of an unanswering app tier is an ordinary pause in a multi-minute compile, not a reason to stop watching it.")]
+	public void Poll_ShouldTolerate_AFailingRunShorterThanTheWindow() {
+		// Arrange - under the 1/2/5/5… backoff the N-th failure is observed at 5N-12 seconds, so the 20th
+		// lands at 88 s: the last one still inside the 90 s window, one step short of the give-up.
+		const int toleratedFailures = 20;
 		ScriptedDataProvider provider = new(round => round <= toleratedFailures);
-
-		// Act - run past the first success so the loop is demonstrably still alive after the near-miss.
-		Exception thrown = RunPollUntil(provider, () => provider.Calls >= toleratedFailures + 2);
-
-		// Assert
-		thrown.Should().BeNull(
-			because: $"{toleratedFailures} consecutive failures is one short of the budget, and the round after them succeeded");
-		provider.Calls.Should().BeGreaterThan(toleratedFailures,
-			because: "the loop has to reach the succeeding round for the tolerance to mean anything");
-	}
-
-	[Test]
-	[Description("The other side of the same boundary: the MaxConsecutiveFailures-th consecutive failure is the one that throws - not the one before it, and not a later one.")]
-	public void Poll_ShouldThrow_OnExactlyTheBudgetOfConsecutiveFailures() {
-		// Arrange - every round fails, so the budget is reached at exactly MaxConsecutiveFailures rounds.
-		ScriptedDataProvider provider = new(_ => true);
-		CompilationHistoryPoller sut = new(provider, TestPollIntervalMilliseconds);
+		FakeTimeProvider clock = new();
 		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: toleratedFailures + 2);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
 
 		// Act
 		Action act = () => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
 
 		// Assert
-		act.Should().Throw<InvalidOperationException>(
-			because: "a sustained run of failures has to be reported rather than polled through");
-		provider.Calls.Should().Be(CompilationHistoryPoller.MaxConsecutiveFailures,
-			because: "the throw must land on the budget-th round exactly - an earlier one abandons a compile too soon, a later one means the comparison drifted");
+		act.Should().NotThrow(
+			because: "the run of failures stayed inside the 90 s window and the round after it succeeded");
+		provider.Calls.Should().BeGreaterThan(toleratedFailures,
+			because: "the loop has to reach the succeeding round for the tolerance to mean anything");
 	}
 
 	[Test]
-	[Description("A successful round RESETS the consecutive counter. Drop that reset - make the budget cumulative instead of consecutive - and every other test here still passes, yet a long healthy compile with scattered timeouts would be aborted.")]
-	public void Poll_ShouldResetFailureCount_AfterASuccessfulRound() {
-		// Arrange - repeating blocks of (budget - 1) failures followed by one success. The cumulative count
-		// passes the budget several times over; the consecutive count never does.
-		int blockLength = CompilationHistoryPoller.MaxConsecutiveFailures;
+	[Description("A successful round RESETS the window. Drop that reset - make the budget cumulative instead of per-run - and every other test here still passes, yet a long healthy compile with scattered timeouts would be aborted.")]
+	public void Poll_ShouldResetTheWindow_AfterASuccessfulRound() {
+		// Arrange - repeating blocks of nine failures then one success. The cumulative failing time passes
+		// the 90 s window several times over; no single RUN of failures ever does.
+		const int blockLength = 10;
 		ScriptedDataProvider provider = new(round => round % blockLength != 0);
-		int roundsToRun = blockLength * 3;
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: blockLength * 4);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
 
 		// Act
-		Exception thrown = RunPollUntil(provider, () => provider.Calls >= roundsToRun);
+		Action act = () => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
 
 		// Assert
-		thrown.Should().BeNull(
-			because: "no run of failures ever reached the budget, so a cumulative interpretation is the only thing that could have thrown here");
-		provider.Calls.Should().BeGreaterThanOrEqualTo(roundsToRun,
-			because: "the pattern only accumulates past the budget once several blocks have run");
+		act.Should().NotThrow(
+			because: "no single run of failures reached the window, so a cumulative interpretation is the only thing that could have thrown here");
+		delay.Waits.Sum(wait => wait.TotalSeconds).Should().BeGreaterThan(90,
+			because: "the poll has to have spent more than one window's worth of time failing in total for the reset to be what kept it alive");
+	}
+
+	[Test]
+	[Description("The failing rounds are spaced 1 s, 2 s, then 5 s apart and stay at 5 s, so a 90-second tolerance costs about twenty requests instead of the ninety an unbacked-off one-second cadence would fire at an environment that is already struggling.")]
+	public void Poll_ShouldSpaceFailedRounds_OnTheConfiguredBackoff() {
+		// Arrange
+		ScriptedDataProvider provider = new(_ => true);
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: 5);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
+
+		// Act
+		sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		delay.Waits.Select(wait => wait.TotalSeconds).Should().Equal([1d, 2d, 5d, 5d, 5d],
+			because: "the first two retries are quick because most outages are brief, and the rest settle at the last configured step rather than growing without bound");
+	}
+
+	[Test]
+	[Description("A successful round returns to the ordinary one-second cadence: the backoff is a reaction to failure, not a permanent slowdown of a compile that is reporting progress again.")]
+	public void Poll_ShouldReturnToTheNormalInterval_AfterASuccessfulRound() {
+		// Arrange - fail, fail, then succeed for the rest.
+		ScriptedDataProvider provider = new(round => round <= 2);
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: 4);
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
+
+		// Act
+		sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		delay.Waits.Select(wait => wait.TotalSeconds).Should().Equal([1d, 2d, 1d, 1d],
+			because: "the two failures back off 1 s and 2 s, and the rounds after the recovery are one second apart again");
+	}
+
+	[Test]
+	[Description("Cancellation DURING a backoff wait ends the poll at once and without a fault, so a compile that finishes while the poll is backing off does not have to wait out the remaining five seconds.")]
+	public void Poll_ShouldExitPromptly_WhenCancelledDuringBackoff() {
+		// Arrange
+		ScriptedDataProvider provider = new(_ => true);
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts) { CancelDuringWait = true };
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock, delay);
+
+		// Act
+		Action act = () => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		act.Should().NotThrow(
+			because: "a cancellation during a backoff is the compile ending, not a failure of the poll");
+		delay.Waits.Should().ContainSingle(
+			because: "the wait that was cut short must be the last thing the poll does - a further round would mean the cancellation was observed only after the full gap elapsed");
+	}
+
+	[Test]
+	[Description("Every tolerated failed round is reported as a warning: without one nothing at all told the operator that the poll had stopped receiving answers, and silent progress lines look identical to a compile that has simply gone quiet.")]
+	public void Poll_ShouldLogAWarning_PerToleratedRound() {
+		// Arrange
+		ScriptedDataProvider provider = new(_ => true);
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: 3);
+		ILogger logger = Substitute.For<ILogger>();
+		CompilationHistoryPoller sut = CreatePoller(provider, logger, clock, delay);
+
+		// Act
+		sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		logger.ReceivedCalls()
+			.Count(call => call.GetMethodInfo().Name == nameof(ILogger.WriteWarning))
+			.Should().Be(3,
+				because: "each tolerated round is one line, and the round number plus the elapsed/window pair is what makes the lines read as one incident rather than as three unrelated faults");
+	}
+
+	[Test]
+	[Description("The diagnostic must not copy server-derived text through unscrubbed: the failure message the data layer produces routinely carries the full request URI, and this line goes to a console and to CI logs.")]
+	public void Poll_ShouldRedactServerDerivedText_InTheToleratedRoundWarning() {
+		// Arrange
+		ScriptedDataProvider provider = new(_ => true) {
+			FailureMessage = "Failed reading from https://ts1-core-dev04:88/sae_secret/0/odata/VwCompilationHistory"
+		};
+		FakeTimeProvider clock = new();
+		using CancellationTokenSource cts = new();
+		RecordingDelay delay = new(clock, cts, waitsBeforeCancel: 1);
+		ILogger logger = Substitute.For<ILogger>();
+		CompilationHistoryPoller sut = CreatePoller(provider, logger, clock, delay);
+		string warning = null;
+		logger.When(l => l.WriteWarning(Arg.Any<string>())).Do(call => warning ??= call.Arg<string>());
+
+		// Act
+		sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		warning.Should().NotBeNull(
+			because: "the tolerated round has to be reported at all before its redaction can be judged");
+		warning.Should().NotContain("ts1-core-dev04",
+			because: "the environment host is exactly the kind of token UntrustedText.ForConsole exists to remove before a server-derived message reaches a log");
+		warning.Should().Contain("[redacted-uri]",
+			because: "the text is scrubbed rather than dropped, so the operator still sees that a read failed and roughly why");
+		warning.Should().Contain("untrusted-source-text",
+			because: "this warning is captured into the compile-creatio MCP result, and McpPassthroughRedaction only scrubs secrets - it never fences - so without the fence here server-authored prose reaches an agent's context as if clio had written it");
+	}
+
+	[Test]
+	[Description("A round that failed only because the poll was cancelled mid-read is neither counted nor reported: issue #1377 means a cancelled read surfaces as an ordinary failure, and without this guard every normal end of a compile would print a spurious retry warning on its way out.")]
+	public void Poll_ShouldNotReportAFailedRound_WhenItFailedAfterCancellation() {
+		// Arrange - the read cancels the poll and then fails, which is what a read still in flight when the
+		// compile finished does today.
+		using CancellationTokenSource cts = new();
+		ScriptedDataProvider provider = new(_ => {
+			cts.Cancel();
+			return true;
+		});
+		FakeTimeProvider clock = new();
+		ILogger logger = Substitute.For<ILogger>();
+		CompilationHistoryPoller sut = CreatePoller(provider, logger, clock, new RecordingDelay(clock));
+
+		// Act
+		Action act = () => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { });
+
+		// Assert
+		act.Should().NotThrow(
+			because: "a read that lost its race with the end of the compile is not an outage");
+		logger.ReceivedCalls()
+			.Count(call => call.GetMethodInfo().Name == nameof(ILogger.WriteWarning))
+			.Should().Be(0,
+				because: "a round the poll itself ended is not an outage, and warning about it would put a spurious retry line at the end of every successful compile");
+		provider.Calls.Should().Be(1,
+			because: "the guard must be reached by an actual failed round - a poll that never queried would satisfy the assertion above for the wrong reason");
+	}
+
+	[Test]
+	[Description("The backoff sequence repeats its last step rather than running off the end of the configured list, which is what keeps a long outage at a fixed five-second cadence instead of throwing an index error deep inside a background thread.")]
+	public void BackoffFor_ShouldRepeatTheLastStep_BeyondTheConfiguredSequence() {
+		// Arrange
+		CompilationPollingOptions options = CompilationPollingOptions.Default;
+
+		// Act
+		TimeSpan[] observed = [
+			options.BackoffFor(0), options.BackoffFor(1), options.BackoffFor(2), options.BackoffFor(3),
+			options.BackoffFor(99)
+		];
+
+		// Assert
+		observed.Select(step => step.TotalSeconds).Should().Equal([1d, 1d, 2d, 5d, 5d],
+			because: "round zero is not a failure and takes the ordinary interval, the first three failures take the configured steps, and every later one holds at the last step");
+	}
+
+	[Test]
+	[Description("The give-up exception must survive the CLI renderer: the last failure is chained rather than interpolated, because ExceptionReadableMessageExtension drops an outer message that already quotes its carrier's - which on a live stand deleted the window and the round count from the only line the operator sees.")]
+	public void GiveUpException_ShouldStillCarryTheWindowAndRoundCount_WhenRenderedForTheConsole() {
+		// Arrange - the provider fails the way ClassifyingDataProvider surfaces a rejected read, so the
+		// give-up exception wraps a real server-detail carrier and takes the renderer's carrier path.
+		const string carrierMessage =
+			"Failed reading records from entity schema 'CompilationHistory': the environment answered "
+			+ "with a non-JSON page where a DataService response was expected";
+		ScriptedDataProvider provider = new(_ => true) { FailWith = () => new DataProviderFailureException(carrierMessage, serverDetail: "<html>login</html>") };
+		FakeTimeProvider clock = new();
+		CompilationHistoryPoller sut = CreatePoller(provider, Substitute.For<ILogger>(), clock,
+			new RecordingDelay(clock));
+		using CancellationTokenSource cts = new();
+
+		// Act
+		Exception thrown = Assert.Throws<InvalidOperationException>(
+			() => sut.Poll(DateTime.UtcNow.AddMinutes(-1), cts.Token, _ => { }));
+		string rendered = thrown.GetReadableMessageException();
+
+		// Assert
+		rendered.Should().Contain("gave up after",
+			because: "the line the consumer prints is this rendering, and it is the only place the operator learns that MONITORING stopped rather than that the compile failed");
+		rendered.Should().Contain("90 s",
+			because: "how long the poll waited is what tells a brief outage apart from a stand that answered nothing for a minute and a half");
+		rendered.Should().Contain(carrierMessage,
+			because: "chaining must not cost the underlying diagnosis either - both halves have to reach the same line");
 	}
 }

--- a/clio.tests/Common/ConsoleFacingDiagnosticsTests.cs
+++ b/clio.tests/Common/ConsoleFacingDiagnosticsTests.cs
@@ -244,4 +244,65 @@ public sealed class ConsoleFacingDiagnosticsTests {
 		result.Error.Should().NotContain("Your password has expired",
 			because: "the server excerpt never reaches a caller-visible field (issue #1333)");
 	}
+
+	[Test]
+	[Description("A THREE-link chain keeps the middle wrapper too: PackageBuilder wraps the compilation poll's give-up exception, which itself wraps the provider's carrier, and rendering only the outermost message reported that monitoring stopped while silently dropping why.")]
+	public void ReadableMessage_Should_Keep_Every_Wrapper_Above_The_Carrier() {
+		// Arrange
+		DataProviderFailureException carrier = new("Failed reading records: the provider refused.");
+		InvalidOperationException middle = new(
+			"Compilation polling gave up after 93 s of rounds that all failed "
+			+ "(give-up window 90 s, 21 failed rounds)", carrier);
+		InvalidOperationException outer = new("Package compilation could not be monitored", middle);
+
+		// Act
+		string rendered = outer.GetReadableMessageException();
+
+		// Assert
+		rendered.Should().Contain("Package compilation could not be monitored",
+			because: "the outermost wrapper is what names the operation the operator started");
+		rendered.Should().Contain("give-up window 90 s",
+			because: "the middle wrapper carries the elapsed time, the window and the round count - the entire diagnosis of WHY monitoring stopped, which only this link holds");
+		rendered.Should().Contain("the provider refused.",
+			because: "the carrier's own diagnosis still has to survive underneath both wrappers");
+	}
+
+	[Test]
+	[Description("A wrapper that merely restates the message below it is still printed once: the de-duplication that protects the two-link case must not be lost when the walk visits every link.")]
+	public void ReadableMessage_Should_Not_Repeat_A_Wrapper_That_Restates_The_One_Below_It() {
+		// Arrange
+		DataProviderFailureException carrier = new("Failed reading records: the provider refused.");
+		InvalidOperationException middle = new("Monitoring stopped", carrier);
+		InvalidOperationException outer = new("Monitoring stopped while compiling", middle);
+
+		// Act
+		string rendered = outer.GetReadableMessageException();
+
+		// Assert
+		rendered.Should().Contain("Monitoring stopped while compiling",
+			because: "the outermost wrapper is the more specific of the two and is the one worth keeping");
+		rendered.Should().NotContain("Monitoring stopped: Monitoring stopped",
+			because: "printing a restatement twice is exactly the noise the per-link duplicate check exists to prevent");
+	}
+
+	[Test]
+	[Description("A wrapper whose inner carries NO server detail keeps its own text and scrubs the inner: ClassifyingDataProvider rethrows a transport fault unchanged, and that arm used to return the inner message alone - raw, and without the wrapper's diagnosis.")]
+	public void ReadableMessage_Should_Keep_The_Wrapper_And_Scrub_The_Inner_When_There_Is_No_Carrier() {
+		// Arrange
+		Exception inner = new("Connection refused reading https://ts1-core-dev04:88/app/0/DataService");
+		InvalidOperationException outer = new(
+			"Compilation polling gave up after 93 s of rounds that all failed "
+			+ "(give-up window 90 s, 21 failed rounds)", inner);
+
+		// Act
+		string rendered = outer.GetReadableMessageException();
+
+		// Assert
+		rendered.Should().Contain("give-up window 90 s",
+			because: "the wrapper's diagnosis is the only place the window and the round count exist, and returning the inner message alone deleted them");
+		rendered.Should().NotContain("ts1-core-dev04",
+			because: "a transport fault's message routinely carries the full request URI, and this line reaches a console and a CI log unfenced");
+		rendered.Should().Contain("Connection refused",
+			because: "the underlying cause is scrubbed, not dropped - it is still what tells a refused connection apart from a rejected session");
+	}
 }

--- a/clio.tests/ExceptionReadableMessageExtension.Tests.cs
+++ b/clio.tests/ExceptionReadableMessageExtension.Tests.cs
@@ -43,11 +43,18 @@ public class ExceptionReadableMessageExtensionTestCase
 	}
 
 	[Test]
+	[Description("An InvalidOperationException wrapping a fault with no server detail of its own keeps BOTH: the wrapper says what was being done, the inner says what went wrong. Returning the inner alone silently deleted the wrapper's diagnosis - which for the compilation poll's give-up was the window and the failed-round count (issue #1376).")]
 	public void GetReadableMessageException_PrintsCorrectMessage_WhenInvalidOperationException() {
+		// Arrange
 		var innerException = new Exception("InnerMessage");
 		var exception = new InvalidOperationException("Message", innerException);
+
+		// Act
 		var messageResult = exception.GetReadableMessageException();
-		messageResult.Should().Be($"{innerException.Message}");
+
+		// Assert
+		messageResult.Should().Be($"{exception.Message}: {innerException.Message}",
+			because: "the wrapper leads and the inner follows, the same order the WebException arm already uses so the operation context is preserved");
 	}
 
 	[Test]

--- a/clio.tests/Package/PackageBuilderLifetimeTests.cs
+++ b/clio.tests/Package/PackageBuilderLifetimeTests.cs
@@ -71,7 +71,7 @@ public sealed class PackageBuilderLifetimeTests {
 		urlBuilder.Build(Arg.Any<ServiceUrlBuilder.KnownRoute>()).Returns("https://dev.creatio.com/build");
 		ICompilationHistoryPoller poller = Substitute.For<ICompilationHistoryPoller>();
 		poller.GetBaseline().Returns(new CompilationHistory { CreatedOn = DateTime.UtcNow.AddMinutes(-1) });
-		InvalidOperationException pollFault = new("Compilation history is unreachable after 10 rounds.");
+		InvalidOperationException pollFault = new("Compilation polling gave up after 93 s of rounds that all failed (give-up window 90 s, 21 failed rounds)");
 		poller.When(value => value.Poll(Arg.Any<DateTime>(), Arg.Any<CancellationToken>(),
 			Arg.Any<Action<CompilationHistory>>())).Do(_ => throw pollFault);
 		PackageBuilder sut = new(settings, factory, urlBuilder, Substitute.For<ILogger>(), poller);

--- a/clio/Command/CompileConfigurationCommand.cs
+++ b/clio/Command/CompileConfigurationCommand.cs
@@ -98,7 +98,8 @@ public class CompileConfigurationCommand : RemoteCommand<CompileConfigurationOpt
 
 		using CancellationTokenSource cts = new();
 		// The poll fault is CAPTURED, never allowed to escape this lambda - the same guard PackageBuilder.
-		// CompileWithPolling applies. Poll gives up and THROWS after MaxConsecutiveFailures rounds, and an
+		// CompileWithPolling applies. Poll gives up and THROWS once rounds have been failing for longer
+		// than CompilationPollingOptions.GiveUpWindow (issue #1376), and an
 		// unhandled exception on a dedicated thread terminates the whole process: a short app-tier outage
 		// during `clio cc` would have killed clio mid-compile with no error line and no exit code, skipping
 		// cts.Cancel / thread.Join and the result reporting below. Published through a one-element holder with

--- a/clio/Command/WatchCompilationCommand.cs
+++ b/clio/Command/WatchCompilationCommand.cs
@@ -40,7 +40,10 @@ public class WatchCompilationCommand : RemoteCommand<WatchCompilationOptions> {
 	private const int ExitGaveUpWaiting = 2;
 	private const int ExitStartupError = 3;
 
-	// Cadence between poll rounds while the channel is healthy; mirrors CompilationHistoryPoller.Poll's own cadence.
+	// Cadence between poll rounds while the channel is healthy; the same one-second cadence
+	// CompilationPollingOptions.Default gives CompilationHistoryPoller.Poll. This command does NOT go
+	// through Poll - it runs its own loop over PollOnce with IPollRetryPolicy's exponential backoff and
+	// its own --give-up-after-seconds deadline, so the give-up window of issue #1376 does not apply here.
 	private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
 
 	#endregion

--- a/clio/Common/CancellableDelay.cs
+++ b/clio/Common/CancellableDelay.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+
+namespace Clio.Common;
+
+/// <summary>
+/// A wait that a <see cref="CancellationToken"/> can cut short. The single reason this is a service and
+/// not a <c>Thread.Sleep</c> is that it is the seam a test replaces: the poll loop's timing can then be
+/// exercised in full without the test spending the real durations asleep (issue #1376).
+/// </summary>
+public interface ICancellableDelay {
+
+	/// <summary>
+	/// Waits for <paramref name="duration"/> or until <paramref name="ct"/> is cancelled.
+	/// </summary>
+	/// <param name="duration">How long to wait; zero or less does not wait at all.</param>
+	/// <param name="ct">The token whose cancellation ends the wait early.</param>
+	/// <returns>
+	/// <see langword="true"/> when the wait ended because of cancellation, <see langword="false"/> when
+	/// the full duration elapsed.
+	/// </returns>
+	bool WaitOrCancelled(TimeSpan duration, CancellationToken ct);
+
+}
+
+/// <inheritdoc cref="ICancellableDelay"/>
+public sealed class CancellableDelay : ICancellableDelay {
+
+	/// <inheritdoc/>
+	public bool WaitOrCancelled(TimeSpan duration, CancellationToken ct) =>
+		duration <= TimeSpan.Zero ? ct.IsCancellationRequested : ct.WaitHandle.WaitOne(duration);
+
+}

--- a/clio/Common/CompilationHistoryPoller.cs
+++ b/clio/Common/CompilationHistoryPoller.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,13 +26,15 @@ public interface ICompilationHistoryPoller {
 	/// <remarks>
 	/// A failed round is TOLERATED: the environment is mid-compile and may briefly be unable to answer,
 	/// and every consumer runs this on a background thread where an escaping exception would be fatal.
-	/// Only a sustained run of failures gives up, and it does so by throwing so the caller can report it.
+	/// Only a run of failures lasting longer than <see cref="CompilationPollingOptions.GiveUpWindow"/>
+	/// gives up, and it does so by throwing so the caller can report it. Each tolerated round is logged
+	/// as a warning, and the failing rounds are spaced out by the configured backoff.
 	/// </remarks>
 	/// <param name="baseline">Only records with a later <c>CreatedOn</c> are reported.</param>
 	/// <param name="ct">Stops the poll.</param>
 	/// <param name="onNewRecord">Invoked once per newly observed record.</param>
 	/// <exception cref="InvalidOperationException">
-	/// Too many consecutive rounds failed; the last failure is the inner exception.
+	/// Rounds kept failing for longer than the give-up window; the last failure is the inner exception.
 	/// </exception>
 	void Poll(DateTime baseline, CancellationToken ct, Action<CompilationHistory> onNewRecord);
 
@@ -40,33 +42,38 @@ public interface ICompilationHistoryPoller {
 
 public class CompilationHistoryPoller : ICompilationHistoryPoller {
 
-	/// <summary>
-	/// Consecutive failed rounds tolerated before the poll gives up and surfaces the fault. One second
-	/// apart, so this is roughly ten seconds of an environment that cannot answer at all - short enough
-	/// that a genuinely dead stand is reported promptly, long enough that a restarting app tier or a
-	/// single timed-out read does not abandon a compile that has been running for minutes.
-	/// </summary>
-	public const int MaxConsecutiveFailures = 10;
-
-	/// <summary>
-	/// Default gap between rounds, in milliseconds.
-	/// </summary>
-	public const int DefaultPollIntervalMilliseconds = 1_000;
-
 	private readonly IDataProvider _dataProvider;
 
-	private readonly int _pollIntervalMilliseconds;
+	private readonly ILogger _logger;
+
+	private readonly TimeProvider _timeProvider;
+
+	private readonly ICancellableDelay _delay;
+
+	private readonly CompilationPollingOptions _options;
 
 	/// <param name="dataProvider">The provider each round queries through.</param>
-	/// <param name="pollIntervalMilliseconds">
-	/// Gap between rounds. Only a test passes anything but the default: at one second a run that has to
-	/// exhaust the ten-round budget spends ten real seconds sleeping, which is why the budget boundary
-	/// went untested. A near-zero interval makes those rounds run back to back.
+	/// <param name="logger">Where a tolerated failed round is reported.</param>
+	/// <param name="timeProvider">Measures how long the current run of failures has lasted.</param>
+	/// <param name="delay">The wait between rounds, and the seam a test replaces to avoid sleeping.</param>
+	/// <param name="options">
+	/// The timing budget. <see langword="null"/> selects <see cref="CompilationPollingOptions.Default"/>,
+	/// which is what every production caller uses; only a test passes anything else.
 	/// </param>
-	public CompilationHistoryPoller(IDataProvider dataProvider,
-		int pollIntervalMilliseconds = DefaultPollIntervalMilliseconds) {
+	public CompilationHistoryPoller(IDataProvider dataProvider, ILogger logger, TimeProvider timeProvider,
+		ICancellableDelay delay, CompilationPollingOptions options = null) {
+		//Checked here rather than discovered later: every dependency below is first touched on a failed
+		//round, on a background thread, where a NullReferenceException is the fault that ends the process
+		//instead of the outage it was supposed to report.
+		dataProvider.CheckArgumentNull(nameof(dataProvider));
+		logger.CheckArgumentNull(nameof(logger));
+		timeProvider.CheckArgumentNull(nameof(timeProvider));
+		delay.CheckArgumentNull(nameof(delay));
 		_dataProvider = dataProvider;
-		_pollIntervalMilliseconds = pollIntervalMilliseconds;
+		_logger = logger;
+		_timeProvider = timeProvider;
+		_delay = delay;
+		_options = options ?? CompilationPollingOptions.Default;
 	}
 
 	public CompilationHistory GetBaseline() {
@@ -86,21 +93,27 @@ public class CompilationHistoryPoller : ICompilationHistoryPoller {
 	}
 
 	public void Poll(DateTime baseline, CancellationToken ct, Action<CompilationHistory> onNewRecord) {
-		var seen = new HashSet<Guid>();
-		int consecutiveFailures = 0;
+		HashSet<Guid> seen = [];
+		FailureStreak streak = new();
 		while (!ct.IsCancellationRequested) {
-			if (TryPollOnce(baseline, ref consecutiveFailures,
-					out List<CompilationHistory> records)) {
+			//ONE wait per iteration: the backoff REPLACES the normal interval after a failed round, it is
+			//not added to it, so a failing environment is asked on the 1/2/5/5 cadence and a healthy one
+			//stays on the ordinary one-second cadence.
+			bool succeeded = TryPollOnce(baseline, ct, streak, out List<CompilationHistory> records);
+			TimeSpan nextDelay = succeeded
+				? _options.PollInterval
+				: _options.BackoffFor(streak.FailedRounds);
+			if (succeeded) {
 				baseline = ReportNewRecords(records, seen, baseline, onNewRecord);
 			}
-			if (ct.WaitHandle.WaitOne(_pollIntervalMilliseconds)) {
+			if (_delay.WaitOrCancelled(nextDelay, ct)) {
 				break;
 			}
 		}
 	}
 
 	/// <summary>
-	/// Runs one round, reporting whether it succeeded. A failed round within the budget returns
+	/// Runs one round, reporting whether it succeeded. A failed round within the give-up window returns
 	/// <see langword="false"/>, which is NOT the same as a successful round that found nothing - hence a
 	/// <see langword="bool"/> plus an <see langword="out"/> list rather than a null list (Sonar S1168).
 	/// </summary>
@@ -108,28 +121,81 @@ public class CompilationHistoryPoller : ICompilationHistoryPoller {
 	/// A single failed round must NOT end the poll. Before ClassifyingDataProvider (issue #1371) an
 	/// unreachable round came back as an empty list and the loop simply tried again; now it throws, and a
 	/// compile that takes minutes cannot be abandoned because one OData read out of hundreds timed out or
-	/// hit a restarting app tier. Only a SUSTAINED failure is real - that is what the budget distinguishes.
+	/// hit a restarting app tier. Only a SUSTAINED failure is real - that is what the window distinguishes,
+	/// and it is a WINDOW rather than a round count because a count is only a duration when the gap
+	/// between rounds is fixed, and the backoff makes it not (issue #1376).
 	/// </remarks>
 	/// <exception cref="InvalidOperationException">
-	/// <see cref="MaxConsecutiveFailures"/> rounds failed in a row; the last failure is the inner exception.
+	/// Rounds have been failing for longer than <see cref="CompilationPollingOptions.GiveUpWindow"/>; the
+	/// last failure is the inner exception.
 	/// </exception>
-	private bool TryPollOnce(DateTime baseline, ref int consecutiveFailures,
+	private bool TryPollOnce(DateTime baseline, CancellationToken ct, FailureStreak streak,
 		out List<CompilationHistory> records) {
 		try {
 			records = PollOnce(baseline);
-			consecutiveFailures = 0;
+			streak.Reset();
 			return true;
-		} catch (Exception exception) when (exception is not OperationCanceledException) {
-			consecutiveFailures++;
-			if (consecutiveFailures >= MaxConsecutiveFailures) {
-				throw new InvalidOperationException(
-					$"Compilation polling gave up after {MaxConsecutiveFailures} consecutive failed "
-					+ $"rounds. Last failure: {exception.Message}", exception);
-			}
+		//An OperationCanceledException still escapes when the poll was NOT cancelled - that is someone
+		//else's cancellation and is not this poll's to swallow - but one raised by OUR token is handled by
+		//the guard below, exactly like any other fault a cancelled read produces.
+		} catch (Exception exception)
+			when (exception is not OperationCanceledException || ct.IsCancellationRequested) {
 			records = null;
+			//Cancellation checked BEFORE the round is counted or reported. A read that was in flight when
+			//the compile finished usually comes back as an ordinary failure rather than as an
+			//OperationCanceledException (issue #1377), so without this guard every normal `clio cc` would
+			//end with a spurious "polling round failed, retrying" warning on the way out.
+			if (ct.IsCancellationRequested) {
+				return false;
+			}
+			TimeSpan elapsed = streak.RecordFailure(_timeProvider);
+			if (elapsed >= _options.GiveUpWindow) {
+				//The last failure is CHAINED, never interpolated into this message. Interpolating it made
+				//the CLI renderer treat this wrapper's own text as redundant - DescribeOuterContext drops
+				//a link whose message already contains the text below it - so the line lost the elapsed
+				//time, the window and the round count, which is the whole reason this message exists.
+				//Observed on a live stand while verifying issue #1376; the same trap is documented at
+				//PackageBuilder.CompileWithPolling, which wraps this exception a third time.
+				throw new InvalidOperationException(
+					$"Compilation polling gave up after {elapsed.TotalSeconds:F0} s of rounds that all "
+					+ $"failed (give-up window {_options.GiveUpWindow.TotalSeconds:F0} s, "
+					+ $"{streak.FailedRounds} failed rounds)",
+					exception);
+			}
+			//Once per tolerated round, not once per run: with the 1/2/5/5 backoff a 90-second window is
+			//about 20 lines, which is a readable account of an outage rather than a flood, and the round
+			//number plus the elapsed/window pair makes them obviously one incident. The round that gives
+			//up is NOT logged here - it throws, and both consumers already report that fault.
+			_logger.WriteWarning(
+				$"Compilation polling round {streak.FailedRounds} failed "
+				+ $"({elapsed.TotalSeconds:F0} s into a {_options.GiveUpWindow.TotalSeconds:F0} s "
+				+ $"tolerance window); retrying in {_options.BackoffFor(streak.FailedRounds).TotalSeconds:F0} s. "
+				+ $"Reason: {Describe(exception)}");
 			return false;
 		}
 	}
+
+	/// <summary>
+	/// The one rendering allowed into a diagnostic: the readable message, scrubbed AND fenced.
+	/// </summary>
+	/// <remarks>
+	/// <c>GetReadableMessageException</c> alone is not enough. It returns a
+	/// <c>DataProviderFailureException</c>'s already-scrubbed ConsoleMessage - the convention both
+	/// consumers of this poller follow - but for any other exception type it returns the raw
+	/// <c>Message</c>, which for a transport fault routinely carries the full request URI.
+	/// <para>
+	/// <see cref="UntrustedText.Fenced"/> rather than <c>ForConsole</c>, which is what a logger line
+	/// elsewhere in <c>Clio.Common</c> uses (<c>SysSettingsManager</c>). This line is different: it is
+	/// written by a WARNING during <c>compile-creatio</c>, and <c>CompileCreatioTool</c> copies the
+	/// captured log messages into the MCP result through <c>McpPassthroughRedaction.SanitizeAndRedact</c>,
+	/// which scrubs secrets (and only on a passthrough request) but never fences. So without the fence
+	/// here, server-authored prose - an outage is exactly when the answer is some gateway's or proxy's
+	/// own page - reaches an agent's context as if clio had written it. The fence costs a terminal reader
+	/// a marker; dropping it costs an agent the distinction between clio's words and the server's.
+	/// </para>
+	/// </remarks>
+	private static string Describe(Exception exception) =>
+		UntrustedText.Fenced(exception.GetReadableMessageException()) ?? "no detail reported";
 
 	/// <summary>
 	/// Reports every record not seen before and returns the advanced baseline. A real Creatio
@@ -145,6 +211,36 @@ public class CompilationHistoryPoller : ICompilationHistoryPoller {
 			}
 		}
 		return baseline;
+	}
+
+	/// <summary>
+	/// The current run of consecutive failed rounds: how many there have been and when it started. A
+	/// plain mutable state holder local to one <see cref="Poll"/> call - not a service - which is why it
+	/// is passed by reference instead of living in a field: two concurrent polls on one poller instance
+	/// must not share a run.
+	/// </summary>
+	private sealed class FailureStreak {
+
+		private long _startedAt;
+
+		/// <summary>Number of consecutive rounds that have failed, 0 when the last round succeeded.</summary>
+		internal int FailedRounds { get; private set; }
+
+		/// <summary>Ends the current run; the next failure starts the window measurement over.</summary>
+		internal void Reset() => FailedRounds = 0;
+
+		/// <summary>
+		/// Counts one more failed round and returns how long the current run has lasted. The FIRST
+		/// failure of a run returns <see cref="TimeSpan.Zero"/>, so a lone failure can never give up.
+		/// </summary>
+		internal TimeSpan RecordFailure(TimeProvider timeProvider) {
+			if (FailedRounds == 0) {
+				_startedAt = timeProvider.GetTimestamp();
+			}
+			FailedRounds++;
+			return timeProvider.GetElapsedTime(_startedAt);
+		}
+
 	}
 
 }

--- a/clio/Common/CompilationPollingOptions.cs
+++ b/clio/Common/CompilationPollingOptions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Clio.Common;
+
+/// <summary>
+/// The timing budget <see cref="CompilationHistoryPoller.Poll"/> runs on: how often it asks, how long
+/// it keeps asking while the environment cannot answer, and how far apart the retries are spaced while
+/// that lasts.
+/// </summary>
+/// <remarks>
+/// A data-only carrier, deliberately not a service: production uses <see cref="Default"/> everywhere and
+/// only a test supplies anything else, so that the give-up boundary can be exercised without the test
+/// spending the real budget asleep (issue #1376).
+/// </remarks>
+/// <param name="PollInterval">Gap between rounds while the environment is answering.</param>
+/// <param name="GiveUpWindow">
+/// How long a run of failures is tolerated, measured from the FIRST failure of the current run. A
+/// successful round ends the run and the measurement starts over.
+/// </param>
+/// <param name="BackoffSteps">
+/// Gap after the 1st, 2nd, 3rd … failed round. The last entry repeats for every further failure.
+/// </param>
+public sealed record CompilationPollingOptions(
+	TimeSpan PollInterval,
+	TimeSpan GiveUpWindow,
+	IReadOnlyList<TimeSpan> BackoffSteps) {
+
+	/// <summary>
+	/// The production budget: ask once a second, and tolerate an environment that cannot answer at all
+	/// for 90 seconds, backing off 1 s, 2 s, then 5 s between the failing rounds.
+	/// </summary>
+	/// <remarks>
+	/// 90 seconds, not the ~10 that the previous fixed count of 10 one-second rounds amounted to. During
+	/// a package compile the app tier routinely stops answering OData for much longer than ten seconds -
+	/// the measured gaps on a live stand were ~18 s between the compile request and the first history row
+	/// and ~31-33 s between two consecutive projects' rows, and on .NET Framework an IIS application-pool
+	/// recycle adds its own outage on top - so the old budget abandoned the monitoring of a multi-minute
+	/// compile over an ordinary pause. 60 s would be borderline against a recycle landing on top of an
+	/// already slow project; 90 s covers it and still reports a genuinely dead stand inside two minutes.
+	/// <para>
+	/// The backoff keeps the cost of that longer window flat: 1/2/5/5 … yields roughly 21 rounds across
+	/// the 90 seconds instead of the 90 an unbacked-off one-second cadence would fire at an environment
+	/// that is already struggling.
+	/// </para>
+	/// </remarks>
+	public static CompilationPollingOptions Default { get; } = new(
+		PollInterval: TimeSpan.FromSeconds(1),
+		GiveUpWindow: TimeSpan.FromSeconds(90),
+		BackoffSteps: new ReadOnlyCollection<TimeSpan>([
+			TimeSpan.FromSeconds(1),
+			TimeSpan.FromSeconds(2),
+			TimeSpan.FromSeconds(5)
+		]));
+
+	/// <summary>
+	/// The gap to wait after the <paramref name="failedRoundNumber"/>-th consecutive failed round; the
+	/// last configured step repeats once the sequence is exhausted.
+	/// </summary>
+	/// <param name="failedRoundNumber">1-based position of the round within the current failing run.</param>
+	public TimeSpan BackoffFor(int failedRoundNumber) {
+		if (failedRoundNumber <= 0 || BackoffSteps is null || BackoffSteps.Count == 0) {
+			return PollInterval;
+		}
+		int index = Math.Min(failedRoundNumber, BackoffSteps.Count) - 1;
+		return BackoffSteps[index];
+	}
+
+}

--- a/clio/ExceptionReadableMessageExtension.cs
+++ b/clio/ExceptionReadableMessageExtension.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using Clio.Common;
@@ -41,7 +43,8 @@ internal static class ExceptionReadableMessageExtension
 			// enrichment, otherwise the IOE arm below would shadow it and drop the 401-vs-connect signal.
 			_ when TryGetWebException(exception, out WebException nestedWebException)
 				=> $"{exception.Message} ({DescribeWebException(nestedWebException)})",
-			InvalidOperationException ex => ex.InnerException?.Message ?? ex.Message,
+			InvalidOperationException { InnerException: not null } ex => ComposeWithInnerDetail(ex),
+			InvalidOperationException ex => ex.Message,
 			_ => exception.Message
 		};
 	}
@@ -80,9 +83,12 @@ internal static class ExceptionReadableMessageExtension
 	private static string RenderCarrierForConsole(Exception carrier, Exception outer)
 	{
 		StringBuilder line = new();
-		//The outer exception said WHICH operation failed; dropping it left the operator with the
-		//provider's diagnosis and no idea which command produced it.
-		if (!ReferenceEquals(outer, carrier) && DescribeOuterContext(outer, carrier) is { } prefix)
+		//EVERY link above the carrier, not just the outermost one. Each wrapper says something the ones
+		//below it do not - PackageBuilder's "Package compilation could not be monitored" names the
+		//operation, and the poller's own wrapper below it carries the elapsed time, the give-up window and
+		//the failed-round count. Rendering only the outermost message deleted that middle link, so a
+		//three-link chain reported THAT monitoring stopped while silently dropping WHY (issue #1376).
+		if (DescribeChainAboveCarrier(outer, carrier) is { } prefix)
 		{
 			line.Append(prefix).Append(": ");
 		}
@@ -165,6 +171,58 @@ internal static class ExceptionReadableMessageExtension
 
 	/// <summary>Cap on an inner exception's message when it is rendered at debug verbosity.</summary>
 	private const int MaxRenderedInnerMessageLength = 300;
+
+	/// <summary>
+	/// The context every wrapper ABOVE <paramref name="carrier"/> adds, joined with <c>": "</c> from the
+	/// outermost inwards, or <see langword="null"/> when none of them adds anything.
+	/// </summary>
+	/// <remarks>
+	/// A message already quoted by one kept earlier is skipped, so a wrapper that merely restates the one
+	/// below it is not printed twice - the same rule <see cref="DescribeOuterContext"/> applies per link.
+	/// </remarks>
+	private static string DescribeChainAboveCarrier(Exception outer, Exception carrier)
+	{
+		List<string> parts = [];
+		for (Exception current = outer;
+			current != null && !ReferenceEquals(current, carrier);
+			current = current.InnerException)
+		{
+			if (DescribeOuterContext(current, carrier) is not { } part
+				|| parts.Any(kept => kept.Contains(part, StringComparison.Ordinal)))
+			{
+				continue;
+			}
+			parts.Add(part);
+		}
+		return parts.Count == 0 ? null : string.Join(": ", parts);
+	}
+
+	/// <summary>
+	/// An <see cref="InvalidOperationException"/> that wraps a fault carrying NO server-detail of its own:
+	/// the wrapper's own context leads and the inner message follows, scrubbed.
+	/// </summary>
+	/// <remarks>
+	/// This arm used to return the inner message alone. That silently deleted the wrapper's diagnosis
+	/// whenever the inner was not a <c>DataProviderFailureException</c> - and
+	/// <c>ClassifyingDataProvider.Guard</c> rethrows a transport fault UNCHANGED, so an
+	/// <c>HttpRequestException</c> under the compilation poll's give-up wrapper took exactly that path and
+	/// cost the operator the window and the round count (issue #1376). The inner is scrubbed because a
+	/// transport fault's message routinely carries the full request URI and this line reaches a console and
+	/// a CI log.
+	/// </remarks>
+	private static string ComposeWithInnerDetail(InvalidOperationException exception)
+	{
+		string inner = UntrustedText.ForConsole(exception.InnerException.Message)
+			?? exception.InnerException.Message;
+		if (string.IsNullOrWhiteSpace(exception.Message))
+		{
+			return inner;
+		}
+		return string.IsNullOrWhiteSpace(inner)
+			|| exception.Message.Contains(inner, StringComparison.Ordinal)
+			? exception.Message
+			: $"{exception.Message}: {inner}";
+	}
 
 	/// <summary>
 	/// The context the outer exception adds over the carrier's own message, or <see langword="null"/>

--- a/clio/Package/PackageBuilder.cs
+++ b/clio/Package/PackageBuilder.cs
@@ -172,10 +172,14 @@
 				Exception pollFault = Volatile.Read(ref pollFaultBox[0]);
 				if (pollFault is not null) {
 					StopMonitoring(cts, pollThread, httpTask);
-					//The carrier is CHAINED, not interpolated. Interpolating its message made
+					//The fault is CHAINED, not interpolated. Interpolating its message made
 					//DescribeOuterContext treat this wrapper's own text as redundant (outer.Message contains
 					//the carrier's) and drop it, so the line lost every mention of the compile - the wrappers'
-					//context was destroyed by the very interpolation meant to carry it.
+					//context was destroyed by the very interpolation meant to carry it. Chained, EVERY link
+					//prints: this wrapper names the operation and the poller's own wrapper below it carries
+					//the give-up window and the failed-round count. That middle link survives only because
+					//DescribeChainAboveCarrier walks the whole chain - before issue #1376 the renderer kept
+					//just the outermost message and this three-link shape lost its diagnosis silently.
 					throw new InvalidOperationException(
 						"Package compilation could not be monitored", pollFault);
 				}

--- a/clio/docs/commands/compile-configuration.md
+++ b/clio/docs/commands/compile-configuration.md
@@ -115,6 +115,16 @@ significant time depending on configuration size
 - Compilation errors include detailed information: error code, file name,
 line number, and error description
 - The command distinguishes between warnings (yellow) and errors (red)
+- Progress monitoring tolerates an environment that briefly stops answering: while
+the application tier is unreachable each failed poll round is reported as a warning
+and the next round is delayed 1 s, 2 s, then 5 s. Only after 90 seconds in which no
+round succeeded does the command stop monitoring and report `Compilation progress
+could not be monitored`. That is a warning, not a failure - the server keeps
+compiling and the exit code still comes from the compilation itself.
+- The 90 seconds are measured from the moment the FIRST failed round of the current
+run is detected, and the check happens when a round fails - so with the last 5 s
+backoff step the give-up is observed at about 93 seconds, and a failing read that
+takes time to time out adds its own duration on top of that.
 
 ## Return Values
 

--- a/clio/help/en/compile-configuration.txt
+++ b/clio/help/en/compile-configuration.txt
@@ -97,6 +97,17 @@ NOTES
     - Compilation errors include detailed information: error code, file name,
       line number, and error description
     - The command distinguishes between warnings (yellow) and errors (red)
+    - Progress monitoring tolerates an environment that briefly stops answering:
+      while the application tier is unreachable each failed poll round is reported
+      as a warning and the next round is delayed 1 s, 2 s, then 5 s. Only after
+      90 seconds in which no round succeeded does the command stop monitoring and
+      report "Compilation progress could not be monitored". That is a warning, not
+      a failure - the server keeps compiling and the exit code still comes from the
+      compilation itself.
+    - The 90 seconds are measured from the moment the FIRST failed round of the
+      current run is detected, and the check happens when a round fails - so with
+      the last 5 s backoff step the give-up is observed at about 93 seconds, and a
+      failing read that takes time to time out adds its own duration on top.
 
 RETURN VALUES
     0       Compilation completed successfully

--- a/docs/knowledge/Common/a-wrapper-message-that-quotes-its-inner-is-deleted-by-the-cli-renderer.md
+++ b/docs/knowledge/Common/a-wrapper-message-that-quotes-its-inner-is-deleted-by-the-cli-renderer.md
@@ -1,0 +1,48 @@
+---
+description: ExceptionReadableMessageExtension drops a wrapper's message when that message contains the text below it, so a wrapper that INTERPOLATES the failure it wraps silently loses everything it added; chaining keeps every link, but only since issue #1376 - before that only the outermost wrapper survived
+applies-to:
+  - clio/ExceptionReadableMessageExtension.cs
+  - clio/Common/CompilationHistoryPoller.cs
+  - clio/Package/PackageBuilder.cs
+  - clio/Command/CompileConfigurationCommand.cs
+ticket: "#1376"
+date: 2026-09-11
+---
+
+**What is true** — `ExceptionReadableMessageExtension.DescribeOuterContext` returns `null` for a link
+whose `Message` contains the carrier's (`outer.Message.Contains(carrierMessage)`), and that link is then
+not printed. So a wrapper built as
+
+```csharp
+throw new InvalidOperationException($"… gave up after {elapsed} s …. Last failure: {Describe(inner)}", inner);
+```
+
+prints only `Describe(inner)` — the elapsed time, the window and the round count it was written to carry
+never reach the operator. **Chain the inner exception and keep it out of the message text**; then
+`DescribeChainAboveCarrier` walks every link from the outermost down to the carrier and joins the
+non-duplicate messages with `": "`, so all three of `build-package`'s links print:
+
+```
+Package compilation could not be monitored: Compilation polling gave up after 93 s … (give-up window
+90 s, 21 failed rounds): Failed reading records from entity schema 'CompilationHistory': …
+```
+
+That walk is what issue #1376 added. **Before it, only the OUTERMOST wrapper survived as a prefix and
+every intermediate one was dropped even when correctly chained** — a two-link chain rendered fully and a
+three-link chain silently lost its middle, which is precisely where `PackageBuilder` puts the poller's
+diagnosis.
+
+A wrapper whose inner carries no server detail at all takes a different arm (`ComposeWithInnerDetail`):
+the wrapper's own message leads and the inner follows, scrubbed. That arm used to return the inner
+message alone — raw — and `ClassifyingDataProvider.Guard` rethrows transport faults UNCHANGED, so an
+`HttpRequestException` under a wrapper took exactly that path.
+
+**Why it is this way** — the duplicate rule exists so a wrapper that merely repeats the sentence below
+it is not printed twice, which is the common case across the ~20 commands this renderer serves. It
+cannot tell a repetition apart from a message that quotes the inner as one clause among several.
+
+**What breaks if you ignore it** — observed live on `ts1-core-dev04` while verifying issue #1376: the
+poll's give-up exception was composed with the last failure interpolated, and `clio cc` printed
+`Compilation progress could not be monitored: Failed reading records from entity schema
+'CompilationHistory': …` with no mention of the 90-second window or the 21 failed rounds. Nothing fails,
+nothing logs, and the diagnostic simply is not there.

--- a/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
+++ b/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
@@ -73,9 +73,10 @@ Three consequences worth knowing before writing code against this:
   `new Thread(...)` from `PackageBuilder.CompileWithPolling`, and an unhandled exception on a dedicated
   thread terminates the whole clio process — so before the tolerance was added, one timed-out OData read
   would have killed clio mid-compile and skipped every cleanup step. `Poll` now retries and gives up
-  only after a run of consecutive failures; `PackageBuilder` additionally captures the fault inside the
-  thread lambda and observes it on the main thread. Any new background consumer of `IDataProvider` needs
-  the same two guards.
+  only once rounds have been failing for longer than `CompilationPollingOptions.GiveUpWindow` (90 s,
+  issue #1376 — a duration, not a round count, because the 1/2/5 s backoff makes a count meaningless);
+  `PackageBuilder` additionally captures the fault inside the thread lambda and observes it on the main
+  thread. Any new background consumer of `IDataProvider` needs the same two guards.
 
 **What breaks if you ignore it** — a command that reads through `IDataProvider` on a bypassed or raw
 provider reports **success with an empty result** on expired or rejected credentials: `get-syssetting`


### PR DESCRIPTION
🔗 **Issue:** [#1376](https://github.com/Advance-Technologies-Foundation/clio/issues/1376)

## What changed

`CompilationHistoryPoller.Poll` no longer gives up after 10 consecutive failed rounds (~10 s at the fixed 1 s cadence). It now tolerates a failing run for a **90 s window** measured from the first failure of the streak, resets on any successful round, and backs off **1 / 2 / 5 / 5… s** between failed rounds (the backoff replaces the 1 s interval, so a struggling environment gets ~21 requests over the window instead of 90).

- New `CompilationPollingOptions` record (`PollInterval`, `GiveUpWindow`, `BackoffSteps`, `Default`) and `ICancellableDelay` seam; the poller takes `ILogger`, `TimeProvider` and `ICancellableDelay` through DI (all resolve from existing registrations, no `BindingsModule` change). `MaxConsecutiveFailures` / `DefaultPollIntervalMilliseconds` removed — only tests referenced them.
- One warning per tolerated round (round number, elapsed / window, next delay, fenced reason). The reason is **fenced** (`UntrustedText.Fenced`), not just scrubbed, because `compile-creatio` copies captured log messages into the MCP result and `McpPassthroughRedaction` never fences.
- Give-up throws `InvalidOperationException` with elapsed, window and round count, chaining the last failure. A round that fails after the poll's own token was cancelled (issue #1377's shape, including an `OperationCanceledException` from our token) is neither counted nor logged, so a normal `clio cc` no longer ends with a spurious "retrying" line.
- `ExceptionReadableMessageExtension` (shared CLI renderer): every wrapper link above an `IServerDetailCarrier` is now kept and joined with `: ` (previously only the outermost survived, so the `build-package` path lost the window/round count); the `InvalidOperationException`-with-inner arm now renders `<outer>: <inner scrubbed>` instead of only the inner. Pinned by three new tests in `ConsoleFacingDiagnosticsTests`.
- Docs: `compile-configuration` help + md describe the tolerance window and that the give-up is observed at ~93 s (last 5 s step) plus the duration of a slow failing read.
- Knowledge: new record on wrapper messages vs. the CLI renderer; `remotedataprovider-swallows-every-failure-into-success-false.md` updated.
- `watch-compilation` is untouched (it runs its own loop over `PollOnce` with `PollRetryPolicy`); only a stale comment was corrected.

## Validation

- Build `clio` / `clio.tests` / `clio.mcp.e2e`: 0 errors; `warning CLIO` count 4 = master (two pre-existing CLIO001 in `MobileDiffApplyValidator`).
- `Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit"` — 12353 passed / 28 failed / 40 skipped after rebasing on current master; the 28 are the known macOS-only cluster (DbHubTomlStore, NetFrameworkHttps, profile-path, ProcessExecutor, IIS/identity-service, plus `PackageCreator.Create_ShouldAddInjectableLocalizationAbstraction_WhenAsAppIsTrue`, which asserts a `T:\` path and comes from master's `980fa7c5f`). Failing-name set identical to master's on the pre-rebase baseline. Poller fixture: 13 tests in ~90 ms (was 6 tests, ~1 s).
- Real environment `ts1-core-dev04` (.NET Framework 4.8): (a) `cc -e dev04-0914` — 18 min compile, every CompilationHistory row reported, no spurious warning at the end, exit 0. (b) Give-up path via a local relay that forwards everything to the stand except the poll's DataService reads (a bad-password profile fails the compile POST before polling starts): round warnings at 0 / 1 / 3 / 8 / 13 … / 88 s (1/2/5/5 cadence visible), give-up at round 21 ≈ 93 s, process alive, `clio cc` reports "Compilation progress could not be monitored" as a warning exactly as #1372 established, exit code is the compile's own. Note: the poll reads go through DataService `SelectQuery`, not OData — "OData" in the issue text and old comments was a misnomer.

## Review

- Pre-PR gate: full 3-lens fan-out (bug-detector, quality/tests, Codex CLI). Resolved before opening: High (third wrapper on `build-package` dropped the give-up text), Medium ×3 (unfenced prose into MCP result; non-carrier inner dropped the outer message; give-up boundary not pinned — now asserted at round 21 / tolerated at round 20), all Lows. A narrow Codex recheck of the shared renderer change was started but did not finish within 35 min and was stopped; the chain walk was self-reviewed instead (terminates on `InnerException == null` or the carrier, de-duplicates by containment).
- Docs reviewed and updated (`clio/help/en/compile-configuration.txt`, `clio/docs/commands/compile-configuration.md`).
- MCP reviewed, no update required: no tool name, argument, default, destructive flag, result shape or error envelope changed; `CompileCreatioTool` / `WatchCompilationTool` descriptions never mentioned the round budget.
- ClioRing compatibility reviewed, no Ring-consumed contract changed (warning text inside captured log lines only).

Related: #1377 (cancellation swallowed by `RemoteDataProvider` — the poller now guards on its own token, but the classification itself is still that issue's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1376
