### PR TITLE
Make an unparsable MCP result name its own payload (#1384)

### DIFF
--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -1277,7 +1277,9 @@ public sealed class ApplicationToolE2ETests {
 			return contentPayload;
 		}
 
-		throw new InvalidOperationException("Could not parse SchemaSyncResponse MCP result.");
+		throw new InvalidOperationException(
+			"Could not parse SchemaSyncResponse MCP result: "
+			+ McpResultDiagnostics.Describe(callResult));
 	}
 
 	private static bool TryExtractSchemaSyncResponse(object? value, out JsonElement payload) {

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -1518,7 +1518,9 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 			return contentPayload;
 		}
 
-		throw new InvalidOperationException("Could not parse SchemaSyncResponse MCP result.");
+		throw new InvalidOperationException(
+			"Could not parse SchemaSyncResponse MCP result: "
+			+ McpResultDiagnostics.Describe(callResult));
 	}
 
 	private static bool TryExtractSchemaSyncResponse(object? value, out JsonElement payload) {

--- a/clio.mcp.e2e/Support/Results/ApplicationEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/ApplicationEnvelope.cs
@@ -175,69 +175,76 @@ internal sealed record ApplicationDataForgeColumnHintEnvelope(
 
 internal static class ApplicationResultParser {
 	public static ApplicationListResponseEnvelope ExtractList(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidListEnvelope, out ApplicationListResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidListEnvelope, out ApplicationListResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse list-apps MCP result.");
+		throw new InvalidOperationException($"Could not parse list-apps MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationContextResponseEnvelope ExtractInfo(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidContextEnvelope, out ApplicationContextResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidContextEnvelope, out ApplicationContextResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse get-app-info MCP result.");
+		throw new InvalidOperationException($"Could not parse get-app-info MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationDeleteResponseEnvelope ExtractDelete(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidDeleteEnvelope, out ApplicationDeleteResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidDeleteEnvelope, out ApplicationDeleteResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse delete-app MCP result.");
+		throw new InvalidOperationException($"Could not parse delete-app MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationSectionContextResponseEnvelope ExtractSectionCreate(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidSectionContextEnvelope, out ApplicationSectionContextResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidSectionContextEnvelope, out ApplicationSectionContextResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse create-app-section MCP result.");
+		throw new InvalidOperationException($"Could not parse create-app-section MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationSectionUpdateContextResponseEnvelope ExtractSectionUpdate(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidSectionUpdateContextEnvelope, out ApplicationSectionUpdateContextResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidSectionUpdateContextEnvelope, out ApplicationSectionUpdateContextResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse update-app-section MCP result.");
+		throw new InvalidOperationException($"Could not parse update-app-section MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationSectionDeleteContextResponseEnvelope ExtractSectionDelete(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidSectionDeleteContextEnvelope, out ApplicationSectionDeleteContextResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidSectionDeleteContextEnvelope, out ApplicationSectionDeleteContextResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse delete-app-section MCP result.");
+		throw new InvalidOperationException($"Could not parse delete-app-section MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	public static ApplicationSectionListContextResponseEnvelope ExtractSectionList(CallToolResult callResult) {
-		if (TryExtract(callResult, IsValidSectionListContextEnvelope, out ApplicationSectionListContextResponseEnvelope? envelope)) {
+		McpParseDiagnostics diagnostics = new();
+		if (TryExtract(callResult, IsValidSectionListContextEnvelope, out ApplicationSectionListContextResponseEnvelope? envelope, diagnostics)) {
 			return envelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse list-app-sections MCP result.");
+		throw new InvalidOperationException($"Could not parse list-app-sections MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
-	private static bool TryExtract<T>(CallToolResult callResult, Func<T?, bool> validator, out T? result) {
+	private static bool TryExtract<T>(CallToolResult callResult, Func<T?, bool> validator, out T? result, McpParseDiagnostics diagnostics) {
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryDeserialize(structuredContent, validator, out result)) {
+			TryDeserialize(structuredContent, validator, out result, diagnostics)) {
 			return true;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryDeserialize(content, validator, out result)) {
+			TryDeserialize(content, validator, out result, diagnostics)) {
 			return true;
 		}
 
@@ -255,13 +262,13 @@ internal static class ApplicationResultParser {
 		return true;
 	}
 
-	private static bool TryDeserialize<T>(JsonElement element, Func<T?, bool> validator, out T? result) {
+	private static bool TryDeserialize<T>(JsonElement element, Func<T?, bool> validator, out T? result, McpParseDiagnostics diagnostics) {
 		if (element.ValueKind == JsonValueKind.Array) {
 			foreach (JsonElement item in element.EnumerateArray()) {
 				if (TryGetTextPayload(item, out string? textPayload) &&
 					!string.IsNullOrWhiteSpace(textPayload) &&
-					TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserializeRaw(textPayloadElement, validator, out result)) {
+					TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserializeRaw(textPayloadElement, validator, out result, diagnostics)) {
 					return true;
 				}
 			}
@@ -270,13 +277,13 @@ internal static class ApplicationResultParser {
 		if (element.ValueKind == JsonValueKind.String) {
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserializeRaw(textPayloadElement, validator, out result)) {
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserializeRaw(textPayloadElement, validator, out result, diagnostics)) {
 				return true;
 			}
 		}
 
-		if (TryDeserializeRaw(element, validator, out result)) {
+		if (TryDeserializeRaw(element, validator, out result, diagnostics)) {
 			return true;
 		}
 
@@ -284,14 +291,19 @@ internal static class ApplicationResultParser {
 		return false;
 	}
 
-	private static bool TryDeserializeRaw<T>(JsonElement element, Func<T?, bool> validator, out T? result) {
+	private static bool TryDeserializeRaw<T>(JsonElement element, Func<T?, bool> validator, out T? result, McpParseDiagnostics diagnostics) {
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try {
 			result = JsonSerializer.Deserialize<T>(
 				element.GetRawText(),
 				new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 			return validator(result);
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			result = default;
 			return false;
 		}
@@ -347,12 +359,13 @@ internal static class ApplicationResultParser {
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element) {
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics) {
 		try {
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/ApplicationResultParserDiagnosticsTests.cs
+++ b/clio.mcp.e2e/Support/Results/ApplicationResultParserDiagnosticsTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E.Support.Results;
+
+/// <summary>
+/// Unit test proving that <see cref="ApplicationResultParser.ExtractList"/> — one representative sibling
+/// of <see cref="EntitySchemaStructuredResultParser"/> (GitHub issue #1384) — now embeds the shared
+/// <see cref="McpResultDiagnostics.Describe"/> payload description in its parse-failure message instead of
+/// throwing the old bare "Could not parse list-apps MCP result." sentence, plus the two properties of the
+/// last-<see cref="System.Text.Json.JsonException"/> threading that the siblings gained with it: a real
+/// parse failure is named, and the doomed content-array attempt is not. Two sibling families are covered:
+/// the remaining throw sites share the exact same call shape, so further copies would exercise the
+/// identical code path in <see cref="McpResultDiagnostics"/> that <see cref="McpResultDiagnosticsTests"/>
+/// already covers directly, without adding any new signal.
+/// Constructs a <see cref="CallToolResult"/> in-memory (no MCP server, no stand, no network I/O), so it is
+/// categorized <c>Unit</c> rather than <c>McpE2E.Sandbox</c>.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Category("McpE2E.NoEnvironment")]
+[Property("Module", "McpServer")]
+public sealed class ApplicationResultParserDiagnosticsTests {
+	[Test]
+	[Description("Includes the tool-specific prefix, IsError, and the payload's own text in the message thrown when list-apps returns an unparsable result.")]
+	public void ExtractList_ShouldThrowWithPayloadDiagnostics_WhenResultIsNotAValidListEnvelope() {
+		// Arrange
+		const string serverErrorText = "System.NullReferenceException: Object reference not set to an instance of an object.";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = serverErrorText }]
+		};
+
+		// Act
+		Action act = () => ApplicationResultParser.ExtractList(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "the server's unhandled-exception text does not deserialize into ApplicationListResponseEnvelope")
+			.Which;
+		exception.Message.Should().StartWith("Could not parse list-apps MCP result:",
+			because: "the tool-specific prefix must be preserved unchanged");
+		exception.Message.Should().Contain("IsError=True",
+			because: "an unhandled server exception is exactly the kind of failure IsError should surface");
+		exception.Message.Should().Contain(serverErrorText,
+			because: "the payload's own error text must be visible in the thrown message, not discarded as it was before this diagnostic was added");
+	}
+
+	[Test]
+	[Description("Names the last JsonException when a sibling parser's text payload is not JSON, instead of discarding it inside catch (JsonException) { }.")]
+	public void ExtractResponse_ShouldNameLastJsonError_WhenTextPayloadIsNotJson() {
+		// Arrange
+		const string loginPage = "<!DOCTYPE html><html><body><h1>Sign in</h1></body></html>";
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [new TextContentBlock { Text = loginPage }]
+		};
+
+		// Act
+		Action act = () => GetPkgListResultParser.ExtractResponse(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "an HTML login page does not deserialize into GetPkgListResponseEnvelope")
+			.Which;
+		exception.Message.Should().Contain("LastJsonError=",
+			because: "the sibling parsers now keep the JsonException their catch blocks used to swallow");
+		exception.Message.Should().Contain("Sign in",
+			because: "the page's own text must be visible too, so an authentication redirect is recognizable as one");
+	}
+
+	[Test]
+	[Description("Does not report a LastJsonError when the only exception raised came from the doomed deserialize of the raw content-item array.")]
+	public void ExtractResponse_ShouldNotNameLastJsonError_WhenOnlyTheContentArrayAttemptFailed() {
+		// Arrange
+		const string wellFormedButEmptyEnvelope = /*lang=json,strict*/ "{\"packages\":null}";
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [new TextContentBlock { Text = wellFormedButEmptyEnvelope }]
+		};
+
+		// Act
+		Action act = () => GetPkgListResultParser.ExtractResponse(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "an envelope with no packages array is rejected by the parser's own validity check")
+			.Which;
+		exception.Message.Should().NotContain("LastJsonError=",
+			because: "deserializing the raw content-item array into an object always fails and says nothing about the real payload, so blaming it would misdirect the reader");
+		exception.Message.Should().Contain("packages",
+			because: "the payload itself must still be dumped, which is what actually explains this failure");
+	}
+}

--- a/clio.mcp.e2e/Support/Results/AssertInfrastructureEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/AssertInfrastructureEnvelope.cs
@@ -38,19 +38,20 @@ internal static class AssertInfrastructureResultParser
 {
 	public static AssertInfrastructureEnvelope Extract(CallToolResult callResult)
 	{
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelope(structuredContent, out AssertInfrastructureEnvelope? structuredEnvelope))
+			TryExtractEnvelope(structuredContent, out AssertInfrastructureEnvelope? structuredEnvelope, diagnostics))
 		{
 			return structuredEnvelope!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelope(content, out AssertInfrastructureEnvelope? contentEnvelope))
+			TryExtractEnvelope(content, out AssertInfrastructureEnvelope? contentEnvelope, diagnostics))
 		{
 			return contentEnvelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse assert-infrastructure structured MCP result.");
+		throw new InvalidOperationException($"Could not parse assert-infrastructure structured MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element)
@@ -65,9 +66,9 @@ internal static class AssertInfrastructureResultParser
 		return true;
 	}
 
-	private static bool TryExtractEnvelope(JsonElement element, out AssertInfrastructureEnvelope? envelope)
+	private static bool TryExtractEnvelope(JsonElement element, out AssertInfrastructureEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
-		if (TryDeserialize(element, out envelope))
+		if (TryDeserialize(element, out envelope, diagnostics))
 		{
 			return true;
 		}
@@ -76,7 +77,7 @@ internal static class AssertInfrastructureResultParser
 		{
 			foreach (JsonElement item in element.EnumerateArray())
 			{
-				if (TryDeserialize(item, out envelope))
+				if (TryDeserialize(item, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -86,8 +87,8 @@ internal static class AssertInfrastructureResultParser
 					continue;
 				}
 
-				if (TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserialize(textPayloadElement, out envelope))
+				if (TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserialize(textPayloadElement, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -98,8 +99,8 @@ internal static class AssertInfrastructureResultParser
 		{
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserialize(textPayloadElement, out envelope))
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserialize(textPayloadElement, out envelope, diagnostics))
 			{
 				return true;
 			}
@@ -109,8 +110,12 @@ internal static class AssertInfrastructureResultParser
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out AssertInfrastructureEnvelope? envelope)
+	private static bool TryDeserialize(JsonElement element, out AssertInfrastructureEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try
 		{
 			envelope = JsonSerializer.Deserialize<AssertInfrastructureEnvelope>(
@@ -121,8 +126,9 @@ internal static class AssertInfrastructureResultParser
 				&& envelope.Sections is not null
 				&& envelope.DatabaseCandidates is not null;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			envelope = null;
 			return false;
 		}
@@ -146,15 +152,16 @@ internal static class AssertInfrastructureResultParser
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element)
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics)
 	{
 		try
 		{
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/EntitySchemaEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/EntitySchemaEnvelope.cs
@@ -1,98 +1,173 @@
 using System.Text.Json;
+using Clio.Command.McpServer;
+using Clio.Common;
 using ModelContextProtocol.Protocol;
 
 namespace Clio.Mcp.E2E.Support.Results;
 
 internal static class EntitySchemaStructuredResultParser {
-	public static T Extract<T>(CallToolResult callResult) {
-		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelope(structuredContent, out T? structuredEnvelope)) {
-			return structuredEnvelope!;
-		}
+    public static T Extract<T>(CallToolResult callResult) {
+        McpParseDiagnostics diagnostics = new();
 
-		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelope(content, out T? contentEnvelope)) {
-			return contentEnvelope!;
-		}
+        bool hasStructuredContent = TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent);
+        if (hasStructuredContent &&
+            TryExtractEnvelope(structuredContent, out T? structuredEnvelope, diagnostics)) {
+            return structuredEnvelope!;
+        }
 
-		throw new InvalidOperationException($"Could not parse {typeof(T).Name} MCP result.");
-	}
+        bool hasContent = TrySerializeToJsonElement(callResult.Content, out JsonElement content);
+        if (hasContent &&
+            TryExtractEnvelope(content, out T? contentEnvelope, diagnostics)) {
+            return contentEnvelope!;
+        }
 
-	private static bool TrySerializeToJsonElement(object? value, out JsonElement element) {
-		if (value is null) {
-			element = default;
-			return false;
-		}
+        string message = BuildParseFailureMessage(typeof(T).Name, callResult, diagnostics);
 
-		element = JsonSerializer.SerializeToElement(value);
-		return true;
-	}
+        throw new InvalidOperationException(message, RedactedCopyOf(diagnostics.LastJsonException));
+    }
 
-	private static bool TryExtractEnvelope<T>(JsonElement element, out T? envelope) {
-		if (element.ValueKind == JsonValueKind.Array) {
-			foreach (JsonElement item in element.EnumerateArray()) {
-				if (TryGetTextPayload(item, out string? textPayload) &&
-					!string.IsNullOrWhiteSpace(textPayload) &&
-					TryParseJson(textPayload, out JsonElement parsedPayload) &&
-					TryDeserializeEnvelope(parsedPayload, out envelope)) {
-					return true;
-				}
-			}
-		}
+    /// <summary>
+    /// Composes the parse-failure diagnostic: what shape was expected, and — via
+    /// <see cref="McpResultDiagnostics.Describe"/> — whether the call reported an error and a bounded,
+    /// redacted dump of the actual payload, so an authentication rejection, an HTML login page, a
+    /// serialized unhandled exception, and a plain DTO-shape mismatch are no longer indistinguishable
+    /// from a bare "could not parse" message.
+    /// </summary>
+    private static string BuildParseFailureMessage(
+        string expectedTypeName,
+        CallToolResult callResult,
+        McpParseDiagnostics diagnostics) {
+        string prefix = $"Could not parse {expectedTypeName} MCP result: {DescribeFailureShape(diagnostics)}. ";
 
-		if (element.ValueKind == JsonValueKind.String) {
-			string? textPayload = element.GetString();
-			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement parsedPayload) &&
-				TryDeserializeEnvelope(parsedPayload, out envelope)) {
-				return true;
-			}
-		}
+        // The payload description is asked for a REDUCED budget rather than being truncated a second time
+        // after the prefix is prepended. Truncating twice made the length note describe the already-cut
+        // text — a three-megabyte payload was reported as "4114 characters" — and a note that lies about
+        // the size is worse than no note.
+        return prefix + McpResultDiagnostics.Describe(
+            callResult,
+            diagnostics.LastJsonException,
+            McpResultDiagnostics.PayloadDiagnosticLimit - prefix.Length);
+    }
 
-		if (TryDeserializeEnvelope(element, out envelope)) {
-			return true;
-		}
+    /// <summary>
+    /// A copy of <paramref name="exception"/> whose message has been through the redactor, used as the
+    /// thrown exception's inner exception.
+    /// </summary>
+    /// <remarks>
+    /// The outer message is redacted; the inner exception was not, and NUnit prints inner exceptions in
+    /// full. System.Text.Json failure messages carry a JSON path and an offset rather than values, so the
+    /// risk is small — but "small" is not a property worth relying on for the one string on this path
+    /// that skipped the rule everything else obeys. The exception TYPE is preserved, so a caller (and the
+    /// existing assertion) still sees a <see cref="JsonException"/>.
+    /// </remarks>
+    private static JsonException? RedactedCopyOf(JsonException? exception) =>
+        exception is null ? null : new JsonException(SensitiveErrorTextRedactor.Redact(exception.Message));
 
-		envelope = default;
-		return false;
-	}
+    private static string DescribeFailureShape(McpParseDiagnostics diagnostics) {
+        if (diagnostics.SawValidJson) {
+            return "JSON present but not shaped like the expected type";
+        }
 
-	private static bool TryDeserializeEnvelope<T>(JsonElement element, out T? envelope) {
-		try {
-			envelope = JsonSerializer.Deserialize<T>(
-				element.GetRawText(),
-				new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-			return envelope is not null;
-		}
-		catch (JsonException) {
-			envelope = default;
-			return false;
-		}
-	}
+        if (diagnostics.SawTextPayload) {
+            return "text content present but not JSON";
+        }
 
-	private static bool TryGetTextPayload(JsonElement element, out string? textPayload) {
-		textPayload = null;
-		if (element.ValueKind != JsonValueKind.Object) {
-			return false;
-		}
+        // SawAnyJson, not SawValidJson: an array-shaped StructuredContent sets only the former, and
+        // claiming "no structured content ... at all" directly beside a dump of that array contradicts
+        // the very text printed next to it.
+        if (diagnostics.SawAnyJson) {
+            return "JSON present but not shaped like the expected type";
+        }
 
-		if (element.TryGetProperty("text", out JsonElement textElement) &&
-			textElement.ValueKind == JsonValueKind.String) {
-			textPayload = textElement.GetString();
-			return true;
-		}
+        return "no structured content and no text content at all";
+    }
 
-		return false;
-	}
+    private static bool TrySerializeToJsonElement(object? value, out JsonElement element) {
+        if (value is null) {
+            element = default;
+            return false;
+        }
 
-	private static bool TryParseJson(string value, out JsonElement element) {
-		try {
-			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
-			return true;
-		}
-		catch (JsonException) {
-			element = default;
-			return false;
-		}
-	}
+        element = JsonSerializer.SerializeToElement(value);
+        return true;
+    }
+
+    private static bool TryExtractEnvelope<T>(JsonElement element, out T? envelope, McpParseDiagnostics diagnostics) {
+        if (element.ValueKind == JsonValueKind.Array) {
+            foreach (JsonElement item in element.EnumerateArray()) {
+                if (TryGetTextPayload(item, out string? textPayload) &&
+                    !string.IsNullOrWhiteSpace(textPayload)) {
+                    diagnostics.SawTextPayload = true;
+                    if (TryParseJson(textPayload, out JsonElement parsedPayload, diagnostics) &&
+                        TryDeserializeEnvelope(parsedPayload, out envelope, diagnostics)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (element.ValueKind == JsonValueKind.String) {
+            string? textPayload = element.GetString();
+            if (!string.IsNullOrWhiteSpace(textPayload)) {
+                diagnostics.SawTextPayload = true;
+                if (TryParseJson(textPayload, out JsonElement parsedPayload, diagnostics) &&
+                    TryDeserializeEnvelope(parsedPayload, out envelope, diagnostics)) {
+                    return true;
+                }
+            }
+        }
+
+        if (TryDeserializeEnvelope(element, out envelope, diagnostics)) {
+            return true;
+        }
+
+        envelope = default;
+        return false;
+    }
+
+    private static bool TryDeserializeEnvelope<T>(JsonElement element, out T? envelope, McpParseDiagnostics diagnostics) {
+        // The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt, which every sibling
+        // parser now shares: the attempt is still made, but a bare content-item array must not be recorded
+        // as "JSON was present" nor contribute its always-doomed JsonException.
+        bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
+        try {
+            envelope = JsonSerializer.Deserialize<T>(
+                element.GetRawText(),
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return envelope is not null;
+        }
+        catch (JsonException exception) {
+            diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
+            envelope = default;
+            return false;
+        }
+    }
+
+    private static bool TryGetTextPayload(JsonElement element, out string? textPayload) {
+        textPayload = null;
+        if (element.ValueKind != JsonValueKind.Object) {
+            return false;
+        }
+
+        if (element.TryGetProperty("text", out JsonElement textElement) &&
+            textElement.ValueKind == JsonValueKind.String) {
+            textPayload = textElement.GetString();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics) {
+        try {
+            element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
+            return true;
+        }
+        catch (JsonException exception) {
+            diagnostics.RecordJsonException(exception);
+            element = default;
+            return false;
+        }
+    }
+
 }

--- a/clio.mcp.e2e/Support/Results/EntitySchemaStructuredResultParserTests.cs
+++ b/clio.mcp.e2e/Support/Results/EntitySchemaStructuredResultParserTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E.Support.Results;
+
+/// <summary>
+/// Unit tests for <see cref="EntitySchemaStructuredResultParser.Extract{T}"/>'s parse-failure diagnostics
+/// (GitHub issue #1384). They construct <see cref="CallToolResult"/> instances in-memory (no MCP server, no
+/// stand, no network I/O), so they are categorized <c>Unit</c> rather than <c>McpE2E.Sandbox</c>.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Category("McpE2E.NoEnvironment")]
+[Property("Module", "McpServer")]
+public sealed class EntitySchemaStructuredResultParserTests {
+	/// <summary>A DTO shape that a plain JSON object with a non-numeric "code" cannot satisfy.</summary>
+	private sealed record SampleEnvelope(int Code);
+
+	[Test]
+	[Description("Reports 'no structured content and no text content at all' when the tool result carries neither StructuredContent nor Content.")]
+	public void Extract_ShouldThrowWithNoPayloadShape_WhenResultIsEmpty() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = []
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "there is no structured content and no text content to parse")
+			.WithMessage("*no structured content and no text content at all*",
+				because: "the message must name the exact shape mismatch observed");
+	}
+
+	[Test]
+	[Description("Reports 'text content present but not JSON' and preserves the JsonException message when the tool result's text content is not JSON, e.g. an HTML login page.")]
+	public void Extract_ShouldThrowWithTextNotJsonShape_WhenContentIsHtmlLoginPage() {
+		// Arrange
+		const string htmlLoginPage = "<html><body>Please <a href=\"/login\">sign in</a> to continue.</body></html>";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = htmlLoginPage }]
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "the HTML page is not JSON and cannot be parsed as SampleEnvelope")
+			.Which;
+		exception.Message.Should().Contain("text content present but not JSON",
+			because: "text was found but never parsed as JSON");
+		exception.Message.Should().Contain("IsError=True",
+			because: "an authentication rejection is exactly the kind of failure IsError should surface");
+		exception.InnerException.Should().BeOfType<JsonException>(
+			because: "the JsonException raised while trying to parse the HTML as JSON must be preserved, not discarded");
+	}
+
+	[Test]
+	[Description("Reports 'JSON present but not shaped like the expected type' and preserves the JsonException message when the payload is valid JSON but does not match the DTO shape.")]
+	public void Extract_ShouldThrowWithJsonShapeMismatch_WhenPayloadDoesNotMatchDto() {
+		// Arrange
+		const string mismatchedJson = /*lang=json,strict*/ "{\"Code\":\"not-a-number\"}";
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [new TextContentBlock { Text = mismatchedJson }]
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "\"not-a-number\" cannot be deserialized into the DTO's int Code property")
+			.Which;
+		exception.Message.Should().Contain("JSON present but not shaped like the expected type",
+			because: "valid JSON was parsed but its shape does not match SampleEnvelope");
+		exception.InnerException.Should().BeOfType<JsonException>(
+			because: "the underlying deserialize failure must be threaded through as the inner exception");
+		exception.Message.Should().Contain("LastJsonError=",
+			because: "the last JsonException's message must also appear in the text, not only as an inner exception");
+		exception.Message.Should().Contain("$.Code",
+			because: "the kept JsonException names the offending JSON path, which is what turns a shape mismatch into an actionable report");
+		exception.Message.Should().MatchRegex(@"LineNumber: \d+",
+			because: "the kept JsonException also names where in the payload the mismatch is, rather than only that one happened");
+	}
+
+	[Test]
+	[Description("Includes the actual payload text (an unhandled-exception message forwarded verbatim) in the thrown message so the failure is self-explaining without re-running the call.")]
+	public void Extract_ShouldIncludePayloadText_WhenContentCarriesAnErrorMessage() {
+		// Arrange
+		const string serverErrorText = "System.NullReferenceException: Object reference not set to an instance of an object.";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = serverErrorText }]
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>(
+				because: "the server's unhandled-exception text is not JSON")
+			.WithMessage("*NullReferenceException*",
+				because: "the whole point of this diagnostic is that the payload's own error text must be visible in the thrown message, not discarded");
+	}
+
+	[Test]
+	[Description("Truncates a very long payload to the documented cap and reports the total original length, instead of flooding the CI log unbounded.")]
+	public void Extract_ShouldTruncatePayload_WhenTextContentIsVeryLong() {
+		// Arrange
+		string hugeText = new string('a', 10_000);
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [new TextContentBlock { Text = hugeText }]
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "the 10,000-character payload is not JSON")
+			.Which;
+		exception.Message.Length.Should().BeLessThan(hugeText.Length,
+			because: "the composed message must be capped rather than embedding the full 10,000-character payload");
+		exception.Message.Should().Contain("truncated",
+			because: "the cap must be explicit, not a silent cut");
+		exception.Message.Should().MatchRegex(@"… \d+ characters total, truncated to fit \d+$",
+			because: "the note must report both the kept and the original character count, not just say 'truncated'");
+		exception.Message.Length.Should().BeLessThanOrEqualTo(McpResultDiagnostics.PayloadDiagnosticLimit,
+			because: "the prefix is paid for out of the budget handed to Describe, so the COMPOSED message stays inside the cap instead of exceeding it and then reporting a second, meaningless total");
+	}
+
+	[Test]
+	[Description("Redacts an absolute file path embedded in the payload text before it is surfaced in the thrown message.")]
+	public void Extract_ShouldRedactSensitiveText_WhenPayloadCarriesAnAbsolutePath() {
+		// Arrange
+		const string sensitiveText = "Failed reading /Users/alex/secrets/credentials.json: invalid format";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = sensitiveText }]
+		};
+
+		// Act
+		Action act = () => EntitySchemaStructuredResultParser.Extract<SampleEnvelope>(callResult);
+
+		// Assert
+		InvalidOperationException exception = act.Should().Throw<InvalidOperationException>(
+				because: "the payload is not JSON")
+			.Which;
+		exception.Message.Should().NotContain("/Users/alex/secrets/credentials.json",
+			because: "an absolute path must be redacted before it reaches the thrown message, same as any other MCP-surfaced text");
+		exception.Message.Should().Contain("[redacted-path]",
+			because: "the redactor replaces an absolute path with its stable placeholder rather than dropping the whole message");
+	}
+}

--- a/clio.mcp.e2e/Support/Results/FindAvailableIisPortEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/FindAvailableIisPortEnvelope.cs
@@ -17,19 +17,20 @@ internal static class FindAvailableIisPortResultParser
 {
 	public static FindAvailableIisPortEnvelope Extract(CallToolResult callResult)
 	{
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelope(structuredContent, out FindAvailableIisPortEnvelope? structuredEnvelope))
+			TryExtractEnvelope(structuredContent, out FindAvailableIisPortEnvelope? structuredEnvelope, diagnostics))
 		{
 			return structuredEnvelope!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelope(content, out FindAvailableIisPortEnvelope? contentEnvelope))
+			TryExtractEnvelope(content, out FindAvailableIisPortEnvelope? contentEnvelope, diagnostics))
 		{
 			return contentEnvelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse find-empty-iis-port MCP result.");
+		throw new InvalidOperationException($"Could not parse find-empty-iis-port MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element)
@@ -44,9 +45,9 @@ internal static class FindAvailableIisPortResultParser
 		return true;
 	}
 
-	private static bool TryExtractEnvelope(JsonElement element, out FindAvailableIisPortEnvelope? envelope)
+	private static bool TryExtractEnvelope(JsonElement element, out FindAvailableIisPortEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
-		if (TryDeserialize(element, out envelope))
+		if (TryDeserialize(element, out envelope, diagnostics))
 		{
 			return true;
 		}
@@ -55,7 +56,7 @@ internal static class FindAvailableIisPortResultParser
 		{
 			foreach (JsonElement item in element.EnumerateArray())
 			{
-				if (TryDeserialize(item, out envelope))
+				if (TryDeserialize(item, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -65,8 +66,8 @@ internal static class FindAvailableIisPortResultParser
 					continue;
 				}
 
-				if (TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserialize(textPayloadElement, out envelope))
+				if (TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserialize(textPayloadElement, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -77,8 +78,8 @@ internal static class FindAvailableIisPortResultParser
 		{
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserialize(textPayloadElement, out envelope))
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserialize(textPayloadElement, out envelope, diagnostics))
 			{
 				return true;
 			}
@@ -88,8 +89,12 @@ internal static class FindAvailableIisPortResultParser
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out FindAvailableIisPortEnvelope? envelope)
+	private static bool TryDeserialize(JsonElement element, out FindAvailableIisPortEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try
 		{
 			envelope = JsonSerializer.Deserialize<FindAvailableIisPortEnvelope>(
@@ -102,8 +107,9 @@ internal static class FindAvailableIisPortResultParser
 				&& envelope.IisBoundPortCount >= 0
 				&& envelope.ActiveTcpPortCount >= 0;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			envelope = null;
 			return false;
 		}
@@ -127,15 +133,16 @@ internal static class FindAvailableIisPortResultParser
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element)
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics)
 	{
 		try
 		{
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/FsmModeStatusEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/FsmModeStatusEnvelope.cs
@@ -18,19 +18,20 @@ internal static class FsmModeStatusResultParser
 {
 	public static FsmModeStatusEnvelope Extract(CallToolResult callResult)
 	{
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtract(structuredContent, out FsmModeStatusEnvelope? structuredResult))
+			TryExtract(structuredContent, out FsmModeStatusEnvelope? structuredResult, diagnostics))
 		{
 			return structuredResult!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtract(content, out FsmModeStatusEnvelope? contentResult))
+			TryExtract(content, out FsmModeStatusEnvelope? contentResult, diagnostics))
 		{
 			return contentResult!;
 		}
 
-		throw new InvalidOperationException("Could not parse get-fsm-mode MCP result.");
+		throw new InvalidOperationException($"Could not parse get-fsm-mode MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element)
@@ -45,17 +46,17 @@ internal static class FsmModeStatusResultParser
 		return true;
 	}
 
-	private static bool TryExtract(JsonElement element, out FsmModeStatusEnvelope? status)
+	private static bool TryExtract(JsonElement element, out FsmModeStatusEnvelope? status, McpParseDiagnostics diagnostics)
 	{
-		if (TryDeserialize(element, out status))
+		if (TryDeserialize(element, out status, diagnostics))
 		{
 			return true;
 		}
 
 		if (TryGetTextPayload(element, out string? objectTextPayload) &&
 			!string.IsNullOrWhiteSpace(objectTextPayload) &&
-			TryParseJson(objectTextPayload, out JsonElement objectTextPayloadElement) &&
-			TryDeserialize(objectTextPayloadElement, out status))
+			TryParseJson(objectTextPayload, out JsonElement objectTextPayloadElement, diagnostics) &&
+			TryDeserialize(objectTextPayloadElement, out status, diagnostics))
 		{
 			return true;
 		}
@@ -64,7 +65,7 @@ internal static class FsmModeStatusResultParser
 		{
 			foreach (JsonElement item in element.EnumerateArray())
 			{
-				if (TryDeserialize(item, out status))
+				if (TryDeserialize(item, out status, diagnostics))
 				{
 					return true;
 				}
@@ -74,8 +75,8 @@ internal static class FsmModeStatusResultParser
 					continue;
 				}
 
-				if (TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserialize(textPayloadElement, out status))
+				if (TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserialize(textPayloadElement, out status, diagnostics))
 				{
 					return true;
 				}
@@ -86,7 +87,7 @@ internal static class FsmModeStatusResultParser
 		{
 			foreach (JsonProperty property in element.EnumerateObject())
 			{
-				if (TryExtract(property.Value, out status))
+				if (TryExtract(property.Value, out status, diagnostics))
 				{
 					return true;
 				}
@@ -97,8 +98,8 @@ internal static class FsmModeStatusResultParser
 		{
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserialize(textPayloadElement, out status))
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserialize(textPayloadElement, out status, diagnostics))
 			{
 				return true;
 			}
@@ -108,8 +109,12 @@ internal static class FsmModeStatusResultParser
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out FsmModeStatusEnvelope? status)
+	private static bool TryDeserialize(JsonElement element, out FsmModeStatusEnvelope? status, McpParseDiagnostics diagnostics)
 	{
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try
 		{
 			status = JsonSerializer.Deserialize<FsmModeStatusEnvelope>(
@@ -119,8 +124,9 @@ internal static class FsmModeStatusResultParser
 				!string.IsNullOrWhiteSpace(status.EnvironmentName) &&
 				!string.IsNullOrWhiteSpace(status.Mode);
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			status = null;
 			return false;
 		}
@@ -144,15 +150,16 @@ internal static class FsmModeStatusResultParser
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element)
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics)
 	{
 		try
 		{
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/GetPkgListEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/GetPkgListEnvelope.cs
@@ -24,17 +24,18 @@ internal static class GetPkgListResultParser {
 	}
 
 	public static GetPkgListResponseEnvelope ExtractResponse(CallToolResult callResult) {
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractResponse(structuredContent, out GetPkgListResponseEnvelope? structuredResponse)) {
+			TryExtractResponse(structuredContent, out GetPkgListResponseEnvelope? structuredResponse, diagnostics)) {
 			return structuredResponse!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractResponse(content, out GetPkgListResponseEnvelope? contentResponse)) {
+			TryExtractResponse(content, out GetPkgListResponseEnvelope? contentResponse, diagnostics)) {
 			return contentResponse!;
 		}
 
-		throw new InvalidOperationException("Could not parse list-packages MCP result.");
+		throw new InvalidOperationException($"Could not parse list-packages MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element) {
@@ -47,8 +48,8 @@ internal static class GetPkgListResultParser {
 		return true;
 	}
 
-	private static bool TryExtractResponse(JsonElement element, out GetPkgListResponseEnvelope? response) {
-		if (TryDeserializeResponse(element, out response)) {
+	private static bool TryExtractResponse(JsonElement element, out GetPkgListResponseEnvelope? response, McpParseDiagnostics diagnostics) {
+		if (TryDeserializeResponse(element, out response, diagnostics)) {
 			return true;
 		}
 
@@ -56,8 +57,8 @@ internal static class GetPkgListResultParser {
 			foreach (JsonElement item in element.EnumerateArray()) {
 				if (TryGetTextPayload(item, out string? textPayload) &&
 					!string.IsNullOrWhiteSpace(textPayload) &&
-					TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserializeResponse(textPayloadElement, out response)) {
+					TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserializeResponse(textPayloadElement, out response, diagnostics)) {
 					return true;
 				}
 			}
@@ -66,8 +67,8 @@ internal static class GetPkgListResultParser {
 		if (element.ValueKind == JsonValueKind.String) {
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserializeResponse(textPayloadElement, out response)) {
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserializeResponse(textPayloadElement, out response, diagnostics)) {
 				return true;
 			}
 		}
@@ -76,7 +77,11 @@ internal static class GetPkgListResultParser {
 		return false;
 	}
 
-	private static bool TryDeserializeResponse(JsonElement element, out GetPkgListResponseEnvelope? response) {
+	private static bool TryDeserializeResponse(JsonElement element, out GetPkgListResponseEnvelope? response, McpParseDiagnostics diagnostics) {
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try {
 			GetPkgListResponseEnvelope? parsed = JsonSerializer.Deserialize<GetPkgListResponseEnvelope>(
 				element.GetRawText(),
@@ -89,7 +94,8 @@ internal static class GetPkgListResultParser {
 			response = parsed;
 			return true;
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			response = null;
 			return false;
 		}
@@ -110,12 +116,13 @@ internal static class GetPkgListResultParser {
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element) {
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics) {
 		try {
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/GetProcessSignatureEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/GetProcessSignatureEnvelope.cs
@@ -23,17 +23,18 @@ internal sealed record GetProcessSignatureEnvelope(
 
 internal static class GetProcessSignatureResultParser {
 	public static GetProcessSignatureEnvelope Extract(CallToolResult callResult) {
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelope(structuredContent, out GetProcessSignatureEnvelope? structuredEnvelope)) {
+			TryExtractEnvelope(structuredContent, out GetProcessSignatureEnvelope? structuredEnvelope, diagnostics)) {
 			return structuredEnvelope!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelope(content, out GetProcessSignatureEnvelope? contentEnvelope)) {
+			TryExtractEnvelope(content, out GetProcessSignatureEnvelope? contentEnvelope, diagnostics)) {
 			return contentEnvelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse get-process-signature MCP result.");
+		throw new InvalidOperationException($"Could not parse get-process-signature MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element) {
@@ -46,8 +47,8 @@ internal static class GetProcessSignatureResultParser {
 		return true;
 	}
 
-	private static bool TryExtractEnvelope(JsonElement element, out GetProcessSignatureEnvelope? envelope) {
-		if (TryDeserialize(element, out envelope)) {
+	private static bool TryExtractEnvelope(JsonElement element, out GetProcessSignatureEnvelope? envelope, McpParseDiagnostics diagnostics) {
+		if (TryDeserialize(element, out envelope, diagnostics)) {
 			return true;
 		}
 
@@ -55,8 +56,8 @@ internal static class GetProcessSignatureResultParser {
 			foreach (JsonElement item in element.EnumerateArray()) {
 				if (TryGetTextPayload(item, out string? textPayload) &&
 					!string.IsNullOrWhiteSpace(textPayload) &&
-					TryParseJson(textPayload!, out JsonElement textPayloadElement) &&
-					TryDeserialize(textPayloadElement, out envelope)) {
+					TryParseJson(textPayload!, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserialize(textPayloadElement, out envelope, diagnostics)) {
 					return true;
 				}
 			}
@@ -65,8 +66,8 @@ internal static class GetProcessSignatureResultParser {
 		if (element.ValueKind == JsonValueKind.String) {
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload!, out JsonElement textPayloadElement) &&
-				TryDeserialize(textPayloadElement, out envelope)) {
+				TryParseJson(textPayload!, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserialize(textPayloadElement, out envelope, diagnostics)) {
 				return true;
 			}
 		}
@@ -75,7 +76,11 @@ internal static class GetProcessSignatureResultParser {
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out GetProcessSignatureEnvelope? envelope) {
+	private static bool TryDeserialize(JsonElement element, out GetProcessSignatureEnvelope? envelope, McpParseDiagnostics diagnostics) {
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try {
 			if (element.ValueKind != JsonValueKind.Object) {
 				envelope = null;
@@ -93,7 +98,8 @@ internal static class GetProcessSignatureResultParser {
 			envelope = item;
 			return true;
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			envelope = null;
 			return false;
 		}
@@ -114,12 +120,13 @@ internal static class GetProcessSignatureResultParser {
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element) {
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics) {
 		try {
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException) {
+		catch (JsonException exception) {
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/McpResultDiagnostics.cs
+++ b/clio.mcp.e2e/Support/Results/McpResultDiagnostics.cs
@@ -1,0 +1,440 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Clio.Command.McpServer;
+using Clio.Common;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E.Support.Results;
+
+/// <summary>
+/// Shared, redacted, bounded formatting of an MCP <see cref="CallToolResult"/> payload for embedding in
+/// parse-failure messages across every result parser in this folder. Extracted from
+/// <c>EntitySchemaStructuredResultParser</c> (GitHub issue #1384), whose <c>Extract</c> failure originally
+/// carried this diagnostic alone, so every sibling parser's bare "Could not parse ... MCP result." message
+/// can show what the tool actually returned — whether the call reported an error, the last
+/// <see cref="JsonException"/> encountered while trying to parse the payload, and the actual
+/// <c>StructuredContent</c>/<c>Content</c> — instead of leaving the failure undiagnosable.
+/// </summary>
+internal static partial class McpResultDiagnostics {
+    /// <summary>
+    /// Default maximum number of characters of the composed diagnostic text embedded in a parse-failure
+    /// message. Keeps a huge tool result from flooding CI logs while still showing its beginning, where
+    /// the diagnostic text (an auth rejection, an HTML login page, a serialized exception) actually lives.
+    /// A caller that prepends its own prefix passes a smaller budget, so the final message stays inside
+    /// this number rather than exceeding it by the prefix and then reporting a second, meaningless
+    /// "total".
+    /// </summary>
+    public const int PayloadDiagnosticLimit = 4_000;
+
+    /// <summary>
+    /// Maximum number of characters of a single RAW payload fragment handed to the redaction rules,
+    /// applied before they run rather than only after. Whatever is cut here is reported inline as
+    /// <c>…(+N more characters)</c>, so the true size of the payload is stated instead of being silently
+    /// dropped.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SensitiveErrorTextRedactor.Redact"/> runs ten or more backtracking scans, each with its
+    /// own one-second timeout, and on timeout it discards its whole input and returns the bare
+    /// <c>[redacted]</c> placeholder. A multi-megabyte tool result therefore did not merely take a long
+    /// time — it replaced the diagnostic this class exists to produce with a single placeholder, which is
+    /// exactly the blindness issue #1384 is about.
+    /// <para>
+    /// The cut boundary IS reachable in the rendered text: redaction SHRINKS its input (60 000 characters
+    /// of URIs collapse to a few thousand <c>[redacted-uri]</c> placeholders), so a fragment cut at this
+    /// limit can still end up inside the display budget. That is why both credential rules also match an
+    /// unterminated quoted value running to the end of the input — a secret sliced as
+    /// <c>…{"password":"s3c</c> would otherwise match neither rule, since both of the terminated forms
+    /// require the closing quote, and half a secret would ship.
+    /// </para>
+    /// </remarks>
+    public const int RawPayloadInputLimit = 64_000;
+
+    private const string RedactedValue = "[redacted]";
+
+    /// <summary>
+    /// The secret-key words this harness redacts, mirroring
+    /// <c>SensitiveErrorTextRedactor.CredentialPairRegex</c>'s own alternation. Kept <c>internal</c> so
+    /// <c>McpResultDiagnosticsTests</c> can compare it against the production pattern and fail when a key
+    /// is added there and not here.
+    /// </summary>
+    internal const string CredentialKeyCore =
+        @"password|pwd|pass|secret|token|api[_-]?key|client[_-]?secret|client[_-]?id|private[_-]?key|" +
+        @"access[_-]?key|connection ?string|data ?source|server|host|hostname|initial ?catalog|database|" +
+        @"uid|user ?id|authorization|auth|bearer|set-cookie|cookie|asp\.net_sessionid|aspxauth|bpmcsrf|" +
+        @"jsessionid|phpsessid|session[_-]?id|[xc]srf[_-]?token";
+
+    // Keys matched EXACTLY, with no prefix/suffix tolerance. They exist only so a secret nested one level
+    // deep under a secret key — {"token":{"value":"abc123"}} — is still redacted, since no regex here
+    // matches a balanced object as a value. Expanding them fuzzily would redact "defaultValue",
+    // "displayValue", "values" and most of a normal Creatio payload, which would cost more diagnostic
+    // signal than the nesting case is worth.
+    private const string ExactCredentialKeys = @"value|credentials|payload";
+
+    // The key as it is actually spelled in an OAuth or connection payload: access_token, refreshToken,
+    // idToken, dbPassword, clientId. Anchoring the alternation to the WHOLE quoted key matched none of
+    // them, and OAuth envelopes are a real path through this harness. The prefix/suffix classes exclude
+    // the quote character, so a match cannot run past the key.
+    //
+    // This over-redacts on purpose and the redactor's own policy says to: "tokenCount", "author",
+    // "guid" and "serverName" will read [redacted]. Over-redacting a field that only helps a reader is
+    // acceptable; leaking a credential into a build log everyone on the build can read is not.
+    private const string CredentialKeyPattern =
+        $@"[\w.-]*?(?:{CredentialKeyCore})[\w.-]*|{ExactCredentialKeys}";
+
+    /// <summary>
+    /// Characters held back from the content-block budget for the fields composed around it and for the
+    /// "N more blocks" tail, so neither is pushed past the display cap.
+    /// </summary>
+    private const int TailHeadroom = 200;
+
+    private const int RegexTimeoutMilliseconds = 1_000;
+
+    // A JSON-quoted credential property — "password": "s3cr3t" — which the production redactor does NOT
+    // reach: its CredentialPairRegex requires \b(key)\b\s*[=:], and the key's own CLOSING quote sits
+    // between the key and the colon, so the pair never matches. Measured against the shipped rules:
+    // Redact("{\"password\":\"s3cr3t\"}") returns that input verbatim.
+    //
+    // This post-pass is deliberately LOCAL to the e2e harness rather than a change to the production
+    // redactor: that file is being moved and edited by two open pull requests (#1473, #1493), and issue
+    // #1384 is a test-infrastructure change. The production gap is reported separately.
+    //
+    // The value alternation takes the terminated string first, then an UNTERMINATED one running to the
+    // end of the input (a secret sliced by RawPayloadInputLimit), then the bare JSON literals. The whole
+    // pair is rewritten in its JSON shape — "key":"[redacted]" — rather than the key=value shape the
+    // production rule uses, so the surrounding dump stays readable as JSON instead of losing a quote.
+    [GeneratedRegex(
+        $@"""(?<key>{CredentialKeyPattern})""\s*:\s*(?:""[^""]*""|""[^""]*\z|null|true|false|-?\d+(?:\.\d+)?)",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, RegexTimeoutMilliseconds)]
+    private static partial Regex JsonCredentialPropertyRegex();
+
+    // The escaped-quote spellings of a JSON quote, captured into a group so the replacement puts back the
+    // SAME form it found rather than mixing the two inside one document.
+    private const string EscapedQuote = @"\\""|\\u0022";
+
+    // The SAME pair after one level of JSON escaping. This is not a hypothetical shape — StructuredContent
+    // routinely holds a string property whose value is itself serialized JSON (a nested envelope, a tool's
+    // raw response body), and GetRawText() renders that inner document with every quote escaped, so the
+    // plain rule above (which requires a literal quote immediately after the key) matches nothing at all
+    // and the secret ships in the clear. BOTH escaped spellings are covered: a hand-written \"password\"
+    // and the "password" that System.Text.Json's default encoder actually emits — measured, not
+    // assumed: SerializeToElement(new { body = "{\"password\":\"s3cr3t\"}" }).GetRawText() produces the
+    // " form, so a rule that knew only the backslash-quote spelling redacted nothing at all.
+    [GeneratedRegex(
+        $@"(?<q>{EscapedQuote})(?<key>{CredentialKeyPattern})\k<q>\s*:\s*(?:\k<q>[^""]*?\k<q>|\k<q>[^""]*\z|null|true|false|-?\d+(?:\.\d+)?)",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase, RegexTimeoutMilliseconds)]
+    private static partial Regex EscapedJsonCredentialPropertyRegex();
+
+    /// <summary>
+    /// Describes an MCP tool result's payload for a parse-failure message: whether the call reported an
+    /// error (<c>IsError</c>), the last <see cref="JsonException"/> encountered while trying to parse the
+    /// payload (if the caller tracked one), and a redacted dump of both <c>StructuredContent</c> and every
+    /// <c>Content</c> block's <c>type</c> plus its <c>text</c> — or, for a block that carries no
+    /// <c>text</c> string at all (an image, an audio or an embedded-resource block), that block's own raw
+    /// JSON, so a non-text answer is named rather than silently skipped.
+    /// </summary>
+    /// <remarks>
+    /// The returned text is ALREADY redacted and already bounded to <paramref name="limit"/>. Bounding
+    /// happens here, not at the call sites, so a caller that forgets cannot flood a CI log; and because
+    /// every fragment is redacted BEFORE the composed text is capped, the cap can never cut a secret out
+    /// of a redaction rule's reach. A caller that prepends its own prefix passes a REDUCED
+    /// <paramref name="limit"/> instead of truncating the composed message a second time — truncating
+    /// twice made the length note report the already-truncated size rather than the payload's.
+    /// <para>
+    /// This method never throws. Composing a diagnostic runs serialization and ten timed regexes over
+    /// attacker-shaped input on a path whose whole job is to REPORT a failure, so an exception here would
+    /// replace the parse failure the caller is trying to explain with an unrelated one.
+    /// </para>
+    /// </remarks>
+    /// <param name="callResult">The tool result that could not be parsed, or <c>null</c> when none was available.</param>
+    /// <param name="lastJsonException">
+    /// The last <see cref="JsonException"/> raised while attempting to parse the payload, when the caller
+    /// tracks one. Pass <c>null</c> when no parse attempt ever raised one.
+    /// </param>
+    /// <param name="limit">Maximum characters of the returned text. Defaults to <see cref="PayloadDiagnosticLimit"/>.</param>
+    public static string Describe(
+        CallToolResult? callResult,
+        JsonException? lastJsonException = null,
+        int limit = PayloadDiagnosticLimit) {
+        if (callResult is null) {
+            return "(no result)";
+        }
+
+        try {
+            StringBuilder builder = new();
+            builder.Append("IsError=").Append(callResult.IsError.ToString());
+
+            if (lastJsonException is not null) {
+                builder.Append(" LastJsonError=\"")
+                    .Append(RedactBounded(lastJsonException.Message))
+                    .Append('"');
+            }
+
+            bool hasStructuredContent = TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent);
+            bool hasContent = TrySerializeToJsonElement(callResult.Content, out JsonElement content);
+
+            builder.Append(" StructuredContent=").Append(DescribePayload(hasStructuredContent ? structuredContent : null));
+            builder.Append(" Content=").Append(DescribeContentItems(hasContent ? content : null, limit));
+
+            return Truncate(builder.ToString(), limit);
+        }
+        catch (Exception exception) {
+            return $"(diagnostics unavailable: {exception.GetType().Name}: {SafeRedact(exception.Message)})";
+        }
+    }
+
+    /// <summary>
+    /// Describes an MCP tool result's payload, taking the last <see cref="JsonException"/> from the
+    /// diagnostics a parser accumulated while it tried every accepted shape.
+    /// </summary>
+    public static string Describe(
+        CallToolResult? callResult,
+        McpParseDiagnostics diagnostics,
+        int limit = PayloadDiagnosticLimit) =>
+        Describe(callResult, diagnostics.LastJsonException, limit);
+
+    /// <summary>
+    /// Truncates <paramref name="text"/> to <paramref name="limit"/> characters and states both the kept
+    /// and the original length, instead of embedding an unbounded tool result verbatim in an exception
+    /// message. The cut never splits a surrogate pair, so an emoji near the boundary cannot leave invalid
+    /// UTF-16 that breaks whatever serializes the message next.
+    /// </summary>
+    public static string Truncate(string text, int limit = PayloadDiagnosticLimit) {
+        if (limit <= 0) {
+            return string.Empty;
+        }
+
+        if (text.Length <= limit) {
+            return text;
+        }
+
+        // The note is part of the budget, not an addition to it: appending it AFTER cutting to the limit
+        // made the result limit + note characters, so a caller that subtracted its own prefix from the
+        // budget still overshot. The note's own text depends only on the original length and the budget,
+        // never on the kept count, so it can be measured before the cut.
+        string note = $" … {text.Length} characters total, truncated to fit {limit}";
+        return note.Length >= limit
+            ? note[..limit]
+            : TextUtilities.TruncateWithoutSplittingSurrogatePair(text, limit - note.Length) + note;
+    }
+
+    /// <summary>
+    /// Bounds a raw payload fragment, then redacts it with the production rules, then closes the
+    /// JSON-quoted credential gap those rules do not cover. Every string this class emits goes through
+    /// here — a payload dump reaches a TeamCity build log, readable by everyone who can see the build.
+    /// What the bound cut away is stated rather than dropped silently.
+    /// </summary>
+    private static string RedactBounded(string? rawText) {
+        if (string.IsNullOrEmpty(rawText)) {
+            return string.Empty;
+        }
+
+        if (rawText.Length <= RawPayloadInputLimit) {
+            return RedactJsonCredentialProperties(SensitiveErrorTextRedactor.Redact(rawText));
+        }
+
+        // The marker goes in FRONT. Appended after the fragment it was correct and useless: it sat sixty
+        // thousand characters into a four-thousand-character display budget, so the reader saw a cut
+        // fragment and no statement that anything had been cut.
+        string bounded = TextUtilities.TruncateWithoutSplittingSurrogatePair(rawText, RawPayloadInputLimit);
+        return $"…({rawText.Length} characters, first {bounded.Length} shown) "
+            + RedactJsonCredentialProperties(SensitiveErrorTextRedactor.Redact(bounded));
+    }
+
+    /// <summary>
+    /// Applies the two JSON-quoted credential rules on top of an already production-redacted text. The
+    /// escaped form runs first so the plain rule cannot match a fragment of it and leave a dangling
+    /// backslash behind. A regex timeout collapses the fragment to the placeholder rather than returning
+    /// text whose credential rules never finished running.
+    /// </summary>
+    private static string RedactJsonCredentialProperties(string text) =>
+        SensitiveErrorTextRedactor.ExecuteRegex(() => {
+            string result = EscapedJsonCredentialPropertyRegex().Replace(text, match => {
+                string quote = match.Groups["q"].Value;
+                return $"{quote}{match.Groups["key"].Value}{quote}:{quote}{RedactedValue}{quote}";
+            });
+            return JsonCredentialPropertyRegex().Replace(result,
+                match => $"\"{match.Groups["key"].Value}\":\"{RedactedValue}\"");
+        });
+
+    /// <summary>Redaction that cannot itself throw, for the last-resort message composed in a catch block.</summary>
+    private static string SafeRedact(string? text) {
+        try {
+            return RedactBounded(text);
+        }
+        catch (Exception) {
+            return RedactedValue;
+        }
+    }
+
+    private static string DescribePayload(JsonElement? element) {
+        if (element is null) {
+            return "(none)";
+        }
+
+        return RedactBounded(element.Value.GetRawText());
+    }
+
+    /// <summary>
+    /// Renders each content block's <c>type</c> and, when present, its <c>text</c>. A block that carries
+    /// no <c>text</c> string — an image, an audio or an embedded-resource block, or any shape this
+    /// harness does not know — is dumped as its own raw JSON instead of being reported as "(no text)",
+    /// which named the block's existence while discarding everything that said what the tool answered.
+    /// </summary>
+    /// <remarks>
+    /// The per-fragment bound is not enough on its own: five hundred blocks of a hundred kilobytes each
+    /// are five hundred fragments, so the builder would still reach tens of megabytes and pay ten timed
+    /// regex scans per block — on the path that is supposed to REPORT a failure quickly. Blocks are
+    /// therefore appended only while the rendered text stays under <paramref name="limit"/>, and the rest
+    /// are counted rather than rendered.
+    /// </remarks>
+    private static string DescribeContentItems(JsonElement? content, int limit) {
+        if (content is null) {
+            return "(none)";
+        }
+
+        JsonElement contentElement = content.Value;
+        if (contentElement.ValueKind != JsonValueKind.Array) {
+            return RedactBounded(contentElement.GetRawText());
+        }
+
+        // Headroom for the fields composed around this section and for the "more blocks" tail, so both
+        // stay inside the caller's budget and are actually READ. A tail that lands past the display cap
+        // is the same as no tail at all.
+        int blockBudget = Math.Max(limit - TailHeadroom, TailHeadroom);
+
+        StringBuilder builder = new();
+        builder.Append('[');
+        bool isFirst = true;
+        int skippedBlocks = 0;
+        foreach (JsonElement item in contentElement.EnumerateArray()) {
+            if (skippedBlocks > 0) {
+                skippedBlocks++;
+                continue;
+            }
+
+            StringBuilder itemBuilder = new();
+            AppendContentItem(itemBuilder, item);
+
+            // The FIRST block is always rendered even when it alone blows the budget: the outer cap and
+            // the fragment's own size marker already describe that case, and rendering nothing at all
+            // would leave the reader with no payload whatsoever - the failure this class exists to fix.
+            if (!isFirst && builder.Length + itemBuilder.Length > blockBudget) {
+                skippedBlocks = 1;
+                continue;
+            }
+
+            if (!isFirst) {
+                builder.Append(", ");
+            }
+
+            isFirst = false;
+            builder.Append(itemBuilder);
+        }
+
+        if (skippedBlocks > 0) {
+            builder.Append(", …, ").Append(skippedBlocks).Append(" more blocks");
+        }
+
+        builder.Append(']');
+        return builder.ToString();
+    }
+
+    private static void AppendContentItem(StringBuilder builder, JsonElement item) {
+        bool isObject = item.ValueKind == JsonValueKind.Object;
+
+        // The type is server-supplied text like everything else on this path, so it is redacted too
+        // rather than being trusted because the protocol says it should be a short enum-like word.
+        string itemType = isObject &&
+            item.TryGetProperty("type", out JsonElement typeElement) &&
+            typeElement.ValueKind == JsonValueKind.String
+                ? RedactBounded(typeElement.GetString() ?? "(unknown)")
+                : "(unknown)";
+
+        if (isObject &&
+            item.TryGetProperty("text", out JsonElement textElement) &&
+            textElement.ValueKind == JsonValueKind.String) {
+            builder.Append("{type=").Append(itemType)
+                .Append(", text=\"").Append(RedactBounded(textElement.GetString())).Append("\"}");
+            return;
+        }
+
+        // No text string: show the block itself rather than the fact that it had none. An image or
+        // embedded-resource block, or a shape this harness has not seen, is exactly the case the bare
+        // "(no text)" made undiagnosable.
+        builder.Append("{type=").Append(itemType)
+            .Append(", raw=").Append(RedactBounded(item.GetRawText())).Append('}');
+    }
+
+    private static bool TrySerializeToJsonElement(object? value, out JsonElement element) {
+        if (value is null) {
+            element = default;
+            return false;
+        }
+
+        element = JsonSerializer.SerializeToElement(value);
+        return true;
+    }
+}
+
+/// <summary>
+/// Accumulates what a result parser's parse attempt actually observed, so its failure message can name the
+/// mismatch precisely — and, above all, can name the last <see cref="JsonException"/> instead of
+/// discarding it inside a <c>catch (JsonException) { }</c> block (GitHub issue #1384). Shared by every
+/// parser in this folder, so there is one definition of "what did we see" rather than one per envelope.
+/// </summary>
+internal sealed class McpParseDiagnostics {
+    /// <summary>Whether any content item carried a non-blank <c>text</c> string.</summary>
+    public bool SawTextPayload { get; set; }
+
+    /// <summary>
+    /// Whether a well-formed JSON value of ANY kind was handed to a deserialize attempt — an array
+    /// included.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="SawValidJson"/> on purpose. The array-wrapper suppression below is about
+    /// whose exception to BLAME; it must not make the parser claim there was no JSON. Without this flag a
+    /// result whose StructuredContent is a JSON array reported "no structured content and no text content
+    /// at all" directly beside a dump of that very array.
+    /// </remarks>
+    public bool SawAnyJson { get; private set; }
+
+    /// <summary>Whether a JSON value that is a plausible candidate for the expected type was handed to a deserialize attempt.</summary>
+    public bool SawValidJson { get; private set; }
+
+    /// <summary>The last <see cref="JsonException"/> raised while parsing text as JSON or deserializing JSON as the expected type.</summary>
+    public JsonException? LastJsonException { get; private set; }
+
+    /// <summary>
+    /// Records that <paramref name="element"/> is about to be deserialized as the expected type, and
+    /// reports whether it is a MEANINGFUL candidate.
+    /// </summary>
+    /// <remarks>
+    /// A JSON array reaching a deserialize call is, for every envelope type in this folder that is not
+    /// itself array-shaped, the raw MCP content-item wrapper falling through (already unpacked, and known
+    /// not to match) rather than a genuine candidate. The attempt is still made — it is the only path
+    /// that could recognize a genuinely array-shaped type, and what counts as a successful parse must not
+    /// change — but its doomed exception must not be blamed for a mismatch the real payload caused.
+    /// The cost is deliberate and small: for the two list-returning parsers an array IS the expected
+    /// shape, so a genuine array-shaped mismatch there yields no <c>LastJsonError</c> — the payload dump,
+    /// which is what issue #1384 is actually about, still shows what came back.
+    /// </remarks>
+    public bool RecordDeserializeAttempt(JsonElement element) {
+        bool isMeaningfulJsonCandidate = element.ValueKind != JsonValueKind.Array;
+        // An EMPTY array is the "no content at all" case, not a payload: Content = [] serializes to [],
+        // and counting it as JSON would make an empty result claim a shape mismatch it never saw.
+        SawAnyJson |= isMeaningfulJsonCandidate || element.GetArrayLength() > 0;
+        if (isMeaningfulJsonCandidate) {
+            SawValidJson = true;
+        }
+
+        return isMeaningfulJsonCandidate;
+    }
+
+    /// <summary>Keeps <paramref name="exception"/> as the last parse failure, unless the attempt was the doomed array-wrapper one.</summary>
+    public void RecordJsonException(JsonException exception, bool isMeaningfulJsonCandidate = true) {
+        if (isMeaningfulJsonCandidate) {
+            LastJsonException = exception;
+        }
+    }
+}

--- a/clio.mcp.e2e/Support/Results/McpResultDiagnosticsTests.cs
+++ b/clio.mcp.e2e/Support/Results/McpResultDiagnosticsTests.cs
@@ -1,0 +1,550 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Clio.Command.McpServer;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E.Support.Results;
+
+/// <summary>
+/// Unit tests for <see cref="McpResultDiagnostics"/> (GitHub issue #1384), the payload-describing helper
+/// shared by <see cref="EntitySchemaStructuredResultParser"/> and every sibling result parser in this
+/// folder. They construct <see cref="CallToolResult"/> instances in-memory (no MCP server, no stand, no
+/// network I/O), so they are categorized <c>Unit</c> rather than <c>McpE2E.Sandbox</c>.
+/// </summary>
+[TestFixture]
+[Category("Unit")]
+[Category("McpE2E.NoEnvironment")]
+[Property("Module", "McpServer")]
+public sealed class McpResultDiagnosticsTests {
+	[Test]
+	[Description("Describes a result with neither StructuredContent nor Content as IsError plus '(none)' for both payload fields.")]
+	public void Describe_ShouldReportNonePayloads_WhenResultIsEmpty() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = []
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("IsError=False",
+			because: "the call did not report an error");
+		description.Should().Contain("StructuredContent=(none)",
+			because: "no StructuredContent was present on the result");
+		description.Should().Contain("Content=(none)",
+			because: "an empty Content array carries no items to describe");
+	}
+
+	[Test]
+	[Description("Describes a text Content item by rendering its type and text verbatim.")]
+	public void Describe_ShouldRenderContentItem_WhenResultCarriesTextPayload() {
+		// Arrange
+		const string payloadText = "plain diagnostic text";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = payloadText }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("IsError=True",
+			because: "the call reported an error");
+		description.Should().Contain($"{{type=text, text=\"{payloadText}\"}}",
+			because: "the single text content item's type and text must both be rendered");
+	}
+
+	[Test]
+	[Description("Describes StructuredContent by dumping its raw serialized JSON.")]
+	public void Describe_ShouldRenderStructuredContent_WhenResultCarriesStructuredPayload() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [],
+			StructuredContent = JsonSerializer.SerializeToElement(new { code = 7 })
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("StructuredContent={\"code\":7}",
+			because: "the structured payload's raw JSON must be embedded so the actual shape mismatch is visible");
+	}
+
+	[Test]
+	[Description("Redacts an absolute file path embedded in a Content item's text.")]
+	public void Describe_ShouldRedactSensitiveText_WhenContentCarriesAnAbsolutePath() {
+		// Arrange
+		const string sensitiveText = "Failed reading /Users/alex/secrets/credentials.json: invalid format";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = sensitiveText }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("/Users/alex/secrets/credentials.json",
+			because: "an absolute path must be redacted before it reaches the diagnostic text");
+		description.Should().Contain("[redacted-path]",
+			because: "the redactor replaces an absolute path with its stable placeholder rather than dropping the whole message");
+	}
+
+	[Test]
+	[Description("Includes the last JsonException's redacted message and it is only appended when the caller supplies one.")]
+	public void Describe_ShouldIncludeLastJsonError_WhenCallerSuppliesOne() {
+		// Arrange
+		CallToolResult callResult = new() { IsError = false, Content = [] };
+		JsonException lastJsonException;
+		try {
+			JsonSerializer.Deserialize<int>("not-json");
+			throw new InvalidOperationException("Expected a JsonException to be thrown by the arrange step.");
+		}
+		catch (JsonException exception) {
+			lastJsonException = exception;
+		}
+
+		// Act
+		string descriptionWithException = McpResultDiagnostics.Describe(callResult, lastJsonException);
+		string descriptionWithoutException = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		descriptionWithException.Should().Contain("LastJsonError=",
+			because: "the caller supplied a JsonException, so its message must appear in the description");
+		descriptionWithoutException.Should().NotContain("LastJsonError=",
+			because: "no JsonException was supplied, so the description must not fabricate one");
+	}
+
+	[Test]
+	[Description("Truncates text longer than the documented cap and reports the total original length, instead of flooding the CI log unbounded.")]
+	public void Truncate_ShouldCapAndReportTotalLength_WhenTextExceedsTheLimit() {
+		// Arrange
+		string hugeText = new string('a', McpResultDiagnostics.PayloadDiagnosticLimit + 5_000);
+
+		// Act
+		string truncated = McpResultDiagnostics.Truncate(hugeText);
+
+		// Assert
+		truncated.Length.Should().BeLessThan(hugeText.Length,
+			because: "the truncated text must be capped rather than embedding the full original payload");
+		truncated.Should().EndWith(
+			$" … {hugeText.Length} characters total, truncated to fit {McpResultDiagnostics.PayloadDiagnosticLimit}",
+			because: "the note must state the EXACT original length; a regex on \\d+ accepted the number the double truncation used to produce, which described the already-cut text rather than the payload");
+		truncated.Length.Should().Be(McpResultDiagnostics.PayloadDiagnosticLimit,
+			because: "the note is paid for out of the budget, so the result lands ON the limit rather than overshooting it by the note's own length");
+	}
+
+	[Test]
+	[Description("Leaves text at or under the documented cap unchanged.")]
+	public void Truncate_ShouldReturnTextUnchanged_WhenTextIsAtOrUnderTheLimit() {
+		// Arrange
+		string shortText = new string('a', McpResultDiagnostics.PayloadDiagnosticLimit);
+
+		// Act
+		string result = McpResultDiagnostics.Truncate(shortText);
+
+		// Assert
+		result.Should().Be(shortText,
+			because: "text at exactly the cap must not be marked as truncated");
+	}
+
+	[Test]
+	[Description("Renders an HTML login page returned in a text block instead of collapsing it into a bare parse failure.")]
+	public void Describe_ShouldRenderHtmlLoginPage_WhenToolAnsweredWithASignInPage() {
+		// Arrange
+		const string loginPage =
+			"<!DOCTYPE html><html><head><title>Creatio</title></head>" +
+			"<body><form id=\"loginForm\"><h1>Sign in</h1></form></body></html>";
+		CallToolResult callResult = new() {
+			IsError = false,
+			Content = [new TextContentBlock { Text = loginPage }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("<!DOCTYPE html>",
+			because: "an authentication redirect answers with an HTML page, and recognizing it is the whole point of dumping the payload");
+		description.Should().Contain("Sign in",
+			because: "the page's own text must survive into the diagnostic so the reader sees it is a login page, not a shape mismatch");
+	}
+
+	[Test]
+	[Description("Renders a stderr-like blob returned in a text block verbatim rather than skipping it as unparsable.")]
+	public void Describe_ShouldRenderStderrBlob_WhenTextIsNeitherJsonNorHtml() {
+		// Arrange
+		const string stderrBlob =
+			"Unhandled exception. System.Net.Http.HttpRequestException: Connection refused\n" +
+			"   at Clio.Common.ApplicationClient.ExecutePostRequest(String url)";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = stderrBlob }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("HttpRequestException: Connection refused",
+			because: "a process's error output is a legitimate payload shape and must be shown, not discarded for not being JSON");
+		description.Should().Contain("IsError=True",
+			because: "the reader needs to know the call itself reported an error alongside the blob");
+	}
+
+	[Test]
+	[Description("Dumps a content block that carries no text string (an image block) as its own raw JSON instead of reporting only '(no text)'.")]
+	public void Describe_ShouldDumpRawBlock_WhenContentItemCarriesNoTextString() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [ImageContentBlock.FromBytes(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, "image/png")]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("{type=image",
+			because: "the block's declared type must still be named");
+		description.Should().Contain("image/png",
+			because: "a block with no text string must be dumped whole, since '(no text)' named the block's existence while discarding everything that said what came back");
+		description.Should().Contain("raw={",
+			because: "the block must be rendered as its own raw JSON object, which is the replacement for the placeholder that used to hide it");
+	}
+
+	[Test]
+	[Description("Redacts a JSON-quoted credential property in StructuredContent, which the production key=value redaction rule does not reach.")]
+	public void Describe_ShouldRedactJsonQuotedCredential_WhenStructuredContentCarriesAPassword() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [],
+			StructuredContent = JsonSerializer.SerializeToElement(new { login = "Supervisor", password = "s3cr3t-value" })
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("s3cr3t-value",
+			because: "an e2e payload dump reaches a TeamCity log readable by everyone who can see the build, so a credential must never appear in it");
+		description.Should().Contain("\"password\":\"[redacted]\"",
+			because: "the pair must be rewritten in its JSON shape so the surrounding dump stays readable rather than losing a quote");
+		description.Should().Contain("Supervisor",
+			because: "redaction is surgical: the non-secret fields that explain the failure must survive");
+	}
+
+	[Test]
+	[Description("Redacts a credential property that is nested one JSON-escaping level deep, as a serialized response body inside StructuredContent is.")]
+	public void Describe_ShouldRedactEscapedJsonCredential_WhenStructuredContentNestsSerializedJson() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [],
+			StructuredContent = JsonSerializer.SerializeToElement(
+				new { body = "{\"password\":\"s3cr3t-value\",\"code\":1}" })
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("s3cr3t-value",
+			because: "a response body carried as a string property is escaped, not plain, and the secret inside it leaks just as badly");
+	}
+
+	[Test]
+	[Description("Redacts a session cookie and a bearer token carried in a text block.")]
+	public void Describe_ShouldRedactCookieAndBearerToken_WhenTextBlockCarriesThem() {
+		// Arrange
+		const string secretText =
+			"Request rejected. Cookie: BPMCSRF=Zq19Lk; .ASPXAUTH=A1B2C3 Authorization: Bearer abc.def.ghi";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = secretText }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("Zq19Lk",
+			because: "a Creatio forms-auth cookie value IS the session, so it belongs in the same class as a password");
+		description.Should().NotContain("abc.def.ghi",
+			because: "a bearer token must not reach a build log");
+		description.Should().Contain("[redacted]",
+			because: "the secrets must be replaced with the stable placeholder rather than the whole message being dropped");
+	}
+
+	[Test]
+	[Description("Caps a multi-megabyte payload with an explicit marker and still shows the payload's beginning, rather than collapsing into a bare placeholder or flooding the log.")]
+	public void Describe_ShouldCapAndStillShowTheBeginning_WhenPayloadIsMultiMegabyte() {
+		// Arrange
+		const string leadingErrorText = "Access denied for user.";
+		string hugePayload = leadingErrorText + new string('x', 3_000_000);
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = hugePayload }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Length.Should().BeLessThan(McpResultDiagnostics.PayloadDiagnosticLimit + 200,
+			because: "a three-megabyte tool result must not reach a CI log, whether or not the caller remembered to truncate");
+		description.Should().Contain(
+			$"…({hugePayload.Length} characters, first {McpResultDiagnostics.RawPayloadInputLimit} shown)",
+			because: "the note must state the payload's EXACT size, not the size of the text left after cutting it");
+		description.Should().Contain(leadingErrorText,
+			because: "the beginning, where the error text lives, is exactly what must survive the cap");
+		description.Should().NotBe("[redacted]",
+			because: "bounding the raw text before the redaction rules run is what stops their one-second timeout from discarding the whole diagnostic");
+	}
+
+	[Test]
+	[Description("Redacts before capping, so a secret near the cap boundary cannot be cut out of a redaction rule's reach.")]
+	public void Describe_ShouldRedactBeforeCapping_WhenASecretSitsNearTheBoundary() {
+		// Arrange
+		string paddedSecret =
+			new string('p', McpResultDiagnostics.PayloadDiagnosticLimit - 40) + "{\"password\":\"s3cr3t-value\"}";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = paddedSecret }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("s3cr3t-value",
+			because: "capping a composed message that had not been redacted yet would let a secret straddle the boundary and survive");
+	}
+
+	[Test]
+	[Description("Redacts OAuth token keys in both snake_case and camelCase, which anchoring the rule to the whole quoted key missed entirely.")]
+	public void Describe_ShouldRedactOAuthTokenKeys_WhenStructuredContentCarriesATokenResponse() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [],
+			StructuredContent = JsonSerializer.SerializeToElement(new Dictionary<string, object?> {
+				["access_token"] = "opaque123",
+				["refresh_token"] = "r456",
+				["accessToken"] = "camel789",
+				["refreshToken"] = "camel012",
+				["idToken"] = "camel345",
+				["clientId"] = "client678",
+				["dbPassword"] = "db901",
+				["expires_in"] = 3600
+			})
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		foreach (string secret in new[] { "opaque123", "r456", "camel789", "camel012", "camel345", "client678", "db901" }) {
+			description.Should().NotContain(secret,
+				because: "an OAuth envelope spells its keys with a prefix or a suffix, so a rule anchored to the whole quoted key redacted none of them");
+		}
+
+		description.Should().Contain("3600",
+			because: "redaction is surgical: a non-secret field that explains the failure must survive");
+	}
+
+	[Test]
+	[Description("Redacts a secret nested one level under a secret key, which no rule here can match as a balanced object value.")]
+	public void Describe_ShouldRedactNestedSecret_WhenSecretKeyHoldsAnObject() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [],
+			StructuredContent = JsonSerializer.SerializeToElement(
+				new { token = new { value = "abc123" } })
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().NotContain("abc123",
+			because: "the outer key's value is an object no regex here matches, so the inner key has to carry the redaction instead");
+	}
+
+	[Test]
+	[Description("Redacts a credential written with literal backslash-quote escaping, the spelling a double-encoded body carries.")]
+	public void Describe_ShouldRedactBackslashQuotedCredential_WhenTextBlockIsDoubleEncodedJson() {
+		// Arrange
+		const string doubleEncodedBody = "{\"body\":\"{\\\"password\\\":\\\"s3cr3t-value\\\"}\"}";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = doubleEncodedBody }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("\\\"password\\\"",
+			because: "the arrange must actually carry the backslash-quote spelling, otherwise this test would prove nothing about that branch");
+		description.Should().NotContain("s3cr3t-value",
+			because: "a body that reaches the harness already double-encoded spells its quotes with a backslash rather than \\u0022");
+	}
+
+	[Test]
+	[Description("Redacts a credential whose closing quote was cut away by the raw input bound, instead of leaking the half that survived.")]
+	public void Describe_ShouldRedactUnterminatedSecret_WhenTheRawBoundCutsThroughIt() {
+		// Arrange
+		// The padding is URIs, not filler: redaction SHRINKS them (roughly 500 characters each collapse to
+		// "[redacted-uri]"), which is exactly why the raw-input boundary is reachable inside the display
+		// budget at all. Plain filler would push the cut point far past the display cap and the test would
+		// prove nothing.
+		string uriToken = "https://host.example.com/" + new string('a', 470) + " ";
+		StringBuilder padding = new();
+		while (padding.Length < McpResultDiagnostics.RawPayloadInputLimit - 20) {
+			padding.Append(uriToken);
+		}
+
+		string paddedSecret = padding.ToString()[..(McpResultDiagnostics.RawPayloadInputLimit - 20)]
+			+ "{\"password\":\"s3cr3t-value\"}";
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = [new TextContentBlock { Text = paddedSecret }]
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("\"password\":\"[redacted]\"",
+			because: "the unterminated value must be rewritten, proving the rule fired at all rather than the secret simply falling outside the window");
+		description.Should().NotContain("s3cr3t",
+			because: "the raw bound cuts before the value's closing quote, and a rule that requires that quote would have let the surviving half of the secret through");
+	}
+
+	[Test]
+	[Description("Stops rendering content blocks once the budget is spent and counts the rest, rather than building a multi-megabyte diagnostic out of many small blocks.")]
+	public void Describe_ShouldCountRemainingBlocks_WhenContentCarriesFarMoreThanTheBudget() {
+		// Arrange
+		ContentBlock[] blocks = [.. Enumerable.Range(0, 500)
+			.Select(index => new TextContentBlock { Text = new string('b', 1_000) + index })];
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = blocks
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().Contain("more blocks",
+			because: "the blocks past the budget must be counted, so the reader knows the dump is partial rather than complete");
+		description.Length.Should().BeLessThan(McpResultDiagnostics.PayloadDiagnosticLimit + 200,
+			because: "five hundred blocks of a kilobyte each must not each be redacted and appended on a failure-reporting path");
+	}
+
+	[Test]
+	[Description("Returns a diagnostics-unavailable note instead of throwing when describing the payload itself fails, so the original parse failure is never masked.")]
+	public void Describe_ShouldReportUnavailable_WhenSerializingThePayloadThrows() {
+		// Arrange
+		CallToolResult callResult = new() {
+			IsError = true,
+			Content = new ThrowingContentList()
+		};
+
+		// Act
+		string description = McpResultDiagnostics.Describe(callResult);
+
+		// Assert
+		description.Should().StartWith("(diagnostics unavailable:",
+			because: "this method composes the explanation of another failure, so it must never replace that failure with one of its own");
+		description.Should().MatchRegex(@"\(diagnostics unavailable: \w+Exception: ",
+			because: "naming the type of the failure is what makes an unavailable diagnostic actionable rather than merely silent");
+	}
+
+	[Test]
+	[Description("Does not leave a lone high surrogate when the cap falls inside a surrogate pair.")]
+	public void Truncate_ShouldNotSplitASurrogatePair_WhenTheCapFallsInsideOne() {
+		// Arrange: one leading char shifts the emoji run onto odd offsets, so the cut provably lands
+		// BETWEEN the two halves of one pair rather than happening to miss it.
+		const int limit = 60;
+		string emojiRun = "a" + string.Concat(Enumerable.Repeat("\U0001F600", 100));
+		string note = $" … {emojiRun.Length} characters total, truncated to fit {limit}";
+
+		// Act
+		string truncated = McpResultDiagnostics.Truncate(emojiRun, limit);
+
+		// Assert
+		string kept = truncated[..^note.Length];
+		kept.Length.Should().Be(limit - note.Length - 1,
+			because: "the cut fell inside a surrogate pair, so exactly one orphaned half must have been dropped - if it were not, this test would pass without testing anything");
+		char.IsHighSurrogate(kept[^1]).Should().BeFalse(
+			because: "a lone high surrogate is invalid UTF-16 and makes whatever serializes the message next throw instead of reporting the failure");
+	}
+
+	[Test]
+	[Description("Covers every secret key the production redactor knows, so a key added there cannot silently go unredacted here.")]
+	public void CredentialKeyCore_ShouldCoverEveryProductionCredentialKey() {
+		// Arrange
+		GeneratedRegexAttribute productionRule = typeof(SensitiveErrorTextRedactor)
+			.GetMethod("CredentialPairRegex", BindingFlags.NonPublic | BindingFlags.Static)!
+			.GetCustomAttribute<GeneratedRegexAttribute>()!;
+		string productionKeyAlternation = Regex.Match(productionRule.Pattern, @"\\b\((?<keys>[^)]*)\)\\b").Groups["keys"].Value;
+		string[] productionKeys = productionKeyAlternation.Split('|', StringSplitOptions.RemoveEmptyEntries);
+
+		// Act
+		string[] missingKeys = [.. productionKeys.Where(key => !McpResultDiagnostics.CredentialKeyCore.Contains(key, StringComparison.Ordinal))];
+
+		// Assert
+		productionKeys.Should().NotBeEmpty(
+			because: "the oracle is worthless if it silently extracts nothing from the production pattern");
+		missingKeys.Should().BeEmpty(
+			because: "this harness duplicates the production key list, so a key added to SensitiveErrorTextRedactor and not here would leak through the e2e payload dump unnoticed");
+	}
+
+	/// <summary>
+	/// A content collection whose enumeration throws, standing in for any payload whose serialization
+	/// fails on this path (a lazily materialized list, a cyclic graph, a throwing property getter).
+	/// </summary>
+	private sealed class ThrowingContentList : IList<ContentBlock> {
+		public ContentBlock this[int index] {
+			get => throw new NotSupportedException("Materializing the content blocks is not supported.");
+			set => throw new NotSupportedException("Materializing the content blocks is not supported.");
+		}
+
+		public int Count => 1;
+
+		public bool IsReadOnly => true;
+
+		public IEnumerator<ContentBlock> GetEnumerator() =>
+			throw new NotSupportedException("Materializing the content blocks is not supported.");
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public void Add(ContentBlock item) => throw new NotSupportedException();
+
+		public void Clear() => throw new NotSupportedException();
+
+		public bool Contains(ContentBlock item) => throw new NotSupportedException();
+
+		public void CopyTo(ContentBlock[] array, int arrayIndex) => throw new NotSupportedException();
+
+		public int IndexOf(ContentBlock item) => throw new NotSupportedException();
+
+		public void Insert(int index, ContentBlock item) => throw new NotSupportedException();
+
+		public bool Remove(ContentBlock item) => throw new NotSupportedException();
+
+		public void RemoveAt(int index) => throw new NotSupportedException();
+	}
+}

--- a/clio.mcp.e2e/Support/Results/ShowPassingInfrastructureEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/ShowPassingInfrastructureEnvelope.cs
@@ -64,19 +64,20 @@ internal static class ShowPassingInfrastructureResultParser
 {
 	public static ShowPassingInfrastructureEnvelope Extract(CallToolResult callResult)
 	{
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtractEnvelope(structuredContent, out ShowPassingInfrastructureEnvelope? structuredEnvelope))
+			TryExtractEnvelope(structuredContent, out ShowPassingInfrastructureEnvelope? structuredEnvelope, diagnostics))
 		{
 			return structuredEnvelope!;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtractEnvelope(content, out ShowPassingInfrastructureEnvelope? contentEnvelope))
+			TryExtractEnvelope(content, out ShowPassingInfrastructureEnvelope? contentEnvelope, diagnostics))
 		{
 			return contentEnvelope!;
 		}
 
-		throw new InvalidOperationException("Could not parse show-passing-infrastructure MCP result.");
+		throw new InvalidOperationException($"Could not parse show-passing-infrastructure MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element)
@@ -91,9 +92,9 @@ internal static class ShowPassingInfrastructureResultParser
 		return true;
 	}
 
-	private static bool TryExtractEnvelope(JsonElement element, out ShowPassingInfrastructureEnvelope? envelope)
+	private static bool TryExtractEnvelope(JsonElement element, out ShowPassingInfrastructureEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
-		if (TryDeserialize(element, out envelope))
+		if (TryDeserialize(element, out envelope, diagnostics))
 		{
 			return true;
 		}
@@ -102,7 +103,7 @@ internal static class ShowPassingInfrastructureResultParser
 		{
 			foreach (JsonElement item in element.EnumerateArray())
 			{
-				if (TryDeserialize(item, out envelope))
+				if (TryDeserialize(item, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -112,8 +113,8 @@ internal static class ShowPassingInfrastructureResultParser
 					continue;
 				}
 
-				if (TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryDeserialize(textPayloadElement, out envelope))
+				if (TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryDeserialize(textPayloadElement, out envelope, diagnostics))
 				{
 					return true;
 				}
@@ -124,8 +125,8 @@ internal static class ShowPassingInfrastructureResultParser
 		{
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryDeserialize(textPayloadElement, out envelope))
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryDeserialize(textPayloadElement, out envelope, diagnostics))
 			{
 				return true;
 			}
@@ -135,8 +136,12 @@ internal static class ShowPassingInfrastructureResultParser
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out ShowPassingInfrastructureEnvelope? envelope)
+	private static bool TryDeserialize(JsonElement element, out ShowPassingInfrastructureEnvelope? envelope, McpParseDiagnostics diagnostics)
 	{
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try
 		{
 			envelope = JsonSerializer.Deserialize<ShowPassingInfrastructureEnvelope>(
@@ -149,8 +154,9 @@ internal static class ShowPassingInfrastructureResultParser
 				envelope.Filesystem is not null &&
 				envelope.RecommendedByEngine is not null;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 			envelope = null;
 			return false;
 		}
@@ -174,15 +180,16 @@ internal static class ShowPassingInfrastructureResultParser
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element)
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics)
 	{
 		try
 		{
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}

--- a/clio.mcp.e2e/Support/Results/ShowWebAppListEnvelope.cs
+++ b/clio.mcp.e2e/Support/Results/ShowWebAppListEnvelope.cs
@@ -16,19 +16,20 @@ internal static class ShowWebAppListResultParser
 {
 	public static IReadOnlyList<ShowWebAppListEnvironmentEnvelope> Extract(CallToolResult callResult)
 	{
+		McpParseDiagnostics diagnostics = new();
 		if (TrySerializeToJsonElement(callResult.StructuredContent, out JsonElement structuredContent) &&
-			TryExtract(structuredContent, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> structuredResult))
+			TryExtract(structuredContent, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> structuredResult, diagnostics))
 		{
 			return structuredResult;
 		}
 
 		if (TrySerializeToJsonElement(callResult.Content, out JsonElement content) &&
-			TryExtract(content, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> contentResult))
+			TryExtract(content, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> contentResult, diagnostics))
 		{
 			return contentResult;
 		}
 
-		throw new InvalidOperationException("Could not parse show-webApp-list MCP result.");
+		throw new InvalidOperationException($"Could not parse show-webApp-list MCP result: {McpResultDiagnostics.Describe(callResult, diagnostics)}");
 	}
 
 	/// <summary>
@@ -47,7 +48,7 @@ internal static class ShowWebAppListResultParser
 			return content.GetRawText();
 		}
 
-		throw new InvalidOperationException("Could not read the show-webApp-list MCP result payload.");
+		throw new InvalidOperationException($"Could not read the show-webApp-list MCP result payload: {McpResultDiagnostics.Describe(callResult)}");
 	}
 
 	private static bool TrySerializeToJsonElement(object? value, out JsonElement element)
@@ -62,9 +63,9 @@ internal static class ShowWebAppListResultParser
 		return true;
 	}
 
-	private static bool TryExtract(JsonElement element, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments)
+	private static bool TryExtract(JsonElement element, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments, McpParseDiagnostics diagnostics)
 	{
-		if (TryDeserialize(element, out environments))
+		if (TryDeserialize(element, out environments, diagnostics))
 		{
 			return true;
 		}
@@ -73,7 +74,7 @@ internal static class ShowWebAppListResultParser
 		// read from appsettings.json at call time and a read problem travels as a warning next to it.
 		if (element.ValueKind == JsonValueKind.Object &&
 			element.TryGetProperty("environments", out JsonElement wrapped) &&
-			TryDeserialize(wrapped, out environments))
+			TryDeserialize(wrapped, out environments, diagnostics))
 		{
 			return true;
 		}
@@ -82,7 +83,7 @@ internal static class ShowWebAppListResultParser
 		{
 			foreach (JsonElement item in element.EnumerateArray())
 			{
-				if (TryDeserialize(item, out environments))
+				if (TryDeserialize(item, out environments, diagnostics))
 				{
 					return true;
 				}
@@ -92,8 +93,8 @@ internal static class ShowWebAppListResultParser
 					continue;
 				}
 
-				if (TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-					TryExtract(textPayloadElement, out environments))
+				if (TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+					TryExtract(textPayloadElement, out environments, diagnostics))
 				{
 					return true;
 				}
@@ -104,8 +105,8 @@ internal static class ShowWebAppListResultParser
 		{
 			string? textPayload = element.GetString();
 			if (!string.IsNullOrWhiteSpace(textPayload) &&
-				TryParseJson(textPayload, out JsonElement textPayloadElement) &&
-				TryExtract(textPayloadElement, out environments))
+				TryParseJson(textPayload, out JsonElement textPayloadElement, diagnostics) &&
+				TryExtract(textPayloadElement, out environments, diagnostics))
 			{
 				return true;
 			}
@@ -115,8 +116,12 @@ internal static class ShowWebAppListResultParser
 		return false;
 	}
 
-	private static bool TryDeserialize(JsonElement element, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments)
+	private static bool TryDeserialize(JsonElement element, out IReadOnlyList<ShowWebAppListEnvironmentEnvelope> environments, McpParseDiagnostics diagnostics)
 	{
+		// The array-wrapper rule lives in McpParseDiagnostics.RecordDeserializeAttempt: a bare MCP
+		// content-item array reaching this last-resort attempt must not be recorded as "JSON was present"
+		// nor contribute its always-doomed exception to the failure message.
+		bool isMeaningfulJsonCandidate = diagnostics.RecordDeserializeAttempt(element);
 		try
 		{
 			ShowWebAppListEnvironmentEnvelope[]? deserialized = JsonSerializer.Deserialize<ShowWebAppListEnvironmentEnvelope[]>(
@@ -131,8 +136,9 @@ internal static class ShowWebAppListResultParser
 				return true;
 			}
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception, isMeaningfulJsonCandidate);
 		}
 
 		environments = [];
@@ -157,15 +163,16 @@ internal static class ShowWebAppListResultParser
 		return false;
 	}
 
-	private static bool TryParseJson(string value, out JsonElement element)
+	private static bool TryParseJson(string value, out JsonElement element, McpParseDiagnostics diagnostics)
 	{
 		try
 		{
 			element = JsonSerializer.SerializeToElement(JsonSerializer.Deserialize<JsonElement>(value));
 			return true;
 		}
-		catch (JsonException)
+		catch (JsonException exception)
 		{
+			diagnostics.RecordJsonException(exception);
 			element = default;
 			return false;
 		}


### PR DESCRIPTION
🔗 **Issue:** [#1384](https://github.com/Advance-Technologies-Foundation/clio/issues/1384)

Test infrastructure only — every changed file is under `clio.mcp.e2e/**`; `git diff master -- clio/` is empty.

## What changed

Every MCP-result envelope parser under `clio.mcp.e2e/Support/Results/` (the `EntitySchema*` extractor and its eight siblings: Application, AssertInfrastructure, FindAvailableIisPort, FsmModeStatus, GetPkgList, GetProcessSignature, ShowPassingInfrastructure, ShowWebAppList) now fails with a message that carries the evidence instead of the bare `Could not parse <T> MCP result.`:

```
Could not parse list-packages MCP result: IsError=True LastJsonError="'M' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0." StructuredContent=(none) Content=[{type=text, text="MCP tool 'list-packages' failed: Unauthorized Supervisor for [redacted-uri] [clio-login kind=implicit …]"}]
```

- `McpResultDiagnostics.Describe` builds the dump: `IsError`, the last `JsonException` (kept by a shared `McpParseDiagnostics` instead of being swallowed; an array wrapper tried by the two list-returning parsers is not blamed), `StructuredContent`, every `Content` block's `type`/`text`, and the raw block JSON for non-text blocks.
- Safety pipeline, in this order: cap the raw payload (64 000 chars per fragment, with a per-block budget so many small blocks cannot build a multi-MB message) → production `SensitiveErrorTextRedactor.Redact` → an e2e-local JSON-credential post-pass (`"password":"…"`, `"access_token"`, `"refreshToken"`, `"clientId"`… — prefix/suffix-tolerant key match, `\"` and `"` escaped forms, unterminated value at the end of input) → bounded truncation that never splits a surrogate pair and charges the "… N characters total" note against the budget. `Describe` is wrapped so a failure inside the diagnostics can never mask the original parse failure. The production redactor misses the JSON property shape (`Redact("{\"password\":\"s3cr3t\"}")` returns the input verbatim, measured) — that is filed as #1497; the e2e post-pass is removed there once the production rule lands.
- A test oracle reflects the production `CredentialPairRegex` alternation and fails if a production key is missing from the e2e list.
- The inner `JsonException` attached to the thrown exception is a copy with a redacted message.
- `using Clio.Common;` added beside `using Clio.Command.McpServer;` so the files compile whichever of #1473 (redactor move) or this PR merges first.

## Tests

66 tests in `clio.mcp.e2e` tagged `[Category("Unit")]` + `[Category("McpE2E.NoEnvironment")]` (the documented no-environment lane selects positively on the latter): HTML login page, stderr blob, non-text block, wrong DTO shape with `$.Code`/`LineNumber` named, `IsError=true`, 3 MB payload capped without collapsing to `[redacted]`, secret cut at the 64 000 boundary, OAuth token keys, escaped JSON forms, cookie + bearer, nested secret object, throwing content enumeration, surrogate pair at the cut, 500-block budget, array-wrapper not blamed, exact truncation totals. `Validated: dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj --filter "Category=Unit"` — 66/66 on net10.0 and net8.0. `GenerateSourceCode_Should_Refuse_NonPositive_Timeout` already asserts the stable substring.

## Real boundary

Real clio MCP server against a throwaway `ts1-core-dev04` profile with a wrong password, `list-packages`: master's build → `Could not parse list-packages MCP result.`; this build → the message quoted above (URI redacted, `LastJsonError` names the actual reason).

## Review

- Pre-PR gate: single combined security + test-quality lens (test infrastructure). Fixed before opening: OAuth-style keys (`access_token`, `refreshToken`…) surviving both rules; fixtures missing the `McpE2E.NoEnvironment` category; double truncation misreporting the total; `Describe` able to throw and mask the parse failure; per-fragment cap allowing a multi-MB message; half a secret at the raw-cut boundary; a shape message contradicting its own dump; unredacted `type`; nested secret object; raw inner exception. Codex CLI review was started but did not finish within 45 min and was stopped.
- Docs reviewed, no update required (test infrastructure). MCP reviewed, no update required (no tool contract change). ClioRing compatibility reviewed, no Ring-consumed contract changed.

Follow-ups: #1497 (production JSON-credential redaction); `TransientPlatformConditionRetryGateTests` has the same `Unit`-only categorisation gap — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #1384
