### PR TITLE
Cut the missing-dependency diagnostic fan-out to two bounded parallel reads (#1461)

### DIFF
--- a/clio.tests/Command/EntitySchemaDependencyResolverTests.cs
+++ b/clio.tests/Command/EntitySchemaDependencyResolverTests.cs
@@ -22,6 +22,12 @@ internal sealed class EntitySchemaDependencyResolverTests
 
 	private const string SelectQueryUrl = "http://local/DataService/json/SyncReply/SelectQuery";
 
+	/// <summary>
+	/// Identity of the package being edited, as the caller already holds it. The dependency read must use
+	/// it rather than resolve the name again through the whole installed-package list (issue #1461).
+	/// </summary>
+	private static readonly Guid TargetPackageUId = new("6f1b6b4a-7f2e-4a4c-9a1e-2f3d4c5b6a70");
+
 	private FindEntitySchemaCommand _findCommand;
 	private IPackageDependencyManager _dependencyManager;
 	private IApplicationClient _applicationClient;
@@ -40,7 +46,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		// Stubbed in Setup rather than per test: an unstubbed IReadOnlyList<string> member answers with an
 		// empty collection, which happens to be the "no existing dependencies" case, so a test that meant to
 		// exercise the filter would silently pass without it.
-		_dependencyManager.GetDependencies(Arg.Any<string>(), Arg.Any<int>()).Returns([]);
+		_dependencyManager.GetDependencies(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<int>()).Returns([]);
 		SetInstalledApplications();
 		_resolver = new EntitySchemaDependencyResolver(_findCommand, _dependencyManager, _applicationClient,
 			_serviceUrlBuilder, _logger);
@@ -75,6 +81,14 @@ internal sealed class EntitySchemaDependencyResolverTests
 	private static EntitySchemaSearchResult Result(string packageName) =>
 		new("Opportunity", packageName, "Creatio", "Opportunity");
 
+	/// <summary>Every warning the resolver wrote, in order, so a test can assert on the set as a whole.</summary>
+	/// <returns>The warning texts.</returns>
+	private List<string> Warnings() =>
+		_logger.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(ILogger.WriteWarning))
+			.Select(call => (string)call.GetArguments()[0]!)
+			.ToList();
+
 	[Test]
 	[Description("Reports the single candidate without touching the package, because the failing designer response carries no evidence that a missing dependency is the cause (issue #722).")]
 	public void Resolve_ShouldReportTheCandidateWithoutWriting_WhenExactlyOneCandidateExists() {
@@ -82,7 +96,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CrtLeadOppMgmtApp", "Custom");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().Equal(["CrtLeadOppMgmtApp"],
@@ -98,7 +112,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CrtLeadOppMgmtApp");
 
 		// Act
-		_resolver.Resolve("Opportunity", "Custom");
+		_resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		_dependencyManager.DidNotReceive()
@@ -115,7 +129,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CoreLeadOpportunity", "CrtLeadOppMgmtApp", "SalesEnterprise", "Custom");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().Equal(["CrtLeadOppMgmtApp", "SalesEnterprise", "CoreLeadOpportunity"],
@@ -131,7 +145,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("Custom", "CrtLeadOppMgmtApp");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().Equal(["CrtLeadOppMgmtApp"],
@@ -142,11 +156,11 @@ internal sealed class EntitySchemaDependencyResolverTests
 	[Description("Drops packages the target already depends on, so a candidate list never proposes a dependency that is already declared (issue #722).")]
 	public void Resolve_ShouldExcludeExistingDependencies_WhenTargetAlreadyDependsOnACandidate() {
 		// Arrange
-		_dependencyManager.GetDependencies("Custom", Arg.Any<int>()).Returns(["crtcore", "CoreLeadOpportunity"]);
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>()).Returns(["crtcore", "CoreLeadOpportunity"]);
 		SetContributingPackages("CoreLeadOpportunity", "CrtLeadOppMgmtApp", "CrtCore");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().Equal(["CrtLeadOppMgmtApp"],
@@ -159,11 +173,11 @@ internal sealed class EntitySchemaDependencyResolverTests
 	[Description("Reports nothing at all when every contributing package is already a dependency, because a missing dependency is then not what the caller is looking at (issue #722).")]
 	public void Resolve_ShouldReportNoCandidates_WhenEveryContributorIsAlreadyADependency() {
 		// Arrange
-		_dependencyManager.GetDependencies("Custom", Arg.Any<int>()).Returns(["CrtLeadOppMgmtApp"]);
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>()).Returns(["CrtLeadOppMgmtApp"]);
 		SetContributingPackages("CrtLeadOppMgmtApp");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().BeEmpty(
@@ -182,7 +196,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CrtLeadOppMgmtApp", "CoreLeadOpportunity");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().Equal(["CoreLeadOpportunity", "CrtLeadOppMgmtApp"],
@@ -195,12 +209,12 @@ internal sealed class EntitySchemaDependencyResolverTests
 	[Description("Marks the candidate list as unfiltered when the current-dependencies read failed, so the caller can carry that caveat into the message instead of asserting the list excludes declared dependencies (issue #722).")]
 	public void Resolve_ShouldReportDependenciesUnknown_WhenTheExistingDependencyReadFailed() {
 		// Arrange
-		_dependencyManager.GetDependencies("Custom", Arg.Any<int>())
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
 			.Throws(new InvalidOperationException("SelectQuery failed"));
 		SetContributingPackages("CrtLeadOppMgmtApp");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.DependenciesKnown.Should().BeFalse(
@@ -217,7 +231,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 			.Throws(new InvalidOperationException("SelectQuery unreachable"));
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.LookupSucceeded.Should().BeFalse(
@@ -234,12 +248,12 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CrtLeadOppMgmtApp");
 
 		// Act
-		_resolver.Resolve("Opportunity", "Custom");
+		_resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		_findCommand.Received(1).FindSchemas(Arg.Any<FindEntitySchemaOptions>(),
 			Arg.Is<int>(timeout => timeout > 0 && timeout != Timeout.Infinite));
-		_dependencyManager.Received(1).GetDependencies("Custom",
+		_dependencyManager.Received(1).GetDependencies(TargetPackageUId, "Custom",
 			Arg.Is<int>(timeout => timeout > 0 && timeout != Timeout.Infinite));
 		_applicationClient.Received().ExecutePostRequest(SelectQueryUrl, Arg.Any<string>(),
 			Arg.Is<int>(timeout => timeout > 0 && timeout != Timeout.Infinite), Arg.Any<int>(), Arg.Any<int>());
@@ -256,13 +270,10 @@ internal sealed class EntitySchemaDependencyResolverTests
 			.Throws(new InvalidOperationException(secretBearingMessage));
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
-		List<string> warnings = _logger.ReceivedCalls()
-			.Where(call => call.GetMethodInfo().Name == nameof(ILogger.WriteWarning))
-			.Select(call => (string)call.GetArguments()[0]!)
-			.ToList();
+		List<string> warnings = Warnings();
 		warnings.Should().ContainSingle(because: "the failed lookup must be reported exactly once");
 		warnings[0].Should().NotContain("eyJzdWIiOiIxIn0",
 			because: "an un-redacted server body reaching a warning is the same leak this change removes from the error messages");
@@ -273,18 +284,171 @@ internal sealed class EntitySchemaDependencyResolverTests
 	}
 
 	[Test]
-	[Description("Returns no candidates without reading the package dependencies when no other package contains the schema (ENG-91314).")]
+	[Description("Returns no candidates when no other package contains the schema (ENG-91314). The dependency read is no longer skipped in this case: it runs alongside the schema search, so it costs a round-trip but no wall-clock time (issue #1461).")]
 	public void Resolve_ShouldReportNoCandidates_WhenSchemaNotFoundInOtherPackages() {
 		// Arrange
 		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>()).Returns([]);
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("UsrNonExistent", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("UsrNonExistent", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().BeEmpty(
 			because: "there are no candidate packages to report");
-		_dependencyManager.DidNotReceive().GetDependencies(Arg.Any<string>(), Arg.Any<int>());
+		resolution.LookupSucceeded.Should().BeTrue(
+			because: "the search ran to completion, so its empty answer is a finding of fact");
+		_dependencyManager.Received(1).GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>());
+		_applicationClient.DidNotReceive().ExecutePostRequest(SelectQueryUrl, Arg.Any<string>(), Arg.Any<int>(),
+			Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Description("Starts the schema search and the dependency read before either has finished, so the diagnostic costs the slower of the two reads rather than their sum on an environment that has stopped answering (issue #1461).")]
+	public void Resolve_ShouldRunTheSchemaSearchAndTheDependencyReadConcurrently_WhenEnrichingAFailure() {
+		// Arrange — a two-sided rendezvous, so NO sequential order can pass: whichever read runs first blocks
+		// in SignalAndWait until the other arrives, and a sequential implementation never sends it. The
+		// timeout makes that a failed assertion within ten seconds rather than a hung test run.
+		using Barrier bothReadsInFlight = new(2);
+		bool schemaSearchMetTheDependencyRead = false;
+		bool dependencyReadMetTheSchemaSearch = false;
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
+			.Returns(_ => {
+				dependencyReadMetTheSchemaSearch = bothReadsInFlight.SignalAndWait(TimeSpan.FromSeconds(10));
+				return new List<string>();
+			});
+		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>())
+			.Returns(_ => {
+				schemaSearchMetTheDependencyRead = bothReadsInFlight.SignalAndWait(TimeSpan.FromSeconds(10));
+				return new List<EntitySchemaSearchResult> { Result("CrtLeadOppMgmtApp") };
+			});
+
+		// Act
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+		// Assert
+		schemaSearchMetTheDependencyRead.Should().BeTrue(
+			because: "the schema search must still be running when the dependency read starts");
+		dependencyReadMetTheSchemaSearch.Should().BeTrue(
+			because: "the dependency read must still be running when the schema search starts - asserting only one direction would let a sequential implementation that simply reordered the reads pass");
+		resolution.Candidates.Should().Equal(["CrtLeadOppMgmtApp"],
+			because: "running the reads concurrently must not change what they report");
+	}
+
+	[Test]
+	[Description("Gives up on the offloaded schema search after a bounded wait, so a thread pool that never schedules it cannot make the diagnosis wait without end (issue #1461).")]
+	public void Resolve_ShouldReportLookupFailure_WhenTheOffloadedSchemaSearchDoesNotFinishInTime() {
+		// Arrange
+		using ManualResetEventSlim releaseTheSchemaSearch = new();
+		_resolver.ContributorsWaitTimeoutMs = 200;
+		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>())
+			.Returns(_ => {
+				// Stands in for a read that never answers. Released in the assert phase so the test leaves no
+				// thread blocked behind it.
+				releaseTheSchemaSearch.Wait(TimeSpan.FromSeconds(30));
+				return new List<EntitySchemaSearchResult>();
+			});
+
+		try {
+			// Act
+			EntitySchemaDependencyResolution resolution =
+				_resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+			// Assert
+			resolution.LookupSucceeded.Should().BeFalse(
+				because: "a search that was never scheduled is the absence of an answer, not the answer 'nothing contributes this schema'");
+			resolution.LookupFailureReason.Should().Contain("did not finish within",
+				because: "the caller must be told the lookup was abandoned rather than completed");
+		} finally {
+			releaseTheSchemaSearch.Set();
+		}
+	}
+
+	[Test]
+	[Description("Says nothing about an unfiltered candidate list when there is no candidate list, because the dependency-read warning now travels into the MCP tool result and would describe a list that was never built (issue #1461).")]
+	public void Resolve_ShouldNotWarnAboutTheCandidateList_WhenTheDependencyReadFailedAndNothingContributes() {
+		// Arrange
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
+			.Throws(new InvalidOperationException("GetPackageProperties unreachable"));
+		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>()).Returns([]);
+
+		// Act
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("UsrNonExistent", TargetPackageUId, "Custom");
+
+		// Assert
+		resolution.Candidates.Should().BeEmpty(because: "no package contributes the schema");
+		Warnings().Should().BeEmpty(
+			because: "a caller whose lookup produced no candidate list must not be told that list may be unfiltered");
+	}
+
+	[Test]
+	[Description("Says nothing about an unfiltered candidate list when the schema search itself failed, so the only failure reported is the one that actually stopped the lookup (issue #1461).")]
+	public void Resolve_ShouldReportOnlyTheLookupFailure_WhenBothReadsFailed() {
+		// Arrange
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
+			.Throws(new InvalidOperationException("GetPackageProperties unreachable"));
+		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>())
+			.Throws(new InvalidOperationException("SelectQuery unreachable"));
+
+		// Act
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+		// Assert
+		resolution.LookupSucceeded.Should().BeFalse(because: "the search never completed");
+		Warnings().Should().ContainSingle(
+				because: "only the failure that stopped the lookup may be reported; the dependency read's failure describes a list that was never built")
+			.Which.Should().Contain("SelectQuery unreachable",
+				because: "the reported failure must be the one that stopped the lookup");
+	}
+
+	[Test]
+	[Description("Still warns that the candidate list is unfiltered when the dependency read failed but candidates were found, because that list really may contain packages the target already depends on (issue #722).")]
+	public void Resolve_ShouldWarnAboutTheCandidateList_WhenTheDependencyReadFailedAndCandidatesExist() {
+		// Arrange
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
+			.Throws(new InvalidOperationException("GetPackageProperties unreachable"));
+		SetContributingPackages("CrtLeadOppMgmtApp");
+
+		// Act
+		_resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+		// Assert
+		Warnings().Should().ContainSingle(
+				because: "the caveat belongs to the list, so it is stated exactly once, where the list exists")
+			.Which.Should().Contain("already dependencies",
+				because: "the caller must learn that the list was never filtered");
+	}
+
+	[Test]
+	[Description("Reports the schema search's own failure rather than the wrapper a blocked task would raise, so the caller reads the reason the environment gave (issue #1461).")]
+	public void Resolve_ShouldReportTheOriginalFailure_WhenTheConcurrentSchemaSearchThrows() {
+		// Arrange
+		_findCommand.FindSchemas(Arg.Any<FindEntitySchemaOptions>(), Arg.Any<int>())
+			.Throws(new InvalidOperationException("SelectQuery unreachable"));
+
+		// Act
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+		// Assert
+		resolution.LookupFailureReason.Should().Be("SelectQuery unreachable",
+			because: "awaiting the offloaded read must rethrow the original exception, not an AggregateException whose text buries the reason behind 'One or more errors occurred'");
+	}
+
+	[Test]
+	[Description("Still reports the candidates, marked unfiltered, when the dependency read fails while the schema search succeeds - one read failing must never discard the other's result (issue #1461).")]
+	public void Resolve_ShouldKeepTheSchemaSearchResult_WhenTheConcurrentDependencyReadFails() {
+		// Arrange
+		_dependencyManager.GetDependencies(TargetPackageUId, "Custom", Arg.Any<int>())
+			.Throws(new InvalidOperationException("GetPackageProperties unreachable"));
+		SetContributingPackages("CrtLeadOppMgmtApp", "CoreLeadOpportunity");
+
+		// Act
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
+
+		// Assert
+		resolution.Candidates.Should().Equal(["CoreLeadOpportunity", "CrtLeadOppMgmtApp"],
+			because: "the read that did answer must still be reported when the other one failed");
+		resolution.DependenciesKnown.Should().BeFalse(
+			because: "the caller must carry the caveat that the list was never filtered");
 	}
 
 	[Test]
@@ -294,7 +458,7 @@ internal sealed class EntitySchemaDependencyResolverTests
 		SetContributingPackages("CrtLeadOppMgmtApp", "CrtLeadOppMgmtApp");
 
 		// Act
-		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", "Custom");
+		EntitySchemaDependencyResolution resolution = _resolver.Resolve("Opportunity", TargetPackageUId, "Custom");
 
 		// Assert
 		resolution.Candidates.Should().ContainSingle(

--- a/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
+++ b/clio.tests/Command/RemoteEntitySchemaColumnManagerTests.cs
@@ -75,7 +75,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 		_dependencyResolver = Substitute.For<IEntitySchemaDependencyResolver>();
 		// Stubbed here, not per test: an unstubbed member returning a reference type answers with null, and a
 		// null resolution would fail the load path with a NullReferenceException before any assertion runs.
-		_dependencyResolver.Resolve(Arg.Any<string>(), Arg.Any<string>())
+		_dependencyResolver.Resolve(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>())
 			.Returns(EntitySchemaDependencyResolution.None);
 		_entitySchemaPublisher = Substitute.For<IEntitySchemaPublisher>();
 		_savedSchema = null;
@@ -2942,7 +2942,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldNotRetryTheDesignerLoad_WhenSchemaIsUnavailable() {
 		// Arrange
 		SetupUnavailableSchema();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(new EntitySchemaDependencyResolution(["UsrOwner"], 1, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -2964,7 +2964,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldThrowEnrichedError_WhenNoCandidateIsFound() {
 		// Arrange
 		SetupUnavailableSchema();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(EntitySchemaDependencyResolution.None);
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3026,7 +3026,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 		});
 
 		// Assert
-		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<string>());
+		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>());
 	}
 
 	[Test]
@@ -3043,7 +3043,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 		});
 
 		// Assert
-		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<string>());
+		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>());
 	}
 
 	[Test]
@@ -3201,7 +3201,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldNameRankedCandidatePackagesInTheError_WhenSchemaIsUnavailable() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp", "SalesEnterprise", "CrtOpportunity"], 2, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3232,7 +3232,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldClaimNoCause_WhenNoCandidatePackageWasFound() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(EntitySchemaDependencyResolution.None);
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3253,11 +3253,11 @@ internal class RemoteEntitySchemaColumnManagerTests
 	}
 
 	[Test]
-	[Description("Asks the resolver for candidates on a read path, so a read can name the fix; the lookup itself never changes the package on any path (issue #722).")]
+	[Description("Asks the resolver for candidates on a read path, so a read can name the fix; the lookup itself never changes the package on any path (issue #722). Passes the package identity the request was already scoped to, so the resolver does not re-resolve it by name (issue #1461).")]
 	public void GetSchemaProperties_ShouldRequestCandidates_WhenSchemaIsUnavailable() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp"], 1, true, true));
 
 		// Act
@@ -3270,7 +3270,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 		act.Should().Throw<NonJsonServiceResponseException>()
 			.Which.Message.Should().Contain("CrtLeadOppMgmtApp",
 				because: "the read path carried no candidate information at all before, which is what made it unactionable");
-		_dependencyResolver.Received(1).Resolve("UsrVehicle", "UsrPkg");
+		_dependencyResolver.Received(1).Resolve("UsrVehicle", PackageUId, "UsrPkg");
 	}
 
 	[Test]
@@ -3284,7 +3284,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 				throw new SessionExpiredServiceResponseException(
 					"GetSchemaDesignItem was answered with the Creatio sign-in response instead of JSON. " +
 					"Verify the environment credentials."));
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp"], 1, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3302,7 +3302,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 			because: "a sign-in response says nothing about packages, so naming one would be a claim without evidence");
 		// The resolver is the only thing that can add a dependency, so proving it was never called is what
 		// proves an expired session cannot rewrite a package's dependency list.
-		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<string>());
+		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>());
 	}
 
 	[Test]
@@ -3320,7 +3320,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 			.Returns(_ => new Clio.Command.EntitySchemaDesigner.DesignerResponse<EntityDesignSchemaDto> {
 				Success = true, Schema = null
 			});
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp"], 1, true, true));
 
 		// Act
@@ -3361,7 +3361,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 			.Returns(_ => new Clio.Command.EntitySchemaDesigner.DesignerResponse<EntityDesignSchemaDto> {
 				Success = true, Schema = null
 			});
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp"], 1, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3383,7 +3383,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 			because: "naming candidates here would offer a fix for a problem the caller does not have");
 		// The lookup must not run at all on this path: it costs remote reads to build a diagnosis that is
 		// known to be wrong before it is computed.
-		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<string>());
+		_dependencyResolver.DidNotReceive().Resolve(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>());
 	}
 
 	[Test]
@@ -3391,7 +3391,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldReportTheFailedLookup_WhenTheCandidateSearchCouldNotComplete() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(EntitySchemaDependencyResolution.LookupFailed("SelectQuery unreachable"));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3418,7 +3418,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldCarryTheUnfilteredCaveatIntoTheError_WhenTheDependencyReadFailed() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp", "SalesEnterprise"], 1, true, false));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3443,7 +3443,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 	public void ModifyColumn_ShouldNotClaimAmbiguity_WhenExactlyOneCandidateIsReported() {
 		// Arrange
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg").Returns(
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg").Returns(
 			new EntitySchemaDependencyResolution(["CrtLeadOppMgmtApp"], 1, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",
@@ -3472,7 +3472,7 @@ internal class RemoteEntitySchemaColumnManagerTests
 			"PkgFoxtrot", "PkgGolf", "PkgHotel"
 		];
 		SetupMarkupSchemaResponse();
-		_dependencyResolver.Resolve("UsrVehicle", "UsrPkg")
+		_dependencyResolver.Resolve("UsrVehicle", Arg.Any<Guid>(), "UsrPkg")
 			.Returns(new EntitySchemaDependencyResolution(candidates, 3, true, true));
 		var options = new ModifyEntitySchemaColumnOptions {
 			Package = "UsrPkg", SchemaName = "UsrVehicle",

--- a/clio.tests/Package/PackageDependencyManager.Tests.cs
+++ b/clio.tests/Package/PackageDependencyManager.Tests.cs
@@ -24,6 +24,9 @@ public class PackageDependencyManagerTests
 	private const string TargetPackageName = "MyApp";
 	private const string DependencyPackageName = "CrtLeadOppMgmtApp";
 
+	/// <summary>Bound the schema-designer diagnosis puts on this read; any positive value proves it travels.</summary>
+	private const int DiagnosticTimeoutMs = 30_000;
+
 	#endregion
 
 	#region Fields: Private
@@ -74,6 +77,20 @@ public class PackageDependencyManagerTests
 		_applicationClient
 			.ExecutePostRequest<PackagePropertiesResponse>(
 				Arg.Any<string>(), Arg.Do<string>(body => _loadRequestBody = body))
+			.Returns(new PackagePropertiesResponse { Success = true, Package = package });
+	}
+
+	/// <summary>
+	/// Same as <see cref="ArrangeGetPackageProperties(WorkspacePackageDto)"/> for the bounded read, whose
+	/// explicit timeout argument the default-argument stub above does not match.
+	/// </summary>
+	/// <param name="package">Package properties the server answers with.</param>
+	/// <param name="requestTimeoutMs">Timeout the call under test is expected to pass.</param>
+	private void ArrangeGetPackageProperties(WorkspacePackageDto package, int requestTimeoutMs) {
+		_applicationClient
+			.ExecutePostRequest<PackagePropertiesResponse>(
+				Arg.Any<string>(), Arg.Do<string>(body => _loadRequestBody = body), requestTimeoutMs,
+				Arg.Any<int>(), Arg.Any<int>())
 			.Returns(new PackagePropertiesResponse { Success = true, Package = package });
 	}
 
@@ -479,6 +496,63 @@ public class PackageDependencyManagerTests
 		// Assert
 		dependencies.Should().BeEmpty(
 			because: "a package with no declared dependencies is an ordinary state, not an error");
+	}
+
+	[Test]
+	[Description("Reads the declared dependencies straight from the package identity the caller already holds, without the installed-package listing, so the schema-designer diagnosis costs one round-trip instead of two (issue #1461).")]
+	public void GetDependenciesByUId_ShouldSkipThePackageListing_WhenTheCallerSuppliesTheIdentity() {
+		// Arrange
+		ArrangeInstalledPackages();
+		ArrangeGetPackageProperties(new WorkspacePackageDto {
+			UId = _targetUId,
+			Name = TargetPackageName,
+			DependsOnPackages = [
+				new WorkspacePackageDto { UId = _dependencyUId, Name = DependencyPackageName, Version = "8.2.1.999" }
+			]
+		}, DiagnosticTimeoutMs);
+
+		// Act
+		IReadOnlyList<string> dependencies =
+			_manager.GetDependencies(_targetUId, TargetPackageName, DiagnosticTimeoutMs);
+
+		// Assert
+		dependencies.Should().Equal([DependencyPackageName],
+			because: "the by-UId read must return the same declared dependency names as the by-name read");
+		_packageListProvider.DidNotReceiveWithAnyArgs().GetPackages(default, default);
+		_loadRequestBody.Should().Be(JsonConvert.SerializeObject(_targetUId),
+			because: "the properties request must carry the identity the caller supplied, unchanged");
+	}
+
+	[Test]
+	[Description("Refuses an empty package UId instead of asking the server about it, because GetPackageProperties answers that with a generic failure naming neither the mistake nor the package (issue #1461).")]
+	public void GetDependenciesByUId_ShouldThrow_WhenTheUIdIsEmpty() {
+		// Arrange
+		ArrangeGetPackageProperties(new WorkspacePackageDto { UId = _targetUId, Name = TargetPackageName },
+			DiagnosticTimeoutMs);
+
+		// Act
+		Action act = () => _manager.GetDependencies(Guid.Empty, TargetPackageName, DiagnosticTimeoutMs);
+
+		// Assert
+		act.Should().Throw<ArgumentException>(
+			because: "an empty identifier is a caller mistake, and this overload exists to enrich an error message rather than add an unhelpful one");
+		_applicationClient.DidNotReceiveWithAnyArgs()
+			.ExecutePostRequest<PackagePropertiesResponse>(default, default);
+	}
+
+	[Test]
+	[Description("Applies the caller's timeout to the by-UId dependency read, so an environment that accepts the connection and then stops answering costs a bounded wait (issue #1461).")]
+	public void GetDependenciesByUId_ShouldBoundTheRead_WhenATimeoutIsSupplied() {
+		// Arrange
+		ArrangeGetPackageProperties(new WorkspacePackageDto { UId = _targetUId, Name = TargetPackageName },
+			DiagnosticTimeoutMs);
+
+		// Act
+		_manager.GetDependencies(_targetUId, TargetPackageName, DiagnosticTimeoutMs);
+
+		// Assert
+		_applicationClient.Received(1).ExecutePostRequest<PackagePropertiesResponse>(
+			Arg.Any<string>(), Arg.Any<string>(), DiagnosticTimeoutMs, Arg.Any<int>(), Arg.Any<int>());
 	}
 
 	[Test]

--- a/clio/Command/EntitySchemaDesigner/EntitySchemaDependencyResolver.cs
+++ b/clio/Command/EntitySchemaDesigner/EntitySchemaDependencyResolver.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Clio.Command.McpServer;
 using Clio.Common;
 using Clio.Package;
@@ -79,10 +81,17 @@ public interface IEntitySchemaDependencyResolver
 	/// Determines which packages could supply <paramref name="schemaName"/> to
 	/// <paramref name="targetPackageName"/>.
 	/// </summary>
+	/// <remarks>
+	/// The target package is identified by UId as well as by name because every caller is holding the UId
+	/// already - it is what the designer request was scoped to. Passing only the name would make the
+	/// dependency read resolve it again through the full installed-package list, one extra round-trip on a
+	/// path that is already failing.
+	/// </remarks>
 	/// <param name="schemaName">Entity schema name that was unavailable (for example <c>Opportunity</c>).</param>
+	/// <param name="targetPackageUId">Identifier of the package that is being edited.</param>
 	/// <param name="targetPackageName">Package that is being edited (for example <c>Custom</c>).</param>
 	/// <returns>The candidates found, and whether the searches behind them actually completed.</returns>
-	EntitySchemaDependencyResolution Resolve(string schemaName, string targetPackageName);
+	EntitySchemaDependencyResolution Resolve(string schemaName, Guid targetPackageUId, string targetPackageName);
 
 }
 
@@ -110,6 +119,16 @@ internal sealed class EntitySchemaDependencyResolver : IEntitySchemaDependencyRe
 	/// <summary>Upper bound on the failure text embedded in a log warning.</summary>
 	private const int MaxLoggedFailureLength = 300;
 
+	/// <summary>
+	/// Upper bound on the wait for the offloaded schema search, covering its own read bound PLUS the delay
+	/// before the thread pool schedules it at all - which no per-request timeout can cap.
+	/// </summary>
+	/// <remarks>
+	/// Settable only so a test can prove the guard without blocking for a minute; production never assigns
+	/// it. Same kind of seam as <c>ReauthExecutor.LoginVersion</c>.
+	/// </remarks>
+	internal int ContributorsWaitTimeoutMs { get; set; } = DiagnosticReadTimeoutMs * 2;
+
 	private readonly FindEntitySchemaCommand _findCommand;
 	private readonly IPackageDependencyManager _dependencyManager;
 	private readonly IApplicationClient _applicationClient;
@@ -127,14 +146,57 @@ internal sealed class EntitySchemaDependencyResolver : IEntitySchemaDependencyRe
 	}
 
 	/// <inheritdoc/>
-	public EntitySchemaDependencyResolution Resolve(string schemaName, string targetPackageName) {
+	public EntitySchemaDependencyResolution Resolve(string schemaName, Guid targetPackageUId,
+		string targetPackageName) {
 		try {
-			List<string> contributors = FindContributingPackages(schemaName, targetPackageName);
+			// The two independent reads run at the same time, so the diagnostic costs max(read1, read2)
+			// rather than read1 + read2. On an environment that accepts the connection and then stops
+			// answering that is the difference between one DiagnosticReadTimeoutMs wait and two, which is
+			// what pushed this path towards the MCP client's own ceiling and turned an enriched message into
+			// an opaque abort.
+			//
+			// The resolver stays SYNCHRONOUS and blocks once, here. Making it asynchronous would propagate
+			// async through LoadSchema and the whole MCP tool -> command -> manager chain above it, for a path
+			// that runs only when something has already failed; nothing in project-context.md or the analyzer
+			// configuration forbids blocking, and clio already does it (HostsCommand,
+			// CompileConfigurationCommand, InstallProcessBuilderCommand and ~90 other GetAwaiter().GetResult()
+			// sites).
+			//
+			// Exactly ONE read is offloaded, for two separate reasons. First, ReadExistingDependencies handles
+			// its own failures and never throws, so running it on the calling thread holds no pool thread.
+			// Second, awaiting a SINGLE task with GetAwaiter().GetResult() rethrows the original exception,
+			// while Task.WhenAll would not do: .Wait()/.Result on it wraps the fault in an AggregateException
+			// whose text buries the reason the environment gave, and GetAwaiter().GetResult() on it surfaces
+			// only the first fault - which would turn the dependency read's "degrade, do not throw" contract
+			// into a thrown failure whenever it lost the race.
+			//
+			// Two requests are therefore in flight on the shared IApplicationClient. That is a supported
+			// state: CreatioClientAdapter guards its Lazy<CreatioClient> with ExecutionAndPublication and a
+			// lifetime lock, ReauthExecutor exists precisely so "a parallel burst of failing requests triggers
+			// exactly one Login", and LoginDiagnostics counts RequestsInFlight with Interlocked. Two facts this
+			// method does not state - that the dependency read now runs even when nothing contributes the
+			// schema, and what a warning written on the offloaded thread depends on to reach an MCP response -
+			// are in
+			// docs/knowledge/Command/the-dependency-diagnosis-runs-two-reads-in-parallel-off-a-sync-method.md.
+			Task<List<string>> contributorsTask = Task.Run(
+				() => Measure(() => FindContributingPackages(schemaName, targetPackageName), "schema search"));
+			(HashSet<string> existingDependencies, bool dependenciesKnown, string? dependencyFailureReason) =
+				Measure(() => ReadExistingDependencies(targetPackageUId, targetPackageName), "dependency read");
+			// Bounded even though the read inside is bounded: the task has to be SCHEDULED before its own
+			// timeout starts running, and on a saturated thread pool the injection delay is unbounded. Twice
+			// the read's own budget leaves the read itself room to answer while still capping this wait.
+			// Waited through the handle rather than with Task.Wait(int) on purpose - Wait throws an
+			// AggregateException for a faulted task, and this path has to surface the exception the
+			// environment actually raised, which the GetAwaiter().GetResult() below does.
+			if (!((IAsyncResult)contributorsTask).AsyncWaitHandle.WaitOne(ContributorsWaitTimeoutMs)) {
+				throw new TimeoutException(
+					"The lookup of the packages that contribute the schema did not finish within "
+					+ $"{ContributorsWaitTimeoutMs} ms.");
+			}
+			List<string> contributors = contributorsTask.GetAwaiter().GetResult();
 			if (contributors.Count == 0) {
 				return EntitySchemaDependencyResolution.None;
 			}
-			(HashSet<string> existingDependencies, bool dependenciesKnown) =
-				ReadExistingDependencies(targetPackageName);
 			List<string> candidates = contributors
 				.Where(name => !existingDependencies.Contains(name))
 				.ToList();
@@ -143,19 +205,62 @@ internal sealed class EntitySchemaDependencyResolver : IEntitySchemaDependencyRe
 				// is NOT what the caller is looking at. Saying nothing is the correct answer here.
 				return EntitySchemaDependencyResolution.None;
 			}
-			HashSet<string> applicationPackages = ReadInstalledApplicationPackages();
+			// Read three keeps its original condition. Gating it on "more than one candidate" would save a
+			// round-trip on the single-candidate case but silently change the surfaced text: the message
+			// switches on ApplicationCandidateCount, so a lone candidate that IS an installed application is
+			// reported as ", installed applications first: X" today and would become ": X". It cannot DOUBLE
+			// the wait either - a stand can answer the schema search and then hang on this one, costing up to
+			// one more DiagnosticReadTimeoutMs, but it is never reached unless read one already answered.
+			HashSet<string> applicationPackages =
+				Measure(ReadInstalledApplicationPackages, "installed applications");
 			List<string> ranked = Rank(candidates, applicationPackages, out int applicationCandidateCount);
+			// The dependency read's failure is reported HERE and nowhere else. It is written now that a
+			// candidate list actually exists, because the warning describes that list ("may include packages
+			// that are already dependencies") and because it does reach an MCP client: BaseTool sets
+			// PreserveMessages and copies the captured lines into the tool result on both the success and the
+			// failure path. Written where the read fails, it would reach a caller whose lookup produced no
+			// list at all and describe one that was never built.
+			if (!dependenciesKnown) {
+				_logger.WriteWarning(
+					$"Could not read the current dependencies of package '{targetPackageName}': " +
+					$"{dependencyFailureReason}. " +
+					"The candidate list may include packages that are already dependencies.");
+			}
 			return new EntitySchemaDependencyResolution(ranked, applicationCandidateCount, true,
 				dependenciesKnown);
 		} catch (Exception ex) when (ex is not OutOfMemoryException) {
 			// Broad catch is intentional: FindSchemas can fail with HttpRequestException, JsonException,
 			// InvalidOperationException, or ArgumentException depending on the remote state. None of these
 			// should abort the caller - the enriched error message in LoadSchema takes over. The failure is
-			// carried in the result, not only logged: the log warning does not reach an MCP client, so a
-			// caller told only "no candidates" would read a search that never ran as a finding of fact.
+			// carried in the RESULT rather than only in this warning: the CLI prints the warning, but the
+			// message LoadSchema builds is the only thing an MCP agent acts on, so a caller told just "no
+			// candidates" would read a search that never ran as a finding of fact.
 			string reason = DescribeFailure(ex);
 			_logger.WriteWarning($"Dependency candidate lookup failed for schema '{schemaName}': {reason}");
 			return EntitySchemaDependencyResolution.LookupFailed(reason);
+		}
+	}
+
+	/// <summary>
+	/// Runs one diagnostic read and reports how long it took, at debug verbosity.
+	/// </summary>
+	/// <remarks>
+	/// Debug rather than info on purpose: these reads only ever run on a path that is already reporting a
+	/// failure, and an extra line on the normal CLI output would change what the caller sees for a change
+	/// meant to alter nothing but the timing. <c>ConsoleLogger.WriteDebug</c> drops the line unless the
+	/// process was started with <c>--debug</c>.
+	/// </remarks>
+	/// <typeparam name="T">Result type of the read.</typeparam>
+	/// <param name="read">The read to run.</param>
+	/// <param name="description">Short name of the read, used in the log line.</param>
+	/// <returns>Whatever <paramref name="read"/> returned.</returns>
+	private T Measure<T>(Func<T> read, string description) {
+		long startedAt = Stopwatch.GetTimestamp();
+		try {
+			return read();
+		} finally {
+			_logger.WriteDebug($"Dependency diagnostic {description} took "
+				+ $"{Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds:F0} ms.");
 		}
 	}
 
@@ -206,24 +311,25 @@ internal sealed class EntitySchemaDependencyResolver : IEntitySchemaDependencyRe
 	/// clio acts on by itself. Walking the whole chain would cost one GetPackageProperties request per
 	/// package on a path that is already a failure path.
 	/// </remarks>
+	/// <param name="targetPackageUId">Identifier of the package being edited, as the caller already holds it.</param>
 	/// <param name="targetPackageName">Package being edited.</param>
 	/// <returns>
-	/// The case-insensitive set of declared dependency names, and whether the read actually succeeded. A
-	/// failed read yields an empty set with <see langword="false"/> - the caller must not mistake that for
-	/// "this package declares no dependencies".
+	/// The case-insensitive set of declared dependency names, whether the read actually succeeded, and - when
+	/// it did not - the redacted reason. A failed read yields an empty set with <see langword="false"/>: the
+	/// caller must not mistake that for "this package declares no dependencies". The failure is RETURNED
+	/// rather than logged here, so the caller can report it only once a candidate list the warning can
+	/// describe actually exists.
 	/// </returns>
-	private (HashSet<string> Existing, bool ReadSucceeded) ReadExistingDependencies(string targetPackageName) {
+	private (HashSet<string> Existing, bool ReadSucceeded, string? FailureReason) ReadExistingDependencies(
+		Guid targetPackageUId, string targetPackageName) {
 		try {
-			return (_dependencyManager.GetDependencies(targetPackageName, DiagnosticReadTimeoutMs)
-				.ToHashSet(StringComparer.OrdinalIgnoreCase), true);
+			return (_dependencyManager
+				.GetDependencies(targetPackageUId, targetPackageName, DiagnosticReadTimeoutMs)
+				.ToHashSet(StringComparer.OrdinalIgnoreCase), true, null);
 		} catch (Exception ex) when (ex is not OutOfMemoryException) {
 			// Degrade to "nothing known to be a dependency": an unfiltered candidate list is still useful,
 			// while failing here would suppress the whole diagnosis.
-			_logger.WriteWarning(
-				$"Could not read the current dependencies of package '{targetPackageName}': " +
-				$"{DescribeFailure(ex)}. " +
-				"The candidate list may include packages that are already dependencies.");
-			return (new HashSet<string>(StringComparer.OrdinalIgnoreCase), false);
+			return (new HashSet<string>(StringComparer.OrdinalIgnoreCase), false, DescribeFailure(ex));
 		}
 	}
 

--- a/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
+++ b/clio/Command/EntitySchemaDesigner/RemoteEntitySchemaColumnManager.cs
@@ -1254,7 +1254,10 @@ internal sealed class RemoteEntitySchemaColumnManager : IRemoteEntitySchemaColum
 			// Runs on the READ paths too - the lookup never writes anything. Without it the read paths
 			// reported the bare transport failure and named no package at all, which is what made
 			// `get-entity-schema-properties --package <app>` unactionable for the caller (issue #722).
-			resolution = _dependencyResolver.Resolve(schemaName, packageName);
+			// The UId is passed as well as the name: the resolver reads the package's declared dependencies,
+			// and the request above already resolved the package, so resolving it again by name would cost an
+			// extra full installed-package round-trip on a path that is already failing.
+			resolution = _dependencyResolver.Resolve(schemaName, packageUId, packageName);
 		}
 		if (schemaUnavailable) {
 			try {

--- a/clio/Package/IPackageDependencyManager.cs
+++ b/clio/Package/IPackageDependencyManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Clio.Package;
@@ -45,23 +46,36 @@ public interface IPackageDependencyManager
 	IReadOnlyList<string> GetDependencies(string packageName);
 
 	/// <summary>
-	/// Reads the dependencies <paramref name="packageName"/> currently declares with an explicit
-	/// per-request timeout, without changing anything.
+	/// Reads the dependencies the package identified by <paramref name="packageUId"/> currently declares,
+	/// with an explicit per-request timeout and without changing anything.
 	/// </summary>
 	/// <remarks>
-	/// Same contract as <see cref="GetDependencies(string)"/>, which reads with no timeout at all. The bound
-	/// exists for callers that run this read inside an already-failing operation - the entity-schema designer
-	/// reads it only to build an error message. An environment that accepts the connection and then stops
-	/// answering must cost such a caller a bounded wait, not a hung tool call; in a long-lived MCP server an
-	/// unbounded read there holds the tenant open with no way back.
+	/// <para>
+	/// Returns the same DIRECT dependency names as <see cref="GetDependencies(string)"/>, but it is NOT the
+	/// same contract in two respects. That overload reads with no timeout at all, and it resolves the name
+	/// against the installed packages first, so an unknown package fails with "Package with name X not found
+	/// in the environment"; this one asks the server about the UId it is given and reports whatever
+	/// <c>GetPackageProperties</c> answers, so a UId that does not exist surfaces as the server's own
+	/// message. The bound exists for callers that run this read inside an already-failing operation - the
+	/// entity-schema designer reads it only to build an error message. An environment that accepts the
+	/// connection and then stops answering must cost such a caller a bounded wait, not a hung tool call; in a
+	/// long-lived MCP server an unbounded read there holds the tenant open with no way back.
+	/// </para>
+	/// <para>
+	/// The UId is taken from the caller rather than resolved by name on purpose. Resolving a name costs a
+	/// whole <c>GetPackages("{}")</c> round-trip - the full installed-package list - only to arrive at a UId
+	/// the caller already holds, which doubles the cost of a read that exists to enrich an error message.
+	/// <paramref name="packageName"/> is carried only for the failure text.
+	/// </para>
 	/// </remarks>
-	/// <param name="packageName">Package whose dependency list is read.</param>
+	/// <param name="packageUId">Identifier of the package whose dependency list is read; must not be empty.</param>
+	/// <param name="packageName">Package name, used only to describe a failed read.</param>
 	/// <param name="requestTimeoutMs">
-	/// Per-request timeout in milliseconds, applied to both the package lookup and the properties read, or
-	/// <see cref="System.Threading.Timeout.Infinite"/> for no bound.
+	/// Per-request timeout in milliseconds, or <see cref="System.Threading.Timeout.Infinite"/> for no bound.
 	/// </param>
 	/// <returns>The declared dependency package names.</returns>
-	IReadOnlyList<string> GetDependencies(string packageName, int requestTimeoutMs);
+	/// <exception cref="ArgumentException"><paramref name="packageUId"/> is <see cref="Guid.Empty"/>.</exception>
+	IReadOnlyList<string> GetDependencies(Guid packageUId, string packageName, int requestTimeoutMs);
 
 	/// <summary>
 	/// Removes the requested dependencies from <paramref name="packageName"/> and persists the change.

--- a/clio/Package/PackageDependencyManager.cs
+++ b/clio/Package/PackageDependencyManager.cs
@@ -83,13 +83,25 @@ internal sealed class PackageDependencyManager : BasePackageOperation, IPackageD
 	}
 
 	/// <inheritdoc cref="IPackageDependencyManager.GetDependencies(string)"/>
-	public IReadOnlyList<string> GetDependencies(string packageName) =>
-		GetDependencies(packageName, Timeout.Infinite);
-
-	/// <inheritdoc cref="IPackageDependencyManager.GetDependencies(string, int)"/>
-	public IReadOnlyList<string> GetDependencies(string packageName, int requestTimeoutMs) {
+	public IReadOnlyList<string> GetDependencies(string packageName) {
 		packageName.CheckArgumentNullOrWhiteSpace(nameof(packageName));
-		(_, WorkspacePackageDto package) = LoadTargetPackage(packageName, requestTimeoutMs);
+		(_, WorkspacePackageDto package) = LoadTargetPackage(packageName);
+		return ToDependencyNames(package.DependsOnPackages);
+	}
+
+	/// <inheritdoc cref="IPackageDependencyManager.GetDependencies(Guid, string, int)"/>
+	public IReadOnlyList<string> GetDependencies(Guid packageUId, string packageName, int requestTimeoutMs) {
+		packageName.CheckArgumentNullOrWhiteSpace(nameof(packageName));
+		// An empty UId is rejected rather than sent: GetPackageProperties answers it with a generic failure
+		// that names neither the caller's mistake nor the package, and this overload exists to enrich an
+		// error message - an unhelpful one inside it is worse than none.
+		if (packageUId == Guid.Empty) {
+			throw new ArgumentException("Package UId must not be empty.", nameof(packageUId));
+		}
+		// Straight to the properties read: the caller already resolved the package, so the GetPackages("{}")
+		// lookup LoadTargetPackage performs would re-derive a UId that is right here, at the cost of a second
+		// round-trip on a path that is already failing.
+		WorkspacePackageDto package = LoadPackageProperties(packageUId, packageName, requestTimeoutMs);
 		return ToDependencyNames(package.DependsOnPackages);
 	}
 
@@ -131,13 +143,12 @@ internal sealed class PackageDependencyManager : BasePackageOperation, IPackageD
 	/// <param name="packageName">Package to resolve.</param>
 	/// <returns>The installed package list (the add path needs it to resolve dependencies) and the properties.</returns>
 	/// <exception cref="InvalidOperationException">The package is not installed in the environment.</exception>
-	private (List<PackageInfo> Installed, WorkspacePackageDto Package) LoadTargetPackage(string packageName,
-		int requestTimeoutMs = Timeout.Infinite) {
+	private (List<PackageInfo> Installed, WorkspacePackageDto Package) LoadTargetPackage(string packageName) {
 		List<PackageInfo> installedPackages =
-			_applicationPackageListProvider.GetPackages("{}", requestTimeoutMs).ToList();
+			_applicationPackageListProvider.GetPackages("{}", Timeout.Infinite).ToList();
 		PackageInfo targetPackage = FindPackage(installedPackages, packageName)
 			?? throw new InvalidOperationException($"Package with name \"{packageName}\" not found in the environment.");
-		return (installedPackages, LoadPackageProperties(targetPackage.Descriptor.UId, packageName, requestTimeoutMs));
+		return (installedPackages, LoadPackageProperties(targetPackage.Descriptor.UId, packageName));
 	}
 
 	/// <summary>

--- a/docs/knowledge/Command/the-dependency-diagnosis-runs-two-reads-in-parallel-off-a-sync-method.md
+++ b/docs/knowledge/Command/the-dependency-diagnosis-runs-two-reads-in-parallel-off-a-sync-method.md
@@ -1,0 +1,31 @@
+---
+description: EntitySchemaDependencyResolver.Resolve offloads the schema search with Task.Run - the dependency read is now issued even when nothing contributes the schema, and a warning written on the offloaded thread reaches the MCP response only because Task.Run flows the ExecutionContext
+applies-to:
+  - clio/Command/EntitySchemaDesigner/EntitySchemaDependencyResolver.cs
+ticket: "#1461"
+date: 2026-09-11
+---
+
+**What is true** — two facts the method does not state (the reasoning for the blocking wait and for the
+concurrent use of one `IApplicationClient` is in the comment inside `Resolve` and is not repeated here):
+
+- **The dependency read is issued even when no package contributes the schema.** The old code returned
+  early on an empty schema search and never asked. It now costs one `GetPackageProperties` round-trip in
+  that case, at no wall-clock cost, because it was already running.
+- **A warning written inside the offloaded read reaches the MCP tool result only by inheritance.**
+  `Task.Run` flows the `ExecutionContext`, so the `AsyncLocal` capture buffer `ConsoleLogger` appends to is
+  the caller's, and `BaseTool` copies those lines into the result. Replace `Task.Run` with anything that
+  suppresses the flow — `ExecutionContext.SuppressFlow`, a raw `Thread`, a custom scheduler — and those
+  warnings vanish from the tool result with nothing failing anywhere.
+
+**Why it is this way** — the reads exist only to enrich an error message. Run one after another against an
+environment that accepts the connection and then stops answering they added up: the schema search, then the
+dependency read, which was itself TWO round-trips before this change (the full installed-package list to
+resolve the package name, then its properties), then the installed-application ranking. Each request is
+bounded at 30 s, but the implicit `Login()` inside Creatio.Client is not, so the 30 s is a bound on the read
+and not a guarantee about the call.
+
+**What breaks if you ignore it** — the bound is per request, not a wall-clock guard around the group, so any
+read added here sequentially reintroduces the sum and pushes the tool call back towards the MCP client's own
+ceiling, where the caller gets an opaque abort instead of the candidate list. And a warning that silently
+stops reaching the response is invisible in CLI use, where it still prints.


### PR DESCRIPTION
🔗 **Issue:** [#1461](https://github.com/Advance-Technologies-Foundation/clio/issues/1461)

Follow-up to #1395 (both Major performance findings from that review). Failure path only — the successful entity-schema read is untouched.

## What changed

`EntitySchemaDependencyResolver.Resolve` — the diagnostic that names the missing package dependency when the designer answers with an HTML page — went from four sequential bounded reads to at most three, two of them concurrent:

1. **No duplicate `SysPackage` fetch.** `Resolve(schemaName, Guid targetPackageUId, string targetPackageName)` takes the UId `LoadSchema` already holds and reads dependencies through the new `IPackageDependencyManager.GetDependencies(Guid, string, int)` → `LoadPackageProperties` (one round trip). The by-name `GetDependencies(string, int)` that #1395 added for this single consumer is removed; `GetDependencies(string)` is unchanged. `Guid.Empty` is rejected with `ArgumentException`.
2. **Schema search and dependency read run concurrently.** The schema search (`FindSchemas`) is offloaded with `Task.Run`; the dependency read (which degrades instead of throwing) runs on the calling thread; `Resolve` then blocks once with `GetAwaiter().GetResult()` so the original exception (not an `AggregateException`) reaches the existing catch and the enriched message is still built. The resolver and `IEntitySchemaDependencyResolver` stay synchronous — `LoadSchema` and the MCP command chain are untouched; the repository already blocks on tasks this way in ~90 places and has no rule against it. Each read keeps its 30 s bound, and the wait on the offloaded task is itself bounded (2× the read timeout) so a saturated thread pool cannot stall `Resolve` indefinitely. Two concurrent requests on one `IApplicationClient` are safe: `CreatioClientAdapter` builds the client under a `Lazy(ExecutionAndPublication)`, and `ReauthExecutor`'s login de-duplication is documented for exactly a parallel burst.
3. **Installed-applications read is unchanged and still runs after the schema search** — it is deliberately NOT gated on `candidates.Count > 1`: the message text branches on `ApplicationCandidateCount` and is documented in `add-package-dependency` help/docs, and the read is unreachable in the "environment hangs" scenario anyway (it runs only after the schema search answered).
4. The "could not read current dependencies" warning is now emitted only when a candidate list is actually returned (previously it would have reached the MCP response on a `LookupFailed`/`None` outcome describing a list that never existed). Per-read elapsed time is logged at `--debug`.

Knowledge: new record `docs/knowledge/Command/the-dependency-diagnosis-runs-two-reads-in-parallel-off-a-sync-method.md` (the dependency read now runs even when the schema search finds nothing; the `ExecutionContext` trap for warnings written on the offloaded thread).

## Tests

~20 mock/`Received` sites updated for the new signatures; +10 new: both reads in flight at once (two-sided `Barrier` rendezvous — any sequential order fails within 10 s, never hangs); original exception text preserved; read 1 survives read 2's failure and vice versa; no dependency warning when there is no candidate list (3 shapes); UId path never calls `GetPackages`; `Guid.Empty` rejected; timeout parameter honoured; bounded wait on a never-completing search.

## Validation

- Build `clio` (net8.0 + net10.0) / `clio.tests` / `clio.mcp.e2e`: 0 errors; `warning CLIO` unchanged (2 pre-existing CLIO001 in `MobileDiffApplyValidator`).
- `Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Command|Module=McpServer|Module=Package)"` — 9923 passed / 6 failed, failing-name set identical to master (5× `ExtractIdentityService_*` + `PackageCreator.Create_ShouldAddInjectableLocalizationAbstraction_WhenAsAppIsTrue`, macOS-only).
- e2e `EntitySchemaDesignerHtmlResponseE2ETests` (the enriched message through the MCP boundary): 3/3.
- Real environment `ts1-core-dev04` (.NET Framework 4.8): `get-entity-schema-properties --package Custom --schema-name Opportunity` (`Custom` does not depend on the package owning `Opportunity`, so the designer answers HTML) — enriched message with 9 candidates byte-identical between master's build and this build; wall-clock 1.7–2.1 s on both (a healthy stand answers in ms, the saving shows only when a read hangs — covered by the unit tests); `--debug` shows dependency read 57 ms running alongside schema search 597 ms, installed apps 54 ms. Happy path (`Contact` in `Custom`) unchanged. Nothing was created on the stand.

## Review

- Pre-PR gate: Codex CLI ("No blocking findings") + bug-detector + quality lenses; no Blocker/High. Fixed before opening: warning reaching the MCP response without a candidate list; one-directional concurrency test; knowledge record duplicating the code comment; interface remarks claiming "same contract" as the by-name read; `Guid.Empty` guard; comments overstating what read 3 can cost; bounded wait on the offloaded task.
- Docs reviewed, no update required (`clio/help/en/get-entity-schema-properties.txt`, `add-package-dependency.txt`, `clio/docs/commands/get-entity-schema-properties.md`, `add-package-dependency.md`, `clio/Commands.md` — no option or message text changed).
- MCP reviewed, no update required (`clio/Command/McpServer/Tools/EntitySchemaTool.cs`, `GetEntitySchemaPropertiesTool`; tool contracts unchanged; `EntitySchemaDesignerHtmlResponseE2ETests` green).
- ClioRing compatibility reviewed, no Ring-consumed contract changed.
- Sonar note for the drive-green pass: the single `GetAwaiter().GetResult()` and `AsyncWaitHandle.WaitOne` on new code may raise S4462; the justification is in the code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1461
