### PR TITLE
Add related-issue deduplication to the shared workflow

### DIFF
--- a/.ai/skills/clio-issue-workflow/SKILL.md
+++ b/.ai/skills/clio-issue-workflow/SKILL.md
@@ -14,7 +14,7 @@ Treat the issue number or URL as required input. The original Clio issue remains
 ## Route the request
 
 - For `take`, `triage`, `fix`, `implement`, or `resolve`, start with the `claim-clio-issue` skill; claiming always precedes investigation.
-- Continue with the `investigate-clio-issue` skill to prove the failure boundary and identify every affected repository.
+- Continue with the `investigate-clio-issue` skill to prove the failure boundary, identify every affected repository, and check related open, unclaimed issues before deciding whether one PR should resolve multiple reports.
 - Use the `repair-clio-issue` skill only when the user authorized implementation. A triage-only request stops after publishing the diagnosis and any authorized downstream issue relationships.
 - For brainstorming, planning, explanation, or review-only requests, stay read-only and do not claim the issue.
 
@@ -64,6 +64,6 @@ If the field, option, permission, or API support is missing, report the exact fa
 
 ## Completion
 
-Report the original issue, assignee, current stage, linked branch or PR, owning repositories, blocking downstream issues, validation state, and any genuine human decision still required.
+Report the original issue, assignee, current stage, linked branch or PR, owning repositories, blocking downstream issues, related-issue search and grouping decision, validation state, and any genuine human decision still required.
 
 Do not add coordination artifacts beyond the assignee, Issue Type, labels, stage field, Development link, issue relationships, and normal issue or PR comments required to explain a blocker.

--- a/.ai/skills/investigate-clio-issue/SKILL.md
+++ b/.ai/skills/investigate-clio-issue/SKILL.md
@@ -29,6 +29,20 @@ Confirm that the original issue is open, assigned to the current GitHub user, li
 
 Do not routinely spend a cross-provider review during investigation. Engage the other coding agent only when the user explicitly requests it or a concrete high-risk ambiguity could materially change repository ownership or the repair: destructive/security/authentication behavior, concurrency, migration, public protocol compatibility, or unfamiliar Creatio platform behavior. Claude is the consultant when running as Codex; Codex is the consultant when running as Claude. Ask for a narrow, independent challenge to the current root cause and smallest repair, with concrete evidence rather than a broad audit. Verify its claims locally and distinguish accepted, rejected, and unresolved findings. If Collab is unavailable or quota-limited, record that and continue without retrying; investigation consultation is optional and is not a blocker.
 
+## Check related open, unclaimed issues
+
+Before handing investigation to repair, search open issues in Clio and any confirmed owning repository using the affected command, symbols, error text, and reported behavior. Start with unassigned issues, then inspect plausible candidates' full bodies, comments, acceptance criteria, assignees, Development links, and matching issue branches. An empty assignee list alone does not prove an issue is unclaimed: an existing branch or active PR is ownership evidence. Do not take over or regroup claimed or ambiguous work, including work assigned to the current user from another task.
+
+Compare root causes and required outcomes, not just similar titles or labels. Decide autonomously within the user's authorized scope:
+
+- **One PR:** the original issue and candidates belong to the same repository and one cohesive repair fully satisfies each issue's acceptance criteria with a shared validation boundary. This includes duplicate reports and different symptoms of the same defect. Route issues in other repositories through the downstream procedure below; never link them to the original Clio branch as a group.
+- **Separate PRs:** the issues have independent causes, require separately useful changes, belong to different repositories, or combining them would materially broaden scope or complicate validation. Cross-link relevant evidence and preserve required downstream dependencies.
+- **Uncertain:** retain the original repair boundary and record what evidence is missing; do not treat a suspected duplicate as confirmed or block otherwise independent work.
+
+Record the search scope, candidate issue links, evidence, and the one-PR/separate-PR decision in the original issue's diagnosis comment, including when no candidates are found. If search is unavailable or incomplete, disclose that limitation rather than claiming no related issues exist. Finding a related issue does not authorize unrelated repairs, third-party writes, or closing it as a duplicate.
+
+When implementation is authorized and one PR is selected, claim only the additional issues included in that repair. Immediately before assignment, re-read their open state, assignees, branches, and PR links; exclude any candidate whose ownership changed or is ambiguous. Assign the current user and verify sole assignment using the claim skill's readback rule. For these grouped issues only, link the original issue's existing Development branch instead of creating another branch or worktree; retain the original issue as coordinator. Verify the link and `Investigating` stage through the canonical procedure. If setup fails, stop the grouped handoff and report the incomplete claim without hiding successful writes. Apply the metadata gate below to every included issue. A triage-only request records the proposed grouping without claiming additional issues or starting repair.
+
 ## Normalize issue metadata
 
 After the diagnosis is evidence-backed and before handing work to repair or another owner:
@@ -70,4 +84,4 @@ Set and verify the original issue's stage using the `clio-issue-workflow` skill:
 - `Waiting for human approval` when investigation is complete but a human decision, permission, or missing answer blocks progress.
 - `Investigating` only while evidence gathering can still continue without human input.
 
-Return the diagnosis, evidence, verified Issue Type and labels, affected repositories, existing or created downstream issues, relationships added, proposed repair boundary, cross-agent contribution or unavailability, and unresolved questions.
+Return the diagnosis, evidence, verified Issue Type and labels, affected repositories, existing or created downstream issues, relationships added, related-issue search and grouping decision, included issues and their verified claims, proposed repair boundary, cross-agent contribution or unavailability, and unresolved questions. Set and verify the same handoff stage for every grouped issue; the original issue remains authoritative for overall status.

--- a/.ai/skills/repair-clio-issue/SKILL.md
+++ b/.ai/skills/repair-clio-issue/SKILL.md
@@ -13,6 +13,8 @@ Confirm that the original issue is open, assigned to the current GitHub user, ha
 
 ## Establish each repair branch
 
+Honor the investigation's related-issue grouping decision. Before grouped repair, verify each included issue is still open, solely assigned to the current user, linked to the shared Development branch, classified by the metadata gate, and in `Fixing`. On ownership conflict, stop and report it. Use the coordinator's existing branch and worktree for the group; do not run separate branch creation for its additional issues. Keep grouped issues' stages aligned and verified as work moves through QA or waits for human input.
+
 For the original Clio issue, continue on its existing `<login>/issue-<number>` branch and isolated worktree.
 
 For a downstream issue:
@@ -33,6 +35,8 @@ Verify the original Clio issue's `Mitigation stage = Fixing` through the `clio-i
 4. Follow all repository-specific validation, review, and delivery policies.
 
 After the first meaningful commit, run the affected repository's mandatory pre-PR review gate, then open a draft pull request immediately. Do not create an empty or placeholder commit solely to open a PR. Link the PR to its own issue and reference the original Clio issue. A cross-repository closing reference must be fully qualified as `Advance-Technologies-Foundation/clio#<number>` and may be used only when that one PR completely resolves the original; otherwise preserve the original as the coordination issue.
+
+For a grouped PR, explain the shared cause and map validation to each included issue's acceptance criteria. Add a separate closing reference for every issue the PR fully resolves and verify each Development PR link. Use non-closing references for related issues outside the repair. If new evidence splits the repair boundary, revise the grouping, issue comments, and PR references before delivery; never leave a closing reference for an issue with unmet criteria.
 
 ## Validate and review
 


### PR DESCRIPTION
The issue workflow now searches for related open, unclaimed reports before repair and decides whether one cohesive PR can satisfy their acceptance criteria. It records the evidence, protects existing ownership, reuses the coordinator branch for grouped issues, and requires per-issue validation and accurate closing references. Cross-repository work keeps its existing downstream flow.

Closes #1480

Validation: quick_validate.py passed for all three canonical skills; scripts/verify-agent-docs.ps1 and git diff --check passed. Knowledge check found no records covering the changed files. No runtime code changed, so module tests do not apply. Codex and Claude wrappers both load the changed canonical files.

Comprehensive parallel review covered quality, performance, security, testing, edge cases, intent and KISS. No blocking findings; clarified the repository boundary in response to an advisory finding. Claude consultation skipped for instruction-only work per its skill policy.
