### PR TITLE
Show installed toolkit versions in clio ver

### DIFF
--- a/clio.tests/Command/InfoCommandTests.cs
+++ b/clio.tests/Command/InfoCommandTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Clio.Command.McpServer.Knowledge;
 using Clio.Common;
+using Clio.Common.Skills;
 using Clio.Project.NuGet;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +29,7 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 	private readonly ILogger _logger = Substitute.For<ILogger>();
 	private InfoCommand _sut;
 	private readonly IInstalledKnowledgeVersions _knowledgeVersions = Substitute.For<IInstalledKnowledgeVersions>();
+	private readonly IInstalledToolkitVersions _toolkitVersions = Substitute.For<IInstalledToolkitVersions>();
 
 	#endregion
 
@@ -38,6 +40,7 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 		containerBuilder.AddSingleton(_bundledPackageCatalog);
 		containerBuilder.AddSingleton(_logger);
 		containerBuilder.AddSingleton(_knowledgeVersions);
+		containerBuilder.AddSingleton(_toolkitVersions);
 	}
 
 	#endregion
@@ -48,6 +51,7 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 	public void SetUp() {
 		_sut = Container.GetRequiredService<InfoCommand>();
 		_knowledgeVersions.Read().Returns(new Dictionary<string, string>());
+		_toolkitVersions.Read().Returns(new Dictionary<string, string>());
 	}
 
 	[TearDown]
@@ -55,6 +59,7 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 		_bundledPackageCatalog.ClearReceivedCalls();
 		_logger.ClearReceivedCalls();
 		_knowledgeVersions.ClearReceivedCalls();
+		_toolkitVersions.ClearReceivedCalls();
 	}
 
 	[Test]
@@ -152,8 +157,26 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 			.Contain("knowledge:   not installed or unavailable", because: "absence must not look like a current remote version");
 	}
 
+	[TestCase(false)]
+	[TestCase(true)]
+	[Description("Default and all output show per-agent toolkit versions and sanitize metadata.")]
+	public void Execute_ShouldReportToolkitVersions_WhenInstalled(bool all) {
+		// Arrange
+		_toolkitVersions.Read().Returns(new Dictionary<string, string> {
+			["codex"] = "1.10.0", ["claude"] = "1.9.0\nforged", ["cursor"] = "not installed"
+		});
+		// Act
+		int result = _sut.Execute(new InfoCommandOptions { All = all });
+		// Assert
+		result.Should().Be(0, because: "toolkit inspection is informational");
+		_logger.ReceivedCalls().Select(call => call.GetArguments()[0]).Should()
+			.Contain("toolkit (codex):   1.10.0", because: "the installed agent version must be visible")
+			.And.Contain("toolkit (cursor):   not installed", because: "missing installations must be explicit")
+			.And.NotContain("toolkit (claude):   1.9.0\nforged", because: "metadata cannot forge console lines");
+	}
+
 	[Test]
-	[Description("A component-specific version query does not inspect knowledge state.")]
+	[Description("A component-specific version query does not inspect knowledge or toolkit state.")]
 	public void Execute_ShouldSkipKnowledge_WhenOnlyClioIsRequested() {
 		// Arrange
 		InfoCommandOptions options = new() { Clio = true };
@@ -164,6 +187,7 @@ public class InfoCommandTests : BaseCommandTests<InfoCommandOptions> {
 		// Assert
 		result.Should().Be(0, because: "the existing component-specific output stays supported");
 		_knowledgeVersions.ReceivedCalls().Should().BeEmpty(because: "a clio-only query needs no knowledge I/O");
+		_toolkitVersions.ReceivedCalls().Should().BeEmpty(because: "a clio-only query needs no toolkit I/O");
 	}
 
 }

--- a/clio.tests/Common/Skills/InstalledToolkitVersionsTests.cs
+++ b/clio.tests/Common/Skills/InstalledToolkitVersionsTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using Clio.Common.Skills;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common.Skills;
+
+[TestFixture]
+[Category("Unit")]
+[Property("Module", "Common")]
+[NonParallelizable]
+public sealed class InstalledToolkitVersionsTests {
+	private MockFileSystem _files;
+	private ServiceProvider _provider;
+	private IInstalledToolkitVersions _sut;
+	private string _originalCodexHome;
+	private string _originalClaudeHome;
+	private static string Root => OperatingSystem.IsWindows() ? @"C:\home" : "/home";
+
+	[SetUp]
+	public void SetUp() {
+		_originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+		_originalClaudeHome = Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR");
+		Environment.SetEnvironmentVariable("CODEX_HOME", null);
+		Environment.SetEnvironmentVariable("CLAUDE_CONFIG_DIR", null);
+		ServiceCollection services = new();
+		services.AddSingleton<MockFileSystem>();
+		services.AddSingleton<System.IO.Abstractions.IFileSystem>(provider => provider.GetRequiredService<MockFileSystem>());
+		services.AddSingleton<Clio.Common.IFileSystem, Clio.Common.FileSystem>();
+		IUserHomeProvider home = Substitute.For<IUserHomeProvider>();
+		home.GetAgentHome(Arg.Any<string>()).Returns(call => Path.Combine(Root, "." + call.Arg<string>()));
+		services.AddSingleton(home);
+		services.AddSingleton<IInstalledToolkitVersions, InstalledToolkitVersions>();
+		_provider = services.BuildServiceProvider();
+		_files = _provider.GetRequiredService<MockFileSystem>();
+		_sut = _provider.GetRequiredService<IInstalledToolkitVersions>();
+	}
+
+	[TearDown]
+	public void TearDown() {
+		Environment.SetEnvironmentVariable("CODEX_HOME", _originalCodexHome);
+		Environment.SetEnvironmentVariable("CLAUDE_CONFIG_DIR", _originalClaudeHome);
+		_provider.Dispose();
+	}
+
+	[Test]
+	[Description("CODEX_HOME selects the same installation that the Codex CLI updates, even when the default home is stale.")]
+	public void Read_ShouldHonorCodexHome_WhenOverrideIsSet() {
+		// Arrange
+		const string relative = "plugins/cache/creatio/creatio-ai-app-development-toolkit/1.10.0/.codex-plugin/plugin.json";
+		AddManifest("codex", relative, "1.0.0");
+		string customHome = Path.Combine(Root, "custom-codex");
+		Environment.SetEnvironmentVariable("CODEX_HOME", customHome);
+		_files.AddFile(Path.Combine(customHome, relative), new MockFileData(JsonSerializer.Serialize(new {
+			name = ToolkitDistribution.PluginName, version = "2.0.0"
+		})));
+		// Act
+		var versions = _sut.Read();
+		// Assert
+		versions["codex"].Should().Be("2.0.0", because: "the custom installation is the one updated by the CLI");
+	}
+
+	[Test]
+	[Description("All four agents report absence on a clean home without invoking any external program.")]
+	public void Read_ShouldReportMissing_WhenNoToolkitIsInstalled() {
+		// Arrange / Act
+		IReadOnlyDictionary<string, string> versions = _sut.Read();
+		// Assert
+		versions.Should().HaveCount(4, because: "each supported agent has a visible status");
+		versions.Values.Should().OnlyContain(value => value == "not installed", because: "a clean home has no installed toolkit");
+	}
+
+	[TestCase("cursor", "plugins/local/creatio-ai-app-development-toolkit/.cursor-plugin/plugin.json")]
+	[TestCase("copilot", "installed-plugins/creatio/creatio-ai-app-development-toolkit/plugin.json")]
+	[TestCase("codex", "plugins/cache/creatio/creatio-ai-app-development-toolkit/1.10.0/.codex-plugin/plugin.json")]
+	[Description("Installed manifests supply the toolkit version independently of clio or cache directory names.")]
+	public void Read_ShouldReadManifestVersion_WhenAgentIsInstalled(string agent, string relative) {
+		// Arrange
+		AddManifest(agent, relative, "2.3.4-beta.1");
+		// Act
+		var versions = _sut.Read();
+		// Assert
+		versions[agent].Should().Be("2.3.4-beta.1", because: "only the installed manifest supplies the product version");
+	}
+
+	[TestCase("1.9.0", "1.10.0")]
+	[TestCase("1.10.0-beta.1", "1.10.0")]
+	[TestCase("1.10.0", "local")]
+	[Description("Codex selection follows semver ordering and gives local payloads priority over older caches.")]
+	public void Read_ShouldSelectActiveCodexPayload_WhenMultipleCachesExist(string older, string active) {
+		// Arrange
+		AddManifest("codex", $"plugins/cache/creatio/creatio-ai-app-development-toolkit/{older}/.codex-plugin/plugin.json", "1.0.0");
+		AddManifest("codex", $"plugins/cache/creatio/creatio-ai-app-development-toolkit/{active}/.codex-plugin/plugin.json", "2.0.0");
+		// Act
+		var versions = _sut.Read();
+		// Assert
+		versions["codex"].Should().Be("2.0.0", because: "stale cache entries must not become the reported active version");
+	}
+
+	[Test]
+	[Description("Claude user-scope registry data is used while project entries are excluded from global reporting.")]
+	public void Read_ShouldReportClaudeUserVersion_WhenRegistryContainsMultipleScopes() {
+		// Arrange
+		string installPath = Path.Combine(Root, ".claude", "installed");
+		_files.AddDirectory(installPath);
+		string registry = JsonSerializer.Serialize(new { plugins = new Dictionary<string, object> {
+			[ToolkitDistribution.PluginSource] = new[] {
+				new { scope = "project", version = "9.0.0", installPath },
+				new { scope = "user", version = "1.10.0", installPath }
+			}
+		} });
+		_files.AddFile(Path.Combine(Root, ".claude", "plugins", "installed_plugins.json"), new MockFileData(registry));
+		// Act
+		var versions = _sut.Read();
+		// Assert
+		versions["claude"].Should().Be("1.10.0", because: "update-toolkit manages global user installations");
+	}
+
+	[TestCase("{")]
+	[TestCase("[]")]
+	[TestCase("{\"name\":\"creatio-ai-app-development-toolkit\",\"version\":42}")]
+	[TestCase("{\"name\":\"other\",\"version\":\"1.0.0\"}")]
+	[Description("Malformed metadata is isolated to its agent and does not suppress valid sibling versions.")]
+	public void Read_ShouldIsolateInvalidMetadata_WhenManifestIsUnreadable(string json) {
+		// Arrange
+		_files.AddFile(Path.Combine(Root, ".cursor", "plugins/local/creatio-ai-app-development-toolkit/.cursor-plugin/plugin.json"), new MockFileData(json));
+		AddManifest("copilot", "installed-plugins/creatio/creatio-ai-app-development-toolkit/plugin.json", "3.0.0");
+		// Act
+		var versions = _sut.Read();
+		// Assert
+		versions["cursor"].Should().Be("unknown (metadata unavailable)", because: "unreadable metadata cannot establish a version");
+		versions["copilot"].Should().Be("3.0.0", because: "one agent's failure must not hide another agent");
+	}
+
+	private void AddManifest(string agent, string relative, string version) =>
+		_files.AddFile(Path.Combine(Root, "." + agent, relative), new MockFileData(JsonSerializer.Serialize(new {
+			name = ToolkitDistribution.PluginName, version
+		})));
+}

--- a/clio.tests/Common/Skills/InstalledToolkitVersionsTests.cs
+++ b/clio.tests/Common/Skills/InstalledToolkitVersionsTests.cs
@@ -78,6 +78,7 @@ public sealed class InstalledToolkitVersionsTests {
 
 	[TestCase("cursor", "plugins/local/creatio-ai-app-development-toolkit/.cursor-plugin/plugin.json")]
 	[TestCase("copilot", "installed-plugins/creatio/creatio-ai-app-development-toolkit/plugin.json")]
+	[TestCase("copilot", "installed-plugins/creatio/creatio-ai-app-development-toolkit/.github/plugin/plugin.json")]
 	[TestCase("codex", "plugins/cache/creatio/creatio-ai-app-development-toolkit/1.10.0/.codex-plugin/plugin.json")]
 	[Description("Installed manifests supply the toolkit version independently of clio or cache directory names.")]
 	public void Read_ShouldReadManifestVersion_WhenAgentIsInstalled(string agent, string relative) {

--- a/clio/Command/InfoCommand.cs
+++ b/clio/Command/InfoCommand.cs
@@ -1,4 +1,5 @@
 using Clio.Common;
+using Clio.Common.Skills;
 using Clio.Command.McpServer.Knowledge;
 using System.Collections.Generic;
 using Clio.Project.NuGet;
@@ -55,6 +56,7 @@ namespace Clio.Command
 		private readonly ILogger _logger;
 		private readonly IBundledPackageCatalog _bundledPackageCatalog;
 		private readonly IInstalledKnowledgeVersions _knowledgeVersions;
+		private readonly IInstalledToolkitVersions _toolkitVersions;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="InfoCommand"/> class.
@@ -64,14 +66,16 @@ namespace Clio.Command
 		/// Catalog answering what bundled-package version this clio distribution carries.
 		/// </param>
 		/// <param name="knowledgeVersions">Reader for locally installed knowledge bundle versions.</param>
+		/// <param name="toolkitVersions">Reader for locally installed toolkit versions per agent.</param>
 		public InfoCommand(ILogger logger, IBundledPackageCatalog bundledPackageCatalog,
-			IInstalledKnowledgeVersions knowledgeVersions)
+			IInstalledKnowledgeVersions knowledgeVersions, IInstalledToolkitVersions toolkitVersions)
         {
 			logger.CheckArgumentNull(nameof(logger));
 			bundledPackageCatalog.CheckArgumentNull(nameof(bundledPackageCatalog));
 			_logger = logger;
 			_bundledPackageCatalog = bundledPackageCatalog;
 			_knowledgeVersions = knowledgeVersions ?? throw new ArgumentNullException(nameof(knowledgeVersions));
+			_toolkitVersions = toolkitVersions ?? throw new ArgumentNullException(nameof(toolkitVersions));
 		}
 
 		// Reported from the archive rather than from a constant, so this line describes the bytes an install
@@ -123,6 +127,10 @@ namespace Clio.Command
 				// both read it from the archive.
 				_logger.WriteInfo($"process-builder:   {GetBundledProcessBuilderVersion()}");
 				WriteKnowledgeVersions();
+				foreach (KeyValuePair<string, string> toolkit in _toolkitVersions.Read()) {
+					_logger.WriteInfo($"toolkit ({TextUtilities.SanitizeForDisplay(toolkit.Key, maxLength: 128)}):   "
+						+ TextUtilities.SanitizeForDisplay(toolkit.Value, maxLength: 128));
+				}
 				_logger.WriteInfo($"dotnet:   {Environment.Version.ToString()}");
 				_logger.WriteInfo($"settings file path: {SettingsRepository.AppSettingsFile}");
 				return 0;

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -421,7 +421,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 <a id="get-version"></a>
 <a id="i"></a>
 <a id="ver"></a>
-- [`info`](docs/commands/info.md) - Show clio, cliogate, bundled process-builder, installed knowledge, and .NET runtime versions, `get-version`, `i`, `ver`
+- [`info`](docs/commands/info.md) - Show clio, cliogate, bundled process-builder, installed knowledge, toolkit per agent, and .NET runtime versions, `get-version`, `i`, `ver`
 <a id="install-sql-schema"></a>
 <a id="sql-schema-install"></a>
 <a id="execute-sql-schema"></a>

--- a/clio/Common/Skills/IInstalledToolkitVersions.cs
+++ b/clio/Common/Skills/IInstalledToolkitVersions.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Clio.Common.Skills;
+
+/// <summary>Reads toolkit versions from local coding-agent installations without running agent CLIs.</summary>
+public interface IInstalledToolkitVersions {
+	/// <summary>Returns a version or an explicit unavailable status for each supported agent.</summary>
+	IReadOnlyDictionary<string, string> Read();
+}

--- a/clio/Common/Skills/InstalledToolkitVersions.cs
+++ b/clio/Common/Skills/InstalledToolkitVersions.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Management.Automation;
+
+namespace Clio.Common.Skills;
+
+/// <summary>Reads the installed toolkit metadata owned by each supported coding agent.</summary>
+public sealed class InstalledToolkitVersions(IFileSystem fileSystem, IUserHomeProvider homeProvider)
+	: IInstalledToolkitVersions {
+	private const string Unknown = "unknown (metadata unavailable)";
+	private const string Missing = "not installed";
+	private const long MaximumMetadataBytes = 1024 * 1024;
+
+	/// <inheritdoc />
+	public IReadOnlyDictionary<string, string> Read() {
+		Dictionary<string, string> result = new(StringComparer.Ordinal);
+		foreach (string agent in new[] { "claude", "codex", "cursor", "copilot" }) {
+			try {
+				string home = GetAgentHome(agent);
+				result[agent] = agent switch {
+					"claude" => ReadClaude(home),
+					"codex" => ReadCodex(home),
+					"cursor" => ReadManifest(fileSystem.Combine(home, "plugins", "local", ToolkitDistribution.PluginName),
+						[".cursor-plugin/plugin.json", ".claude-plugin/plugin.json", "plugin.json"]),
+					_ => ReadManifest(fileSystem.Combine(home, "installed-plugins", ToolkitDistribution.MarketplaceName,
+						ToolkitDistribution.PluginName), ["plugin.json", ".claude-plugin/plugin.json"])
+				};
+			}
+			catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
+				or JsonException or InvalidOperationException or ArgumentException or System.Security.SecurityException) {
+				// Optional agent metadata must never prevent other component versions from being reported.
+				result[agent] = Unknown;
+			}
+		}
+		return result;
+	}
+
+	private string GetAgentHome(string agent) {
+		string variable = agent switch {
+			"codex" => "CODEX_HOME",
+			"claude" => "CLAUDE_CONFIG_DIR",
+			_ => null
+		};
+		string customHome = variable is null ? null : Environment.GetEnvironmentVariable(variable);
+		return string.IsNullOrWhiteSpace(customHome) ? homeProvider.GetAgentHome(agent) : fileSystem.GetFullPath(customHome);
+	}
+
+	private string ReadClaude(string home) {
+		string path = fileSystem.Combine(home, "plugins", "installed_plugins.json");
+		if (!fileSystem.ExistsFile(path)) {
+			return Missing;
+		}
+		using JsonDocument document = ReadJson(path);
+		if (!document.RootElement.TryGetProperty("plugins", out JsonElement plugins)) {
+			return Unknown;
+		}
+		if (!plugins.TryGetProperty(ToolkitDistribution.PluginSource, out JsonElement entries)) {
+			return Missing;
+		}
+		List<string> versions = [];
+		foreach (JsonElement entry in entries.EnumerateArray()) {
+			if (StringProperty(entry, "scope") == "user") {
+				string installPath = StringProperty(entry, "installPath");
+				versions.Add(!string.IsNullOrWhiteSpace(installPath) && fileSystem.ExistsDirectory(installPath)
+					? VersionProperty(entry) : Unknown);
+			}
+		}
+		return versions.Count == 0 ? Missing : string.Join(", ", versions.Distinct(StringComparer.Ordinal));
+	}
+
+	private string ReadCodex(string home) {
+		string root = fileSystem.Combine(home, "plugins", "cache", ToolkitDistribution.MarketplaceName,
+			ToolkitDistribution.PluginName);
+		if (!fileSystem.ExistsDirectory(root)) {
+			return Missing;
+		}
+		string[] directories = fileSystem.GetDirectories(root);
+		if (directories.Length == 0) {
+			return Missing;
+		}
+		// Codex prefers "local", otherwise the greatest cache version (semver, with ordinal fallback).
+		Array.Sort(directories, (left, right) => CompareCacheVersions(Path.GetFileName(left), Path.GetFileName(right)));
+		string active = directories.FirstOrDefault(path => Path.GetFileName(path) == "local") ?? directories[^1];
+		return ReadManifest(active, [".codex-plugin/plugin.json", ".claude-plugin/plugin.json", "plugin.json"]);
+	}
+
+	private static int CompareCacheVersions(string left, string right) {
+		if (SemanticVersion.TryParse(left, out SemanticVersion leftVersion)
+			&& SemanticVersion.TryParse(right, out SemanticVersion rightVersion)) {
+			return leftVersion.CompareTo(rightVersion);
+		}
+		return string.Compare(left, right, StringComparison.Ordinal);
+	}
+
+	private string ReadManifest(string root, string[] candidates) {
+		if (!fileSystem.ExistsDirectory(root)) {
+			return Missing;
+		}
+		foreach (string relative in candidates) {
+			string path = fileSystem.Combine(root, relative);
+			if (!fileSystem.ExistsFile(path)) {
+				continue;
+			}
+			using JsonDocument document = ReadJson(path);
+			return StringProperty(document.RootElement, "name") == ToolkitDistribution.PluginName
+				? VersionProperty(document.RootElement) : Unknown;
+		}
+		return Unknown;
+	}
+
+	private JsonDocument ReadJson(string path) {
+		if (fileSystem.GetFilesInfos(path).Length > MaximumMetadataBytes) {
+			throw new InvalidOperationException("Toolkit metadata exceeds the read limit.");
+		}
+		return JsonDocument.Parse(fileSystem.ReadAllText(path));
+	}
+
+	private static string VersionProperty(JsonElement element) {
+		string version = StringProperty(element, "version");
+		return string.IsNullOrWhiteSpace(version) ? Unknown : version;
+	}
+
+	private static string StringProperty(JsonElement element, string name) =>
+		element.TryGetProperty(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+			? value.GetString() : null;
+}

--- a/clio/Common/Skills/InstalledToolkitVersions.cs
+++ b/clio/Common/Skills/InstalledToolkitVersions.cs
@@ -12,6 +12,7 @@ public sealed class InstalledToolkitVersions(IFileSystem fileSystem, IUserHomePr
 	: IInstalledToolkitVersions {
 	private const string Unknown = "unknown (metadata unavailable)";
 	private const string Missing = "not installed";
+	private const string PluginsDirectory = "plugins";
 	private const long MaximumMetadataBytes = 1024 * 1024;
 
 	/// <inheritdoc />
@@ -23,10 +24,10 @@ public sealed class InstalledToolkitVersions(IFileSystem fileSystem, IUserHomePr
 				result[agent] = agent switch {
 					"claude" => ReadClaude(home),
 					"codex" => ReadCodex(home),
-					"cursor" => ReadManifest(fileSystem.Combine(home, "plugins", "local", ToolkitDistribution.PluginName),
+					"cursor" => ReadManifest(fileSystem.Combine(home, PluginsDirectory, "local", ToolkitDistribution.PluginName),
 						[".cursor-plugin/plugin.json", ".claude-plugin/plugin.json", "plugin.json"]),
 					_ => ReadManifest(fileSystem.Combine(home, "installed-plugins", ToolkitDistribution.MarketplaceName,
-						ToolkitDistribution.PluginName), ["plugin.json", ".claude-plugin/plugin.json"])
+						ToolkitDistribution.PluginName), ["plugin.json", ".github/plugin/plugin.json", ".github/plugin.json", ".claude-plugin/plugin.json"])
 				};
 			}
 			catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
@@ -49,30 +50,28 @@ public sealed class InstalledToolkitVersions(IFileSystem fileSystem, IUserHomePr
 	}
 
 	private string ReadClaude(string home) {
-		string path = fileSystem.Combine(home, "plugins", "installed_plugins.json");
+		string path = fileSystem.Combine(home, PluginsDirectory, "installed_plugins.json");
 		if (!fileSystem.ExistsFile(path)) {
 			return Missing;
 		}
 		using JsonDocument document = ReadJson(path);
-		if (!document.RootElement.TryGetProperty("plugins", out JsonElement plugins)) {
+		if (!document.RootElement.TryGetProperty(PluginsDirectory, out JsonElement plugins)) {
 			return Unknown;
 		}
 		if (!plugins.TryGetProperty(ToolkitDistribution.PluginSource, out JsonElement entries)) {
 			return Missing;
 		}
 		List<string> versions = [];
-		foreach (JsonElement entry in entries.EnumerateArray()) {
-			if (StringProperty(entry, "scope") == "user") {
-				string installPath = StringProperty(entry, "installPath");
-				versions.Add(!string.IsNullOrWhiteSpace(installPath) && fileSystem.ExistsDirectory(installPath)
-					? VersionProperty(entry) : Unknown);
-			}
+		foreach (JsonElement entry in entries.EnumerateArray().Where(entry => StringProperty(entry, "scope") == "user")) {
+			string installPath = StringProperty(entry, "installPath");
+			versions.Add(!string.IsNullOrWhiteSpace(installPath) && fileSystem.ExistsDirectory(installPath)
+				? VersionProperty(entry) : Unknown);
 		}
 		return versions.Count == 0 ? Missing : string.Join(", ", versions.Distinct(StringComparer.Ordinal));
 	}
 
 	private string ReadCodex(string home) {
-		string root = fileSystem.Combine(home, "plugins", "cache", ToolkitDistribution.MarketplaceName,
+		string root = fileSystem.Combine(home, PluginsDirectory, "cache", ToolkitDistribution.MarketplaceName,
 			ToolkitDistribution.PluginName);
 		if (!fileSystem.ExistsDirectory(root)) {
 			return Missing;

--- a/clio/docs/commands/info.md
+++ b/clio/docs/commands/info.md
@@ -16,7 +16,7 @@ clio i [OPTIONS]
 ## Description
 
 Displays version information for clio, cliogate, the bundled `CrtProcessBuilder`
-package, installed knowledge bundles, and the .NET runtime
+package, installed knowledge bundles, toolkit versions per coding agent, and the .NET runtime
 environment. By default (without options), displays all component versions
 and the path to the settings file.
 
@@ -70,6 +70,10 @@ clio:   8.0.1.97
 gate:   2.0.0.38
 process-builder:   1.0.0.0
 knowledge (creatio-curated):   1.14.10
+toolkit (claude):   1.10.0
+toolkit (codex):   1.10.0
+toolkit (cursor):   not installed
+toolkit (copilot):   not installed
 dotnet: 8.0.0
 settings file path: C:\Users\username\.clio\appsettings.json
 
@@ -77,6 +81,12 @@ Individual component output:
 clio:   8.0.1.97
 
 ## Notes
+
+- Toolkit versions are read locally for the global installations managed by `clio update-toolkit`:
+  Claude, Codex, Cursor, and Copilot. Each agent gets a separate line. Absent installations show
+  `not installed`; unreadable or missing version metadata shows `unknown (metadata unavailable)`.
+  No agent CLI or remote update check is run. Component-only options skip toolkit inspection.
+  `CODEX_HOME` and `CLAUDE_CONFIG_DIR` overrides are honored when set.
 
 - Knowledge versions are read from local installation records, including disabled sources, without
   checking publishers for updates. This reports GitHub Release and NuGet bundles; use `info-knowledge`

--- a/clio/help/en/info.txt
+++ b/clio/help/en/info.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 
 DESCRIPTION
     Displays version information for clio, cliogate, the bundled
-    CrtProcessBuilder package, installed knowledge bundles, and the .NET runtime
+    CrtProcessBuilder package, installed knowledge bundles, toolkit versions per agent, and the .NET runtime
     environment. By default (without options), displays all component versions 
     and the path to the settings file.
 
@@ -56,6 +56,10 @@ OUTPUT FORMAT
         gate:   2.0.0.38
         process-builder:   1.0.0.0
         knowledge (creatio-curated):   1.14.10
+        toolkit (claude):   1.10.0
+        toolkit (codex):   1.10.0
+        toolkit (cursor):   not installed
+        toolkit (copilot):   not installed
         dotnet: 8.0.0
         settings file path: C:\Users\username\.clio\appsettings.json
 
@@ -63,6 +67,11 @@ OUTPUT FORMAT
         clio:   8.0.1.97
 
 NOTES
+    - Toolkit versions are read locally for global Claude, Codex, Cursor and
+      Copilot installations. Missing installs show 'not installed'; unreadable
+      version metadata shows 'unknown (metadata unavailable)'. No agent CLI or
+      remote check is run. Component-only options skip toolkit inspection.
+      CODEX_HOME and CLAUDE_CONFIG_DIR overrides are honored when set.
     - Knowledge versions come from local installation records, including disabled
       GitHub Release/NuGet sources. Git checkouts use info-knowledge instead.
       No publisher update check is performed. Each installed source is

--- a/docs/knowledge/Common/toolkit-agent-installed-version-metadata.md
+++ b/docs/knowledge/Common/toolkit-agent-installed-version-metadata.md
@@ -1,0 +1,29 @@
+---
+description: toolkit agents record installed versions differently; Codex selects local first and otherwise the greatest cache version, while Claude global installs are user-scope registry entries
+applies-to:
+  - clio/Common/Skills/InstalledToolkitVersions.cs
+ticket: "#1500"
+date: 2026-09-12
+---
+
+**What is true** — Claude stores global toolkit entries in
+`plugins/installed_plugins.json` under the plugin source key with `scope: user`.
+Codex selects `local` first, otherwise the greatest cache version using semantic
+version comparison and ordinal fallback, then reads the selected plugin manifest.
+Copilot marketplace installations live under
+`installed-plugins/<marketplace>/<plugin>/`. Cursor's clio installer copies its
+runtime into `plugins/local/<plugin>/`.
+Codex and Claude CLI subprocesses inherit `CODEX_HOME` and `CLAUDE_CONFIG_DIR`;
+version inspection must honor these too or report a stale default installation.
+
+Sources: local Claude installed registry; [Codex store implementation](https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/store.rs);
+[Copilot configuration directory reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference).
+
+**Why it is this way** — each agent owns its installation format and release
+selection. The toolkit's product version belongs to installed metadata, not clio
+or a remote marketplace listing.
+
+**What breaks if you ignore it** — reporting the first cache directory can report
+an obsolete version after an update, and reporting a marketplace version can claim
+an update the user has not installed. Cache directory names may also be hashes
+rather than product versions; read the selected payload's manifest.

--- a/spec/toolkit-version/toolkit-version-adr.md
+++ b/spec/toolkit-version/toolkit-version-adr.md
@@ -1,0 +1,18 @@
+# Toolkit version reporting
+
+Issue: #1500. Decision: extend `info` (aliases `ver`, `get-version`, `i`) with one
+DI-resolved local metadata reader. Reuse the existing filesystem and user-home
+abstractions and interface auto-registration. No installer calls, network requests,
+new persisted state, or new command options are required.
+
+Read Claude's global user registry, Codex's selected cache manifest, Cursor's local
+plugin manifest, and Copilot's installed marketplace plugin manifest. Report each
+agent separately. Missing installations and unknown versions are explicit; an
+individual read failure does not prevent other component output. Sanitize values
+at the console boundary. Component-specific options perform no toolkit reads.
+
+Validation covers all four formats, stale Codex caches, malformed metadata,
+absence, and command output. The complete Common unit suite is required because
+the reader is under Common. Ring does not consume this command; no Ring protocol
+changes are involved. MCP has no dedicated `info` tool and needs no new tool for
+this human-facing local diagnostic.

--- a/spec/toolkit-version/toolkit-version-story.md
+++ b/spec/toolkit-version/toolkit-version-story.md
@@ -1,0 +1,15 @@
+# Show toolkit versions in clio ver
+
+Issue: #1500. Status: review.
+
+As a toolkit user, I can run `clio ver` after `clio update-toolkit` and see the
+version installed for each coding agent alongside existing component versions.
+
+Acceptance and validation:
+
+- [x] Default and `--all` output include per-agent toolkit information.
+- [x] Local metadata is authoritative; absence and unreadability are explicit.
+- [x] Component selectors and existing output remain supported.
+- [x] Unit coverage and a real CLI probe pass.
+- [x] Documentation and MCP/Ring compatibility reviews are complete.
+- [ ] Required reviews and delivery gates pass.


### PR DESCRIPTION
`clio ver` now shows the installed Creatio AI App Development Toolkit version separately for Claude, Codex, Cursor, and Copilot. For example, it reports `toolkit (codex):   1.10.0` after installation. Missing installations and unreadable version metadata receive explicit statuses without hiding other component versions.

The reader uses local agent metadata, honors Codex/Claude home overrides, and preserves existing component-only selectors. No agent CLI, installer, or remote version lookup is involved.

Closes #1500.

Validation:
- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit" -- NUnit.NumberOfTestWorkers=2`: 12,657 passed, 25 skipped.
- `dotnet build clio/clio.csproj -c Debug -m:1`: .NET 8/.NET 10 passed; no CLIO diagnostics in changed files (existing unrelated warnings remain).
- Real .NET 8 and .NET 10 `ver`, `ver --all`, and component-only CLI probes passed. Local Claude and Codex both report 1.10.0.
- Seven-lens parallel pre-PR review completed; the custom-home finding was fixed and rechecked. Final comprehensive seven-lens review completed with no findings. Claude review rev_7cf42c2303874b78 found no blocking defects; its advisory ordering recommendation was not adopted because selection must follow native Codex. Copilot native manifest path was independently verified and covered.

Docs updated together; wiki aliases and shipped templates reviewed, no changes required. MCP reviewed, no update required: `info` has no dedicated tool and `clio-run` dispatches registered tools, not arbitrary CLI verbs. No new MCP tool is needed for this local human-facing diagnostic. Matching guidance search found no affected article.

ClioRing compatibility reviewed, no Ring-consumed contract changed. Inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing/Services`, and `clio-ring/ClioRing.Desktop/actions.json`; the `info` action icon is unrelated to the CLI version command. No Ring test/AOT gate applies.
