### PR TITLE
Pin that a swallowed timeout is not a caller cancellation on data-provider reads (#1377)

### DIFF
--- a/clio.tests/Common/ClassifyingDataProviderTests.cs
+++ b/clio.tests/Common/ClassifyingDataProviderTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 using ATF.Repository;
 using ATF.Repository.Providers;
 using Clio.Common;
@@ -26,6 +27,27 @@ public class ClassifyingDataProviderTests {
 	private const string ExpiredPasswordError = "5: Your password has expired.";
 
 	private const string GenericProviderError = "SqlException: deadlock victim";
+
+	/// <summary>
+	/// What a request TIMEOUT looks like once ATF has swallowed it. Verified with ilspycmd against
+	/// creatio.client 2.0.2: the synchronous <c>CreatioClient.ExecutePostRequest</c> passes
+	/// <c>CancellationToken.None</c>, so the only cancellation source in the stack is
+	/// <c>CreateTimeout</c>'s <c>CancelAfter</c>. Reaching the authentication step's 100 000 ms cap
+	/// produces <c>WebException(WebExceptionStatus.Timeout)</c> whose message is the cancellation prose,
+	/// and <c>RemoteDataProvider.GetItems</c> concatenates the message with its inner message.
+	/// Reproduced live against a listener that accepts and never answers: after 100 s clio reported
+	/// <c>Failed reading records from entity schema 'VwWebServiceV2': The operation was canceled.The
+	/// operation was canceled.</c>
+	/// </summary>
+	private const string SwallowedTimeoutError = "The operation was canceled.The operation was canceled.";
+
+	/// <summary>
+	/// The other timeout wording: the request itself outlives its cap (1 800 000 ms for a select,
+	/// 600 000 ms for a batch), <c>ReadResponseBody</c> observes it through <c>Task.Result</c>, and the
+	/// resulting <c>AggregateException(TaskCanceledException)</c> is what ATF swallows.
+	/// </summary>
+	private const string SwallowedTaskCanceledError =
+		"One or more errors occurred. (A task was canceled.)A task was canceled.";
 
 	/// <summary>Mirrors ClassifyingDataProvider.MaxFailureDetailLength, which is private to it.</summary>
 	private const int MaxFailureDetailLength = 300;
@@ -307,7 +329,7 @@ public class ClassifyingDataProviderTests {
 	}
 
 	[Test]
-	[Description("Cancellation is the caller's own decision and must reach it unchanged rather than being rewritten into a diagnosis about credentials.")]
+	[Description("Cancellation is the caller's own decision and must reach it unchanged rather than being rewritten into a diagnosis about credentials. This guards the DECORATOR CONTRACT for a shape the production stack does not produce: IDataProvider takes no CancellationToken and the synchronous Creatio client passes CancellationToken.None, so no caller token can reach the transport (issue #1377).")]
 	public void GetItems_ShouldPropagateCancellationUnchanged() {
 		// Arrange
 		IDataProvider sut = new ClassifyingDataProvider(
@@ -319,6 +341,79 @@ public class ClassifyingDataProviderTests {
 		// Assert
 		act.Should().Throw<OperationCanceledException>(
 			because: "a co-operative shutdown is not a provider failure");
+	}
+
+	[Test]
+	[Description("An unsuccessful read whose text says the operation was canceled is a TRANSPORT TIMEOUT, not a caller cancellation, and must stay a data-provider failure (issue #1377).")]
+	public void GetItems_ShouldKeepASwallowedTimeoutAsAProviderFailure() {
+		// Arrange
+		IDataProvider sut = BuildFailing(SwallowedTimeoutError);
+
+		// Act
+		Action act = () => sut.GetItems(BuildSelectQuery("VwWebServiceV2"));
+
+		// Assert
+		Exception thrown = act.Should().Throw<DataProviderFailureException>(
+			because: "no caller token can reach this call - IDataProvider carries none and the synchronous CreatioClient.ExecutePostRequest passes CancellationToken.None, so CreateTimeout's CancelAfter is the only cancellation source and this text can only mean the 100 000 / 1 800 000 ms cap was reached").Which;
+		thrown.Should().NotBeAssignableTo<OperationCanceledException>(
+			because: "re-raising it as a cancellation would hide every timeout and make CompilationHistoryPoller's 'exception is not OperationCanceledException' filter tolerate a dead environment forever");
+		thrown.Message.Should().Contain("VwWebServiceV2",
+			because: "the operator still needs the failing read named");
+	}
+
+	[Test]
+	[Description("The same rule on the process path: a run that came back unsuccessful with cancellation prose timed out and must stay a data-provider failure (issue #1377).")]
+	public void ExecuteProcess_ShouldKeepASwallowedTimeoutAsAProviderFailure() {
+		// Arrange
+		IDataProvider sut = BuildFailing(SwallowedTimeoutError);
+		IExecuteProcessRequest request = Substitute.For<IExecuteProcessRequest>();
+		request.ProcessSchemaName.Returns("UsrTestProcess");
+
+		// Act
+		Action act = () => sut.ExecuteProcess(request);
+
+		// Assert
+		Exception thrown = act.Should().Throw<DataProviderFailureException>(
+			because: "RemoteDataProvider.ExecuteProcess catches every exception into Success = false exactly as GetItems does, and the cancellation prose there has the same single cause - an expired request cap").Which;
+		thrown.Should().NotBeAssignableTo<OperationCanceledException>(
+			because: "a timed-out process run is a failure the caller must see, not a shutdown it asked for");
+		thrown.Message.Should().Contain("UsrTestProcess",
+			because: "the failing process has to be named");
+	}
+
+	[Test]
+	[Description("The wording the request cap itself produces - AggregateException(TaskCanceledException) via Task.Result - is also a timeout and must not be reported as a cancellation (issue #1377).")]
+	public void GetItems_ShouldKeepASwallowedTaskCancellationAsAProviderFailure() {
+		// Arrange
+		IDataProvider sut = BuildFailing(SwallowedTaskCanceledError);
+
+		// Act
+		Action act = () => sut.GetItems(BuildSelectQuery("Contact"));
+
+		// Assert
+		act.Should().Throw<DataProviderFailureException>(
+			because: "ReadResponseBody observes the send through Task.Result, so a request that outlived its 1 800 000 ms cap reaches ErrorMessage in this shape - still a timeout")
+			.Which.Should().NotBeAssignableTo<OperationCanceledException>(
+				because: "the two timeout wordings must be classified identically");
+	}
+
+	[Test]
+	[Description("A thrown AggregateException(TaskCanceledException) - the shape Task.Result produces on the value-returning members - must travel out unchanged rather than being rewritten into a verdict about credentials (issue #1377).")]
+	public void GetSysSettingValue_ShouldNotRewriteAThrownTaskCancellationIntoAnAuthenticationVerdict() {
+		// Arrange
+		IDataProvider sut = new ClassifyingDataProvider(new ThrowingDataProvider(
+			() => new AggregateException(new TaskCanceledException("A task was canceled."))));
+
+		// Act
+		Action act = () => sut.GetSysSettingValue<string>("SchemaNamePrefix");
+
+		// Assert
+		Exception thrown = act.Should().Throw<AggregateException>(
+			because: "a transport fault is rethrown unchanged so the network arms of SysSettingsCommand.CategorizeFailure stay reachable").Which;
+		thrown.Should().NotBeAssignableTo<AuthenticationException>(
+			because: "nothing in a task-cancellation names a credential, and claiming one would send the operator to repair a working password");
+		thrown.Should().NotBeOfType<DataProviderFailureException>(
+			because: "there is an original exception to preserve here, so the non-JSON-page rewrite must not fire either");
 	}
 
 	[Test]

--- a/clio/Common/ClassifyingDataProvider.cs
+++ b/clio/Common/ClassifyingDataProvider.cs
@@ -26,6 +26,29 @@ namespace Clio.Common;
 /// reach a caller as an empty result.
 /// </para>
 /// <para>
+/// The provider's per-member behaviour is NOT uniform, and the difference decides what this decorator
+/// can see (verified with ilspycmd against ATF.Repository 2.0.3.5, issue #1377):
+/// <c>GetItems</c> and <c>ExecuteProcess</c> catch <c>Exception</c>, so everything becomes
+/// <c>Success == false</c>; <c>BatchExecute</c> catches only <c>WebException</c>, so any other fault
+/// ESCAPES as a thrown exception; <c>GetDefaultValues</c> is a stub that returns <c>Success = true</c>
+/// without contacting the server at all.
+/// </para>
+/// <para>
+/// A <c>Success == false</c> whose text reads "The operation was canceled." or "A task was canceled."
+/// is a TIMEOUT, never a caller's cancellation. <see cref="IDataProvider"/> carries no
+/// <see cref="System.Threading.CancellationToken"/> and the synchronous
+/// <c>CreatioClient.ExecutePostRequest</c> (creatio.client 2.0.2) passes
+/// <c>CancellationToken.None</c>, so <c>CreateTimeout</c>'s <c>CancelAfter</c> is the only cancellation
+/// source in the whole stack. It surfaces in three shapes: a
+/// <c>WebException(WebExceptionStatus.Timeout)</c> from the authentication step's 100 000 ms cap, an
+/// <c>AggregateException(TaskCanceledException)</c> from the <c>Task.Result</c> body read once the
+/// request cap expires (1 800 000 ms for a select, 600 000 ms for a batch), or that same text carried
+/// in <c>ErrorMessage</c> after <c>GetItems</c> / <c>ExecuteProcess</c> swallowed it. None of the three
+/// is an <see cref="OperationCanceledException"/>, and none of them may be reported as one: doing so
+/// would hide every timeout from the operator and make <c>CompilationHistoryPoller</c>'s
+/// <c>exception is not OperationCanceledException</c> filter tolerate a dead environment forever.
+/// </para>
+/// <para>
 /// <see cref="IDataProvider.GetSysSettingValue{T}"/> and <see cref="IDataProvider.GetFeatureEnabled"/>
 /// return a plain value with no <c>Success</c> flag to inspect, and their provider implementations do
 /// <b>not</b> catch - a login page instead of JSON surfaces as a raw <c>JsonReaderException</c>. Those
@@ -118,8 +141,11 @@ public sealed class ClassifyingDataProvider : IDataProvider {
 		try {
 			return call();
 		} catch (OperationCanceledException) {
-			//Cancellation is the caller's own decision, not a provider failure; rewriting it would hide
-			//a co-operative shutdown behind a diagnosis about credentials.
+			//A decorator-contract guard, not a production path: no caller token reaches this stack (see
+			//the transport paragraph in the class remarks), so a real timeout arrives as a WebException
+			//or an AggregateException and is classified below. Kept so that a future consumer which does
+			//own a token gets its co-operative shutdown back unchanged rather than as a credentials
+			//diagnosis.
 			throw;
 		} catch (AuthenticationException) {
 			//Already the strongest available diagnosis, whichever way CategorizeFailure later reads it

--- a/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
+++ b/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
@@ -8,7 +8,7 @@ applies-to:
   - clio/BindingsModule.cs
   - clio/Command/SysSettingsCommand.cs
   - clio/Package/PackageBuilder.cs
-ticket: "#1371"
+ticket: "#1371, #1377"
 date: 2026-09-03
 ---
 
@@ -21,6 +21,9 @@ date: 2026-09-03
   .Models<T>()` resolves through `LoadDataCollection`, which is literally
   `(items != null && items.Success) ? items.Items : new List<Dictionary<string, object>>()`.
 - `GetDefaultValues` is a stub that returns a hardcoded `Success = true` and never contacts the server.
+- The catch is **not uniform**: `GetItems` and `ExecuteProcess` catch `Exception`, but `BatchExecute`
+  catches only `WebException` — anything else thrown there ESCAPES as an exception instead of becoming
+  `Success = false`.
 - `GetSysSettingValue<T>` and `GetFeatureEnabled` return a plain value with **no** `Success` flag, and
   they do **not** catch: a failure reaches the caller as the raw `JsonReaderException` /
   `WebException`.
@@ -34,6 +37,29 @@ date: 2026-09-03
 `BindingsModule` — the active-environment `IDataProvider` registration and the per-environment
 `Func<EnvironmentSettings, ISysSettingsManager>` factory — and is the single barrier that turns those
 two failure shapes into an `AuthenticationException` or an `InvalidOperationException`.
+
+**A `Success == false` that says "canceled" is a TIMEOUT, never a caller cancellation** — verified with
+`ilspycmd` against `creatio.client` 2.0.2 (issue #1377):
+
+- `ATF.Repository.Providers.RemoteDataProvider` → `CreatioClientAdapter.ExecutePostRequest(url, data,
+  timeout)` → the **synchronous** `Creatio.Client.CreatioClient.ExecutePostRequest`, which hardcodes
+  `CancellationToken.None` when calling `ExecutePostRequestAsync`. `IDataProvider` takes no
+  `CancellationToken` either, so a caller-owned token has **no channel** into the transport. The only
+  cancellation source in the whole stack is `CreatioClient.CreateTimeout(timeout, token)`, which does
+  `CancellationTokenSource.CreateLinkedTokenSource(None)` + `CancelAfter(timeout)`.
+- Three caps are in play: **100 000 ms** on the authentication step (`EnsureAuthenticatedAsync`),
+  **1 800 000 ms** on a select (`GetItems`, `ExecuteProcess`), **600 000 ms** on a batch
+  (`BatchExecute`, `GetSysSettingValue<T>`, `GetFeatureEnabled`).
+- The authentication cap is converted by `ExecuteLegacyWebRequest`, which catches
+  `OperationCanceledException` and rethrows `new WebException(msg, ex, WebExceptionStatus.Timeout,
+  null)`. The request cap reaches clio through `ReadResponseBody`'s `Task.Result`, i.e. as
+  `AggregateException(TaskCanceledException)`. **Neither is an `OperationCanceledException`**, so
+  `ClassifyingDataProvider.Guard`'s `catch (OperationCanceledException) { throw; }` is unreachable in
+  production — it is a decorator-contract guard, kept for a future consumer that owns a token.
+- Reproduced live (2026-09-11) against a local listener that accepts the connection and never answers:
+  after exactly 100 s `clio save-state` printed
+  `Failed reading records from entity schema 'VwWebServiceV2': The operation was canceled.The operation
+  was canceled.` — a `Success == false` carrying cancellation prose with no token anywhere.
 
 **Why it is this way** — the provider is a third-party assembly and its swallow-and-report contract
 cannot be changed from clio. An earlier attempt (PR #1233) put a second DataService probe request in
@@ -76,6 +102,15 @@ Three consequences worth knowing before writing code against this:
   only after a run of consecutive failures; `PackageBuilder` additionally captures the fault inside the
   thread lambda and observes it on the main thread. Any new background consumer of `IDataProvider` needs
   the same two guards.
+
+**What breaks if you ignore the timeout fact** — re-raising that text as an `OperationCanceledException`
+(the change issue #1377 originally proposed) would hide **every** timeout: the operator would be told a
+shutdown happened where a 30-minute select actually expired, and `CompilationHistoryPoller.TryPollOnce`,
+whose filter is `when (exception is not OperationCanceledException)`, would stop counting the round at
+all — so a stand that answers nothing would be polled forever instead of the poller giving up on its
+failure budget. The characterization tests in
+`clio.tests/Common/ClassifyingDataProviderTests.cs` (`*KeepASwallowedTimeout*`) exist to stop exactly
+that change.
 
 **What breaks if you ignore it** — a command that reads through `IDataProvider` on a bypassed or raw
 provider reports **success with an empty result** on expired or rejected credentials: `get-syssetting`


### PR DESCRIPTION
🔗 **Issue:** [#1377](https://github.com/Advance-Technologies-Foundation/clio/issues/1377)

## Outcome: the reported defect does not exist — this PR pins the real behaviour instead

The issue asked to re-raise a "swallowed cancellation" on the response-returning `IDataProvider` members as `OperationCanceledException`. Decompiling `ATF.Repository 2.0.3.5` and `creatio.client 2.0.2` shows there is no caller cancellation to recover:

- `IDataProvider` takes no `CancellationToken`, and the synchronous `CreatioClient.ExecutePostRequest` passes `CancellationToken.None`. The only cancellation source in the stack is `CreateTimeout`'s `CancelAfter` — i.e. a request **timeout** (100 000 ms auth step, 1 800 000 ms select, 600 000 ms batch).
- It surfaces as `WebException(Timeout)` from the auth step, `AggregateException(TaskCanceledException)` from the `.Result` body read, or as `Success == false` carrying "The operation was canceled." from `GetItems` / `ExecuteProcess`. `BatchExecute` catches only `WebException`, so the aggregate escapes; `GetDefaultValues` always returns `Success = true`.
- Reproduced live against a listener that accepts the connection and never answers: after exactly 100 s clio printed `Failed reading records from entity schema 'VwWebServiceV2': The operation was canceled.` — no token anywhere.

Re-raising that text as `OperationCanceledException` would relabel every timeout as a shutdown and make `CompilationHistoryPoller` (filter `exception is not OperationCanceledException`) tolerate a dead stand forever. Full diagnosis on the issue.

## What changed

- **Tests** (`ClassifyingDataProviderTests`, +4): the swallowed "canceled" text stays a `DataProviderFailureException` for `GetItems` and `ExecuteProcess`; the `AggregateException(TaskCanceledException)` shape is classified the same way; a thrown aggregate on `GetSysSettingValue<T>` is not rewritten into an authentication verdict. `GetItems_ShouldPropagateCancellationUnchanged` kept, with a `[Description]` saying it guards the decorator contract for a shape the production stack does not produce.
- **`ClassifyingDataProvider` remarks**: the per-member catch behaviour and the timeout facts, replacing the paragraph that implied a cancellation could reach the response-returning path; the `catch (OperationCanceledException) { throw; }` is annotated as a contract guard.
- **Knowledge**: `docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md` records the transport facts, the three caps and what breaks if the text is ever re-raised as a cancellation.

No production behaviour changed. The poller-side race (a round failing after the poll's own token was cancelled) is handled where the token lives, in #1477.

## Validation

- Build `clio` / `clio.tests`: 0 errors, `warning CLIO` count unchanged.
- `Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=Common"` — 1426 passed / 20 failed / 3 skipped; the 20 are the known macOS-only cluster (DbHubTomlStore, NetFrameworkHttps, profile-path, ProcessExecutor), unchanged. Fixture 21 → 25 passing.

## Review

- Pre-PR gate: review skipped — comments, tests and a knowledge record only, no production code path changed; the tests were self-reviewed for AAA / `because` / `[Description]`.
- Docs reviewed, no update required. MCP reviewed, no update required. ClioRing compatibility reviewed, no Ring-consumed contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1377
