### PR TITLE
fix: PropsBuilder honours TargetFramework conditions (#1283)

### DIFF
--- a/clio.tests/Common/PropsBuilder.Tests.cs
+++ b/clio.tests/Common/PropsBuilder.Tests.cs
@@ -270,7 +270,10 @@ public class PropsBuilder_Tests
 		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Is("*.dll"), Arg.Is(SearchOption.TopDirectoryOnly))
 			.Returns(ci => [
 				Path.Combine(ci.ArgAt<string>(0), "System.Text.Json.dll"),
-				Path.Combine(ci.ArgAt<string>(0), "Terrasoft.Common.dll")
+				Path.Combine(ci.ArgAt<string>(0), "Terrasoft.Common.dll"),
+				//An unreferenced dll, so the props file is written and the assertions below
+				//are made against real content instead of a file that never existed
+				Path.Combine(ci.ArgAt<string>(0), "ATF.Repository.dll")
 			]);
 
 		//Act
@@ -278,16 +281,21 @@ public class PropsBuilder_Tests
 
 		//Assert
 		string net472Props = CapturedPropsContent("net472");
+		net472Props.Should().Contain("ATF.Repository",
+			because: "an unreferenced dll must be written into the props file");
 		net472Props.Should().NotContain("System.Text.Json",
 			because: "it is already referenced under a matching net472 condition");
 		net472Props.Should().NotContain("Terrasoft.Common",
 			because: "it is referenced unconditionally, so it applies to net472 too");
 	}
 
-	private string CapturedPropsContent(string moniker) =>
-		_writtenPropsFiles.TryGetValue(ExpectedPropsPath(moniker), out string content)
-			? content
-			: string.Empty;
+	private string CapturedPropsContent(string moniker){
+		//Returning string.Empty for a file that was never written would turn "nothing was
+		//written" into a passing NotContain assertion
+		_writtenPropsFiles.TryGetValue(ExpectedPropsPath(moniker), out string content).Should().BeTrue(
+			because: $"the {moniker} props file had to be written for this assertion to mean anything");
+		return content;
+	}
 
 	private void MockConditionalCsProjAndTemplateReads(){
 		_fileSystem.When(fs => fs.WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>()))
@@ -296,6 +304,73 @@ public class PropsBuilder_Tests
 			.Returns(MockPropItemTemplate);
 		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".csproj")))
 			.Returns(MockCsProjWithConditionalReferences());
+	}
+
+	[TestCase("'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'")]
+	[TestCase("!('$(TargetFramework)' == 'net472')")]
+	[TestCase("'$(TargetFramework)' == 'net472' And '$(Configuration)' == 'Debug'")]
+	[TestCase("'$(TargetFrameworkVersion)' == 'v4.7.2'")]
+	[Description("Writes the dll into the props file when the existing reference carries a condition clio cannot evaluate (issue 1283)")]
+	public void Build_ReferencesDll_When_ConditionCannotBeEvaluated(string condition){
+		//Arrange
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".tpl"))).Returns(MockPropItemTemplate);
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".csproj"))).Returns($@"
+			<Project Sdk=""Microsoft.NET.Sdk"">
+				<ItemGroup>
+					<Reference Condition=""{condition}"" Include=""ATF.Repository"">
+						<HintPath>$(CoreLibPath)/ATF.Repository.dll</HintPath>
+					</Reference>
+				</ItemGroup>
+			</Project>");
+		_fileSystem.When(fs => fs.WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>()))
+			.Do(ci => _writtenPropsFiles[ci.ArgAt<string>(0)] = ci.ArgAt<string>(1));
+		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Is("*.dll"), Arg.Is(SearchOption.TopDirectoryOnly))
+			.Returns(ci => [Path.Combine(ci.ArgAt<string>(0), "ATF.Repository.dll")]);
+
+		//Act
+		_sut.Build(PackageName);
+
+		//Assert
+		CapturedPropsContent("net472").Should().Contain("ATF.Repository",
+			because: "a duplicate reference is an MSBuild warning, while a missing one is a "
+				+ "compile error, so an unreadable condition must not drop the dependency");
+	}
+
+	[TestCase("'net472' == '$(TargetFramework)'")]
+	[TestCase("  '$(TargetFramework)'=='net472'  ")]
+	[TestCase("'$(TargetFramework)' != 'netstandard2.0'")]
+	[Description("Understands the operand orders, spacing and negation of a simple target-framework condition (issue 1283)")]
+	public void Build_SkipsDll_When_SimpleConditionMatchesTargetFramework(string condition){
+		//Arrange
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".tpl"))).Returns(MockPropItemTemplate);
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".csproj"))).Returns($@"
+			<Project Sdk=""Microsoft.NET.Sdk"">
+				<ItemGroup>
+					<Reference Condition=""{condition}"" Include=""ATF.Repository"">
+						<HintPath>$(CoreLibPath)/ATF.Repository.dll</HintPath>
+					</Reference>
+					<Reference Include=""Castle.Core"">
+						<HintPath>$(CoreLibPath)/Castle.Core.dll</HintPath>
+					</Reference>
+				</ItemGroup>
+			</Project>");
+		_fileSystem.When(fs => fs.WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>()))
+			.Do(ci => _writtenPropsFiles[ci.ArgAt<string>(0)] = ci.ArgAt<string>(1));
+		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Is("*.dll"), Arg.Is(SearchOption.TopDirectoryOnly))
+			.Returns(ci => [
+				Path.Combine(ci.ArgAt<string>(0), "ATF.Repository.dll"),
+				Path.Combine(ci.ArgAt<string>(0), "Newtonsoft.Json.dll")
+			]);
+
+		//Act
+		_sut.Build(PackageName);
+
+		//Assert
+		string net472Props = CapturedPropsContent("net472");
+		net472Props.Should().NotContain("ATF.Repository",
+			because: "the condition resolves to net472, so the reference already applies");
+		net472Props.Should().Contain("Newtonsoft.Json",
+			because: "an unreferenced dll must still be written");
 	}
 
 }

--- a/clio.tests/Common/PropsBuilder.Tests.cs
+++ b/clio.tests/Common/PropsBuilder.Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Clio.Common;
 using FluentAssertions;
@@ -38,10 +39,36 @@ public class PropsBuilder_Tests
 				<PackageReference Include=""ATF.Repository"" Version=""2.0.1.5"" />
 			</ItemGroup>
 		</Project>";
+	private static readonly Func<string> MockCsProjWithConditionalReferences = () => @"
+		<Project Sdk=""Microsoft.NET.Sdk"">
+			<PropertyGroup>
+				<TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+			</PropertyGroup>
+			<ItemGroup>
+				<Reference Condition=""'$(TargetFramework)' == 'net472'"" Include=""System.Text.Json"">
+					<HintPath>$(CoreLibPath)/System.Text.Json.dll</HintPath>
+				</Reference>
+				<PackageReference Condition=""'$(TargetFramework)' == 'netstandard2.0'"" Include=""System.Text.Json"" Version=""8.0.0"" />
+				<Reference Include=""Terrasoft.Common"">
+					<HintPath>$(CoreLibPath)/Terrasoft.Common.dll</HintPath>
+				</Reference>
+			</ItemGroup>
+			<Choose>
+				<When Condition=""'$(TargetFramework)' == 'net472'"">
+					<ItemGroup>
+						<Reference Include=""Castle.Core"">
+							<HintPath>$(CoreLibPath)/Castle.Core.dll</HintPath>
+						</Reference>
+					</ItemGroup>
+				</When>
+			</Choose>
+		</Project>";
+
 	#region Setup/Teardown
 
 	[SetUp]
 	public void SetUp(){
+		_writtenPropsFiles.Clear();
 		_fileSystem = Substitute.For<IFileSystem>();
 		_fileSystem.ExistsDirectory(Arg.Any<string>()).Returns(true);
 		_logger = Substitute.For<ILogger>();
@@ -65,6 +92,7 @@ public class PropsBuilder_Tests
 	private IFileSystem _fileSystem;
 	private ILogger _logger;
 	private IWorkspacePathBuilder _workspacePathBuilder;
+	private readonly Dictionary<string, string> _writtenPropsFiles = new();
 
 	#endregion
 
@@ -210,5 +238,64 @@ public class PropsBuilder_Tests
 	private static string ExpectedPropsPath(string moniker) =>
 		Path.Combine(RootPath, PackageFolderPath, PackageName, "Files",
 			$"{PackageName}-{moniker}.nuget.props");
+
+	[Test]
+	[Description("References a dll that is only declared for another target framework (issue 1283)")]
+	public void Build_ReferencesDll_When_ExistingReferenceIsScopedToAnotherTargetFramework(){
+		//Arrange
+		MockConditionalCsProjAndTemplateReads();
+		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Is("*.dll"), Arg.Is(SearchOption.TopDirectoryOnly))
+			.Returns(ci => [
+				Path.Combine(ci.ArgAt<string>(0), "System.Text.Json.dll"),
+				Path.Combine(ci.ArgAt<string>(0), "Castle.Core.dll"),
+				Path.Combine(ci.ArgAt<string>(0), "Terrasoft.Common.dll")
+			]);
+
+		//Act
+		_sut.Build(PackageName);
+
+		//Assert
+		string netStandardProps = CapturedPropsContent("netstandard");
+		netStandardProps.Should().Contain("System.Text.Json",
+			because: "the existing reference to it applies to net472 only");
+		netStandardProps.Should().Contain("Castle.Core",
+			because: "its reference lives in a Choose/When scoped to net472");
+	}
+
+	[Test]
+	[Description("Skips a dll that is already referenced for the target framework being built (issue 1283)")]
+	public void Build_SkipsDll_When_ExistingReferenceAppliesToTargetFramework(){
+		//Arrange
+		MockConditionalCsProjAndTemplateReads();
+		_fileSystem.GetFiles(Arg.Any<string>(), Arg.Is("*.dll"), Arg.Is(SearchOption.TopDirectoryOnly))
+			.Returns(ci => [
+				Path.Combine(ci.ArgAt<string>(0), "System.Text.Json.dll"),
+				Path.Combine(ci.ArgAt<string>(0), "Terrasoft.Common.dll")
+			]);
+
+		//Act
+		_sut.Build(PackageName);
+
+		//Assert
+		string net472Props = CapturedPropsContent("net472");
+		net472Props.Should().NotContain("System.Text.Json",
+			because: "it is already referenced under a matching net472 condition");
+		net472Props.Should().NotContain("Terrasoft.Common",
+			because: "it is referenced unconditionally, so it applies to net472 too");
+	}
+
+	private string CapturedPropsContent(string moniker) =>
+		_writtenPropsFiles.TryGetValue(ExpectedPropsPath(moniker), out string content)
+			? content
+			: string.Empty;
+
+	private void MockConditionalCsProjAndTemplateReads(){
+		_fileSystem.When(fs => fs.WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>()))
+			.Do(ci => _writtenPropsFiles[ci.ArgAt<string>(0)] = ci.ArgAt<string>(1));
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".tpl")))
+			.Returns(MockPropItemTemplate);
+		_fileSystem.ReadAllText(Arg.Is<string>(s => s.EndsWith(".csproj")))
+			.Returns(MockCsProjWithConditionalReferences());
+	}
 
 }

--- a/clio/Common/PropsBuilder.cs
+++ b/clio/Common/PropsBuilder.cs
@@ -132,16 +132,18 @@ public class PropsBuilder : IPropsBuilder
 
 	#region Fields: Private
 
+	private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
 	//Matches a whole condition that is a single $(TargetFramework) comparison, in either
 	//operand order: '$(TargetFramework)' == 'net472' and 'net472' != '$(TargetFramework)'
 	private static readonly Regex SimpleTargetFrameworkConditionRegex = new(
 		@"^\s*(?:'\$\(TargetFramework\)'\s*(?<operator>==|!=)\s*'(?<framework>[^']*)'"
 		+ @"|'(?<framework2>[^']*)'\s*(?<operator2>==|!=)\s*'\$\(TargetFramework\)')\s*$",
-		RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexTimeout);
 
 	//Any mention of the property, used to tell "no opinion" from "an expression we cannot evaluate"
 	private static readonly Regex TargetFrameworkMentionRegex = new(
-		@"\$\(TargetFramework[^)]*\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		@"\$\(TargetFramework[^)]*\)", RegexOptions.Compiled | RegexOptions.IgnoreCase, RegexTimeout);
 
 	private readonly IFileSystem _fileSystem;
 	private readonly ILogger _logger;

--- a/clio/Common/PropsBuilder.cs
+++ b/clio/Common/PropsBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Clio.Workspaces;
 
@@ -119,7 +120,10 @@ public class PropsBuilder : IPropsBuilder
 
 	#region Constants: Private
 
+	private const string ConditionTag = "Condition";
 	private const string IncludeTag = "Include";
+	private const string Net472TargetFramework = "net472";
+	private const string NetStandardTargetFramework = "netstandard2.0";
 	private const string ProjExtension = ".csproj";
 	private const string PropsExtension = ".props";
 	private const string ReferenceTag = "Reference";
@@ -127,6 +131,11 @@ public class PropsBuilder : IPropsBuilder
 	#endregion
 
 	#region Fields: Private
+
+	//Matches '$(TargetFramework)' == 'net472' and its negated and unspaced forms
+	private static readonly Regex TargetFrameworkConditionRegex = new(
+		@"'\$\(TargetFramework\)'\s*(?<operator>==|!=)\s*'(?<framework>[^']*)'",
+		RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 	private readonly IFileSystem _fileSystem;
 	private readonly ILogger _logger;
@@ -194,6 +203,39 @@ public class PropsBuilder : IPropsBuilder
 		_fileSystem.WriteAllTextToFile(propsFilePath, propsContent);
 		return true;
 	}
+	/// <summary>
+	/// Decides whether a csproj element applies to the target framework being built.
+	/// </summary>
+	/// <param name="element">Element to inspect, usually a Reference.</param>
+	/// <param name="targetFramework">Target framework being built: net472 or netstandard2.0.</param>
+	/// <remarks>
+	/// A Reference restricted to one target framework - directly, or through an enclosing
+	/// Choose/When - says nothing about the others. Treating it as "already referenced"
+	/// everywhere drops the dependency from the props file of every other target framework,
+	/// and the package then fails to compile for them.
+	/// Only conditions written against $(TargetFramework) are interpreted; any other condition
+	/// is assumed to apply, which keeps the previous behaviour for conditions clio cannot read.
+	/// </remarks>
+	private static bool AppliesToTargetFramework(XElement element, string targetFramework){
+		for (XElement current = element; current is not null; current = current.Parent) {
+			string condition = current.Attribute(ConditionTag)?.Value;
+			if (string.IsNullOrWhiteSpace(condition)) {
+				continue;
+			}
+			Match match = TargetFrameworkConditionRegex.Match(condition);
+			if (!match.Success) {
+				continue;
+			}
+			bool negated = match.Groups["operator"].Value == "!=";
+			bool matchesFramework = string.Equals(match.Groups["framework"].Value, targetFramework,
+				StringComparison.OrdinalIgnoreCase);
+			if (matchesFramework == negated) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	private string GetPathTo(ItemType itemType, string packageName){
 		return itemType switch {
 			ItemType.NugetFolder => FilePathGetter(_workspacePathBuilder.NugetFolderPath),
@@ -247,8 +289,10 @@ public class PropsBuilder : IPropsBuilder
 		_fileSystem.CreateOrOverwriteExistsDirectoryIfNeeded(destinationFolder, true);
 		foreach (string dll in enumerableDlls) {
 			string dllName = Path.GetFileNameWithoutExtension(dll);
+			string targetFramework = moniker == Moniker.net472 ? Net472TargetFramework : NetStandardTargetFramework;
 			bool isReferenced = csproj
 				.Descendants(ReferenceTag)
+				.Where(e => AppliesToTargetFramework(e, targetFramework))
 				.Any(e => e.Attribute(IncludeTag)?.Value == dllName);
 
 			if (isReferenced) {

--- a/clio/Common/PropsBuilder.cs
+++ b/clio/Common/PropsBuilder.cs
@@ -132,10 +132,16 @@ public class PropsBuilder : IPropsBuilder
 
 	#region Fields: Private
 
-	//Matches '$(TargetFramework)' == 'net472' and its negated and unspaced forms
-	private static readonly Regex TargetFrameworkConditionRegex = new(
-		@"'\$\(TargetFramework\)'\s*(?<operator>==|!=)\s*'(?<framework>[^']*)'",
+	//Matches a whole condition that is a single $(TargetFramework) comparison, in either
+	//operand order: '$(TargetFramework)' == 'net472' and 'net472' != '$(TargetFramework)'
+	private static readonly Regex SimpleTargetFrameworkConditionRegex = new(
+		@"^\s*(?:'\$\(TargetFramework\)'\s*(?<operator>==|!=)\s*'(?<framework>[^']*)'"
+		+ @"|'(?<framework2>[^']*)'\s*(?<operator2>==|!=)\s*'\$\(TargetFramework\)')\s*$",
 		RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+	//Any mention of the property, used to tell "no opinion" from "an expression we cannot evaluate"
+	private static readonly Regex TargetFrameworkMentionRegex = new(
+		@"\$\(TargetFramework[^)]*\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 	private readonly IFileSystem _fileSystem;
 	private readonly ILogger _logger;
@@ -213,8 +219,12 @@ public class PropsBuilder : IPropsBuilder
 	/// Choose/When - says nothing about the others. Treating it as "already referenced"
 	/// everywhere drops the dependency from the props file of every other target framework,
 	/// and the package then fails to compile for them.
-	/// Only conditions written against $(TargetFramework) are interpreted; any other condition
-	/// is assumed to apply, which keeps the previous behaviour for conditions clio cannot read.
+	/// Only a condition that is a single $(TargetFramework) comparison is interpreted. A
+	/// condition that mentions the property inside something more complex - And, Or, a negation,
+	/// a property function - is treated as NOT applying, so the dll is written into the props
+	/// file. That direction is deliberate: a duplicate reference is an MSBuild warning, while a
+	/// missing one is a compile error. A condition that does not mention $(TargetFramework) at
+	/// all is assumed to apply, as before.
 	/// </remarks>
 	private static bool AppliesToTargetFramework(XElement element, string targetFramework){
 		for (XElement current = element; current is not null; current = current.Parent) {
@@ -222,13 +232,22 @@ public class PropsBuilder : IPropsBuilder
 			if (string.IsNullOrWhiteSpace(condition)) {
 				continue;
 			}
-			Match match = TargetFrameworkConditionRegex.Match(condition);
+			Match match = SimpleTargetFrameworkConditionRegex.Match(condition);
 			if (!match.Success) {
+				if (TargetFrameworkMentionRegex.IsMatch(condition)) {
+					//The condition depends on the target framework in a way clio cannot evaluate
+					return false;
+				}
 				continue;
 			}
-			bool negated = match.Groups["operator"].Value == "!=";
-			bool matchesFramework = string.Equals(match.Groups["framework"].Value, targetFramework,
-				StringComparison.OrdinalIgnoreCase);
+			string comparisonOperator = match.Groups["operator"].Success
+				? match.Groups["operator"].Value
+				: match.Groups["operator2"].Value;
+			string framework = match.Groups["framework"].Success
+				? match.Groups["framework"].Value
+				: match.Groups["framework2"].Value;
+			bool negated = comparisonOperator == "!=";
+			bool matchesFramework = string.Equals(framework, targetFramework, StringComparison.OrdinalIgnoreCase);
 			if (matchesFramework == negated) {
 				return false;
 			}

--- a/clio/docs/commands/switch-nuget-to-dll-reference.md
+++ b/clio/docs/commands/switch-nuget-to-dll-reference.md
@@ -39,6 +39,17 @@ references an analyzer or tooling-only NuGet package — no props file is writte
 no `<Import>` is added, because MSBuild fails the whole project when it imports a file with
 no root element. A warning names the skipped props file.
 
+A dependency that the csproj already declares is left out of the props file, and that check
+honours the `Condition` of the `<Reference>` and of any enclosing `<Choose>`/`<When>`. A
+`<Reference>` restricted to one target framework therefore no longer suppresses the dependency for
+the others — the shape clio's own package template uses for `System.Text.Json`,
+`Microsoft.Extensions.Http` and `Microsoft.Extensions.DependencyInjection`, which are a `net472`
+`<Reference>` plus a `netstandard2.0` `<PackageReference>`. Only a condition that is a single
+`$(TargetFramework)` comparison is interpreted; a condition that mentions the property inside
+something more complex (`And`, `Or`, a negation, a property function) is treated as not applying, so
+the dependency is kept in the props file — a duplicate reference is an MSBuild warning, a missing
+one is a compile error.
+
 A NuGet package that contributes no assembly at all — an analyzer, for example — keeps its
 `PackageReference` in the csproj instead of being commented out. A package is considered
 materialized when a copied assembly is named after it, which also covers packages whose assembly

--- a/clio/help/en/switch-nuget-to-dll-reference.txt
+++ b/clio/help/en/switch-nuget-to-dll-reference.txt
@@ -24,6 +24,10 @@ NOTES
     the command exits with code 1. A nuget package that contributes no assembly,
     such as an analyzer, keeps its PackageReference. An unusable props file left
     by an older clio version, and its import, are removed on the next run.
+    The "already referenced" check honours the Condition of the <Reference> and
+    of any enclosing <Choose>/<When>, so a reference scoped to one target
+    framework no longer suppresses the dependency for the others. A condition
+    clio cannot evaluate keeps the dependency in the props file.
 
 EXAMPLES
     clio switch-nuget-to-dll-reference MyPackage

--- a/docs/knowledge/Common/props-reference-check-is-target-framework-scoped.md
+++ b/docs/knowledge/Common/props-reference-check-is-target-framework-scoped.md
@@ -1,0 +1,24 @@
+---
+description: a Reference scoped to one TargetFramework must not suppress the props entry for the others
+applies-to:
+  - clio/Common/PropsBuilder.cs
+ticket: GH-1283
+date: 2026-08-30
+---
+
+**What is true** — `PropsBuilder` decides whether a dll is already referenced by the package csproj.
+That check has to honour the `Condition` of the `<Reference>` and of every enclosing
+`<Choose>`/`<When>`. `XDocument.Descendants` walks into conditional blocks and returns elements that
+do not apply to the target framework being built.
+
+Only conditions written against `$(TargetFramework)` are interpreted. Any other condition is assumed
+to apply, which keeps the earlier behaviour for expressions clio cannot evaluate.
+
+**Why it is this way** — the package template clio ships declares a dependency twice: a `<Reference>`
+for `net472` and a `<PackageReference>` for `netstandard2.0` (`System.Text.Json`,
+`Microsoft.Extensions.Http`, `Microsoft.Extensions.DependencyInjection`).
+
+**What breaks if you ignore it** — building the netstandard props file, the net472-only `<Reference>`
+counts as "already referenced": the dll is written into no props file and copied into no
+`Files/Libs/netstandard`. Combined with `switch-nuget-to-dll-reference` commenting out the
+`PackageReference`, the netstandard build then has no source for the dependency at all.

--- a/docs/knowledge/Common/props-reference-check-is-target-framework-scoped.md
+++ b/docs/knowledge/Common/props-reference-check-is-target-framework-scoped.md
@@ -11,8 +11,11 @@ That check has to honour the `Condition` of the `<Reference>` and of every enclo
 `<Choose>`/`<When>`. `XDocument.Descendants` walks into conditional blocks and returns elements that
 do not apply to the target framework being built.
 
-Only conditions written against `$(TargetFramework)` are interpreted. Any other condition is assumed
-to apply, which keeps the earlier behaviour for expressions clio cannot evaluate.
+Only a condition that is a single `$(TargetFramework)` comparison is interpreted. A condition that
+mentions the property inside something more complex - an `And`, an `Or`, a negation, a property
+function - is treated as NOT applying, so the dll **is** written into the props file. That direction
+is deliberate: a duplicate reference is an MSBuild warning, while a missing one is a compile error.
+A condition that does not mention `$(TargetFramework)` at all is assumed to apply, as before.
 
 **Why it is this way** — the package template clio ships declares a dependency twice: a `<Reference>`
 for `net472` and a `<PackageReference>` for `netstandard2.0` (`System.Text.Json`,


### PR DESCRIPTION
🔗 **Issue:** [#1283](https://github.com/Advance-Technologies-Foundation/clio/issues/1283)

Re-opens the fix from #1284, which GitHub auto-closed when its base branch (`Alexandr-Kravchuk/issue-263`, PR #1281) merged and was deleted. Same four commits (Sonar quality gate was green on #1284), rebased onto current `master` without conflicts, plus one documentation commit.

## Problem

`PropsBuilder` decided "this dll is already referenced" with `XDocument.Descendants("Reference")`, which walks into `<Choose>`/`<When>` and ignores the `Condition` on the element and on its ancestors. A `<Reference>` restricted to one target framework therefore suppressed the props entry for **every** framework. clio's own package template hits this — `clio/tpl/package/Files/PackageName.csproj` declares `System.Text.Json`, `Microsoft.Extensions.Http` and `Microsoft.Extensions.DependencyInjection` as a net472-only `<Reference>` plus a netstandard2.0 `<PackageReference>`; building the netstandard props file, the net472 reference counted, so the dll was written into no props file and copied into no `Files/Libs/netstandard`.

## What changed

- Conditions written against `$(TargetFramework)` are evaluated for the moniker being built, walking up through the enclosing `<Choose>`/`<When>` (`AppliesToTargetFramework`; `==`/`!=`, either operand order). Any other condition (`And`/`Or`/negation/functions) is treated as "cannot evaluate" and the dependency is **kept** in the props file — leaking a reference is recoverable, a missing one breaks the build.
- The two `TargetFramework` regexes carry a one-second match timeout (Sonar S6444).
- Knowledge record `docs/knowledge/Common/props-reference-check-is-target-framework-scoped.md` states the rule and the unevaluable-condition direction; `empty-props-file-breaks-msbuild-import.md` re-checked.
- New (5th commit): a paragraph in `clio/help/en/switch-nuget-to-dll-reference.txt` and `clio/docs/commands/switch-nuget-to-dll-reference.md` describing both user-visible behaviours.

## Validation

- Build `clio` / `clio.tests` (`--no-incremental`): 0 errors; `warning CLIO` = 4 on both master and this branch.
- `Validated: dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit"` — master 12527 passed / 28 failed, branch 12536 passed / 28 failed; failing-name sets identical (known macOS-only cluster). `PropsBuilder|SwitchNugetToDll|NugetMaterializer` fixtures: 44 → 53 passed, 0 failed.
- End-to-end on the shipped template (local, no Creatio needed): a workspace with one package stamped from `clio/tpl/package`, `switch-nuget-to-dll-reference Pkg1283` run with master's build and with this build:
  - master prints three `[WAR] Keeping the <pkg> package reference … produced no assembly to reference` and the netstandard props file / `Files/Libs/netstandard` lack the three assemblies (10 files);
  - this build prints no warnings; `Pkg1283-netstandard.nuget.props` gains exactly the three `<Choose>` blocks, `Files/Libs/netstandard` has 13 files (the three dlls added), the three netstandard `<PackageReference>`s are commented out because they materialised; `Pkg1283-net472.nuget.props` and `Files/Libs/net472` are byte-identical between the two builds.
- `scripts/check-knowledge-applies-to.py`: same output as master (one pre-existing stale record under `docs/knowledge/McpServer/`, unrelated).

## Review

- Reviewed on #1284 (Sonar quality gate passed, knowledge-base check addressed); this re-open adds only a docs commit — review skipped for the delta (docs only).
- Docs reviewed and updated (`clio/help/en/switch-nuget-to-dll-reference.txt`, `clio/docs/commands/switch-nuget-to-dll-reference.md`; `Commands.md` / `WikiAnchors.txt` unchanged).
- MCP reviewed, no update required (no MCP tool exists for `switch-nuget-to-dll-reference`). ClioRing compatibility reviewed, no Ring-consumed contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1283
