### PR TITLE
Extract the sys-setting failure classifier behind ISysSettingFailureClassifier (#1379)

### DIFF
--- a/clio.tests/Command/ApplyEnvironmentManifestCommandTests.cs
+++ b/clio.tests/Command/ApplyEnvironmentManifestCommandTests.cs
@@ -28,6 +28,23 @@ namespace Clio.Tests.Command;
 [Property("Module", "Command")]
 public sealed class ApplyEnvironmentManifestCommandTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
 	private const string ManifestPath = "manifest.yaml";
 
 	private IEnvironmentManager _environmentManager;
@@ -80,7 +97,7 @@ public sealed class ApplyEnvironmentManifestCommandTests {
 			Substitute.For<FeatureCommand>(
 				Substitute.For<IApplicationClient>(), environmentSettings, provider,
 				Substitute.For<IServiceUrlBuilder>(), Substitute.For<IFeatureStateService>()),
-			new SysSettingsCommand(_sysSettingsManager, _logger, Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider()),
+			BuildCommand(_sysSettingsManager, null, _logger),
 			_setWebServiceUrlCommand,
 			provider,
 			environmentSettings) {

--- a/clio.tests/Command/McpServer/SchemaNamePrefixToolTests.cs
+++ b/clio.tests/Command/McpServer/SchemaNamePrefixToolTests.cs
@@ -17,6 +17,17 @@ namespace Clio.Tests.Command.McpServer;
 public sealed class SchemaNamePrefixToolTests {
 
 	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tests reach it is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static ISysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
+	/// <summary>
 	/// Builds a <see cref="SysSettingsManager"/> whose only meaningful collaborator is the data provider.
 	/// The read path exercised here (<c>GetSysSettingValueByCode</c>) resolves the value through the
 	/// provider, so the remaining constructor dependencies are inert substitutes.
@@ -70,7 +81,7 @@ public sealed class SchemaNamePrefixToolTests {
 		SysSettingsManager manager = BuildSysSettingsManager(dataProvider);
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>()).Returns(manager);
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("sandbox"));
@@ -94,7 +105,7 @@ public sealed class SchemaNamePrefixToolTests {
 		SysSettingsManager manager = BuildSysSettingsManager(dataProvider);
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>()).Returns(manager);
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("sandbox"));
@@ -116,7 +127,7 @@ public sealed class SchemaNamePrefixToolTests {
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>())
 			.Returns(_ => throw new HttpRequestException("Connection refused."));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("offline-env"));
@@ -138,7 +149,7 @@ public sealed class SchemaNamePrefixToolTests {
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>())
 			.Returns(_ => throw new InvalidOperationException("Environment 'unknown' is not registered."));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("unknown"));
@@ -162,7 +173,7 @@ public sealed class SchemaNamePrefixToolTests {
 		SysSettingsManager manager = BuildSysSettingsManager(dataProvider);
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>()).Returns(manager);
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("sandbox"));
@@ -181,7 +192,7 @@ public sealed class SchemaNamePrefixToolTests {
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>())
 			.Returns(_ => throw new HttpRequestException("Connection refused."));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("offline-env"));
@@ -210,8 +221,7 @@ public sealed class SchemaNamePrefixToolTests {
 				"The SSL connection could not be established",
 				new System.Security.Authentication.AuthenticationException(
 					"The remote certificate is invalid according to the validation procedure.")));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(),
-			Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("tls-env"));
@@ -231,8 +241,7 @@ public sealed class SchemaNamePrefixToolTests {
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>())
 			.Returns(_ => throw new AggregateException(new HttpRequestException("Connection refused.")));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(),
-			Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("offline-env"));
@@ -252,8 +261,7 @@ public sealed class SchemaNamePrefixToolTests {
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>())
 			.Returns(_ => throw new EnvironmentResolutionException("Environment 'ghost' is not registered."));
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(),
-			Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver, BuildClassifier());
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("ghost"));

--- a/clio.tests/Command/McpServer/SetLogoToolTests.cs
+++ b/clio.tests/Command/McpServer/SetLogoToolTests.cs
@@ -17,6 +17,23 @@ namespace Clio.Tests.Command.McpServer;
 [Property("Module", "McpServer")]
 public class SetLogoToolTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
 	private const string LogoFile = "C:/brand/logo.svg";
 
 	/// <summary>An arbitrary package the fake command reports back; the tool only relays whatever it resolved.</summary>
@@ -518,8 +535,7 @@ public class SetLogoToolTests {
 
 		public FakeSetLogoCommand(SetLogoResult result = null)
 			: base(Substitute.For<IApplicationClient>(), new EnvironmentSettings(),
-				new SysSettingsCommand(Substitute.For<ISysSettingsManager>(), Substitute.For<ILogger>(),
-					Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider()),
+				BuildCommand(Substitute.For<ISysSettingsManager>()),
 				Substitute.For<IPackageDataBinder>(), Substitute.For<IFileSystem>()) {
 			_result = result ?? SetLogoResult.Successful(["logo"], BoundPackageName, []);
 		}

--- a/clio.tests/Command/McpServer/SysSettingsToolTests.cs
+++ b/clio.tests/Command/McpServer/SysSettingsToolTests.cs
@@ -17,8 +17,37 @@ namespace Clio.Tests.Command.McpServer;
 [Property("Module", "McpServer")]
 public sealed class SysSettingsToolTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
+	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tools receive the capability is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static ISysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
 	private static IToolCommandResolver BuildResolver(ISysSettingsManager manager, IFileSystem fileSystem = null) {
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), fileSystem ?? Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		ILogger logger = Substitute.For<ILogger>();
+		SysSettingsCommand command = BuildCommand(manager, fileSystem ?? Substitute.For<IFileSystem>(), logger);
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsCommand>(Arg.Any<EnvironmentOptions>()).Returns(command);
 		return commandResolver;
@@ -47,7 +76,7 @@ public sealed class SysSettingsToolTests {
 	public void GetSysSetting_Should_Return_AllUsers_Default_Value_From_Environment() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetAllUsersDefaultWithType("MaxFileSize").Returns(("10485760", "Integer"));
-		SysSettingGetTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
 
@@ -70,7 +99,7 @@ public sealed class SysSettingsToolTests {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetAllUsersDefaultWithType("UsrApiSecret")
 			.Returns(("ENCRYPTED_CIPHERTEXT_BASE64", "SecureText"));
-		SysSettingGetTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "UsrApiSecret"));
 
@@ -88,7 +117,7 @@ public sealed class SysSettingsToolTests {
 	public void GetSysSetting_Should_Return_Empty_For_Unconfigured_SecureText() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetAllUsersDefaultWithType("UsrEmptySecret").Returns((string.Empty, "SecureText"));
-		SysSettingGetTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "UsrEmptySecret"));
 
@@ -102,7 +131,7 @@ public sealed class SysSettingsToolTests {
 	public void GetSysSetting_Should_Return_Empty_When_Setting_Is_Not_Configured() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetAllUsersDefaultWithType("UnknownCode").Returns((string.Empty, (string)null));
-		SysSettingGetTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "UnknownCode"));
 
@@ -117,7 +146,7 @@ public sealed class SysSettingsToolTests {
 	[Description("get-sys-setting short-circuits with a validation failure when the caller omits the required code argument.")]
 	public void GetSysSetting_Should_Fail_When_Code_Is_Missing() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
-		SysSettingGetTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", ""));
 
@@ -131,7 +160,7 @@ public sealed class SysSettingsToolTests {
 	[Category("Unit")]
 	[Description("get-sys-setting maps HttpRequestException raised during environment resolution to a 'Network error' diagnostic message.")]
 	public void GetSysSetting_Should_Categorize_Network_Errors() {
-		SysSettingGetTool tool = new(BuildResolverThatThrows(new HttpRequestException("Connection refused.")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolverThatThrows(new HttpRequestException("Connection refused.")), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("offline", "MaxFileSize"));
 
@@ -149,7 +178,7 @@ public sealed class SysSettingsToolTests {
 	[Category("Unit")]
 	[Description("get-sys-setting reports a transport failure whose text merely contains the digits 401 as a network error, not as rejected credentials.")]
 	public void GetSysSetting_Should_Not_Categorize_Incidental401Digits_As_Authentication_Failure(string message) {
-		SysSettingGetTool tool = new(BuildResolverThatThrows(new HttpRequestException(message)), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingGetTool tool = new(BuildResolverThatThrows(new HttpRequestException(message)), BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
 
@@ -163,7 +192,8 @@ public sealed class SysSettingsToolTests {
 	[Description("get-sys-setting reads the typed status of an HttpRequestException, so a 401 is recognized even when the message does not spell it out.")]
 	public void GetSysSetting_Should_Categorize_TypedUnauthorizedStatus_As_Authentication_Failure() {
 		SysSettingGetTool tool = new(BuildResolverThatThrows(
-			new HttpRequestException("The request failed.", null, HttpStatusCode.Unauthorized)), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			new HttpRequestException("The request failed.", null, HttpStatusCode.Unauthorized)),
+			BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
 
@@ -177,7 +207,8 @@ public sealed class SysSettingsToolTests {
 	[Description("get-sys-setting maps an HTTP 401 raised during environment resolution to an authentication diagnostic instead of a generic network failure.")]
 	public void GetSysSetting_Should_Categorize_Http401_As_Authentication_Failure() {
 		SysSettingGetTool tool = new(BuildResolverThatThrows(new HttpRequestException(
-			"Response status code does not indicate success: 401 (Unauthorized).")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			"Response status code does not indicate success: 401 (Unauthorized).")),
+			BuildClassifier());
 
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
 
@@ -205,7 +236,7 @@ public sealed class SysSettingsToolTests {
 	[Category("Unit")]
 	[Description("list-sys-settings maps unexpected exceptions raised during resolution to a generic 'Failed listing' diagnostic.")]
 	public void ListSysSettings_Should_Categorize_Generic_Failures() {
-		SysSettingsListTool tool = new(BuildResolverThatThrows(new TimeoutException("read timed out")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingsListTool tool = new(BuildResolverThatThrows(new TimeoutException("read timed out")), BuildClassifier());
 
 		SysSettingsListResult result = tool.ListSysSettings(new ListSysSettingsArgs("local"));
 
@@ -222,7 +253,8 @@ public sealed class SysSettingsToolTests {
 	[Description("list-sys-settings maps a Creatio authentication rejection to a structured authentication diagnostic instead of returning a successful empty catalog.")]
 	public void ListSysSettings_Should_Categorize_Authentication_Failures() {
 		SysSettingsListTool tool = new(BuildResolverThatThrows(new System.Security.Authentication.AuthenticationException(
-			"Authentication failed while listing sys-settings: Your password has expired.")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			"Authentication failed while listing sys-settings: Your password has expired.")),
+			BuildClassifier());
 
 		SysSettingsListResult result = tool.ListSysSettings(new ListSysSettingsArgs("local"));
 
@@ -239,7 +271,8 @@ public sealed class SysSettingsToolTests {
 	[Description("list-sys-settings maps an HTTP 401 raised during environment resolution to an authentication diagnostic instead of a generic network failure.")]
 	public void ListSysSettings_Should_Categorize_Http401_As_Authentication_Failure() {
 		SysSettingsListTool tool = new(BuildResolverThatThrows(new HttpRequestException(
-			"Response status code does not indicate success: 401 (Unauthorized).")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			"Response status code does not indicate success: 401 (Unauthorized).")),
+			BuildClassifier());
 
 		SysSettingsListResult result = tool.ListSysSettings(new ListSysSettingsArgs("local"));
 
@@ -266,7 +299,7 @@ public sealed class SysSettingsToolTests {
 	[Description("create-sys-setting short-circuits with a validation failure when a required field (code) is empty.")]
 	public void CreateSysSetting_Should_Reject_Missing_Required_Fields() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
-		SysSettingCreateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingCreateResult result = tool.CreateSysSetting(
 			new CreateSysSettingArgs("local", "", "Display", "Integer"));
@@ -282,7 +315,7 @@ public sealed class SysSettingsToolTests {
 	[Description("create-sys-setting refuses unknown value-type-names to keep the tool surface aligned with Creatio's internal type registry.")]
 	public void CreateSysSetting_Should_Reject_Unsupported_Value_Type() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
-		SysSettingCreateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingCreateResult result = tool.CreateSysSetting(
 			new CreateSysSettingArgs("local", "MyCode", "MyName", "UnsupportedType"));
@@ -305,7 +338,7 @@ public sealed class SysSettingsToolTests {
 			.Returns(new SysSettingsManager.InsertSysSettingResponse(
 				new SysSettingsManager.ResponseStatus(string.Empty, string.Empty, Array.Empty<object>()),
 				Guid.NewGuid(), 1, false, true));
-		SysSettingCreateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		// Act
 		SysSettingCreateResult result = tool.CreateSysSetting(
@@ -324,7 +357,7 @@ public sealed class SysSettingsToolTests {
 	[Category("Unit")]
 	[Description("create-sys-setting maps UnauthorizedAccessException raised during environment resolution to an 'Authentication error' diagnostic.")]
 	public void CreateSysSetting_Should_Categorize_Authentication_Errors() {
-		SysSettingCreateTool tool = new(BuildResolverThatThrows(new UnauthorizedAccessException("Forbidden")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolverThatThrows(new UnauthorizedAccessException("Forbidden")), BuildClassifier());
 
 		SysSettingCreateResult result = tool.CreateSysSetting(
 			new CreateSysSettingArgs("local", "MyCode", "MyName", "Text"));
@@ -348,7 +381,7 @@ public sealed class SysSettingsToolTests {
 				Guid.NewGuid(), 1, false, true));
 		manager.UpdateSysSetting(Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>()).Returns(true);
 		manager.GetAllUsersDefaultByCode("UsrApiSecret").Returns("ENCRYPTED_CIPHERTEXT_BASE64");
-		SysSettingCreateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingCreateResult result = tool.CreateSysSetting(
 			new CreateSysSettingArgs("local", "UsrApiSecret", "API secret", "SecureText", Value: "plaintext"));
@@ -376,7 +409,7 @@ public sealed class SysSettingsToolTests {
 	[Description("update-sys-setting short-circuits with a validation failure when the caller omits the required code argument.")]
 	public void UpdateSysSetting_Should_Reject_Missing_Code() {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
-		SysSettingUpdateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
 			new UpdateSysSettingArgs("local", "", "x"));
@@ -391,7 +424,7 @@ public sealed class SysSettingsToolTests {
 	[Category("Unit")]
 	[Description("update-sys-setting maps HttpRequestException raised during environment resolution to a 'Network error' diagnostic message.")]
 	public void UpdateSysSetting_Should_Categorize_Network_Errors() {
-		SysSettingUpdateTool tool = new(BuildResolverThatThrows(new HttpRequestException("Connection refused.")), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolverThatThrows(new HttpRequestException("Connection refused.")), BuildClassifier());
 
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
 			new UpdateSysSettingArgs("offline", "MaxFileSize", "10485760"));
@@ -410,7 +443,7 @@ public sealed class SysSettingsToolTests {
 		manager.UpdateSysSetting("UsrApiSecret", Arg.Any<object>(), Arg.Any<string>()).Returns(true);
 		manager.GetAllUsersDefaultWithType("UsrApiSecret")
 			.Returns(("ENCRYPTED_CIPHERTEXT_BASE64", "SecureText"));
-		SysSettingUpdateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
 			new UpdateSysSettingArgs("local", "UsrApiSecret", "plaintext", "SecureText"));
@@ -437,7 +470,7 @@ public sealed class SysSettingsToolTests {
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("logo.png").Returns(true);
 		fileSystem.OpenReadStream("logo.png").Returns(_ => new MemoryStream(bytes));
-		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -457,7 +490,7 @@ public sealed class SysSettingsToolTests {
 	public void UpdateSysSetting_Should_Reject_Both_Value_And_FilePath() {
 		// Arrange
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
-		SysSettingUpdateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -480,7 +513,7 @@ public sealed class SysSettingsToolTests {
 		manager.GetAllUsersDefaultWithType("SchemaNamePrefix").Returns(("Usr", "Text"));
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("logo.png").Returns(true);
-		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -504,7 +537,7 @@ public sealed class SysSettingsToolTests {
 		manager.GetAllUsersDefaultWithType("UsrNope").Returns((string.Empty, (string)null));
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("logo.png").Returns(true);
-		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -529,7 +562,7 @@ public sealed class SysSettingsToolTests {
 			FileSecurityMode.DenyList, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "exe", "svg" }, true));
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("payload.svg").Returns(true);
-		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -553,7 +586,7 @@ public sealed class SysSettingsToolTests {
 		manager.GetAllUsersDefaultWithType("LogoImage").Returns((string.Empty, "Binary"));
 		manager.GetFileSecurityPolicy().Returns(new FileSecurityPolicy(
 			FileSecurityMode.AllowList, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "png" }, false));
-		SysSettingUpdateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -577,7 +610,7 @@ public sealed class SysSettingsToolTests {
 		manager.GetFileSecurityPolicy().Returns(FileSecurityPolicy.UnknownPolicy);
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("logo.png").Returns(true);
-		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager, fileSystem), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -602,7 +635,7 @@ public sealed class SysSettingsToolTests {
 		manager.GetFileSecurityPolicy().Returns(FileSecurityPolicy.DisabledPolicy);
 		manager.TryValidateBinaryValue(Arg.Any<string>(), out Arg.Any<string>())
 			.Returns(call => { call[1] = "Binary value exceeds the 10,485,760-byte limit."; return false; });
-		SysSettingUpdateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingUpdateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -636,7 +669,7 @@ public sealed class SysSettingsToolTests {
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("logo.png").Returns(true);
 		fileSystem.OpenReadStream("logo.png").Returns(_ => new MemoryStream(bytes));
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), fileSystem, new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, fileSystem);
 
 		// Act
 		command.UpdateSysSetting(new SysSettingsOptions { Code = "LogoImage", Value = "logo.png", Type = "Binary" });
@@ -655,7 +688,7 @@ public sealed class SysSettingsToolTests {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile(Arg.Any<string>()).Returns(false);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), fileSystem, new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, fileSystem);
 
 		// Act
 		Action act = () => command.UpdateSysSetting(
@@ -681,7 +714,7 @@ public sealed class SysSettingsToolTests {
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("big.png").Returns(true);
 		fileSystem.OpenReadStream("big.png").Returns(oversized);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), fileSystem, new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, fileSystem);
 
 		// Act
 		Action act = () => command.UpdateSysSetting(
@@ -705,7 +738,7 @@ public sealed class SysSettingsToolTests {
 			FileSecurityMode.DenyList, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "exe" }, true));
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		fileSystem.ExistsFile("QUJD").Returns(false); // an inline Base64 value, not a file
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), fileSystem, new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, fileSystem);
 
 		// Act
 		Action act = () => command.UpdateSysSetting(
@@ -730,7 +763,7 @@ public sealed class SysSettingsToolTests {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetFileSecurityPolicy().Returns(new FileSecurityPolicy(
 			FileSecurityMode.DenyList, new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "exe" }, true));
-		SysSettingCreateTool tool = new(BuildResolver(manager), new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SysSettingCreateTool tool = new(BuildResolver(manager), BuildClassifier());
 
 		// Act
 		SysSettingCreateResult result = tool.CreateSysSetting(
@@ -757,7 +790,7 @@ public sealed class SysSettingsToolTests {
 		// Arrange
 		SysSettingGetTool tool = new(
 			BuildResolverThatThrows(new UnauthorizedAccessException("denied")),
-			new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			BuildClassifier());
 
 		// Act
 		SysSettingGetResult result = tool.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
@@ -782,7 +815,7 @@ public sealed class SysSettingsToolTests {
 		// Arrange
 		SysSettingsListTool tool = new(
 			BuildResolverThatThrows(new HttpRequestException("Connection refused.")),
-			new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			BuildClassifier());
 
 		// Act
 		SysSettingsListResult result = tool.ListSysSettings(new ListSysSettingsArgs("offline"));
@@ -803,7 +836,7 @@ public sealed class SysSettingsToolTests {
 		// Arrange
 		SysSettingCreateTool tool = new(
 			BuildResolverThatThrows(new UnauthorizedAccessException("denied")),
-			new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			BuildClassifier());
 
 		// Act
 		SysSettingCreateResult result = tool.CreateSysSetting(
@@ -825,7 +858,7 @@ public sealed class SysSettingsToolTests {
 		// Arrange
 		SysSettingUpdateTool tool = new(
 			BuildResolverThatThrows(new HttpRequestException("Connection refused.")),
-			new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+			BuildClassifier());
 
 		// Act
 		SysSettingUpdateResult result = tool.UpdateSysSetting(
@@ -855,17 +888,18 @@ public sealed class SysSettingsToolTests {
 		ILogger logger = Substitute.For<ILogger>();
 		List<string> lines = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => lines.Add(call.Arg<string>()));
-		IOperationCorrelationIdProvider ids = new OperationCorrelationIdProvider();
+		ISysSettingFailureClassifier classifier =
+			new SysSettingFailureClassifier(logger, new OperationCorrelationIdProvider());
 
 		// Act
 		string correlationId = tool switch {
-			"get" => new SysSettingGetTool(resolver, ids, logger)
+			"get" => new SysSettingGetTool(resolver, classifier)
 				.GetSysSetting(new GetSysSettingArgs("local", "MaxFileSize")).CorrelationId,
-			"list" => new SysSettingsListTool(resolver, ids, logger)
+			"list" => new SysSettingsListTool(resolver, classifier)
 				.ListSysSettings(new ListSysSettingsArgs("local")).CorrelationId,
-			"create" => new SysSettingCreateTool(resolver, ids, logger)
+			"create" => new SysSettingCreateTool(resolver, classifier)
 				.CreateSysSetting(new CreateSysSettingArgs("local", "UsrThing", "Thing", "Text")).CorrelationId,
-			var _ => new SysSettingUpdateTool(resolver, ids, logger)
+			var _ => new SysSettingUpdateTool(resolver, classifier)
 				.UpdateSysSetting(new UpdateSysSettingArgs("local", "UsrThing", "1")).CorrelationId
 		};
 

--- a/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
+++ b/clio.tests/Command/McpServer/ToolContractGetToolTests.cs
@@ -3617,7 +3617,7 @@ public sealed class ToolContractGetToolTests {
 			because: "#1222 requires a correlation ID so the caller can point an operator at the log line");
 		// PR #1373 review (Blocker) - the field-name assertions above could not catch the drift that shipped: the
 		// error-category DESCRIPTION enumerated the branch values and had already lost `Configuration`, the value
-		// CategorizeFailure returns for every EnvironmentResolutionException. Reflected over the constants so the
+		// ISysSettingFailureClassifier.Categorize returns for every EnvironmentResolutionException. Reflected over the constants so the
 		// next category cannot reopen it.
 		string errorCategoryDescription = contract.OutputContract.Fields
 			.Single(field => field.Name == "error-category").Description;
@@ -3632,7 +3632,7 @@ public sealed class ToolContractGetToolTests {
 				because: $"an agent branching on error-category meets '{category}' at runtime, and an undeclared value sends it down its generic path - the looping behaviour issue #1329 exists to remove");
 		}
 		// PR #1373 review - the cause field must NOT advertise a trust label the classifier does not keep:
-		// CategorizeFailure's ProviderFailure arm sets Cause from the provider's message, which is built from the
+		// ISysSettingFailureClassifier.Categorize's ProviderFailure arm sets Cause from the provider's message, which is built from the
 		// environment's HTTP response.
 		string causeDescription = contract.OutputContract.Fields
 			.Single(field => field.Name == "cause").Description;

--- a/clio.tests/Command/SysSettingFailureClassifierDiRegistrationTests.cs
+++ b/clio.tests/Command/SysSettingFailureClassifierDiRegistrationTests.cs
@@ -1,0 +1,91 @@
+using System;
+using Clio.Command;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command;
+
+/// <summary>
+/// Issue #1379: the sys-setting failure classifier is an injected service, so the container - not a
+/// static member of <c>SysSettingsCommand</c> - is what every consumer depends on.
+/// </summary>
+/// <remarks>
+/// The five MCP tool classes are instantiated by the MCP SDK through
+/// <see cref="ActivatorUtilities"/> against the host container, and <c>SysSettingsCommand</c> is
+/// resolved per environment by <c>ToolCommandResolver</c> from a child of the same registrations. A
+/// missing or unsatisfiable registration therefore does not fail at compile time: it fails when a tool
+/// is first called, on whatever transport happens to reach it. That is the failure this fixture makes
+/// loud, and it is why it asserts construction of the consumers rather than only of the classifier.
+/// </remarks>
+[TestFixture]
+[Category("Unit")]
+[NonParallelizable]
+[Property("Module", "Command")]
+public sealed class SysSettingFailureClassifierDiRegistrationTests {
+
+	private static EnvironmentSettings BuildSettings() => new() {
+		Uri = "https://tenant-a.creatio.example.com",
+		Login = "Supervisor",
+		Password = "Supervisor"
+	};
+
+	private static IServiceProvider BuildContainer() => new BindingsModule().Register(BuildSettings());
+
+	[Test]
+	[Description("The container resolves ISysSettingFailureClassifier to the production implementation, so no consumer has to reach into a command's statics for the classification.")]
+	public void Container_Should_Resolve_The_Classifier() {
+		// Arrange
+		IServiceProvider container = BuildContainer();
+
+		// Act
+		ISysSettingFailureClassifier classifier = container.GetRequiredService<ISysSettingFailureClassifier>();
+
+		// Assert
+		classifier.Should().BeOfType<SysSettingFailureClassifier>(
+			because: "the assembly interface scan is what registers it; a skip-list entry or a renamed interface "
+				+ "would leave every sys-setting tool unconstructible at first call rather than at build time");
+	}
+
+	[Test]
+	[Description("The classifier is registered transient, like the correlation-id provider and the logger-driven siblings the scan produces, so no consumer inherits a shared instance by accident.")]
+	public void Classifier_Should_Be_Registered_Transient() {
+		// Arrange
+		ServiceCollection services = [];
+
+		// Act
+		new BindingsModule().RegisterInto(services, BuildSettings());
+
+		// Assert
+		services.Should().ContainSingle(descriptor =>
+				descriptor.ServiceType == typeof(ISysSettingFailureClassifier),
+			because: "two registrations would make which one wins depend on declaration order")
+			.Which.Lifetime.Should().Be(ServiceLifetime.Transient,
+				because: "the classifier holds no mutable state, and its logger is a process singleton "
+					+ "regardless of lifetime");
+	}
+
+	[Test]
+	[Description("Every consumer of the classifier can be constructed from the container: the four sys-setting MCP tools, the schema-name-prefix tool, and the command itself.")]
+	public void Container_Should_Construct_Every_Classifier_Consumer() {
+		// Arrange
+		IServiceProvider container = BuildContainer();
+
+		// Act
+		Action act = () => {
+			ActivatorUtilities.CreateInstance<SysSettingGetTool>(container);
+			ActivatorUtilities.CreateInstance<SysSettingsListTool>(container);
+			ActivatorUtilities.CreateInstance<SysSettingCreateTool>(container);
+			ActivatorUtilities.CreateInstance<SysSettingUpdateTool>(container);
+			ActivatorUtilities.CreateInstance<SchemaNamePrefixTool>(container);
+			container.GetRequiredService<SysSettingsCommand>();
+		};
+
+		// Assert
+		act.Should().NotThrow(
+			because: "the MCP SDK builds a tool class on first call; an unsatisfiable dependency surfaces there, "
+				+ "on whatever transport reached it, instead of at build time");
+	}
+}

--- a/clio.tests/Command/SysSettingsErrorClassificationTests.cs
+++ b/clio.tests/Command/SysSettingsErrorClassificationTests.cs
@@ -5,7 +5,9 @@ using System.Security.Authentication;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Clio.Command;
+using Clio.Common;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Clio.Tests.Command;
@@ -19,6 +21,28 @@ namespace Clio.Tests.Command;
 [Category("Unit")]
 public sealed class SysSettingsErrorClassificationTests {
 
+	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tests reach it is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static ISysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
+	/// <summary>
+	/// The legacy message-only shorthand these assertions are written against. It lives here rather than on
+	/// the classifier because no production caller wants a failure stripped of its cause, its recovery
+	/// action and the correlation ID - that loss is what issue #1329 was about.
+	/// </summary>
+	/// <param name="ex">The failure to classify.</param>
+	/// <param name="operationLabel">The operation, as it reads inside the legacy message.</param>
+	/// <returns>The classified failure's legacy message alone.</returns>
+	private static string CategorizeError(Exception ex, string operationLabel) =>
+		BuildClassifier().Categorize(ex, operationLabel, correlationId: null).Error;
+
 	private const string Operation = "reading sys-setting";
 	private const string AuthenticationError = "Authentication error reading sys-setting.";
 	private const string NetworkError = "Network error reading sys-setting.";
@@ -29,7 +53,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_Authentication_For_An_Aggregate_Wrapping_AuthenticationException() {
 		AggregateException exception = new(new AuthenticationException("credentials were rejected"));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError,
 			because: "switching on the outer type alone saw the wrapper and reported the generic failure");
@@ -41,7 +65,7 @@ public sealed class SysSettingsErrorClassificationTests {
 		AggregateException exception = new(
 			new HttpRequestException("request failed", null, HttpStatusCode.Unauthorized));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError);
 	}
@@ -52,7 +76,7 @@ public sealed class SysSettingsErrorClassificationTests {
 		AggregateException exception = new(new AggregateException(
 			new HttpRequestException("request failed", null, HttpStatusCode.Unauthorized)));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError);
 	}
@@ -64,7 +88,7 @@ public sealed class SysSettingsErrorClassificationTests {
 			new HttpRequestException("service unavailable", null, HttpStatusCode.ServiceUnavailable),
 			new AuthenticationException("credentials were rejected"));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError,
 			because: "no single inner represents a multi-fault aggregate, but a credential rejection among "
@@ -78,7 +102,7 @@ public sealed class SysSettingsErrorClassificationTests {
 			new HttpRequestException("service unavailable", null, HttpStatusCode.ServiceUnavailable),
 			new InvalidOperationException("nothing to do"));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(GenericFailure);
 	}
@@ -90,7 +114,7 @@ public sealed class SysSettingsErrorClassificationTests {
 		HttpRequestException exception = new(
 			"upstream said 401 somewhere in its body", null, status);
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(NetworkError,
 			because: "only 401 short-circuited, so a typed 404 or 500 fell through to the text match and "
@@ -103,7 +127,7 @@ public sealed class SysSettingsErrorClassificationTests {
 		HttpRequestException exception = new(
 			"not found", new AuthenticationException("unauthorized"), HttpStatusCode.NotFound);
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(NetworkError);
 	}
@@ -113,7 +137,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Still_Match_Prose_When_No_Typed_Status_Is_Present() {
 		HttpRequestException exception = new("The remote server returned 401");
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError);
 	}
@@ -128,7 +152,7 @@ public sealed class SysSettingsErrorClassificationTests {
 			exception = new AggregateException("wrapped", exception);
 		}
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().NotBeNullOrEmpty(
 			because: "the walk is depth-bounded, so an arbitrarily deep chain returns an answer rather than hanging");
@@ -141,7 +165,7 @@ public sealed class SysSettingsErrorClassificationTests {
 			"The SSL connection could not be established, see inner exception.",
 			new AuthenticationException("The remote certificate is invalid according to the validation procedure."));
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(NetworkError,
 			because: "AuthenticationException is the framework's TLS exception as well as its credential one, and the certificate is what needs fixing");
@@ -152,7 +176,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_Network_For_A_Bare_Tls_AuthenticationException() {
 		AuthenticationException exception = new("The remote certificate is invalid according to the validation procedure.");
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(NetworkError);
 	}
@@ -166,7 +190,7 @@ public sealed class SysSettingsErrorClassificationTests {
 			WebExceptionStatus.TrustFailure,
 			response: null);
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(NetworkError);
 	}
@@ -176,7 +200,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Still_Report_Authentication_For_A_Credential_Rejection() {
 		AuthenticationException exception = new("Creatio rejected the supplied credentials: the password has expired.");
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError);
 	}
@@ -187,7 +211,7 @@ public sealed class SysSettingsErrorClassificationTests {
 		HttpRequestException exception = new(
 			"Rejected while presenting the client certificate", null, HttpStatusCode.Unauthorized);
 
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
+		string message = CategorizeError(exception, Operation);
 
 		message.Should().Be(AuthenticationError);
 	}
@@ -197,7 +221,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_A_NonJson_Response_For_A_JsonException() {
 		JsonException fault = new("'<' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
 
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(fault, "creating sys-setting", "test-id");
+		SysSettingFailure failure = BuildClassifier().Categorize(fault, "creating sys-setting", "test-id");
 
 		failure.Error.Should().Be("Creatio returned a non-JSON response creating sys-setting.",
 			because: "the write path's only remaining diagnosis for a non-login-page body must say what came back, not the uncategorized \"Failed ...\"");
@@ -214,7 +238,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_A_NonJson_Response_For_An_Aggregate_Wrapping_A_JsonException() {
 		AggregateException fault = new(new JsonException("'<' is an invalid start of a value."));
 
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(fault, "updating sys-setting", "test-id");
+		SysSettingFailure failure = BuildClassifier().Categorize(fault, "updating sys-setting", "test-id");
 
 		failure.Error.Should().Contain("non-JSON response updating sys-setting",
 			because: "unwrapping a single-fault aggregate must not lose the non-JSON diagnosis");
@@ -227,7 +251,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_Network_For_A_Transport_Timeout() {
 		TaskCanceledException fault = new("The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.");
 
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(fault, Operation, "test-id");
+		SysSettingFailure failure = BuildClassifier().Categorize(fault, Operation, "test-id");
 
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,
 			because: "an environment that stopped answering is a reachability problem, and the two classifiers must agree on that");
@@ -240,7 +264,7 @@ public sealed class SysSettingsErrorClassificationTests {
 	public void CategorizeError_Should_Report_Network_For_An_Aggregate_Wrapping_A_Transport_Timeout() {
 		AggregateException fault = new(new TaskCanceledException("HttpClient.Timeout elapsed"));
 
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(fault, Operation, "test-id");
+		SysSettingFailure failure = BuildClassifier().Categorize(fault, Operation, "test-id");
 
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,
 			because: "the wrapper must not change the verdict the inner fault earns");

--- a/clio.tests/Command/SysSettingsFailureEnvelopeTests.cs
+++ b/clio.tests/Command/SysSettingsFailureEnvelopeTests.cs
@@ -24,17 +24,56 @@ namespace Clio.Tests.Command;
 [Category("Unit")]
 public sealed class SysSettingsFailureEnvelopeTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
+	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tests reach it is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static ISysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
+	/// <summary>
+	/// The legacy message-only shorthand these assertions are written against. It lives here rather than on
+	/// the classifier because no production caller wants a failure stripped of its cause, its recovery
+	/// action and the correlation ID - that loss is what issue #1329 was about.
+	/// </summary>
+	/// <param name="ex">The failure to classify.</param>
+	/// <param name="operationLabel">The operation, as it reads inside the legacy message.</param>
+	/// <returns>The classified failure's legacy message alone.</returns>
+	private static string CategorizeError(Exception ex, string operationLabel) =>
+		BuildClassifier().Categorize(ex, operationLabel, correlationId: null).Error;
+
 	private const string Operation = "reading sys-setting";
 	private const string CorrelationId = "abc123def456";
 
 	[Test]
 	[Description("A rejected credential is categorized as Authentication and carries the fixed cause, the fixed recovery action and the supplied correlation ID.")]
-	public void CategorizeFailure_Should_Report_Authentication_With_Cause_And_Recovery() {
+	public void Categorize_Should_Report_Authentication_With_Cause_And_Recovery() {
 		// Arrange
 		UnauthorizedAccessException exception = new("denied");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Authentication,
@@ -51,12 +90,12 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("A refused connection is categorized as Network with the network cause and recovery action rather than as a credential failure.")]
-	public void CategorizeFailure_Should_Report_Network_For_A_Refused_Connection() {
+	public void Categorize_Should_Report_Network_For_A_Refused_Connection() {
 		// Arrange
 		SocketException exception = new((int)SocketError.ConnectionRefused);
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,
@@ -69,13 +108,13 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("A DataProviderFailureException is categorized as ProviderFailure and its locally composed message becomes the cause, because that message is the only diagnosis available.")]
-	public void CategorizeFailure_Should_Report_ProviderFailure_With_The_Composed_Message() {
+	public void Categorize_Should_Report_ProviderFailure_With_The_Composed_Message() {
 		// Arrange
 		DataProviderFailureException exception = new(
 			"Failed reading records from entity schema 'SysSettings': the environment answered with a non-JSON page.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.ProviderFailure,
@@ -88,12 +127,12 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("An argument rejection is categorized as Validation, so a caller can tell a bad request from an unreachable environment.")]
-	public void CategorizeFailure_Should_Report_Validation_For_An_Argument_Rejection() {
+	public void Categorize_Should_Report_Validation_For_An_Argument_Rejection() {
 		// Arrange
 		ArgumentException exception = new("code is required.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Validation,
@@ -104,12 +143,12 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("A failure that matches no arm is categorized as Unknown with the fixed generic cause instead of an empty envelope.")]
-	public void CategorizeFailure_Should_Report_Unknown_For_An_Unmatched_Failure() {
+	public void Categorize_Should_Report_Unknown_For_An_Unmatched_Failure() {
 		// Arrange
 		NotSupportedException exception = new("unexpected");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Unknown,
@@ -127,8 +166,8 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		HttpRequestException exception = new("boom", null, HttpStatusCode.Unauthorized);
 
 		// Act
-		string message = SysSettingsCommand.CategorizeError(exception, Operation);
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		string message = CategorizeError(exception, Operation);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		message.Should().Be(failure.Error,
@@ -146,8 +185,7 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		string loggedLine = null;
 		logger.When(l => l.WriteError(Arg.Any<string>()))
 			.Do(call => loggedLine = call.Arg<string>());
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		SysSettingGetResult result = command.TryGetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
@@ -186,12 +224,12 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("An unresolvable environment is reported as a Configuration failure whose cause is the resolver's own actionable text, not as Unknown with 'no cause could be determined' and 'retry' - advice that makes an agent loop.")]
-	public void CategorizeFailure_Should_Report_Configuration_For_An_Unresolvable_Environment() {
+	public void Categorize_Should_Report_Configuration_For_An_Unresolvable_Environment() {
 		// Arrange
 		EnvironmentResolutionException exception = new("Environment 'ghost' is not registered.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Configuration,
@@ -213,9 +251,8 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => lines.Add(call.Arg<string>()));
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(
-			new UnauthorizedAccessException("denied"), Operation, logger,
-			new OperationCorrelationIdProvider());
+		SysSettingFailure failure = BuildClassifier(logger).CategorizeAndLog(
+			new UnauthorizedAccessException("denied"), Operation);
 
 		// Assert
 		lines.Should().ContainSingle(
@@ -234,8 +271,7 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		ILogger logger = Substitute.For<ILogger>();
 		List<string> errors = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => errors.Add(call.Arg<string>()));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 		SysSettingsOptions options = new() { Code = "UsrSetting", Value = "x", Type = "Text" };
 
 		// Act
@@ -271,8 +307,7 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		ILogger logger = Substitute.For<ILogger>();
 		List<string> errors = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => errors.Add(call.Arg<string>()));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		SysSettingUpdateResult result = command.TryUpdateSysSetting(
@@ -296,14 +331,14 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("PR #1373 review: an EnvironmentResolutionException raised for MISSING CREDENTIALS is Authentication, not Configuration - a credential-passthrough caller has no environment to register and cannot reach reg-web-app over mcp-http.")]
-	public void CategorizeFailure_Should_Report_Authentication_For_A_Passthrough_Credential_Refusal() {
+	public void Categorize_Should_Report_Authentication_For_A_Passthrough_Credential_Refusal() {
 		// Arrange
 		EnvironmentResolutionException exception = new(
 			"Authentication material (an access token or a login/password pair) is required for credential-passthrough command execution.",
 			EnvironmentResolutionReason.Authentication);
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Authentication,
@@ -316,13 +351,13 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("PR #1373 review: an EnvironmentResolutionException wrapping a target-URL allowlist rejection is Validation - the request is refused, not the local configuration missing.")]
-	public void CategorizeFailure_Should_Report_Validation_For_A_Refused_Target_Url() {
+	public void Categorize_Should_Report_Validation_For_A_Refused_Target_Url() {
 		// Arrange
 		EnvironmentResolutionException exception = new("Target URL is not allowed by policy.",
 			EnvironmentResolutionReason.Validation, new InvalidOperationException("blocked"));
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Validation,
@@ -333,12 +368,12 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("PR #1373 review: an unregistered environment keeps Configuration and its existing recovery - the Reason default means no existing throw site changed meaning.")]
-	public void CategorizeFailure_Should_Keep_Configuration_For_An_Unregistered_Environment() {
+	public void Categorize_Should_Keep_Configuration_For_An_Unregistered_Environment() {
 		// Arrange
 		EnvironmentResolutionException exception = new("Environment 'ghost' is not registered.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Configuration,
@@ -357,8 +392,7 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		ILogger logger = Substitute.For<ILogger>();
 		List<string> errors = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => errors.Add(call.Arg<string>()));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		SysSettingGetResult quiet = command.TryGetSysSettingQuietly(
@@ -382,8 +416,7 @@ public sealed class SysSettingsFailureEnvelopeTests {
 		ILogger logger = Substitute.For<ILogger>();
 		List<string> errors = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => errors.Add(call.Arg<string>()));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		SysSettingGetResult reported = command.TryGetSysSetting(new GetSysSettingArgs("dev", "UsrSetting"));
@@ -397,14 +430,14 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("Issue #1378: the diagnosed non-JSON write failure lands in the same Network envelope the bare JsonException produced, so no agent branching on error-category and no MCP assertion changes.")]
-	public void CategorizeFailure_Should_Report_Network_For_A_Diagnosed_NonJson_Response() {
+	public void Categorize_Should_Report_Network_For_A_Diagnosed_NonJson_Response() {
 		// Arrange
 		NonJsonWriteResponseException exception = new("Failed reading sys-setting: the environment answered "
 			+ "with an HTML/XML page where a DataService JSON response was expected.",
 			NonJsonWriteResponseKind.NotJson, serverDetail: "<html>404</html>");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,
@@ -421,13 +454,13 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("Issue #1378: NonJsonWriteResponseException derives from InvalidOperationException, so its arm must sit above the provider-failure and unknown arms rather than be captured by them.")]
-	public void CategorizeFailure_Should_Not_Report_A_NonJson_Response_As_ProviderFailure() {
+	public void Categorize_Should_Not_Report_A_NonJson_Response_As_ProviderFailure() {
 		// Arrange
 		NonJsonWriteResponseException exception = new("Failed creating sys-setting: non-JSON.",
 			NonJsonWriteResponseKind.NotJson);
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,
@@ -438,13 +471,13 @@ public sealed class SysSettingsFailureEnvelopeTests {
 
 	[Test]
 	[Description("Issue #1378: a valid-JSON-wrong-shape answer keeps the Network category but must not repeat the not-JSON cause, which names a proxy or WAF page that demonstrably is not what answered.")]
-	public void CategorizeFailure_Should_Report_Its_Own_Cause_For_An_Unexpected_Response_Shape() {
+	public void Categorize_Should_Report_Its_Own_Cause_For_An_Unexpected_Response_Shape() {
 		// Arrange
 		NonJsonWriteResponseException exception = new("Failed reading sys-setting: unexpected shape.",
 			NonJsonWriteResponseKind.UnexpectedShape, serverDetail: "{\"id\":null}");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(exception, Operation, CorrelationId);
+		SysSettingFailure failure = BuildClassifier().Categorize(exception, Operation, CorrelationId);
 
 		// Assert
 		failure.Category.Should().Be(SysSettingErrorCategories.Network,

--- a/clio.tests/Common/ClassifyingDataProviderTests.cs
+++ b/clio.tests/Common/ClassifyingDataProviderTests.cs
@@ -241,7 +241,7 @@ public class ClassifyingDataProviderTests {
 	}
 
 	[Test]
-	[Description("A thrown transport fault is rethrown UNCHANGED: wrapping it into an InvalidOperationException erased the type and made the 'Network error ...' arms of SysSettingsCommand.CategorizeError and SchemaNamePrefixTool unreachable.")]
+	[Description("A thrown transport fault is rethrown UNCHANGED: wrapping it into an InvalidOperationException erased the type and made the 'Network error ...' arms of SysSettingFailureClassifier.CategorizeError and SchemaNamePrefixTool unreachable.")]
 	public void GetItems_ShouldRethrowATransportFaultWithItsOriginalType() {
 		// Arrange
 		HttpRequestException original = new("Connection refused at http://localhost:40124");

--- a/clio.tests/Common/ConsoleFacingDiagnosticsTests.cs
+++ b/clio.tests/Common/ConsoleFacingDiagnosticsTests.cs
@@ -33,6 +33,34 @@ namespace Clio.Tests.Common;
 [Property("Module", "Common")]
 public sealed class ConsoleFacingDiagnosticsTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
+	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tests reach it is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static SysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
 	private const string FenceMarker = "untrusted-source-text";
 
 	private const string PlatformValidationProse = "Column 'Name' is required.";
@@ -140,8 +168,9 @@ public sealed class ConsoleFacingDiagnosticsTests {
 				.ComposeMessage("reading sys-setting"));
 
 		// Act
-		string line = SysSettingsCommand.DescribeFailureForLog(
-			SysSettingsCommand.CategorizeFailure(exception, "reading sys-setting", "abc123"));
+		SysSettingFailureClassifier classifier = BuildClassifier();
+		string line = classifier.DescribeFailureForLog(
+			classifier.Categorize(exception, "reading sys-setting", "abc123"));
 
 		// Assert
 		line.Split($"[{FenceMarker} begin]").Length.Should().Be(2,
@@ -213,7 +242,7 @@ public sealed class ConsoleFacingDiagnosticsTests {
 	}
 
 	[Test]
-	[Description("A proven session rejection reaches Authentication through the PUBLIC read path, not only through CategorizeFailure: the fix is positional, so nothing but an end-to-end assertion pins it")]
+	[Description("A proven session rejection reaches Authentication through the PUBLIC read path, not only through ISysSettingFailureClassifier.Categorize: the fix is positional, so nothing but an end-to-end assertion pins it")]
 	public void TryGetSysSetting_Should_Report_Authentication_For_A_Rejected_Session() {
 		// Arrange
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
@@ -222,8 +251,7 @@ public sealed class ConsoleFacingDiagnosticsTests {
 				"Authentication failed while reading sys-setting 'SslCertificateThumbprint': "
 				+ "The password for the registered user has expired.",
 				"5: Your password has expired."));
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(),
-			Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingGetResult result =

--- a/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
@@ -196,7 +196,7 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 		// Assert
 		act.Should().Throw<UnauthorizedAccessException>(
 			because: "ServerReadinessWaiter, GetCreatioInfoCommand, SchemaNamePrefixTool and "
-				+ "SysSettingsCommand.CategorizeError all classify a refused credential by this type")
+				+ "SysSettingFailureClassifier.CategorizeError all classify a refused credential by this type")
 			.Which.Message.Should().Contain("clio-login",
 				because: "the diagnostic context is the deliverable and must reach the caller in the message");
 	}

--- a/clio.tests/Common/LoginDiagnosticsTests.cs
+++ b/clio.tests/Common/LoginDiagnosticsTests.cs
@@ -437,7 +437,7 @@ internal class LoginDiagnosticsTests {
 				+ "credential stops failing fast and burns the readiness budget on further rejected logins), "
 				+ "GetCreatioInfoCommand (BaseProbeFailure.Authentication), SchemaNamePrefixTool (the "
 				+ "MCP-visible 'Authentication error reading SchemaNamePrefix.' result) and "
-				+ "SysSettingsCommand.CategorizeError");
+				+ "SysSettingFailureClassifier.CategorizeError");
 	}
 
 	#endregion

--- a/clio.tests/Common/ServerProseInDiagnosticsTests.cs
+++ b/clio.tests/Common/ServerProseInDiagnosticsTests.cs
@@ -27,6 +27,34 @@ namespace Clio.Tests.Common;
 [Category("Unit")]
 public sealed class ServerProseInDiagnosticsTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
+	/// <summary>
+	/// The production classifier under a substituted logger. Issue #1379 moved these operations off
+	/// <c>SysSettingsCommand</c>'s statics and behind <see cref="ISysSettingFailureClassifier"/>; what is
+	/// asserted below is unchanged, only how the tests reach it is.
+	/// </summary>
+	/// <param name="logger">The sink to assert on, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A classifier writing to <paramref name="logger"/>.</returns>
+	private static ISysSettingFailureClassifier BuildClassifier(ILogger logger = null) =>
+		new SysSettingFailureClassifier(logger ?? Substitute.For<ILogger>(),
+			new OperationCorrelationIdProvider());
+
 	/// <summary>A hostile ErrorCode=5 envelope: a token, an address, a bidi override and an instruction.</summary>
 	private const string HostileAuthenticationError =
 		"5: Your password has expired. token=eyJhbGciOiJIUzI1NiJ9.abcdefgh.ijklmnop "
@@ -137,8 +165,7 @@ public sealed class ServerProseInDiagnosticsTests {
 		List<string> debugLines = [];
 		logger.When(l => l.WriteError(Arg.Any<string>())).Do(call => errorLines.Add(call.Arg<string>()));
 		logger.When(l => l.WriteDebug(Arg.Any<string>())).Do(call => debugLines.Add(call.Arg<string>()));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(),
-			new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		SysSettingGetResult result = command.TryGetSysSetting(new GetSysSettingArgs("local", "MaxFileSize"));
@@ -168,8 +195,7 @@ public sealed class ServerProseInDiagnosticsTests {
 			.Returns(new SysSettingsManager.InsertSysSettingResponse(
 				new SysSettingsManager.ResponseStatus("1", HostileGenericError, null),
 				Guid.Empty, 0, false, false));
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(),
-			Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(
@@ -199,8 +225,7 @@ public sealed class ServerProseInDiagnosticsTests {
 		ISysSettingsManager manager = Substitute.For<ISysSettingsManager>();
 		manager.GetAllUsersDefaultWithType("UsrThing").Returns((null, "Text"));
 		manager.UpdateSysSetting("UsrThing", Arg.Any<object>(), Arg.Any<string>()).Returns(false);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(),
-			Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingUpdateResult result = command.TryUpdateSysSetting(
@@ -305,7 +330,7 @@ public sealed class ServerProseInDiagnosticsTests {
 			"5: Your password has expired.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeFailure(
+		SysSettingFailure failure = BuildClassifier().Categorize(
 			exception, "reading sys-setting 'SslCertificateThumbprint'", "abc123def456");
 
 		// Assert
@@ -366,8 +391,8 @@ public sealed class ServerProseInDiagnosticsTests {
 		Exception wrapped = new InvalidOperationException("Could not read the environment.", carrier);
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(
-			wrapped, "reading sys-setting", logger, new OperationCorrelationIdProvider());
+		SysSettingFailure failure = BuildClassifier(logger).CategorizeAndLog(
+			wrapped, "reading sys-setting");
 
 		// Assert
 		debugLines.Should().Contain(line => line.Contains(failure.CorrelationId, StringComparison.Ordinal)
@@ -387,8 +412,8 @@ public sealed class ServerProseInDiagnosticsTests {
 			"reading records", "Column 'Name' is required on entity SysSettings.");
 
 		// Act
-		SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(
-			carrier, "reading sys-setting", logger, new OperationCorrelationIdProvider());
+		SysSettingFailure failure = BuildClassifier(logger).CategorizeAndLog(
+			carrier, "reading sys-setting");
 
 		// Assert
 		debugLines.Should().ContainSingle(line => line.Contains(failure.CorrelationId, StringComparison.Ordinal),

--- a/clio.tests/Common/SysSettingsManagerNewBehaviorTests.cs
+++ b/clio.tests/Common/SysSettingsManagerNewBehaviorTests.cs
@@ -26,6 +26,23 @@ namespace Clio.Tests.Common;
 [Category("Unit")]
 public class SysSettingsManagerNewBehaviorTests {
 
+	/// <summary>
+	/// Builds the command and its classifier over ONE logger. Two substitutes would make any future
+	/// assertion on a log line pass vacuously - the line would be written to the instance the test never
+	/// looks at.
+	/// </summary>
+	/// <param name="manager">The sys-settings manager the command reads and writes through.</param>
+	/// <param name="fileSystem">The file system, or <see langword="null"/> for an inert substitute.</param>
+	/// <param name="logger">The shared sink, or <see langword="null"/> for an inert substitute.</param>
+	/// <returns>A command whose classifier writes to the same logger it does.</returns>
+	private static SysSettingsCommand BuildCommand(ISysSettingsManager manager, IFileSystem fileSystem = null,
+		ILogger logger = null) {
+		ILogger sink = logger ?? Substitute.For<ILogger>();
+		return new SysSettingsCommand(manager, sink, fileSystem ?? Substitute.For<IFileSystem>(),
+			new OperationCorrelationIdProvider(),
+			new SysSettingFailureClassifier(sink, new OperationCorrelationIdProvider()));
+	}
+
 	#region Helpers
 
 	// Both lines a failed CLI update writes end with "(correlation-id: X)". Pulling the ID out is how a
@@ -518,7 +535,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
 		applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>()).Returns(InsertSuccessJson);
 		ISysSettingsManager manager = BuildSut(BuildRejectedProvider(), applicationClient);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(
@@ -537,7 +554,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		// Arrange
 		IApplicationClient applicationClient = BuildAcceptedClient();
 		ISysSettingsManager manager = BuildSut(BuildRejectedProvider(), applicationClient);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(
@@ -558,7 +575,7 @@ public class SysSettingsManagerNewBehaviorTests {
 	public void TryUpdateSysSetting_ShouldReportAuthenticationFailure_WhenCredentialsAreRejected() {
 		// Arrange
 		ISysSettingsManager manager = BuildSut(BuildRejectedProvider());
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingUpdateResult result = command.TryUpdateSysSetting(
@@ -666,7 +683,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		List<string> loggedErrors = [];
 		logger.When(value => value.WriteError(Arg.Any<string>()))
 			.Do(call => loggedErrors.Add(call.ArgAt<string>(0)));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		command.TryUpdateSysSetting(new SysSettingsOptions {
@@ -694,7 +711,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		List<string> loggedErrors = [];
 		logger.When(value => value.WriteError(Arg.Any<string>()))
 			.Do(call => loggedErrors.Add(call.ArgAt<string>(0)));
-		SysSettingsCommand command = new(manager, logger, Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager, null, logger);
 
 		// Act
 		command.TryUpdateSysSetting(new SysSettingsOptions {
@@ -718,7 +735,7 @@ public class SysSettingsManagerNewBehaviorTests {
 
 	// A gateway/WAF/404 page that is NOT the Creatio login page: ThrowIfSessionRejected only fires when the
 	// body PROVES a rejected session, so this shape is the one that reaches JsonSerializer.Deserialize on the
-	// write path. It is what makes SysSettingsCommand.CategorizeError's JsonException arm reachable, and
+	// write path. It is what makes SysSettingFailureClassifier.CategorizeError's JsonException arm reachable, and
 	// nothing exercised it before.
 	private const string NonJsonGatewayPage = "<html><head><title>404 Not Found</title></head><body>404</body></html>";
 
@@ -728,7 +745,7 @@ public class SysSettingsManagerNewBehaviorTests {
 	// about the operator-visible result still holds - it is pinned at the command level by
 	// SysSettingsFailureEnvelopeTests instead of by the exception type here.
 	[Test]
-	[Description("A non-JSON gateway/404 answer to InsertSysSettingRequest surfaces as a diagnosed NonJsonWriteResponseException rather than a parsed response or a bare JsonException, so the write path reaches the non-JSON arm of SysSettingsCommand.CategorizeError instead of the uncategorized \"Failed creating sys-setting.\".")]
+	[Description("A non-JSON gateway/404 answer to InsertSysSettingRequest surfaces as a diagnosed NonJsonWriteResponseException rather than a parsed response or a bare JsonException, so the write path reaches the non-JSON arm of SysSettingFailureClassifier.CategorizeError instead of the uncategorized \"Failed creating sys-setting.\".")]
 	public void InsertSysSetting_ThrowsNonJsonWriteResponseException_WhenWriteEndpointAnswersWithANonJsonPage() {
 		// Arrange
 		ISysSettingsManager sut = BuildSut(new DataProviderMock(), BuildClientAnswering(NonJsonGatewayPage));
@@ -981,7 +998,7 @@ public class SysSettingsManagerNewBehaviorTests {
 				{ "TextValue", "ENCRYPTED_BASE64_CIPHERTEXT_PAYLOAD" }
 			});
 		ISysSettingsManager managerForTryList = BuildSut(providerMock);
-		SysSettingsCommand command = new(managerForTryList, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(managerForTryList);
 
 		SysSettingsListResult result = command.TryListSysSettings(new ListSysSettingsArgs("local"));
 
@@ -997,7 +1014,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		Guid settingId = Guid.NewGuid();
 		DataProviderMock providerMock = SetupSysSettingsMock(settingId, "UsrEmptySecret", "SecureText", valueRow: null);
 		ISysSettingsManager managerForTryList = BuildSut(providerMock);
-		SysSettingsCommand command = new(managerForTryList, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(managerForTryList);
 
 		SysSettingsListResult result = command.TryListSysSettings(new ListSysSettingsArgs("local"));
 
@@ -1029,7 +1046,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		});
 		providerMock.MockItems("SysSettingsValue").Returns(new List<Dictionary<string, object>>());
 		ISysSettingsManager managerForTryList = BuildSut(providerMock);
-		SysSettingsCommand command = new(managerForTryList, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(managerForTryList);
 
 		// Act
 		SysSettingsListResult result = command.TryListSysSettings(new ListSysSettingsArgs("local"));
@@ -1481,7 +1498,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		IDataProvider dataProvider = new ClassifyingDataProvider(new ThrowingDataProvider(
 			() => new HttpRequestException("Connection refused at http://localhost:40124")));
 		ISysSettingsManager manager = BuildSut(dataProvider);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingUpdateResult result = command.TryUpdateSysSetting(
@@ -1501,7 +1518,7 @@ public class SysSettingsManagerNewBehaviorTests {
 		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
 		applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>()).Returns(LoginPageBody);
 		ISysSettingsManager manager = BuildSut(new DataProviderMock(), applicationClient);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(
@@ -1575,7 +1592,7 @@ public class SysSettingsManagerNewBehaviorTests {
 	public void SysSettingsCommand_Get_ShouldThrowAuthenticationException_WhenCredentialsAreRejected() {
 		// Arrange
 		ISysSettingsManager manager = BuildSut(BuildRejectedProvider());
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(), Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		Action act = () => command.Execute(new SysSettingsOptions { Code = "MaxFileSize", IsGet = true });
@@ -1592,7 +1609,8 @@ public class SysSettingsManagerNewBehaviorTests {
 		SysSettingsManager manager = (SysSettingsManager)BuildSut(BuildRejectedProvider());
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>()).Returns(manager);
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver,
+			new SysSettingFailureClassifier(Substitute.For<ILogger>(), new OperationCorrelationIdProvider()));
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("local"));
@@ -1611,7 +1629,8 @@ public class SysSettingsManagerNewBehaviorTests {
 		SysSettingsManager manager = (SysSettingsManager)BuildSut(BuildRejectedProvider(LoginPageParserError));
 		IToolCommandResolver commandResolver = Substitute.For<IToolCommandResolver>();
 		commandResolver.Resolve<SysSettingsManager>(Arg.Any<EnvironmentOptions>()).Returns(manager);
-		SchemaNamePrefixTool tool = new(commandResolver, new OperationCorrelationIdProvider(), Substitute.For<ILogger>());
+		SchemaNamePrefixTool tool = new(commandResolver,
+			new SysSettingFailureClassifier(Substitute.For<ILogger>(), new OperationCorrelationIdProvider()));
 
 		// Act
 		SchemaNamePrefixResult result = tool.GetSchemaNamePrefix(new GetSchemaNamePrefixArgs("local"));
@@ -2026,7 +2045,7 @@ public class SysSettingsManagerNewBehaviorTests {
 
 		// Assert
 		NonJsonWriteResponseException exception = act.Should().Throw<NonJsonWriteResponseException>(
-			because: "JObject.Parse raises a Newtonsoft JsonReaderException, which derives from no System.Text.Json type and so matched no arm of CategorizeFailure").Which;
+			because: "JObject.Parse raises a Newtonsoft JsonReaderException, which derives from no System.Text.Json type and so matched no arm of ISysSettingFailureClassifier.Categorize").Which;
 		exception.Message.Should().Contain("Failed resolving a lookup value",
 			because: "the operator has to know which step of the Lookup write failed");
 	}
@@ -2065,8 +2084,7 @@ public class SysSettingsManagerNewBehaviorTests {
 			.ExecutePostRequest(Arg.Is<string>(url => url.Contains("PostSysSettingsValues")), Arg.Any<string>())
 			.Returns(NonJsonGatewayPage);
 		ISysSettingsManager manager = BuildSut(new DataProviderMock(), applicationClient);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(),
-			Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(
@@ -2095,8 +2113,7 @@ public class SysSettingsManagerNewBehaviorTests {
 			.ExecutePostRequest(Arg.Is<string>(url => url.Contains("PostSysSettingsValues")), Arg.Any<string>())
 			.Returns(LoginPageBody);
 		ISysSettingsManager manager = BuildSut(new DataProviderMock(), applicationClient);
-		SysSettingsCommand command = new(manager, Substitute.For<ILogger>(),
-			Substitute.For<IFileSystem>(), new OperationCorrelationIdProvider());
+		SysSettingsCommand command = BuildCommand(manager);
 
 		// Act
 		SysSettingCreateResult result = command.TryCreateSysSetting(

--- a/clio/Command/ISysSettingFailureClassifier.cs
+++ b/clio/Command/ISysSettingFailureClassifier.cs
@@ -1,0 +1,91 @@
+using System;
+using Clio.Common;
+
+namespace Clio.Command;
+
+/// <summary>
+/// Classifies a sys-setting operation failure into the structured envelope the results carry, and writes
+/// the one log line whose correlation ID the envelope quotes.
+/// </summary>
+/// <remarks>
+/// Issue #1379. This capability used to live as <c>internal static</c> members of
+/// <c>SysSettingsCommand</c>, which meant every MCP tool that needed a classified failure took an
+/// <see cref="ILogger"/> and an <see cref="IOperationCorrelationIdProvider"/> only to feed those statics,
+/// and named an unrelated command type from its own catch block. It is a cross-module capability - five
+/// MCP tool classes plus the CLI command - so it is an injected service like any other behaviour class.
+/// <para>
+/// The interface is four members rather than the one "classify" suggests: minting the correlation ID and
+/// writing the line that carries it are ONE operation (a token that finds nothing is worse than no
+/// token), and the command's two non-exception report paths and its partial-create path need exactly
+/// those two writes without a classification. Exposing them here is what keeps a single implementation
+/// of each; duplicating them back into the command would be the drift this extraction removes.
+/// Rendering the line is NOT on the interface - it has no caller outside
+/// <see cref="LogFailureLine"/> - and neither is the legacy message-only overload, which had none at
+/// all in production.
+/// </para>
+/// </remarks>
+public interface ISysSettingFailureClassifier {
+
+	/// <summary>
+	/// Classifies a failure into the structured envelope the sys-setting results carry: the legacy
+	/// message, the category an agent branches on, a cause, a recovery action, and the correlation ID
+	/// that finds the log line written for the same failure.
+	/// </summary>
+	/// <param name="ex">The failure to classify.</param>
+	/// <param name="operationLabel">The operation, as it reads inside the legacy message.</param>
+	/// <param name="correlationId">The ID issued for this operation, or <see langword="null"/>.</param>
+	/// <returns>The classified failure.</returns>
+	SysSettingFailure Categorize(Exception ex, string operationLabel, string correlationId);
+
+	/// <summary>
+	/// Classifies a failure AND writes the one log line that carries its correlation ID, plus the
+	/// neutralized server excerpt on the debug channel beside the same ID.
+	/// </summary>
+	/// <remarks>
+	/// A correlation ID on a result that no log line mentions is worse than no ID at all: it invites the
+	/// caller to quote a token that finds nothing. So minting the ID and writing the line are one
+	/// operation, and every site that reports a classified failure goes through here.
+	/// </remarks>
+	/// <param name="ex">The failure to classify.</param>
+	/// <param name="operationLabel">The operation, as it reads inside the legacy message.</param>
+	/// <returns>The classified failure, carrying the freshly minted correlation ID.</returns>
+	SysSettingFailure CategorizeAndLog(Exception ex, string operationLabel);
+
+	/// <summary>
+	/// Writes the one log line carrying the failure's correlation ID, and on the MCP path ALSO sends it
+	/// to the client as a <c>notifications/message</c> under the <c>clio.tool.{correlationId}</c>
+	/// category. For failures that arrive as DATA rather than as an exception, so there is nothing to
+	/// classify but the same record still has to exist.
+	/// </summary>
+	/// <remarks>
+	/// PR #1373 review: writing the line alone was not enough to make the ID resolvable. Running as an
+	/// MCP server every ordinary sink is closed - <c>ConsoleLogger</c> suppresses console writes under
+	/// <c>Program.IsMcpServerMode</c>, the log file exists only when the operator passed <c>--log</c>,
+	/// and the sys-setting tools and <c>SchemaNamePrefixTool</c> are plain <c>[McpServerToolType]</c>
+	/// classes that never flush the way <c>BaseTool</c> does. So the line reached nobody, while the
+	/// shipped recovery text tells the caller to quote the ID.
+	/// The notification is built from the line directly rather than by draining the shared
+	/// <c>PreserveMessages</c> buffer: that buffer belongs to whatever flow is capturing (a
+	/// <c>BaseTool</c> parent may be), and clearing it here would swallow messages this failure did not
+	/// produce. <c>ForwardMessages</c> no-ops when no MCP server is active, so the CLI path is unchanged.
+	/// </remarks>
+	/// <param name="failure">The classified failure whose line is written.</param>
+	void LogFailureLine(SysSettingFailure failure);
+
+	/// <summary>
+	/// Writes the neutralized server excerpt on the DEBUG channel only, tagged with the same correlation
+	/// ID the failure envelope carries. No-ops when the failure carries no server text.
+	/// </summary>
+	/// <remarks>
+	/// Issue #1333. The excerpt is server-authored text, so it may never appear in <c>error</c>,
+	/// <c>cause</c>, the MCP envelope or the default log line - the fixed local diagnostic goes there
+	/// instead. It still has to be recoverable, because an operator who cannot see what Creatio actually
+	/// said cannot tell an expired password from a misconfigured proxy. The channel is debug-gated
+	/// (<c>ConsoleLogger.WriteDebug</c> returns early unless <c>--debug</c> was passed) and its console
+	/// drain is suppressed under MCP server mode, and the correlation ID is the bridge from the reported
+	/// failure to the line.
+	/// </remarks>
+	/// <param name="ex">The failure whose chain is searched for a server excerpt.</param>
+	/// <param name="correlationId">The ID the excerpt is tagged with.</param>
+	void LogServerDetail(Exception ex, string correlationId);
+}

--- a/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
+++ b/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
@@ -252,7 +252,7 @@ internal static partial class SensitiveErrorTextRedactor {
 	/// <remarks>
 	/// An outer cap applied to a composed diagnostic is not the same problem as the cap inside
 	/// <see cref="NeutralizeOrNull"/>: that one clamps the payload BEFORE appending the suffix, so the
-	/// closer always survives. A caller that re-caps the finished message (<c>SysSettingsCommand.SafeDetail</c>
+	/// closer always survives. A caller that re-caps the finished message (<c>SysSettingFailureClassifier.SafeDetail</c>
 	/// re-capping <c>DataProviderFailureException.Message</c>, which is
 	/// <c>ServerReportedFailureText.ComposeMessage</c>'s fenced output) cuts the closer off instead,
 	/// leaving an opener with no terminator. Every field emitted after such a message - <c>error-category</c>,

--- a/clio/Command/McpServer/Tools/SchemaNamePrefixTool.cs
+++ b/clio/Command/McpServer/Tools/SchemaNamePrefixTool.cs
@@ -12,7 +12,7 @@ namespace Clio.Command.McpServer.Tools;
 /// </summary>
 [McpServerToolType]
 public sealed class SchemaNamePrefixTool(IToolCommandResolver commandResolver,
-	IOperationCorrelationIdProvider correlationIds, ILogger logger) {
+	ISysSettingFailureClassifier failures) {
 
 	internal const string GetSchemaNamePrefixToolName = "get-schema-name-prefix";
 
@@ -44,7 +44,7 @@ public sealed class SchemaNamePrefixTool(IToolCommandResolver commandResolver,
 			return new SchemaNamePrefixResult(true, prefix);
 		} catch (Exception ex) {
 			//One classifier, not two. These five hand-written arms disagreed with
-			//SysSettingsCommand.CategorizeFailure on three counts: a TLS handshake failure arrives as an
+			//ISysSettingFailureClassifier's classification on three counts: a TLS handshake failure arrives as an
 			//AuthenticationException and was reported as rejected credentials (sending the operator to
 			//repair a working login while the untrusted certificate stays untouched); an
 			//AggregateException - which is how the Creatio client surfaces a transport fault through
@@ -59,8 +59,7 @@ public sealed class SchemaNamePrefixTool(IToolCommandResolver commandResolver,
 	/// cannot answer "was this a credential failure?" differently (issue #1329).
 	/// </summary>
 	private SchemaNamePrefixResult Failure(Exception ex) {
-		SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(ex, ReadOperationLabel, logger,
-			correlationIds);
+		SysSettingFailure failure = failures.CategorizeAndLog(ex, ReadOperationLabel);
 		return new SchemaNamePrefixResult(false, string.Empty, DescribeError(failure), failure.Category,
 			failure.Cause, failure.RecoveryAction, failure.CorrelationId);
 	}

--- a/clio/Command/McpServer/Tools/SysSettingsTool.cs
+++ b/clio/Command/McpServer/Tools/SysSettingsTool.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using Clio.Common;
 using ModelContextProtocol.Server;
 
 namespace Clio.Command.McpServer.Tools;
@@ -11,7 +10,7 @@ namespace Clio.Command.McpServer.Tools;
 /// </summary>
 [McpServerToolType]
 public sealed class SysSettingGetTool(IToolCommandResolver commandResolver,
-	IOperationCorrelationIdProvider correlationIds, ILogger logger) {
+	ISysSettingFailureClassifier failures) {
 
 	internal const string GetSysSettingToolName = "get-sys-setting";
 
@@ -35,7 +34,7 @@ public sealed class SysSettingGetTool(IToolCommandResolver commandResolver,
 			command = commandResolver.Resolve<SysSettingsCommand>(
 				new EnvironmentOptions { Environment = args.EnvironmentName });
 		} catch (Exception ex) {
-			SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(ex, "reading sys-setting", logger, correlationIds);
+			SysSettingFailure failure = failures.CategorizeAndLog(ex, "reading sys-setting");
 			return new SysSettingGetResult(false, args.Code ?? string.Empty, string.Empty, failure.Error,
 				failure.Category, failure.Cause, failure.RecoveryAction, failure.CorrelationId);
 		}
@@ -48,7 +47,7 @@ public sealed class SysSettingGetTool(IToolCommandResolver commandResolver,
 /// </summary>
 [McpServerToolType]
 public sealed class SysSettingsListTool(IToolCommandResolver commandResolver,
-	IOperationCorrelationIdProvider correlationIds, ILogger logger) {
+	ISysSettingFailureClassifier failures) {
 
 	internal const string ListSysSettingsToolName = "list-sys-settings";
 
@@ -73,7 +72,7 @@ public sealed class SysSettingsListTool(IToolCommandResolver commandResolver,
 			command = commandResolver.Resolve<SysSettingsCommand>(
 				new EnvironmentOptions { Environment = args.EnvironmentName });
 		} catch (Exception ex) {
-			SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(ex, "listing sys-settings", logger, correlationIds);
+			SysSettingFailure failure = failures.CategorizeAndLog(ex, "listing sys-settings");
 			return new SysSettingsListResult(false, Array.Empty<SysSettingItem>(), failure.Error,
 				failure.Category, failure.Cause, failure.RecoveryAction, failure.CorrelationId);
 		}
@@ -86,7 +85,7 @@ public sealed class SysSettingsListTool(IToolCommandResolver commandResolver,
 /// </summary>
 [McpServerToolType]
 public sealed class SysSettingCreateTool(IToolCommandResolver commandResolver,
-	IOperationCorrelationIdProvider correlationIds, ILogger logger) {
+	ISysSettingFailureClassifier failures) {
 
 	internal const string CreateSysSettingToolName = "create-sys-setting";
 
@@ -115,7 +114,7 @@ public sealed class SysSettingCreateTool(IToolCommandResolver commandResolver,
 			command = commandResolver.Resolve<SysSettingsCommand>(
 				new EnvironmentOptions { Environment = args.EnvironmentName });
 		} catch (Exception ex) {
-			SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(ex, "creating sys-setting", logger, correlationIds);
+			SysSettingFailure failure = failures.CategorizeAndLog(ex, "creating sys-setting");
 			return new SysSettingCreateResult(false, args.Code ?? string.Empty, args.ValueTypeName ?? string.Empty,
 				null, failure.Error, Warning: null, failure.Category, failure.Cause, failure.RecoveryAction,
 				failure.CorrelationId);
@@ -129,7 +128,7 @@ public sealed class SysSettingCreateTool(IToolCommandResolver commandResolver,
 /// </summary>
 [McpServerToolType]
 public sealed class SysSettingUpdateTool(IToolCommandResolver commandResolver,
-	IOperationCorrelationIdProvider correlationIds, ILogger logger) {
+	ISysSettingFailureClassifier failures) {
 
 	internal const string UpdateSysSettingToolName = "update-sys-setting";
 
@@ -154,7 +153,7 @@ public sealed class SysSettingUpdateTool(IToolCommandResolver commandResolver,
 			command = commandResolver.Resolve<SysSettingsCommand>(
 				new EnvironmentOptions { Environment = args.EnvironmentName });
 		} catch (Exception ex) {
-			SysSettingFailure failure = SysSettingsCommand.CategorizeAndLog(ex, "updating sys-setting", logger, correlationIds);
+			SysSettingFailure failure = failures.CategorizeAndLog(ex, "updating sys-setting");
 			return new SysSettingUpdateResult(false, args.Code ?? string.Empty, null, failure.Error,
 				failure.Category, failure.Cause, failure.RecoveryAction, failure.CorrelationId);
 		}

--- a/clio/Command/McpServer/Tools/ToolContractGetTool.cs
+++ b/clio/Command/McpServer/Tools/ToolContractGetTool.cs
@@ -555,7 +555,7 @@ internal static class ToolContractCatalog {
 	// the correlation ID beside the legacy message, so an agent has something to act on and an operator
 	// can find the matching log line.
 	// PR #1373 review (Blocker) — COMPOSED from the SysSettingErrorCategories constants, not retyped. The hand-
-	// written list had already drifted: it omitted `Configuration`, which `CategorizeFailure` returns for every
+	// written list had already drifted: it omitted `Configuration`, which `ISysSettingFailureClassifier.Categorize` returns for every
 	// `EnvironmentResolutionException` (an unregistered environment - the most common failure an agent hits, and
 	// the one arm carrying actionable recovery advice). Per
 	// docs/knowledge/McpServer/curated-tool-contract-wins-over-the-description-attribute.md this curated string can
@@ -570,7 +570,7 @@ internal static class ToolContractCatalog {
 			.OrderBy(name => name, StringComparer.Ordinal))
 		+ ". Null on success.";
 	// PR #1373 review — the previous wording claimed `cause` is "never composed from server prose", which
-	// `CategorizeFailure` does not honour: the `ProviderFailure` arm sets it from `DataProviderFailureException.Message`,
+	// `ISysSettingFailureClassifier.Categorize` does not honour: the `ProviderFailure` arm sets it from `DataProviderFailureException.Message`,
 	// built from the environment's HTTP response. Advertising a trust label the code does not keep is worse than no
 	// label - an agent would read environment-influenced text as trusted local guidance, the prompt-injection surface
 	// issue #1333 exists to close. Keeping `Cause` strictly fixed-local for `ProviderFailure` (the reviewer's preferred

--- a/clio/Command/SysSettingFailureClassifier.cs
+++ b/clio/Command/SysSettingFailureClassifier.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Security.Authentication;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Clio.Command.McpServer;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+
+namespace Clio.Command;
+
+/// <inheritdoc cref="ISysSettingFailureClassifier"/>
+public sealed class SysSettingFailureClassifier : ISysSettingFailureClassifier {
+
+	private readonly ILogger _logger;
+	private readonly IOperationCorrelationIdProvider _correlationIds;
+
+	/// <summary>
+	/// Creates the classifier.
+	/// </summary>
+	/// <param name="logger">The sink the failure line and the debug excerpt are written to.</param>
+	/// <param name="correlationIds">Mints the ID the envelope and the log line share.</param>
+	public SysSettingFailureClassifier(ILogger logger, IOperationCorrelationIdProvider correlationIds) {
+		_logger = logger;
+		_correlationIds = correlationIds;
+	}
+
+	/// <inheritdoc/>
+	public SysSettingFailure Categorize(Exception ex, string operationLabel, string correlationId) {
+		//The Creatio client reaches transport faults through Task.Result, which wraps them in an
+		//AggregateException. Switching on the outer type alone therefore saw the wrapper, not the
+		//fault, and an aggregate carrying an AuthenticationException or a typed 401 fell through to
+		//the generic "Failed ..." - losing exactly the credential diagnosis this command exists to
+		//report.
+		Exception fault = UnwrapTransportFault(ex);
+		return fault switch {
+			//A transport TIMEOUT, not a cancellation. HttpClient surfaces its own timeout as a
+			//TaskCanceledException, and nothing on the sys-setting paths supplies a cancellation token,
+			//so a task that "cancels" itself did so because the environment stopped answering. Without
+			//this arm the type matched nothing and a timeout was reported as an unknown failure with
+			//"retry the operation" - advice that makes an agent loop against a silent environment.
+			//Carried over from SysSettingCodes.ClassifyReadFailure, which already made this call, so the
+			//two classifiers agree on what a timeout is.
+			TaskCanceledException => Network(operationLabel, correlationId),
+			HttpRequestException httpEx when IsAuthenticationFailure(httpEx)
+				=> Authentication(operationLabel, correlationId),
+			HttpRequestException => Network(operationLabel, correlationId),
+			WebException webEx when IsAuthenticationFailure(webEx)
+				=> Authentication(operationLabel, correlationId),
+			WebException => Network(operationLabel, correlationId),
+			SocketException => Network(operationLabel, correlationId),
+			UnauthorizedAccessException => Authentication(operationLabel, correlationId),
+			//UNCONDITIONAL, and before the AuthenticationException arms. SessionRejectedException is
+			//only ever raised where the rejection was already PROVEN (a raw body carrying Creatio's
+			//auth-routing markers, or a corroborated provider verdict), so re-asking the question is
+			//not merely redundant - it is wrong. The classifier would run the TLS-prose regex over
+			//this exception's own message, and that message interpolates the operation label, which
+			//carries the caller's operand: reading sys-setting 'SslCertificateThumbprint' matches
+			///certificate/ and flipped a proven credential rejection to "Network error".
+			SessionRejectedException => Authentication(operationLabel, correlationId),
+			//A bare AuthenticationException is asked the same question as the wrapped ones: the framework
+			//raises this type for a TLS handshake too, and a bad server certificate reported as rejected
+			//credentials hides the only diagnosis that leads to the fix.
+			AuthenticationException authEx when IsAuthenticationFailure(authEx)
+				=> Authentication(operationLabel, correlationId),
+			AuthenticationException => Network(operationLabel, correlationId),
+			//An aggregate that carries several distinct faults is not unwrapped, because no single
+			//inner represents it - but a credential failure among them still has to be reported as one.
+			AggregateException aggregate when IsAuthenticationFailure(aggregate)
+				=> Authentication(operationLabel, correlationId),
+			//Issue #1378: the DIAGNOSED form of the arm below, raised by ISysSettingsManager's write
+			//endpoints, which hold the raw body and so can say what arrived and keep a neutralized
+			//excerpt on ServerDetail. It produces the IDENTICAL envelope - same Error, same Network
+			//category, same cause and recovery - so no agent branching on error-category and no MCP
+			//assertion changes; what improves is the debug line and the exception's own message.
+			//Placed ABOVE the DataProviderFailureException and InvalidOperationException arms, which it
+			//would otherwise be captured by: NonJsonWriteResponseException derives from
+			//InvalidOperationException, and being reported as ProviderFailure would claim the data
+			//provider returned an unsuccessful response - which a gateway page is not.
+			//The wrong-SHAPE half keeps the same category - the request still did not reach the service
+			//it was meant for - but must not repeat the not-JSON cause, which names a proxy or WAF page
+			//that demonstrably is not what answered.
+			NonJsonWriteResponseException {
+				Kind: NonJsonWriteResponseKind.UnexpectedShape
+			} => new SysSettingFailure(
+				$"Creatio returned a response of an unexpected shape {operationLabel}.",
+				SysSettingErrorCategories.Network, SysSettingFailureTexts.UnexpectedResponseShapeCause,
+				SysSettingFailureTexts.UnexpectedResponseShapeRecovery, correlationId),
+			NonJsonWriteResponseException => new SysSettingFailure(
+				$"Creatio returned a non-JSON response {operationLabel}.",
+				SysSettingErrorCategories.Network, SysSettingFailureTexts.NonJsonResponseCause,
+				SysSettingFailureTexts.NonJsonResponseRecovery, correlationId),
+			//KEPT, and still reachable (PR review). Since issue #1378 the sys-settings write endpoints
+			//raise the diagnosed NonJsonWriteResponseException above, but the parser fault can also come
+			//from INSIDE the client: Creatio.Client throws JsonException itself rather than returning
+			//the body when the server answers an upload or a re-authenticated call with its login page -
+			//the shape CreatioClientAdapterReauthTests and ReauthExecutorTests pin. That fault never
+			//reaches clio's own deserialize, so the arm above cannot classify it, and without this one
+			//it would fall through to Unknown ("no cause could be determined").
+			JsonException => new SysSettingFailure(
+				$"Creatio returned a non-JSON response {operationLabel}.",
+				SysSettingErrorCategories.Network, SysSettingFailureTexts.NonJsonResponseCause,
+				SysSettingFailureTexts.NonJsonResponseRecovery, correlationId),
+			//BOUNDED and REDACTED wherever an exception MESSAGE is promoted into a caller-visible field.
+			//These arms return the message of ANY exception of those types raised anywhere below, and such
+			//messages are unbounded and can carry paths, URLs or response fragments.
+			ArgumentException argEx => new SysSettingFailure(SafeDetail(argEx.Message),
+				SysSettingErrorCategories.Validation, SafeDetail(argEx.Message),
+				SysSettingFailureTexts.ValidationRecovery, correlationId),
+			//DataProviderFailureException is the one InvalidOperationException whose message IS the
+			//diagnosis - it is composed locally by ClassifyingDataProvider from a response that carries
+			//no exception of its own. An ordinary InvalidOperationException keeps its message too (that
+			//is the pre-existing behaviour) but is not claimed to be a provider verdict.
+			DataProviderFailureException providerEx => new SysSettingFailure(SafeDetail(providerEx.Message),
+				SysSettingErrorCategories.ProviderFailure, SafeDetail(providerEx.Message),
+				SysSettingFailureTexts.ProviderFailureRecovery, correlationId),
+			InvalidOperationException invEx => new SysSettingFailure(SafeDetail(invEx.Message),
+				SysSettingErrorCategories.Unknown, SafeDetail(invEx.Message),
+				SysSettingFailureTexts.UnknownRecovery, correlationId),
+			//An unresolvable environment is a CONFIGURATION failure, not an unknown one. It used to
+			//reach the fallback arm below and be reported as "no cause could be determined" with
+			//"retry the operation" - advice that makes an agent loop, when the resolver had already
+			//said exactly what to fix. The resolver's text is clio-local (EnvironmentNotFoundError,
+			//settings-file paths), so it is safe as the cause; Error keeps the generic label so an
+			//unregistered name is still not promoted into the headline message.
+			//PR #1373 review: routed on the exception's OWN Reason, not on its type. Four of the resolver's
+			//throw sites are authentication and target-URL rejections, and reporting those as
+			//Configuration + "register the environment with reg-web-app" is advice a credential-passthrough
+			//caller over mcp-http cannot act on - it has no environment to register - while an agent
+			//branching on the category will not re-authenticate, because the category says the problem is
+			//local configuration. Reason defaults to Configuration, so every unregistered-name site is
+			//unchanged.
+			EnvironmentResolutionException resolutionEx =>
+				DescribeResolutionFailure(resolutionEx, operationLabel, correlationId),
+			var _ => new SysSettingFailure($"Failed {operationLabel}.",
+				SysSettingErrorCategories.Unknown, SysSettingFailureTexts.UnknownCause,
+				SysSettingFailureTexts.UnknownRecovery, correlationId)
+
+		};
+	}
+
+	/// <inheritdoc/>
+	public SysSettingFailure CategorizeAndLog(Exception ex, string operationLabel) {
+		SysSettingFailure failure = Categorize(ex, operationLabel, _correlationIds.New());
+		LogFailureLine(failure);
+		//Here too, not only in the command's instance ReportFailure (PR #1374 review): this member exists
+		//BECAUSE other callers use it - the MCP tools' catch blocks - and those paths were getting a
+		//correlation ID on the envelope with no matching debug line to bridge to.
+		LogServerDetail(ex, failure.CorrelationId);
+		return failure;
+	}
+
+	/// <inheritdoc/>
+	public void LogFailureLine(SysSettingFailure failure) {
+		string line = DescribeFailureForLog(failure);
+		_logger.WriteError(line);
+		McpLogNotifier.ForwardMessages([new ErrorMessage(line)], failure.CorrelationId);
+	}
+
+	/// <inheritdoc/>
+	public void LogServerDetail(Exception ex, string correlationId) {
+		//The WHOLE chain, not a single unwrap (PR #1374 review). UnwrapTransportFault only steps
+		//through single-inner aggregates and TargetInvocationException, so a carrier re-wrapped by a
+		//domain or transport exception - a SessionRejectedException inside an environment failure -
+		//lost its excerpt silently: the envelope still looked complete and the operator grepped the
+		//correlation ID and found nothing.
+		string detail = FindServerDetail(ex);
+		//Scrubbed and fenced even here, and that is load-bearing rather than belt-and-braces:
+		//ConsoleLogger.WriteDebug suppresses the console DRAIN under MCP server mode but still
+		//CAPTURES into the per-flow buffer BaseTool harvests into CommandExecutionResult.Messages. The
+		//excerpt reaching this line is only control-character normalized and length-capped, so a
+		//bearer token, a target URI or a credential pair inside it would otherwise be intact.
+		string safeDetail = SensitiveErrorTextRedactor.RedactUntrustedOrNull(detail);
+		if (safeDetail is null) {
+			return;
+		}
+		_logger.WriteDebug($"(correlation-id: {correlationId}) server detail: {safeDetail}");
+	}
+
+	/// <summary>Renders a classified failure as one log line, correlation ID last.</summary>
+	/// <remarks>
+	/// Not on <see cref="ISysSettingFailureClassifier"/>: <see cref="LogFailureLine"/> is the only caller,
+	/// and a second way to render the same line is how the two would drift.
+	/// <para>
+	/// The cause is omitted when it is the SAME string as the headline (PR #1374 review). Three arms of
+	/// <see cref="Categorize"/> put one composed diagnostic into both <c>Error</c> and <c>Cause</c>, so
+	/// this line printed it twice - and where that diagnostic carries the fenced server excerpt, twice
+	/// meant two untrusted-source-text fences on one line.
+	/// </para>
+	/// </remarks>
+	/// <param name="failure">The classified failure to render.</param>
+	/// <returns>The single log line.</returns>
+	internal string DescribeFailureForLog(SysSettingFailure failure) {
+		string cause = string.Equals(failure.Error, failure.Cause, StringComparison.Ordinal)
+			? string.Empty
+			: $"Cause: {failure.Cause} ";
+		return $"{failure.Error} {cause}Action: {failure.RecoveryAction} "
+			+ $"(correlation-id: {failure.CorrelationId})";
+	}
+
+	/// <summary>
+	/// Classifies an <see cref="EnvironmentResolutionException"/> by what it is actually about. The
+	/// resolver's text is clio-local (a settings-file path, an allowlist reason, the missing auth kind), so
+	/// it stays safe as the cause; <c>Error</c> keeps the generic label either way, so an unregistered name
+	/// is still not promoted into the headline message.
+	/// </summary>
+	private static SysSettingFailure DescribeResolutionFailure(EnvironmentResolutionException resolutionEx,
+		string operationLabel, string correlationId) {
+		(string category, string recovery) = resolutionEx.Reason switch {
+			EnvironmentResolutionReason.Authentication => (SysSettingErrorCategories.Authentication,
+				SysSettingFailureTexts.PassthroughAuthenticationRecovery),
+			EnvironmentResolutionReason.Validation => (SysSettingErrorCategories.Validation,
+				SysSettingFailureTexts.RefusedTargetRecovery),
+			var _ => (SysSettingErrorCategories.Configuration,
+				SysSettingFailureTexts.ConfigurationRecovery),
+		};
+		//SafeDetail, like the three sibling arms of Categorize. "clio-local" is not the same as
+		//"safe to emit": two resolver throw sites embed an absolute settings-file path verbatim, and on
+		//Windows that path carries the OS account name. Redact turns it into [redacted-path] and leaves
+		//the sentence ("clio settings bootstrap is broken. Repair ...") fully actionable.
+		return new SysSettingFailure($"Failed {operationLabel}.", category, SafeDetail(resolutionEx.Message),
+			recovery, correlationId);
+	}
+
+	private static SysSettingFailure Authentication(string operationLabel, string correlationId) =>
+		new($"Authentication error {operationLabel}.", SysSettingErrorCategories.Authentication,
+			SysSettingFailureTexts.AuthenticationCause,
+			SysSettingFailureTexts.AuthenticationRecovery, correlationId);
+
+	private static SysSettingFailure Network(string operationLabel, string correlationId) =>
+		new($"Network error {operationLabel}.", SysSettingErrorCategories.Network,
+			SysSettingFailureTexts.NetworkCause, SysSettingFailureTexts.NetworkRecovery,
+			correlationId);
+
+	/// <summary>
+	/// The server excerpt of the first <see cref="IServerDetailCarrier"/> anywhere in the exception
+	/// chain, including inside single-fault aggregates, or <see langword="null"/> when there is none.
+	/// </summary>
+	private static string FindServerDetail(Exception exception) {
+		for (Exception current = exception; current is not null; current = current.InnerException) {
+			if (current is IServerDetailCarrier carrier) {
+				return carrier.ServerDetail;
+			}
+			if (current is AggregateException { InnerExceptions.Count: 1 } aggregate
+					&& aggregate.InnerExceptions[0] is IServerDetailCarrier innerCarrier) {
+				return innerCarrier.ServerDetail;
+			}
+		}
+		return null;
+	}
+
+	// Cap on a message promoted into a user-visible field. 300 is what DataProviderFailureException's
+	// detail already uses, so the two paths expose the same amount.
+	private const int MaxPromotedMessageLength = 300;
+
+	// Redaction runs BEFORE the cap, deliberately: SensitiveErrorTextRedactor matches a token as a whole
+	// unit, so capping first can split one in half and leave the visible fragment unredacted. This is the
+	// same order ServiceResponseJsonGuard.BuildPreview uses.
+	// The cap itself goes through ClampPreservingFence rather than a raw slice, on two counts.
+	// Surrogates: Redact only scrubs secrets, it does not touch surrogates, so an astral character
+	// straddling the cap point would leave a lone high surrogate in SysSettingFailure.Error/.Cause - and
+	// System.Text.Json throws on invalid UTF-16, failing the whole tool response instead of truncating
+	// one message. Fences: DataProviderFailureException.Message arrives already composed AND fenced by
+	// ServerReportedFailureText.ComposeMessage, so a blind cut removed the closing marker whenever the
+	// platform's own ErrorMessage ran past roughly 214 characters - a length the SERVER chooses - and
+	// every field emitted after it then read as untrusted to anything keying on the markers.
+	private static string SafeDetail(string message) {
+		if (string.IsNullOrEmpty(message)) {
+			return message;
+		}
+		string redacted = SensitiveErrorTextRedactor.Redact(message);
+		return SensitiveErrorTextRedactor.ClampPreservingFence(redacted, MaxPromotedMessageLength);
+	}
+
+	// Bounds every walk over an exception chain. A chain this deep is not something a transport
+	// produces, and the bound is what keeps a hand-built or self-referencing chain from looping.
+	private const int MaxExceptionUnwrapDepth = 16;
+
+	/// <summary>
+	/// Returns the exception that should be classified: a wrapper carrying exactly one fault unwraps
+	/// to that fault, and everything else is returned unchanged.
+	/// </summary>
+	/// <remarks>
+	/// A multi-fault <see cref="AggregateException"/> is deliberately NOT unwrapped - picking its first
+	/// inner would report one of several failures as if it were the whole story. Those are handled by
+	/// the aggregate arm in <see cref="Categorize"/> instead.
+	/// </remarks>
+	private static Exception UnwrapTransportFault(Exception exception) {
+		Exception current = exception;
+		for (int depth = 0; depth < MaxExceptionUnwrapDepth; depth++) {
+			Exception inner = current switch {
+				AggregateException aggregate when aggregate.InnerExceptions.Count == 1
+					=> aggregate.InnerExceptions[0],
+				TargetInvocationException { InnerException: { } target } => target,
+				var _ => null
+			};
+			if (inner is null) {
+				return current;
+			}
+			current = inner;
+		}
+		return current;
+	}
+
+	// A bounded 401 token, not any occurrence of the digits. "Connection refused at
+	// http://localhost:40124" is a network error, and reporting it as rejected credentials sends the
+	// operator off to fix a working login. The token must also stand alone, so a port or an id containing
+	// 401 does not qualify.
+	// Delegates to the one shared classifier so this layer and SysSettingsManager cannot answer the
+	// same question differently. See AuthenticationFailureClassifier for why that mattered.
+	private static bool IsAuthenticationFailure(Exception exception) =>
+		AuthenticationFailureClassifier.IsAuthenticationFailure(exception);
+}

--- a/clio/Command/SysSettingsCommand.cs
+++ b/clio/Command/SysSettingsCommand.cs
@@ -5,12 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Security.Authentication;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using Clio.Command.McpServer;
 using Clio.Command.McpServer.Tools;
 using Clio.Common;
 using CommandLine;
@@ -67,13 +62,15 @@ namespace Clio.Command
 		private readonly ILogger _logger;
 		private readonly IFileSystem _fileSystem;
 		private readonly IOperationCorrelationIdProvider _correlationIds;
+		private readonly ISysSettingFailureClassifier _failures;
 
 		public SysSettingsCommand(ISysSettingsManager sysSettingsManager, ILogger logger, IFileSystem fileSystem,
-			IOperationCorrelationIdProvider correlationIds){
+			IOperationCorrelationIdProvider correlationIds, ISysSettingFailureClassifier failures){
 			_sysSettingsManager = sysSettingsManager;
 			_logger = logger;
 			_fileSystem = fileSystem;
 			_correlationIds = correlationIds;
+			_failures = failures;
 		}
 
 		/// <summary>
@@ -258,8 +255,7 @@ namespace Clio.Command
 				//an ID and write its own line, which meant the debug-verbosity server excerpt was never
 				//written for the one path an operator actually runs interactively
 				//(apply-environment-manifest, Program.cs).
-				SysSettingFailure failure = CategorizeAndLog(ex, UpdateOperationLabel, _logger,
-					_correlationIds);
+				SysSettingFailure failure = _failures.CategorizeAndLog(ex, UpdateOperationLabel);
 				//PR #1373 review: the local IS used. This second line is what
 				//docs/knowledge/Command/refused-syssetting-update-is-only-visible-as-a-writeerror.md pins as the
 				//Maintainer / apply-environment-manifest flow's ONLY failure signal, and after the classifier was
@@ -403,7 +399,7 @@ namespace Clio.Command
 				//JsonException from PrepareUpdateValue or an ArgumentException from the create-argument
 				//validation is clio's own prose and names the thing that has to be fixed. Routing those
 				//through ReportFailure printed "no cause could be determined ... retry the operation" and
-				//never named the file - and CategorizeFailure sends UnauthorizedAccessException to
+				//never named the file - and the classifier sends UnauthorizedAccessException to
 				//Authentication, telling the operator to repair credentials for a local permission
 				//problem.
 				_logger.WriteError($"Error during set setting '{opts.Code}' value occured.");
@@ -433,7 +429,7 @@ namespace Clio.Command
 		/// That path was completely silent before the classifier was wired in; afterwards every probe against an
 		/// environment where the setting is simply absent minted a correlation ID and wrote a red
 		/// <c>[ERR] … (correlation-id: …)</c> line whose ID appears in no result anywhere - while the command went
-		/// on to report success. That is the inverse of the invariant <see cref="CategorizeAndLog"/> exists for:
+		/// on to report success. That is the inverse of the invariant <see cref="ISysSettingFailureClassifier.CategorizeAndLog"/> exists for:
 		/// an ID in a log line no result mentions is the same defect as an ID on a result no log line mentions. On
 		/// the MCP <c>set-logo</c> surface those lines can also ride along with a <c>success: true</c> response and
 		/// read to an agent as evidence of failure.
@@ -455,7 +451,7 @@ namespace Clio.Command
 				//an unreferenced correlation ID in front of an operator whose command is going to succeed.
 				SysSettingFailure failure = report
 					? ReportFailure(ex, ReadOperationLabel)
-					: CategorizeFailure(ex, ReadOperationLabel, _correlationIds.New());
+					: _failures.Categorize(ex, ReadOperationLabel, _correlationIds.New());
 				return new SysSettingGetResult(false, args.Code, string.Empty, failure.Error,
 					failure.Category, failure.Cause, failure.RecoveryAction, failure.CorrelationId);
 			}
@@ -625,7 +621,7 @@ namespace Clio.Command
 				//operation here too (PR #1374 review). The manager's own "SysSettings with code: {code} is
 				//not updated." lines carry no correlation ID and never have, so minting a bare token here
 				//handed the caller something to grep that resolved to nothing - the exact failure
-				//CategorizeAndLog exists to prevent, and worse on the MCP path, where an agent cannot tell
+				//ISysSettingFailureClassifier.CategorizeAndLog exists to prevent, and worse on the MCP path, where an agent cannot tell
 				//"the line is below my verbosity" from "the line does not exist".
 				return DescribePartialCreate(args, failure: null);
 			}
@@ -642,7 +638,7 @@ namespace Clio.Command
 		/// Partial success, so there is no Error - but the ID and the line that carries it are ONE
 		/// operation here too (PR #1374 review). The manager's own "SysSettings with code: {code} is not
 		/// updated." lines carry no correlation ID and never have, so minting a bare token here handed the
-		/// caller something to grep that resolved to nothing - the exact failure CategorizeAndLog exists to
+		/// caller something to grep that resolved to nothing - the exact failure ISysSettingFailureClassifier.CategorizeAndLog exists to
 		/// prevent, and worse on the MCP path, where an agent cannot tell "the line is below my verbosity"
 		/// from "the line does not exist".
 		/// </remarks>
@@ -659,180 +655,13 @@ namespace Clio.Command
 				$"Sys-setting '{args.Code}' was created, but the initial value could not be applied. "
 				+ $"(correlation-id: {correlationId})");
 			if (failure is not null) {
-				WriteServerDetailAtDebugVerbosity(_logger, failure, correlationId);
+				_failures.LogServerDetail(failure, correlationId);
 			}
 			return new SysSettingCreateResult(true, args.Code, args.ValueTypeName, null,
 				Error: null,
 				Warning: "Sys-setting was created, but the initial value could not be applied.",
 				CorrelationId: correlationId);
 		}
-
-		/// <summary>
-		/// The legacy single-line categorization, kept for callers that surface only the message.
-		/// </summary>
-		/// <remarks>
-		/// Delegates to <see cref="CategorizeFailure"/> so there is one classification, not two. Prefer
-		/// <see cref="CategorizeFailure"/>: this overload drops the actionable cause, the recovery action
-		/// and the correlation ID, which is what issue #1329 was about.
-		/// </remarks>
-		internal static string CategorizeError(Exception ex, string operationLabel) =>
-			CategorizeFailure(ex, operationLabel, correlationId: null).Error;
-
-		/// <summary>
-		/// Classifies a failure into the structured envelope the sys-setting results carry: the legacy
-		/// message, the category an agent branches on, a cause, a recovery action, and the correlation ID
-		/// that finds the log line written for the same failure.
-		/// </summary>
-		/// <param name="ex">The failure to classify.</param>
-		/// <param name="operationLabel">The operation, as it reads inside the legacy message.</param>
-		/// <param name="correlationId">The ID issued for this operation, or <see langword="null"/>.</param>
-		internal static SysSettingFailure CategorizeFailure(Exception ex, string operationLabel,
-			string correlationId) {
-			//The Creatio client reaches transport faults through Task.Result, which wraps them in an
-			//AggregateException. Switching on the outer type alone therefore saw the wrapper, not the
-			//fault, and an aggregate carrying an AuthenticationException or a typed 401 fell through to
-			//the generic "Failed ..." - losing exactly the credential diagnosis this command exists to
-			//report.
-			Exception fault = UnwrapTransportFault(ex);
-			return fault switch {
-				//A transport TIMEOUT, not a cancellation. HttpClient surfaces its own timeout as a
-				//TaskCanceledException, and nothing on the sys-setting paths supplies a cancellation token,
-				//so a task that "cancels" itself did so because the environment stopped answering. Without
-				//this arm the type matched nothing and a timeout was reported as an unknown failure with
-				//"retry the operation" - advice that makes an agent loop against a silent environment.
-				//Carried over from SysSettingCodes.ClassifyReadFailure, which already made this call, so the
-				//two classifiers agree on what a timeout is.
-				TaskCanceledException => Network(operationLabel, correlationId),
-				HttpRequestException httpEx when IsAuthenticationFailure(httpEx)
-					=> Authentication(operationLabel, correlationId),
-				HttpRequestException => Network(operationLabel, correlationId),
-				WebException webEx when IsAuthenticationFailure(webEx)
-					=> Authentication(operationLabel, correlationId),
-				WebException => Network(operationLabel, correlationId),
-				SocketException => Network(operationLabel, correlationId),
-				UnauthorizedAccessException => Authentication(operationLabel, correlationId),
-				//UNCONDITIONAL, and before the AuthenticationException arms. SessionRejectedException is
-				//only ever raised where the rejection was already PROVEN (a raw body carrying Creatio's
-				//auth-routing markers, or a corroborated provider verdict), so re-asking the question is
-				//not merely redundant - it is wrong. The classifier would run the TLS-prose regex over
-				//this exception's own message, and that message interpolates the operation label, which
-				//carries the caller's operand: reading sys-setting 'SslCertificateThumbprint' matches
-				///certificate/ and flipped a proven credential rejection to "Network error".
-				SessionRejectedException => Authentication(operationLabel, correlationId),
-				//A bare AuthenticationException is asked the same question as the wrapped ones: the framework
-				//raises this type for a TLS handshake too, and a bad server certificate reported as rejected
-				//credentials hides the only diagnosis that leads to the fix.
-				AuthenticationException authEx when IsAuthenticationFailure(authEx)
-					=> Authentication(operationLabel, correlationId),
-				AuthenticationException => Network(operationLabel, correlationId),
-				//An aggregate that carries several distinct faults is not unwrapped, because no single
-				//inner represents it - but a credential failure among them still has to be reported as one.
-				AggregateException aggregate when IsAuthenticationFailure(aggregate)
-					=> Authentication(operationLabel, correlationId),
-				//Issue #1378: the DIAGNOSED form of the arm below, raised by ISysSettingsManager's write
-				//endpoints, which hold the raw body and so can say what arrived and keep a neutralized
-				//excerpt on ServerDetail. It produces the IDENTICAL envelope - same Error, same Network
-				//category, same cause and recovery - so no agent branching on error-category and no MCP
-				//assertion changes; what improves is the debug line and the exception's own message.
-				//Placed ABOVE the DataProviderFailureException and InvalidOperationException arms, which it
-				//would otherwise be captured by: NonJsonWriteResponseException derives from
-				//InvalidOperationException, and being reported as ProviderFailure would claim the data
-				//provider returned an unsuccessful response - which a gateway page is not.
-				//The wrong-SHAPE half keeps the same category - the request still did not reach the service
-				//it was meant for - but must not repeat the not-JSON cause, which names a proxy or WAF page
-				//that demonstrably is not what answered.
-				NonJsonWriteResponseException {
-					Kind: NonJsonWriteResponseKind.UnexpectedShape
-				} => new SysSettingFailure(
-					$"Creatio returned a response of an unexpected shape {operationLabel}.",
-					SysSettingErrorCategories.Network, SysSettingFailureTexts.UnexpectedResponseShapeCause,
-					SysSettingFailureTexts.UnexpectedResponseShapeRecovery, correlationId),
-				NonJsonWriteResponseException => new SysSettingFailure(
-					$"Creatio returned a non-JSON response {operationLabel}.",
-					SysSettingErrorCategories.Network, SysSettingFailureTexts.NonJsonResponseCause,
-					SysSettingFailureTexts.NonJsonResponseRecovery, correlationId),
-				//KEPT, and still reachable (PR review). Since issue #1378 the sys-settings write endpoints
-				//raise the diagnosed NonJsonWriteResponseException above, but the parser fault can also come
-				//from INSIDE the client: Creatio.Client throws JsonException itself rather than returning
-				//the body when the server answers an upload or a re-authenticated call with its login page -
-				//the shape CreatioClientAdapterReauthTests and ReauthExecutorTests pin. That fault never
-				//reaches clio's own deserialize, so the arm above cannot classify it, and without this one
-				//it would fall through to Unknown ("no cause could be determined").
-				JsonException => new SysSettingFailure(
-					$"Creatio returned a non-JSON response {operationLabel}.",
-					SysSettingErrorCategories.Network, SysSettingFailureTexts.NonJsonResponseCause,
-					SysSettingFailureTexts.NonJsonResponseRecovery, correlationId),
-				//BOUNDED and REDACTED wherever an exception MESSAGE is promoted into a caller-visible field.
-				//These arms return the message of ANY exception of those types raised anywhere below, and such
-				//messages are unbounded and can carry paths, URLs or response fragments.
-				ArgumentException argEx => new SysSettingFailure(SafeDetail(argEx.Message),
-					SysSettingErrorCategories.Validation, SafeDetail(argEx.Message),
-					SysSettingFailureTexts.ValidationRecovery, correlationId),
-				//DataProviderFailureException is the one InvalidOperationException whose message IS the
-				//diagnosis - it is composed locally by ClassifyingDataProvider from a response that carries
-				//no exception of its own. An ordinary InvalidOperationException keeps its message too (that
-				//is the pre-existing behaviour) but is not claimed to be a provider verdict.
-				DataProviderFailureException providerEx => new SysSettingFailure(SafeDetail(providerEx.Message),
-					SysSettingErrorCategories.ProviderFailure, SafeDetail(providerEx.Message),
-					SysSettingFailureTexts.ProviderFailureRecovery, correlationId),
-				InvalidOperationException invEx => new SysSettingFailure(SafeDetail(invEx.Message),
-					SysSettingErrorCategories.Unknown, SafeDetail(invEx.Message),
-					SysSettingFailureTexts.UnknownRecovery, correlationId),
-				//An unresolvable environment is a CONFIGURATION failure, not an unknown one. It used to
-				//reach the fallback arm below and be reported as "no cause could be determined" with
-				//"retry the operation" - advice that makes an agent loop, when the resolver had already
-				//said exactly what to fix. The resolver's text is clio-local (EnvironmentNotFoundError,
-				//settings-file paths), so it is safe as the cause; Error keeps the generic label so an
-                //unregistered name is still not promoted into the headline message.
-				//PR #1373 review: routed on the exception's OWN Reason, not on its type. Four of the resolver's
-				//throw sites are authentication and target-URL rejections, and reporting those as
-				//Configuration + "register the environment with reg-web-app" is advice a credential-passthrough
-				//caller over mcp-http cannot act on - it has no environment to register - while an agent
-				//branching on the category will not re-authenticate, because the category says the problem is
-				//local configuration. Reason defaults to Configuration, so every unregistered-name site is
-				//unchanged.
-				EnvironmentResolutionException resolutionEx =>
-					DescribeResolutionFailure(resolutionEx, operationLabel, correlationId),
-				var _ => new SysSettingFailure($"Failed {operationLabel}.",
-					SysSettingErrorCategories.Unknown, SysSettingFailureTexts.UnknownCause,
-					SysSettingFailureTexts.UnknownRecovery, correlationId)
-
-			};
-		}
-
-		/// <summary>
-		/// Classifies an <see cref="EnvironmentResolutionException"/> by what it is actually about. The
-		/// resolver's text is clio-local (a settings-file path, an allowlist reason, the missing auth kind), so
-		/// it stays safe as the cause; <c>Error</c> keeps the generic label either way, so an unregistered name
-		/// is still not promoted into the headline message.
-		/// </summary>
-		private static SysSettingFailure DescribeResolutionFailure(EnvironmentResolutionException resolutionEx,
-			string operationLabel, string correlationId) {
-			(string category, string recovery) = resolutionEx.Reason switch {
-				EnvironmentResolutionReason.Authentication => (SysSettingErrorCategories.Authentication,
-					SysSettingFailureTexts.PassthroughAuthenticationRecovery),
-				EnvironmentResolutionReason.Validation => (SysSettingErrorCategories.Validation,
-					SysSettingFailureTexts.RefusedTargetRecovery),
-				var _ => (SysSettingErrorCategories.Configuration,
-					SysSettingFailureTexts.ConfigurationRecovery),
-			};
-			//SafeDetail, like the three sibling arms of CategorizeFailure. "clio-local" is not the same as
-			//"safe to emit": two resolver throw sites embed an absolute settings-file path verbatim, and on
-			//Windows that path carries the OS account name. Redact turns it into [redacted-path] and leaves
-			//the sentence ("clio settings bootstrap is broken. Repair ...") fully actionable.
-			return new SysSettingFailure($"Failed {operationLabel}.", category, SafeDetail(resolutionEx.Message),
-				recovery, correlationId);
-		}
-
-		private static SysSettingFailure Authentication(string operationLabel, string correlationId) =>
-			new($"Authentication error {operationLabel}.", SysSettingErrorCategories.Authentication,
-				SysSettingFailureTexts.AuthenticationCause,
-				SysSettingFailureTexts.AuthenticationRecovery, correlationId);
-
-		private static SysSettingFailure Network(string operationLabel, string correlationId) =>
-			new($"Network error {operationLabel}.", SysSettingErrorCategories.Network,
-				SysSettingFailureTexts.NetworkCause, SysSettingFailureTexts.NetworkRecovery,
-				correlationId);
 
 		/// <summary>
 		/// Writes the failure to the log with its correlation ID and returns it, so the envelope the caller
@@ -847,10 +676,10 @@ namespace Clio.Command
 		/// and fenced at the point of writing.
 		/// </remarks>
 		private SysSettingFailure ReportFailure(Exception ex, string operationLabel) =>
-			//CategorizeAndLog now writes the debug excerpt itself, so every caller of it - not only this
+			//ISysSettingFailureClassifier.CategorizeAndLog writes the debug excerpt itself, so every caller of it - not only this
 			//one - gets the line the correlation ID bridges to. Writing it again here would emit the
 			//excerpt twice for the same failure.
-			CategorizeAndLog(ex, operationLabel, _logger, _correlationIds);
+			_failures.CategorizeAndLog(ex, operationLabel);
 
 		/// <summary>
 		/// The non-exception counterpart of <see cref="ReportFailure"/>: classifies a refusal the environment
@@ -862,60 +691,8 @@ namespace Clio.Command
 			string recoveryAction) {
 			SysSettingFailure failure = new($"Failed {operationLabel}.", category, cause, recoveryAction,
 				_correlationIds.New());
-			WriteAndForwardFailureLine(_logger, failure);
+			_failures.LogFailureLine(failure);
 			return failure;
-		}
-
-		/// <summary>
-		/// Classifies a failure AND writes the one log line that carries its correlation ID, for callers
-		/// that hold no command instance - the MCP tools' environment-resolution catch blocks.
-		/// </summary>
-		/// <remarks>
-		/// A correlation ID on a result that no log line mentions is worse than no ID at all: it invites
-		/// the caller to quote a token that finds nothing. So minting the ID and writing the line are one
-		/// operation, and every site that reports a failure goes through here.
-		/// </remarks>
-		internal static SysSettingFailure CategorizeAndLog(Exception ex, string operationLabel,
-			ILogger logger, IOperationCorrelationIdProvider correlationIds) {
-			SysSettingFailure failure = CategorizeFailure(ex, operationLabel, correlationIds.New());
-			WriteAndForwardFailureLine(logger, failure);
-			//Here too, not only in the instance ReportFailure (PR #1374 review): this overload exists
-			//BECAUSE other callers use it - the MCP tools' catch blocks - and those paths were getting a
-			//correlation ID on the envelope with no matching debug line to bridge to.
-			WriteServerDetailAtDebugVerbosity(logger, ex, failure.CorrelationId);
-			return failure;
-		}
-
-		/// <summary>
-		/// Writes the neutralized server excerpt on the DEBUG channel only, tagged with the same
-		/// correlation ID the failure envelope carries.
-		/// </summary>
-		/// <remarks>
-		/// Issue #1333. The excerpt is server-authored text, so it may never appear in <c>error</c>,
-		/// <c>cause</c>, the MCP envelope or the default log line - the fixed local diagnostic goes there
-		/// instead. It still has to be recoverable, because an operator who cannot see what Creatio
-		/// actually said cannot tell an expired password from a misconfigured proxy. The channel is
-		/// debug-gated (<c>ConsoleLogger.WriteDebug</c> returns early unless <c>--debug</c> was passed)
-		/// and its console drain is suppressed under MCP server mode, and the correlation ID is the bridge
-		/// from the reported failure to the line.
-		/// </remarks>
-		private static void WriteServerDetailAtDebugVerbosity(ILogger logger, Exception ex, string correlationId) {
-			//The WHOLE chain, not a single unwrap (PR #1374 review). UnwrapTransportFault only steps
-			//through single-inner aggregates and TargetInvocationException, so a carrier re-wrapped by a
-			//domain or transport exception - a SessionRejectedException inside an environment failure -
-			//lost its excerpt silently: the envelope still looked complete and the operator grepped the
-			//correlation ID and found nothing.
-			string detail = FindServerDetail(ex);
-			//Scrubbed and fenced even here, and that is load-bearing rather than belt-and-braces:
-			//ConsoleLogger.WriteDebug suppresses the console DRAIN under MCP server mode but still
-			//CAPTURES into the per-flow buffer BaseTool harvests into CommandExecutionResult.Messages. The
-			//excerpt reaching this line is only control-character normalized and length-capped, so a
-			//bearer token, a target URI or a credential pair inside it would otherwise be intact.
-			string safeDetail = SensitiveErrorTextRedactor.RedactUntrustedOrNull(detail);
-			if (safeDetail is null) {
-				return;
-			}
-			logger.WriteDebug($"(correlation-id: {correlationId}) server detail: {safeDetail}");
 		}
 
 		/// <summary>
@@ -926,14 +703,14 @@ namespace Clio.Command
 		/// <remarks>
 		/// PR #1374 review. The CLI write path used to catch <see cref="Exception"/> and route everything
 		/// through <see cref="ReportFailure"/>, which is type-blind: a local fault has no arm in
-		/// <see cref="CategorizeFailure"/>, so a missing <c>--file</c> lost its path and printed
+		/// <see cref="ISysSettingFailureClassifier.Categorize"/>, so a missing <c>--file</c> lost its path and printed
 		/// "no cause could be determined ... retry the operation", and
 		/// <see cref="UnauthorizedAccessException"/> - which on this path is a local file permission -
 		/// was routed to <c>Authentication</c>, sending the operator to repair working credentials.
 		/// <para>
 		/// The predicate is the two carrier types plus the transport types, which is exactly the set whose
 		/// message can hold platform prose. <see cref="EnvironmentResolutionException"/> is included even
-		/// though its text is clio-local, because <see cref="CategorizeFailure"/> has a dedicated arm for
+		/// though its text is clio-local, because <see cref="ISysSettingFailureClassifier.Categorize"/> has a dedicated arm for
 		/// it that gives better advice than its bare message.
 		/// </para>
 		/// </remarks>
@@ -955,23 +732,6 @@ namespace Clio.Command
 		}
 
 		/// <summary>
-		/// The server excerpt of the first <see cref="IServerDetailCarrier"/> anywhere in the exception
-		/// chain, including inside single-fault aggregates, or <see langword="null"/> when there is none.
-		/// </summary>
-		private static string FindServerDetail(Exception exception) {
-			for (Exception current = exception; current is not null; current = current.InnerException) {
-				if (current is IServerDetailCarrier carrier) {
-					return carrier.ServerDetail;
-				}
-				if (current is AggregateException { InnerExceptions.Count: 1 } aggregate
-						&& aggregate.InnerExceptions[0] is IServerDetailCarrier innerCarrier) {
-					return innerCarrier.ServerDetail;
-				}
-			}
-			return null;
-		}
-
-		/// <summary>
 		/// Composes the failure envelope for a provider failure reported WITHOUT an exception - a
 		/// <c>success:false</c> response whose only diagnosis is the platform's own prose.
 		/// </summary>
@@ -988,46 +748,8 @@ namespace Clio.Command
 				described.ComposeMessage(operationLabel),
 				SysSettingErrorCategories.ProviderFailure, described.Cause,
 				SysSettingFailureTexts.ProviderFailureRecovery, _correlationIds.New());
-			WriteAndForwardFailureLine(_logger, failure);
+			_failures.LogFailureLine(failure);
 			return failure;
-		}
-
-		/// <summary>
-		/// Writes the one log line carrying the failure's correlation ID, and on the MCP path ALSO sends it
-		/// to the client as a <c>notifications/message</c> under the <c>clio.tool.{correlationId}</c>
-		/// category.
-		/// </summary>
-		/// <remarks>
-		/// PR #1373 review: writing the line alone was not enough to make the ID resolvable. Running as an
-		/// MCP server every ordinary sink is closed - <see cref="ConsoleLogger"/> suppresses console writes
-		/// under <c>Program.IsMcpServerMode</c>, the log file exists only when the operator passed
-		/// <c>--log</c>, and the sys-setting tools and <c>SchemaNamePrefixTool</c> are plain
-		/// <c>[McpServerToolType]</c> classes that never flush the way <c>BaseTool</c> does. So the line
-		/// reached nobody, while the shipped recovery text tells the caller to quote the ID.
-		/// The notification is built from the line directly rather than by draining the shared
-		/// <c>PreserveMessages</c> buffer: that buffer belongs to whatever flow is capturing (a
-		/// <c>BaseTool</c> parent may be), and clearing it here would swallow messages this failure did not
-		/// produce. <c>ForwardMessages</c> no-ops when no MCP server is active, so the CLI path is unchanged.
-		/// </remarks>
-		private static void WriteAndForwardFailureLine(ILogger logger, SysSettingFailure failure) {
-			string line = DescribeFailureForLog(failure);
-			logger.WriteError(line);
-			McpServer.Tools.McpLogNotifier.ForwardMessages([new ErrorMessage(line)], failure.CorrelationId);
-		}
-
-		/// <summary>Renders a classified failure as one log line, correlation ID last.</summary>
-		/// <remarks>
-		/// The cause is omitted when it is the SAME string as the headline (PR #1374 review). Three arms of
-		/// <see cref="CategorizeFailure"/> put one composed diagnostic into both <c>Error</c> and
-		/// <c>Cause</c>, so this line printed it twice - and where that diagnostic carries the fenced
-		/// server excerpt, twice meant two <c>[untrusted-source-text begin]…[end]</c> pairs on one line.
-		/// </remarks>
-		internal static string DescribeFailureForLog(SysSettingFailure failure) {
-			string cause = string.Equals(failure.Error, failure.Cause, StringComparison.Ordinal)
-				? string.Empty
-				: $"Cause: {failure.Cause} ";
-			return $"{failure.Error} {cause}Action: {failure.RecoveryAction} "
-				+ $"(correlation-id: {failure.CorrelationId})";
 		}
 
 		/// <summary>
@@ -1043,67 +765,6 @@ namespace Clio.Command
 
 		/// <inheritdoc cref="CreateOperationLabel"/>
 		private const string ReadOperationLabel = "reading sys-setting";
-
-		// Cap on a message promoted into a user-visible field. 300 is what DataProviderFailureException's
-		// detail already uses, so the two paths expose the same amount.
-		private const int MaxPromotedMessageLength = 300;
-
-		// Redaction runs BEFORE the cap, deliberately: SensitiveErrorTextRedactor matches a token as a whole
-		// unit, so capping first can split one in half and leave the visible fragment unredacted. This is the
-		// same order ServiceResponseJsonGuard.BuildPreview uses.
-		// The cap itself goes through ClampPreservingFence rather than a raw slice, on two counts.
-		// Surrogates: Redact only scrubs secrets, it does not touch surrogates, so an astral character
-		// straddling the cap point would leave a lone high surrogate in SysSettingFailure.Error/.Cause - and
-		// System.Text.Json throws on invalid UTF-16, failing the whole tool response instead of truncating
-		// one message. Fences: DataProviderFailureException.Message arrives already composed AND fenced by
-		// ServerReportedFailureText.ComposeMessage, so a blind cut removed the closing marker whenever the
-		// platform's own ErrorMessage ran past roughly 214 characters - a length the SERVER chooses - and
-		// every field emitted after it then read as untrusted to anything keying on the markers.
-		private static string SafeDetail(string message) {
-			if (string.IsNullOrEmpty(message)) {
-				return message;
-			}
-			string redacted = McpServer.SensitiveErrorTextRedactor.Redact(message);
-			return McpServer.SensitiveErrorTextRedactor.ClampPreservingFence(redacted, MaxPromotedMessageLength);
-		}
-		// Bounds every walk over an exception chain. A chain this deep is not something a transport
-		// produces, and the bound is what keeps a hand-built or self-referencing chain from looping.
-		private const int MaxExceptionUnwrapDepth = 16;
-
-		/// <summary>
-		/// Returns the exception that should be classified: a wrapper carrying exactly one fault unwraps
-		/// to that fault, and everything else is returned unchanged.
-		/// </summary>
-		/// <remarks>
-		/// A multi-fault <see cref="AggregateException"/> is deliberately NOT unwrapped - picking its first
-		/// inner would report one of several failures as if it were the whole story. Those are handled by
-		/// the aggregate arm in <see cref="CategorizeFailure"/> instead.
-		/// </remarks>
-		private static Exception UnwrapTransportFault(Exception exception) {
-			Exception current = exception;
-			for (int depth = 0; depth < MaxExceptionUnwrapDepth; depth++) {
-				Exception inner = current switch {
-					AggregateException aggregate when aggregate.InnerExceptions.Count == 1
-						=> aggregate.InnerExceptions[0],
-					TargetInvocationException { InnerException: { } target } => target,
-					var _ => null
-				};
-				if (inner is null) {
-					return current;
-				}
-				current = inner;
-			}
-			return current;
-		}
-
-		// A bounded 401 token, not any occurrence of the digits. "Connection refused at
-		// http://localhost:40124" is a network error, and reporting it as rejected credentials sends the
-		// operator off to fix a working login. The token must also stand alone, so a port or an id containing
-		// 401 does not qualify.
-		// Delegates to the one shared classifier so this layer and SysSettingsManager cannot answer the
-		// same question differently. See AuthenticationFailureClassifier for why that mattered.
-		private static bool IsAuthenticationFailure(Exception exception) =>
-			AuthenticationFailureClassifier.IsAuthenticationFailure(exception);
 
 		private static string DescribeUnreadableBinaryTarget(string code) {
 			return $"Sys-setting '{code}' was not found or is not readable by the current user. Uploading a " +

--- a/clio/Common/AuthenticationFailureClassifier.cs
+++ b/clio/Common/AuthenticationFailureClassifier.cs
@@ -24,7 +24,7 @@ namespace Clio.Common;
 /// every exception those calls throw.</item>
 /// <item><c>SysSettingsManager</c>'s write-path check, which has the RAW response body and therefore uses
 /// <see cref="IsAuthenticationFailureResponse"/> rather than the message overload.</item>
-/// <item><c>SysSettingsCommand.CategorizeFailure</c> - the command/MCP envelope.</item>
+/// <item><c>SysSettingFailureClassifier.Categorize</c> - the command/MCP envelope.</item>
 /// </list>
 /// One classifier, used by all of them, is what keeps the answers from diverging again.
 /// </remarks>

--- a/clio/Common/ClassifyingDataProvider.cs
+++ b/clio/Common/ClassifyingDataProvider.cs
@@ -108,7 +108,7 @@ public sealed class ClassifyingDataProvider : IDataProvider {
 	/// A transport fault is RETHROWN UNCHANGED, deliberately. An earlier revision wrapped everything
 	/// non-authentication into an <see cref="InvalidOperationException"/>, which erased the exception type
 	/// and made the <c>HttpRequestException</c> / <c>WebException</c> / <c>SocketException</c> arms of
-	/// <c>SysSettingsCommand.CategorizeFailure</c> and <c>SchemaNamePrefixTool</c> unreachable: a refused
+	/// <c>SysSettingFailureClassifier.Categorize</c> and <c>SchemaNamePrefixTool</c> unreachable: a refused
 	/// connection reported "Failed reading records from entity schema 'X': Connection refused..." instead
 	/// of "Network error reading sys-setting.". Only two rewrites earn their place here - the
 	/// authentication verdict, and the ambiguous non-JSON page - because in both cases the composed
@@ -122,7 +122,7 @@ public sealed class ClassifyingDataProvider : IDataProvider {
 			//a co-operative shutdown behind a diagnosis about credentials.
 			throw;
 		} catch (AuthenticationException) {
-			//Already the strongest available diagnosis, whichever way CategorizeFailure later reads it
+			//Already the strongest available diagnosis, whichever way ISysSettingFailureClassifier.Categorize later reads it
 			//(it asks the same classifier, so a TLS handshake keeps its own answer).
 			throw;
 		} catch (Exception exception) {

--- a/clio/Common/CreatioLoginFailedException.cs
+++ b/clio/Common/CreatioLoginFailedException.cs
@@ -25,7 +25,7 @@ namespace Clio.Common;
 /// <c>AuthenticationRejected</c> and fails fast instead of burning the readiness budget on further
 /// rejected logins), <c>GetCreatioInfoCommand</c> (<c>BaseProbeFailure.Authentication</c>),
 /// <c>SchemaNamePrefixTool</c> (the MCP-visible "Authentication error reading SchemaNamePrefix."
-/// result), and <c>SysSettingsCommand.CategorizeFailure</c>.
+/// result), and <c>SysSettingFailureClassifier.Categorize</c>.
 /// </para>
 /// <para>
 /// <b>Rejected alternative:</b> keeping the original as <see cref="Exception.InnerException"/> behind an

--- a/clio/Common/DataProviderFailureException.cs
+++ b/clio/Common/DataProviderFailureException.cs
@@ -8,7 +8,7 @@ namespace Clio.Common;
 /// </summary>
 /// <remarks>
 /// Derives from <see cref="InvalidOperationException"/> so every existing handler keeps working unchanged
-/// - in particular <c>SysSettingsCommand.CategorizeFailure</c>'s <c>InvalidOperationException invEx =&gt;
+/// - in particular <c>SysSettingFailureClassifier.Categorize</c>'s <c>InvalidOperationException invEx =&gt;
 /// invEx.Message</c> arm, which is what surfaces the composed diagnostic.
 /// <para>
 /// The distinct type exists so a consumer can tell "the data provider failed, and its message is the only

--- a/clio/Common/ISysSettingsManager.cs
+++ b/clio/Common/ISysSettingsManager.cs
@@ -337,7 +337,7 @@ public class SysSettingsManager : ISysSettingsManager
 		//Issue #1378: same treatment as the two write endpoints, because this call is REACHED from the
 		//write path (a Lookup value given as a display name) and holds the raw body just as they do. The
 		//parser here is Newtonsoft, so its failure is a JsonReaderException that does not derive from
-		//System.Text.Json.JsonException - it matched no arm of SysSettingsCommand.CategorizeFailure and
+		//System.Text.Json.JsonException - it matched no arm of SysSettingFailureClassifier.Categorize and
 		//was reported as an uncategorised Unknown with "no cause could be determined".
 		JObject json = ParseLookupResponse(responseJson, "resolving a lookup value");
 		JArray rows = json["rows"] as JArray;
@@ -430,7 +430,7 @@ public class SysSettingsManager : ISysSettingsManager
 	/// Without this check, a rejected session on a write reached the caller as
 	/// "Failed creating sys-setting." / "... is not updated. Invalid response format.": the login page is
 	/// not JSON, so the deserializer threw a <see cref="JsonException"/> that
-	/// <c>SysSettingsCommand.CategorizeFailure</c> has no arm for. The genuinely-malformed-JSON path below is
+	/// <c>SysSettingFailureClassifier.Categorize</c> has no arm for. The genuinely-malformed-JSON path below is
 	/// unaffected, because it is only reached once this check has passed.
 	/// </para>
 	/// </remarks>
@@ -693,7 +693,7 @@ public class SysSettingsManager : ISysSettingsManager
 	/// The cliogate call is an OPTIMIZATION, not the contract: an environment without cliogate installed
 	/// answers it with a 404 whose body is not JSON, and ATF's provider does not catch on this method - so
 	/// the parser failure (a Newtonsoft <c>JsonReaderException</c>, which no arm of
-	/// <c>SysSettingsCommand.CategorizeFailure</c> recognises) escaped as an uncategorised Unknown and the
+	/// <c>SysSettingFailureClassifier.Categorize</c> recognises) escaped as an uncategorised Unknown and the
 	/// SelectQuery path below never ran. That made every reader of this method - get-schema-name-prefix
 	/// above all - report "no cause could be determined" for an environment the DataService path could
 	/// have answered, or could have diagnosed properly as a rejected session.
@@ -952,7 +952,7 @@ public class SysSettingsManager : ISysSettingsManager
 		//rather than as a bare JsonException or a `false` that says the setting was refused.
 		//It ESCAPES rather than being caught and turned into `false`, exactly like the
 		//SessionRejectedException raised from the same spot already did: the two command entry points
-		//(TryUpdateSysSetting) catch every exception and route it through CategorizeFailure, which mints
+		//(TryUpdateSysSetting) catch every exception and route it through ISysSettingFailureClassifier.Categorize, which mints
 		//the correlation ID and writes ServerDetail at debug verbosity. Returning `false` instead would
 		//report RefusedUpdateCause - "the setting may not exist, or the value did not match its type" -
 		//for a gateway page, and the excerpt would have no sink at all. The bool contract is unchanged

--- a/clio/Common/NonJsonWriteResponseException.cs
+++ b/clio/Common/NonJsonWriteResponseException.cs
@@ -45,7 +45,7 @@ public enum NonJsonWriteResponseKind {
 /// Derives from <see cref="InvalidOperationException"/> - the same lineage as
 /// <see cref="DataProviderFailureException"/> - rather than from
 /// <see cref="System.Text.Json.JsonException"/>: a parser exception is a statement about a parser, and
-/// this one is a statement about the environment. <c>SysSettingsCommand.CategorizeFailure</c> has a
+/// this one is a statement about the environment. <c>SysSettingFailureClassifier.Categorize</c> has a
 /// dedicated arm ABOVE its <see cref="InvalidOperationException"/> arm, so this keeps the <c>Network</c>
 /// envelope the <see cref="System.Text.Json.JsonException"/> arm produces rather than degrading to
 /// <c>Unknown</c>.

--- a/clio/Common/SessionRejectedException.cs
+++ b/clio/Common/SessionRejectedException.cs
@@ -9,7 +9,7 @@ namespace Clio.Common;
 /// </summary>
 /// <remarks>
 /// Derives from <see cref="AuthenticationException"/> so every existing handler and test keeps working -
-/// <c>SysSettingsCommand.CategorizeFailure</c>'s authentication arms, <c>SchemaNamePrefixTool</c>'s
+/// <c>SysSettingFailureClassifier.Categorize</c>'s authentication arms, <c>SchemaNamePrefixTool</c>'s
 /// authentication catch, and the classifier's own <c>AuthenticationException</c> shortcut all match a
 /// subclass. The type exists because <see cref="AuthenticationException"/> has nowhere to put
 /// <see cref="ServerDetail"/>, and issue #1333 requires that text to leave the message.

--- a/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
+++ b/docs/knowledge/Common/remotedataprovider-swallows-every-failure-into-success-false.md
@@ -7,6 +7,7 @@ applies-to:
   - clio/Common/ISysSettingsManager.cs
   - clio/BindingsModule.cs
   - clio/Command/SysSettingsCommand.cs
+  - clio/Command/SysSettingFailureClassifier.cs
   - clio/Package/PackageBuilder.cs
 ticket: "#1371"
 date: 2026-09-03
@@ -56,7 +57,7 @@ block and a gateway error page all produce the byte-identical Newtonsoft message
 
 A corollary for anything running the provider on a background thread: a **thrown** transport fault is
 rethrown UNCHANGED (wrapping it erased the type and made the `"Network error …"` arms of
-`SysSettingsCommand.CategorizeError` and `SchemaNamePrefixTool` unreachable), and only the
+`SysSettingFailureClassifier.CategorizeError` and `SchemaNamePrefixTool` unreachable), and only the
 `Success == false` response — which has no original exception — is wrapped.
 
 Three consequences worth knowing before writing code against this:

--- a/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
+++ b/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
@@ -8,6 +8,7 @@ applies-to:
   - clio/Common/DataProviderFailureException.cs
   - clio/Common/NonJsonWriteResponseException.cs
   - clio/Command/SysSettingsCommand.cs
+  - clio/Command/SysSettingFailureClassifier.cs
   - clio/Command/McpServer/SensitiveErrorTextRedactor.cs
   - clio/ExceptionReadableMessageExtension.cs
   - clio/Common/ServerReportedFailureText.cs
@@ -80,7 +81,7 @@ terminal to drop. It does implement `IAuthoritativeErrorMessage` — without tha
 quotes the offending JSON path and value in its own message, so server-chosen bytes reach an MCP
 envelope unfenced and uncapped. A carrier whose message is authoritative must say so.
 
-`SysSettingsCommand.WriteAndForwardFailureLine` is the one path that keeps the fence while writing to the
+`SysSettingFailureClassifier.LogFailureLine` is the one path that keeps the fence while writing to the
 console, because the same line is forwarded to `McpLogNotifier` — it *is* MCP-visible. What changed there
 is only that `DescribeFailureForLog` no longer prints the same composed diagnostic as both `Error` and
 `Cause`, which used to put two fence pairs on one line.


### PR DESCRIPTION
🔗 **Issue:** [#1379](https://github.com/Advance-Technologies-Foundation/clio/issues/1379)

> **Stacked on [#1488](https://github.com/Advance-Technologies-Foundation/clio/pull/1488)** (issue #1378) — base is `Alexandr-Kravchuk/issue-1378` because both change `CategorizeFailure`. Review only the last commit; retarget to `master` once #1488 merges.

## What changed

The sys-setting failure classifier leaves `SysSettingsCommand`'s `internal static` members and becomes a DI service:

- `ISysSettingFailureClassifier` (`clio/Command/`) with four members: `Categorize(ex, operationLabel, correlationId)`, `CategorizeAndLog(ex, operationLabel)` (mints the id, writes the log line, forwards it to MCP, writes `ServerDetail` at debug verbosity), `LogFailureLine`, `LogServerDetail`. Implementation `SysSettingFailureClassifier` takes `ILogger` + `IOperationCorrelationIdProvider`; registered transient by the existing `RegisterAssemblyInterfaceTypes` scan (no `BindingsModule` change), so it resolves in the root container, the per-environment child containers built by `ToolCommandResolver`, and the mcp-http container.
- Consumers moved to the interface: the five `[McpServerToolType]` classes (`SysSettingGetTool`, `SysSettingsListTool`, `SysSettingCreateTool`, `SysSettingUpdateTool`, `SchemaNamePrefixTool`) and `SysSettingsCommand`. The tools no longer take `ILogger` / `IOperationCorrelationIdProvider` (they used them only to feed the statics) and no longer reference any `SysSettingsCommand` member — the only remaining mentions under `clio/Command/McpServer/` are `commandResolver.Resolve<SysSettingsCommand>()`, i.e. the tools executing the command. The rationale comment on `SchemaNamePrefixTool` is preserved.
- Behaviour byte-identical: the `Categorize` body (19 arms, incl. the #1378 `NonJsonWriteResponseException` arms) is a straight move; correlation ids are minted exactly where they were; the log line and the `McpLogNotifier` forward are unchanged.
- `CategorizeError` (no production caller) and `DescribeFailureForLog` (only used inside `LogFailureLine`) are off the interface; tests use fixture-local helpers. Comments in 12 files that named `SysSettingsCommand.CategorizeFailure` now name the classifier; dead `using`s in `SysSettingsCommand` removed.
- New `SysSettingFailureClassifierDiRegistrationTests`: resolves from the container, single transient registration, and constructs all six consumers through `ActivatorUtilities` (the way the MCP SDK does — tool types are not DI registrations, so `ValidateOnBuild` does not cover them).

## Validation

- Build `clio` / `clio.tests` / `clio.mcp.e2e`: 0 errors; `warning CLIO` = 4 on both base and branch.
- `Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit"` — 12462 passed / 28 failed / 40 skipped; failing-name set identical to the base commit's (known macOS-only cluster).
- Real environment `ts1-core-dev04` (.NET Framework), base build vs this build: CLI `get-syssetting SchemaNamePrefix` byte-identical; `set-syssetting` against a wrong-password profile → identical `Authentication error creating sys-setting. Cause: … Action: … (correlation-id: …)` line; MCP stdio `get-schema-name-prefix` and `get-sys-setting` against good and bad profiles → envelopes identical after masking UUIDs / correlation ids; `get-tool-contract` for all five tools identical without masking (services are not part of the tool schema).

## Review

- Pre-PR gate: two lenses (bug-detector, quality/tests); no Blocker/High. Fixed before opening: interface trimmed to the four production members, 12 test names renamed to the new method, one vacuous DI assertion, BOM churn on 7 test files, command+classifier now share one `ILogger` substitute in every fixture, dead `using`. Codex CLI review unavailable (workspace out of credits).
- Docs reviewed, no update required (no command option or behaviour changed).
- MCP reviewed, no update required: only tool constructors / method service parameters changed; names, arguments, descriptions, destructive flags and result shapes are untouched (proven by identical `get-tool-contract` output on the stand).
- ClioRing compatibility reviewed, no Ring-consumed contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
