### PR TITLE
Fix Gallery attribute mappings rejected as inline captions

### DIFF
--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.RegularExpressions;
+using Allure.Net.Commons;
 using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio;
@@ -1305,6 +1306,85 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 		} finally {
 			TryDeleteDirectory(sessionDir);
 			TryDeleteDirectory(outOfBandDir);
+		}
+	}
+
+	[TestCase(PageUpdateTool.ToolName)]
+	[TestCase(PageSyncTool.ToolName)]
+	[Description("Saves Gallery and Playbook attribute mappings with validation enabled and verifies the persisted identifiers through get-page on the explicitly configured sandbox.")]
+	[AllureTag(PageUpdateTool.ToolName, PageSyncTool.ToolName)]
+	[AllureName("Page writers preserve Gallery and Playbook mappings")]
+	[AllureDescription("Creates a unique blank page in Custom, saves both mapping shapes with validation enabled, and reads it back to prove the identifiers were not localized or removed.")]
+	public async Task PageWriters_ShouldPreserveMappings_WhenValidationEnabled(string toolName) {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping sandbox page writes.");
+		}
+		string environmentName = settings.Sandbox.EnvironmentName!;
+		environmentName.Should().NotBeNullOrWhiteSpace(because: "this test must never fall back to a shared environment");
+		string schemaName = "UsrMapping" + Guid.NewGuid().ToString("N")[..12];
+		string outputDirectory = CreateFixtureDirectory("page-mapping-roundtrip");
+		await using var context = Arrange(TimeSpan.FromMinutes(5));
+		await AllureApi.Step("Create a uniquely named sandbox page", async () => {
+			CallToolResult created = await context.Session.CallToolAsync(PageCreateTool.ToolName,
+				new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+					["schema-name"] = schemaName, ["template"] = "BlankPageTemplate",
+					["package-name"] = "Custom", ["environment-name"] = environmentName
+				} }, context.CancellationTokenSource.Token);
+			EntitySchemaStructuredResultParser.Extract<PageCreateResponse>(created).Success.Should().BeTrue(
+				because: "a fresh page isolates this test from existing sandbox content");
+		});
+		PageGetResponse original = await GetPageAsync(context, schemaName, environmentName, outputDirectory);
+		original.Success.Should().BeTrue(because: "the new page must be readable before editing");
+		string originalBody = await File.ReadAllTextAsync(original.Files.BodyFile);
+		const string mappingDiff = """
+			[{"operation":"insert","name":"GalleryProbe","parentName":"Main","propertyName":"items","values":{"type":"crt.Gallery","itemConfig":{"templateValuesMapping":{"caption":"GalleryDS_Name","description":"GalleryDS_Description","image":"GalleryDS_Image","id":"GalleryDS_Id"}}}},
+			{"operation":"insert","name":"PlaybookProbe","parentName":"Main","propertyName":"items","values":{"type":"crt.Playbook","_designOptions":{"templateValuesMapping":{"caption":"PlaybookDS_Name"}}}}]
+			""";
+		string body = Regex.Replace(originalBody,
+			@"/\*\*SCHEMA_VIEW_CONFIG_DIFF\*/[\s\S]*?/\*\*SCHEMA_VIEW_CONFIG_DIFF\*/",
+			"/**SCHEMA_VIEW_CONFIG_DIFF*/" + mappingDiff + "/**SCHEMA_VIEW_CONFIG_DIFF*/",
+			RegexOptions.None, TimeSpan.FromSeconds(1));
+		body.Should().NotBe(originalBody, because: "the probe must actually add both mapping shapes");
+
+		// Act
+		await AllureApi.Step("Save with content validation enabled", async () => {
+			if (toolName == PageUpdateTool.ToolName) {
+				PageUpdateResponse saved = await UpdatePageAsync(context, schemaName, body, environmentName, outputDirectory);
+				saved.Success.Should().BeTrue(because: $"valid mappings must save through update-page: {saved.Error}");
+			} else {
+				CallToolResult saved = await context.Session.CallToolAsync(PageSyncTool.ToolName,
+					new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName, ["validate"] = true, ["skip-sampling"] = true,
+						["output-directory"] = outputDirectory,
+						["pages"] = new[] { new Dictionary<string, object?> { ["schema-name"] = schemaName, ["body"] = body } }
+					} }, context.CancellationTokenSource.Token);
+				PageSyncResponse response = EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(saved);
+				response.Success.Should().BeTrue(because: $"valid mappings must save through sync-pages: {string.Join("; ", response.Pages.Select(page => page.Error))}");
+			}
+		});
+
+		// Assert
+		PageGetResponse readback = await AllureApi.Step("Read the saved schema from Creatio", async () =>
+			await GetPageAsync(context, schemaName, environmentName, outputDirectory));
+		readback.Success.Should().BeTrue(because: "a save response alone does not prove persistence");
+		string persisted = await File.ReadAllTextAsync(readback.Files.BodyFile);
+		string persistedDiff = Regex.Match(persisted,
+			@"/\*\*SCHEMA_VIEW_CONFIG_DIFF\*/(?<diff>[\s\S]*?)/\*\*SCHEMA_VIEW_CONFIG_DIFF\*/",
+			RegexOptions.None, TimeSpan.FromSeconds(1)).Groups["diff"].Value;
+		using JsonDocument actual = JsonDocument.Parse(persistedDiff);
+		using JsonDocument expected = JsonDocument.Parse(mappingDiff);
+		foreach (JsonElement expectedNode in expected.RootElement.EnumerateArray()) {
+			string nodeName = expectedNode.GetProperty("name").GetString()!;
+			JsonElement actualNode = actual.RootElement.EnumerateArray().Single(node => node.GetProperty("name").GetString() == nodeName);
+			string configProperty = nodeName == "GalleryProbe" ? "itemConfig" : "_designOptions";
+			Dictionary<string, string?> actualMapping = actualNode.GetProperty("values").GetProperty(configProperty)
+				.GetProperty("templateValuesMapping").EnumerateObject().ToDictionary(property => property.Name, property => property.Value.GetString());
+			Dictionary<string, string?> expectedMapping = expectedNode.GetProperty("values").GetProperty(configProperty)
+				.GetProperty("templateValuesMapping").EnumerateObject().ToDictionary(property => property.Name, property => property.Value.GetString());
+			AllureApi.Step($"Verify {nodeName} mapping values and paths are unchanged", () => actualMapping.Should().BeEquivalentTo(expectedMapping,
+				because: "mapping slots must retain plain record identifiers at their original paths, without resource prefixes"));
 		}
 	}
 

--- a/clio.mcp.e2e/PageValidateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageValidateToolE2ETests.cs
@@ -467,6 +467,30 @@ public sealed class PageValidateToolE2ETests : McpContractFixtureBase {
 			because: "the ImageInput tooltip literal is a valid, working authoring form and must not produce an error");
 	}
 
+	[TestCase("crt.Gallery", "itemConfig")]
+	[TestCase("crt.Playbook", "_designOptions")]
+	[Description("Accepts attribute-name caption mappings on Gallery and Playbook through the real MCP validator.")]
+	[AllureTag(ToolName)]
+	[AllureName("validate-page accepts Gallery and Playbook attribute mappings")]
+	[AllureDescription("Checks issue #1194 and related #1224 without converting record attribute identifiers to resource bindings.")]
+	public async Task PageValidateTool_ShouldAcceptMapping_WhenCaptionNamesRecordAttribute(string componentType, string configProperty) {
+		// Arrange
+		string diff = """[{"operation":"insert","name":"MappingProbe","values":{"type":"COMPONENT","CONFIG":{"templateValuesMapping":{"caption":"GalleryDS_Name"}}}}]"""
+			.Replace("COMPONENT", componentType).Replace("CONFIG", configProperty);
+		string body = ValidPageBody.Replace("/**SCHEMA_VIEW_CONFIG_DIFF*/[]", "/**SCHEMA_VIEW_CONFIG_DIFF*/" + diff);
+		await using var context = Arrange(TimeSpan.FromMinutes(3));
+
+		// Act
+		PageValidateResponse response = await AllureApi.Step("Validate the mapping through stdio MCP", async () =>
+			await CallAsync(context.Session, context.CancellationTokenSource.Token, body));
+
+		// Assert
+		AllureApi.Step("Verify the mapping is valid", () => response.Valid.Should().BeTrue(
+			because: "template slots name attributes rather than user-visible text"));
+		AllureApi.Step("Verify no content errors were reported", () => response.Validation!.Errors.Should().BeNullOrEmpty(
+			because: "valid mapping identifiers must not require resource registration"));
+	}
+
 	[Test]
 	[Description("Returns valid: true when an inserted crt.EmailComposer carries the platform-authored data.caption literal — a component's data descriptor is component metadata, not page-authored user-visible text, so the localizable-text rule must NOT reject it (issue #1298). Proves the descriptor exemption reaches through the real MCP transport.")]
 	[AllureTag(ToolName)]

--- a/clio.tests/Command/McpServer/SchemaValidationServiceTests.cs
+++ b/clio.tests/Command/McpServer/SchemaValidationServiceTests.cs
@@ -2685,6 +2685,65 @@ public sealed class SchemaValidationServiceTests
 			because: "designer metadata must not produce a localizable-text validation error");
 	}
 
+	[TestCase("insert")]
+	[TestCase("merge")]
+	[Description("Gallery template slots name projected attributes rather than localized UI text, for both insert and merge operations.")]
+	public void ValidateLocalizableTextLiterals_ShouldAcceptGalleryMapping_WhenItemConfigNamesAttributes(string operation) {
+		// Arrange
+		string body = BuildDiffBackedPageBody(
+			"""[{"operation":"OPERATION","name":"Gallery","values":{"type":"crt.Gallery","itemConfig":{"templateValuesMapping":{"caption":"GalleryDS_Name","description":"GalleryDS_Description","image":"GalleryDS_Image","id":"GalleryDS_Id"}}}}]""".Replace("OPERATION", operation),
+			"[]");
+
+		// Act
+		SchemaValidationResult result = SchemaValidationService.ValidateLocalizableTextLiterals(body);
+
+		// Assert
+		result.IsValid.Should().BeTrue(because: "Gallery mappings contain attribute identifiers, not display text");
+		result.Errors.Should().BeEmpty(because: "the caption mapping must not require a resource binding");
+	}
+
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Nested Gallery mappings and a same-body untyped merge use the same scoped exemption for web and mobile bodies.")]
+	public void ValidateLocalizableTextLiterals_ShouldAcceptMapping_WhenNestedOrSameBodyMerge(bool mobile) {
+		// Arrange
+		const string diff = """
+			[{"operation":"insert","name":"Container","values":{"type":"crt.FlexContainer","items":[{"name":"NestedGallery","type":"crt.Gallery","itemConfig":{"templateValuesMapping":{"caption":"NestedDS_Name"}}}]}},
+			{"operation":"insert","name":"Gallery","values":{"type":"crt.Gallery"}},
+			{"operation":"merge","name":"Gallery","values":{"itemConfig":{"templateValuesMapping":{"caption":"GalleryDS_Name"}}}}]
+			""";
+		string body = mobile ? "{\"viewConfigDiff\":" + diff + "}" : BuildDiffBackedPageBody(diff, "[]");
+
+		// Act
+		SchemaValidationResult result = mobile
+			? SchemaValidationService.ValidateMobileLocalizableTextLiterals(body)
+			: SchemaValidationService.ValidateLocalizableTextLiterals(body);
+
+		// Assert
+		result.IsValid.Should().BeTrue(because: "nested nodes and same-body type resolution preserve the Gallery mapping contract");
+		result.Errors.Should().BeEmpty(because: "all captions in this body are attribute identifiers");
+	}
+
+	[TestCase("""{"type":"crt.Gallery","caption":"Visible caption","itemConfig":{"templateValuesMapping":{"caption":"GalleryDS_Name"}}}""")]
+	[TestCase("""{"type":"crt.Gallery","itemConfig":{"caption":"Visible caption","templateValuesMapping":{"caption":"GalleryDS_Name"}}}""")]
+	[TestCase("""{"type":"crt.Gallery","itemConfig":{"items":[{"type":"crt.Label","caption":"Visible caption"}],"templateValuesMapping":{"caption":"GalleryDS_Name"}}}""")]
+	[TestCase("""{"type":"crt.FlexContainer","itemConfig":{"templateValuesMapping":{"caption":"Visible caption"}}}""")]
+	[TestCase("""{"type":"crt.Gallery","templateValuesMapping":{"caption":"Visible caption"}}""")]
+	[Description("The Gallery mapping exemption must not hide captions on the component, sibling item configuration, children, other components or other paths.")]
+	public void ValidateLocalizableTextLiterals_ShouldRejectCaption_WhenOutsideGalleryMapping(string values) {
+		// Arrange
+		string body = BuildDiffBackedPageBody(
+			$$"""[{"operation":"insert","name":"Gallery","values":{{values}}}]""", "[]");
+
+		// Act
+		SchemaValidationResult result = SchemaValidationService.ValidateLocalizableTextLiterals(body);
+
+		// Assert
+		result.IsValid.Should().BeFalse(because: "ordinary visible captions still require localization");
+		result.Errors.Should().ContainSingle(error => error.Contains("Visible caption"),
+			because: "only the real caption should be rejected, not the projected attribute name");
+	}
+
 	[Test]
 	[Description("A Timeline composer's platform-authored data.caption literal is accepted — a component's data descriptor is metadata, not page-authored user-visible text (issue #1298).")]
 	public void ValidateLocalizableTextLiterals_ComposerDataCaptionLiteral_ReturnsValid() {

--- a/clio/Command/SchemaValidationService.cs
+++ b/clio/Command/SchemaValidationService.cs
@@ -2385,10 +2385,11 @@ public static class SchemaValidationService
 	/// page body's <c>viewConfigDiff</c> are authored as localizable-string bindings rather than inline
 	/// literals. Walks every <c>insert</c>/<c>merge</c> entry's <c>values</c> subtree (including nested
 	/// child components) so a panel title, tab caption, or input placeholder set as a plain string is
-	/// rejected at any nesting depth — with two whole-subtree exemptions: <c>_designOptions</c>, and a
+	/// rejected at any nesting depth, except for <c>_designOptions</c> and a
 	/// component's own data descriptor (a <c>data</c> object carrying the platform's <c>typeName</c>
 	/// marker on a node that declares a component type — see <see cref="ComponentDataPropertyName"/>).
-	/// Both are platform-written metadata rather than page-authored text.
+	/// These are platform-written metadata rather than page-authored text. A Gallery's direct
+	/// <c>itemConfig.templateValuesMapping</c> is also excluded because its values name record attributes.
 	/// </summary>
 	/// <param name="jsBody">Raw JavaScript body of a Freedom UI page schema (marker-delimited).</param>
 	/// <returns>
@@ -2397,7 +2398,7 @@ public static class SchemaValidationService
 	/// expression) and any value that references a <c>#ResourceString(Key)#</c> macro — bare,
 	/// concatenated, or wrapped (e.g. <c>#MacrosTemplateString(#ResourceString(Key)#)#</c>) — are
 	/// accepted; non-string and empty values are ignored. Anything inside an exempt subtree
-	/// (<c>_designOptions</c>, a component data descriptor) is not examined at all, at any depth.
+	/// (<c>_designOptions</c>, a component data descriptor, or Gallery's template mapping) is not examined.
 	/// </returns>
 	public static SchemaValidationResult ValidateLocalizableTextLiterals(string jsBody) {
 		var result = new SchemaValidationResult { IsValid = true };
@@ -2671,7 +2672,8 @@ public static class SchemaValidationService
 	// same-name sibling insert's type for a bare merge). It is applied ONLY when this object has no "type" of
 	// its own AND is the entry root; nested children are recursed with an empty entryRootType so a nested
 	// non-exempt node can never inherit an ancestor's exemption.
-	private static void ScanNodeForTextLiterals(JsonElement node, string ownerName, string entryRootType, SchemaValidationResult result) {
+	private static void ScanNodeForTextLiterals(JsonElement node, string ownerName, string entryRootType,
+		SchemaValidationResult result, bool isGalleryItemConfig = false) {
 		switch (node.ValueKind) {
 			case JsonValueKind.Object:
 				string currentName = TryGetNodeName(node, out string nodeName) ? nodeName : ownerName;
@@ -2683,11 +2685,15 @@ public static class SchemaValidationService
 				// for the entry root — see the entryRootType note above).
 				string currentType = TryGetComponentType(node, out string nodeType) ? nodeType : entryRootType;
 				foreach (JsonProperty property in node.EnumerateObject()) {
-					if (IsExemptFromTextScan(currentType, property)) {
+					// Gallery template slots map to record attribute names, not displayed captions.
+					// Carry this context only across the direct Gallery -> itemConfig edge.
+					if (IsExemptFromTextScan(currentType, property) ||
+					    (isGalleryItemConfig && property.NameEquals("templateValuesMapping"))) {
 						continue;
 					}
 					ScanTextPropertyForLiterals(currentName, currentType, property, result);
-					ScanNodeForTextLiterals(property.Value, currentName, string.Empty, result);
+					ScanNodeForTextLiterals(property.Value, currentName, string.Empty, result,
+						currentType == "crt.Gallery" && property.NameEquals("itemConfig"));
 				}
 				break;
 			case JsonValueKind.Array:

--- a/clio/Command/SchemaValidationService.cs
+++ b/clio/Command/SchemaValidationService.cs
@@ -2687,8 +2687,7 @@ public static class SchemaValidationService
 				foreach (JsonProperty property in node.EnumerateObject()) {
 					// Gallery template slots map to record attribute names, not displayed captions.
 					// Carry this context only across the direct Gallery -> itemConfig edge.
-					if (IsExemptFromTextScan(currentType, property) ||
-					    (isGalleryItemConfig && property.NameEquals("templateValuesMapping"))) {
+					if (IsExemptFromTextScan(currentType, property, isGalleryItemConfig)) {
 						continue;
 					}
 					ScanTextPropertyForLiterals(currentName, currentType, property, result);
@@ -2752,13 +2751,14 @@ public static class SchemaValidationService
 		return false;
 	}
 
-	// Single predicate for "this subtree is not page-authored text", so the two conditions cannot drift
+	// Single predicate for "this subtree is not page-authored text", so the exemptions cannot drift
 	// apart at the call sites (the file extracts FormatOwnerNode and ResolveEntryRootType for the same
 	// reason). Used by the literal scanners only - the inserted-widget-caption engine intentionally
-	// applies neither exemption, because it also backs the blocking save gate.
-	private static bool IsExemptFromTextScan(string componentType, JsonProperty property) =>
+	// applies only the designer-metadata exemption, because it also backs the blocking save gate.
+	private static bool IsExemptFromTextScan(string componentType, JsonProperty property, bool isGalleryItemConfig) =>
 		string.Equals(property.Name, DesignOptionsPropertyName, StringComparison.Ordinal) ||
-		IsComponentDescriptorProperty(componentType, property);
+		IsComponentDescriptorProperty(componentType, property) ||
+		(isGalleryItemConfig && property.NameEquals("templateValuesMapping"));
 
 	// True when the property is the data descriptor of a node that declares a component type (see
 	// ComponentDataPropertyName). Callers skip the subtree entirely: it is component metadata, never

--- a/clio/docs/commands/update-page.md
+++ b/clio/docs/commands/update-page.md
@@ -133,7 +133,11 @@ name instead of trying to edit a non-existent local `insert`.
   column captions and validator messages) and register the key's default-language value through
   `--resources`. Binding expressions (any `$`-prefixed value) and non-string values (e.g.
   `placeholder: false`) are not literals and pass. Call `clio get-guidance --name page-schema-resources`
-  for the full rule.
+  for the full rule. Gallery's `itemConfig.templateValuesMapping` is excluded: values such as
+  `caption: "GalleryDS_Name"` name projected record attributes. Keep those identifiers unchanged;
+  captions elsewhere on the Gallery or its children still require localization. For a standalone
+  `merge` that patches this mapping, include `type: "crt.Gallery"` unless another entry in the
+  same body declares that node's type. Designer-only `_designOptions` mappings are also excluded.
   A **component's own data descriptor is exempt**: a `data` object that carries the platform's
   `typeName` marker, on a node declaring a component `type`, is component metadata (uId, schemaType,
   typeName and the caption the platform stamped on it) rather than page-authored text, so a literal

--- a/clio/help/en/update-page.txt
+++ b/clio/help/en/update-page.txt
@@ -108,6 +108,11 @@ DESCRIPTION
       viewConfigDiff must be a localizable-string binding, not an inline
       literal. Bind via #ResourceString(<Key>)# and register the key's
       default-language value with --resources. Inline literals are rejected.
+      Gallery itemConfig.templateValuesMapping values name record attributes
+      (e.g. caption: "GalleryDS_Name") and must stay unchanged. Other captions
+      still require localization. For a standalone merge, repeat type:
+      "crt.Gallery" unless the same body declares that node's type elsewhere.
+      Designer-only _designOptions mappings are also excluded.
       A component's own data descriptor is exempt: a "data" object carrying the
       platform's "typeName" marker, on any node that declares a component type
       and at any depth, is component metadata (uId, schemaType, typeName and


### PR DESCRIPTION
Gallery `itemConfig.templateValuesMapping.caption` names a projected record attribute, but Clio rejected it as unlocalized display text. Exempt only that direct mapping path; continue validating captions on the Gallery, sibling configuration, nested components and unrelated paths. Reuse existing same-body type resolution for merge operations.

Fixes #1194.

Related-issue search: #1224 reports the same symptom under Playbook `_designOptions`, which master already exempts. Added regression coverage for that shape without claiming or closing it. #1312 (AST scope/dataflow) and #1200 (mobile bindings/paired schemas) require independent repairs.

Validation:
- Two Gallery regression cases failed on unchanged master, then passed with this fix.
- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=McpServer)" -v quiet -m:1`: 9,664 passed, 15 existing skips, including after integrating current master.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter "FullyQualifiedName~PageWriters_ShouldPreserveMappings|FullyQualifiedName~PageValidateTool_ShouldAcceptMapping"`: 4 passed. Also 4 passed on net8.0 before the final diagnostic-only upstream merge.
- Newly deployed disposable `clio1194`: Creatio 10.1.585.0 / .NET 8.0.31 / PostgreSQL. Both writers save with validation enabled; get-page verifies exact Gallery and Playbook mapping paths and values. Probe pages remain in this sandbox.

Updated update-page help/docs. Index, aliases and templates reviewed, no update required. MCP reviewed, no update required to adapters or arguments; all three tool paths have real MCP coverage. The current page-schema-resources guide already permits non-displayed attribute names.

ClioRing compatibility reviewed, no Ring-consumed contract changed: inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json` for these three page tools.

Full parallel review covered quality, correctness/performance/testing, security, intent and KISS; one readback-test finding was fixed. Claude review `rev_17a639a0abdb411a` found no blocking defects. The small Sonar predicate adjustment received a scoped combined review; the final upstream merge received three-lens and whole-PR integration review. No blockers remain. Production adds only scoped traversal context, with no new service or state.