### PR TITLE
Require verified native issue relationships in workflow

### DIFF
--- a/.ai/skills/clio-issue-workflow/SKILL.md
+++ b/.ai/skills/clio-issue-workflow/SKILL.md
@@ -28,7 +28,7 @@ Use GitHub's existing primitives only:
 - Issue Type and labels: the evidence-backed classification, normalized before investigation hands work to repair or another owner.
 - `Mitigation stage` issue field: `Investigating`, `Fixing`, `QA`, or `Waiting for human approval`.
 - Development: the linked branch and later the draft pull request.
-- Relationships: the original issue is `blocked by` an issue in another repository when that downstream issue owns work required to resolve the report.
+- Relationships: create and verify GitHub-native `blocked by` / `blocking` links for confirmed dependencies, in the same repository or across repositories. Follow the investigation skill's native relationship procedure before handoff; a diagnosis comment, Markdown link, or shared PR alone does not populate the Relationships section.
 
 Do not introduce claim records, leases, receipts, lock files, custom refs, or a separate state store.
 

--- a/.ai/skills/investigate-clio-issue/SKILL.md
+++ b/.ai/skills/investigate-clio-issue/SKILL.md
@@ -41,6 +41,8 @@ Compare root causes and required outcomes, not just similar titles or labels. De
 
 Record the search scope, candidate issue links, evidence, and the one-PR/separate-PR decision in the original issue's diagnosis comment, including when no candidates are found. If search is unavailable or incomplete, disclose that limitation rather than claiming no related issues exist. Finding a related issue does not authorize unrelated repairs, third-party writes, or closing it as a duplicate.
 
+Apply the native relationship procedure below to confirmed dependencies found by this search, including same-repository issues, before handoff. Selecting one PR for several reports does not by itself make those issues dependent on one another.
+
 When implementation is authorized and one PR is selected, claim only the additional issues included in that repair. Immediately before assignment, re-read their open state, assignees, branches, and PR links; exclude any candidate whose ownership changed or is ambiguous. Assign the current user and verify sole assignment using the claim skill's readback rule. For these grouped issues only, link the original issue's existing Development branch instead of creating another branch or worktree; retain the original issue as coordinator. Verify the link and `Investigating` stage through the canonical procedure. If setup fails, stop the grouped handoff and report the incomplete claim without hiding successful writes. Apply the metadata gate below to every included issue. A triage-only request records the proposed grouping without claiming additional issues or starting repair.
 
 ## Normalize issue metadata
@@ -61,12 +63,25 @@ For every repository that owns required work:
 1. Search for an existing issue before creating a duplicate.
 2. When no suitable issue exists, create one with the original Clio issue link, evidence, acceptance criteria, and exclusions when the target is owned by `Advance-Technologies-Foundation`. Require explicit user confirmation before writing to any third-party, customer-owned, or personal repository.
 3. Before handoff, apply the same metadata normalization and readback gate to every existing or created downstream issue that owns repair work. If its repository has no relevant enabled Issue Type or existing label, or the workflow lacks authority to set them, stop and report the exact metadata blocker rather than starting repair from an unclassified issue.
-4. Mark the original Clio issue as `blocked by` the downstream issue with `gh issue edit ORIGINAL --add-blocked-by DOWNSTREAM_URL`. Use `relates to` only when the downstream work is informative rather than required.
+4. Mark the original Clio issue as `blocked by` the downstream issue using the native relationship procedure below. Informative links alone are cross-references, not dependencies.
 5. Add a concise diagnosis comment to the original issue with the owning repository and downstream issue link. Do not duplicate the full downstream issue body.
 
 Do not use parent-child relationships unless the original issue intentionally represents a larger planned body of work. For multiple required repositories, the original issue may be blocked by multiple downstream issues.
 
-Verify dependencies with `gh issue view --json blockedBy,blocking`. If a required relationship cannot be created, report the exact permission or platform failure and add a concise cross-link comment when authorized; do not silently claim the dependency exists.
+### Create and verify native Relationships
+
+For each confirmed dependency within the authorized scope, use GitHub's native Relationships section, not only issue text or a PR reference:
+
+1. Read both issues' current relationships with `gh issue view ISSUE_URL --json blockedBy,blocking`. Reuse an existing correct link; preserve unrelated links.
+2. If issue A requires issue B to be completed, run `gh issue edit A_URL --add-blocked-by B_URL`. Equivalently, use `gh issue edit B_URL --add-blocking A_URL`; one write establishes both directions. Use full URLs to avoid repository ambiguity.
+3. Re-read both issues and verify B appears in A's `blockedBy` and A appears in B's `blocking`. Inspect the returned issue identities and connection contents/counts; a non-null connection object or successful command exit alone is not proof.
+4. Include the verified direction and issue links in the diagnosis/handoff. If creation or readback fails, report the exact permission, API, or verification failure and the incomplete relationship step. An authorized cross-link comment can preserve context but does not satisfy this step; do not report native linking as complete.
+
+GitHub's Relationships section supports `blocked by` and `blocking`, not a generic `relates to` dependency. For related-but-independent issues, duplicate reports, or shared-fix siblings with no completion dependency, use a concise cross-reference and explicitly report why no native dependency applies. Never invent a blocker or parent-child hierarchy merely to fill the Relationships section. Use parent/sub-issues only for intentional work decomposition as described above, and verify the stored parent and child identities.
+
+Reference: [GitHub issue dependencies](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies).
+
+### Other outcomes
 
 For non-repository outcomes:
 


### PR DESCRIPTION
Related-issue discovery could stop at a diagnosis comment, leaving GitHub Relationships empty even when a real dependency existed. The workflow now requires native blocked-by/blocking links for confirmed dependencies in the same or different repositories and verifies both issue identities after writing. Independent related reports remain cross-references; shared fixes do not invent blockers.

Closes #1486
Follow-up to #1482.

Validation: quick_validate.py passed for both edited canonical skills; pwsh -NoProfile -File scripts/verify-agent-docs.ps1 and git diff --check passed. Installed gh supports the documented flags and JSON fields. Both Codex and Claude wrappers load the canonical files. No runtime code or command/MCP contract changed; module tests do not apply.

Comprehensive parallel review covered quality, testing, correctness, performance, security, intent alignment, and KISS; no findings. The final diff is unchanged from the reviewed diff. Claude consultation skipped for instruction-only work under its skill policy.
