### PR TITLE
docs: correct component registry fallback and local override guidance

### DIFF
--- a/clio/docs/commands/component-registry-refresh.md
+++ b/clio/docs/commands/component-registry-refresh.md
@@ -13,7 +13,7 @@ registry cache from the academy.creatio.com CDN.
 
 The component-registry-refresh command force-pulls one or more Freedom UI
 component-registry payloads from the academy.creatio.com CDN regardless of
-the 24-hour cache TTL applied by the MCP get-component-info tool. This is
+the five-minute registry cache TTL applied by the MCP get-component-info tool. This is
 useful when a user needs to pick up a newly published platform GA without
 waiting for the natural refresh window.
 
@@ -50,8 +50,8 @@ whose working directory is not your shell's, so a relative path is resolved agai
 a directory you did not choose and the override silently misses.
 
 When set, every `get-component-info` call reads the file directly and reports
-`source=local` — the CDN, the on-disk cache, and the embedded snapshot are all
-bypassed. The env variable is read on every call, so edits are visible to a
+`source=local` — the registry's on-disk cache and CDN tiers are bypassed.
+The env variable is read on every call, so edits are visible to a
 long-running `clio mcp serve` without restarting it.
 
 The override also covers the long-form documentation the registry points at.

--- a/clio/docs/commands/get-component-info.md
+++ b/clio/docs/commands/get-component-info.md
@@ -205,7 +205,7 @@ component-info
                                    stdout instead of JSON.
 
 --schema-type                      Component registry to query: 'web'
-                                   (default) or 'mobile'. Mobile ignores
+                                   (default) or 'mobile'. Both honor
                                    --version/--environment.
 ```
 

--- a/clio/docs/commands/get-component-info.md
+++ b/clio/docs/commands/get-component-info.md
@@ -61,9 +61,14 @@ that routes you to `--composite "Expanded list"` for the assembly recipe — an
 agent reaching for the human label still finds the composite instead of
 hand-building it. The closest-type shortlist is capped at 8 entries.
 
-The catalog is loaded through the CDN → file cache → embedded snapshot
-fallback chain (see `component-registry-refresh` for cache control). For
-local payload iteration, point `CLIO_COMPONENT_REGISTRY_LOCAL_FILE` at a
+The catalog is read from the file cache first, then fetched from the CDN on a
+cache miss. Stale cached registries are returned immediately and refreshed in
+the background. If the requested version is unavailable, clio tries `latest`
+through the same cache/CDN chain. If neither version is available, the lookup
+fails; there is no embedded snapshot fallback (see `component-registry-refresh`
+for cache control).
+
+For local payload iteration, point `CLIO_COMPONENT_REGISTRY_LOCAL_FILE` at a
 `ComponentRegistry.json` on disk — it short-circuits every other tier
 (`source=local`) and is re-read on every call. It also covers the long-form
 documentation: `references.docs[]` is resolved against that file's directory
@@ -86,9 +91,10 @@ chosen by:
 `--version` and `--environment` (or `--uri`) are mutually exclusive.
 
 Pass `--schema-type mobile` to query the mobile component registry instead
-of the default web one. The mobile catalog ships as static data inside
-clio.dll, has no CDN tier, and ignores `--version` / `--environment`; its
-responses omit `resolvedTargetVersion` and `resolvedFrom` accordingly.
+of the default web one. It uses the same cache/CDN lookup and version-resolution
+rules, with a separate mobile cache and `MobileComponentRegistry.json` payload.
+Use `CLIO_MOBILE_COMPONENT_REGISTRY_LOCAL_FILE` for a local mobile registry
+and its `mobile-docs/` tree.
 
 Output defaults to JSON (identical to the MCP tool's response shape,
 including the long-form `documentation` field built from any


### PR DESCRIPTION
The component registry articles still described an embedded fallback and a CDN-first lookup after those behaviors had been replaced. Correct the cache-first lookup, stale background refresh, requested-version/latest fallback and five-minute TTL. Align the mobile description and option note with the same shared lookup and version resolution.

PR #1390 already made local registry overrides cover sibling Markdown files and documented missing-file warnings. Preserve that behavior; #1362's original JSON-only limitation and required HTTP workaround are superseded.

Fixes #1362.

Validation: `git diff origin/master...HEAD --check` passed. Traced the documented behavior through ComponentRegistryClient.GetAsync, ComponentRegistryCacheStore.EntryTtl, ComponentRegistryDocsClient and ComponentInfoCommand. Only two Markdown articles changed, so no executable module tests or new tests are needed. Existing local-documentation unit/E2E coverage was inspected, not rerun.

Reviewed command index, aliases/anchors, templates and MCP instructions. The CLI help files for these two commands are absent; no new help surface is introduced. MCP reviewed, no update required. ClioRing compatibility reviewed, no Ring-consumed contract changed (inspected clio-ring/ClioRing.Ipc, clio-ring/ClioRing and clio-ring/ClioRing.Desktop/actions.json). No telemetry vocabulary or collector change.

Pre-PR full parallel agentic review covered quality/testing, security, performance/correctness, intent and KISS. The remaining mobile option-note contradiction was corrected; no blocking findings remain. Claude review skipped under the consultation skill's documentation-only exclusion. Final full parallel review passed on 6e607cec37483135fe59fa262165bed3ca05f286 with no findings. GitHub checks pending.

