### PR TITLE
Expose SQL result file exports through MCP

### DIFF
--- a/clio.mcp.e2e/ExecuteSqlScriptToolE2ETests.cs
+++ b/clio.mcp.e2e/ExecuteSqlScriptToolE2ETests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using Allure.Net.Commons;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Common;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>Real stdio SQL export tests against an explicitly configured disposable Creatio instance.</summary>
+// [AllureNUnit] is intentionally omitted. Sequential async MCP and file reads must not block continuations.
+[TestFixture]
+[AllureFeature(ExecuteSqlScriptTool.ToolName)]
+[Category("McpE2E.Sandbox")]
+[NonParallelizable]
+public sealed class ExecuteSqlScriptToolE2ETests : McpContractFixtureBase {
+	private string _environmentName = null!;
+
+	/// <inheritdoc />
+	private protected override void ConfigureMcpServerSettings(McpE2ESettings settings) {
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("Set McpE2E__AllowDestructiveMcpTests=true and configure a disposable SQL sandbox.");
+		}
+		_environmentName = settings.Sandbox.EnvironmentName!;
+		if (string.IsNullOrWhiteSpace(_environmentName)) {
+			throw new InvalidOperationException("McpE2E__Sandbox__EnvironmentName is required for SQL export validation.");
+		}
+	}
+
+	[TestCase("json", false, false)]
+	[TestCase("json", true, false)]
+	[TestCase("json", false, true)]
+	[TestCase("csv", false, false)]
+	[TestCase("xlsx", false, false)]
+	[Description("Exports a 200-character value through the real MCP process and reads the complete value from disk.")]
+	[AllureTag(ExecuteSqlScriptTool.ToolName)]
+	[AllureName("SQL file exports preserve long cell content")]
+	[AllureDescription("Runs a SELECT on the configured disposable Creatio instance through clio-run, exercising format, destination and silent options, and verifies the saved result.")]
+	public async Task Execute_ShouldPreserveFullValue_WhenExporting(string view, bool useInputFile, bool escapedText) {
+		// Arrange
+		await using ArrangeContext context = Arrange(TimeSpan.FromMinutes(3));
+		string directory = CreateFixtureDirectory("sql-export");
+		string destination = Path.Combine(directory, "result." + view);
+		string expected = new('X', 200);
+		if (escapedText) {
+			expected += "; \"quoted\"\nsecond line\\path";
+		}
+		string sql = $"SELECT '{expected}' AS value";
+		Dictionary<string, object?> args = new() {
+			["environment-name"] = _environmentName, ["view"] = view,
+			["destination-path"] = destination, ["silent"] = true
+		};
+		if (useInputFile) {
+			string input = Path.Combine(directory, "query.sql");
+			await File.WriteAllTextAsync(input, sql);
+			args["file"] = input;
+		} else {
+			args["script"] = sql;
+		}
+		IReadOnlyCollection<string> names = await context.Session.ListReachableToolNamesAsync(context.CancellationTokenSource.Token);
+		AllureApi.Step("Verify SQL tool discovery", () => names.Should().Contain(ExecuteSqlScriptTool.ToolName,
+			because: "the new tool must be discoverable through the MCP catalog"));
+
+		// Act
+		CallToolResult result = await AllureApi.Step("Execute SQL and export through MCP", async () =>
+			await context.Session.CallToolAsync(ExecuteSqlScriptTool.ToolName,
+				new Dictionary<string, object?> { ["args"] = args }, context.CancellationTokenSource.Token));
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(result);
+
+		// Assert
+		AllureApi.Step("Verify transport success", () => result.IsError.Should().NotBeTrue(
+			because: "export must complete without an MCP error"));
+		AllureApi.Step("Verify command success", () => execution.ExitCode.Should().Be(0,
+			because: "the SELECT and file export must succeed"));
+		AllureApi.Step("Verify informational completion", () => execution.Output.Should().Contain(
+			message => message.MessageType == LogDecoratorType.Info,
+			because: "silent mode retains the completion message"));
+		AllureApi.Step("Verify silent output omits the result body", () => execution.Output.Should().NotContain(
+			message => message.Value != null && message.Value.Contains(expected),
+			because: "a file export must not flood the MCP response with SQL input or result values"));
+		AllureApi.Step("Verify the saved path is returned", () => execution.Output.Should().Contain(
+			message => message.Value != null && message.Value.Contains(destination),
+			because: "the caller needs the artifact location for later inspection"));
+		AllureApi.Step("Verify destination exists", () => File.Exists(destination).Should().BeTrue(
+			because: "the destination is the durable result for later inspection"));
+		string value;
+		if (view == "xlsx") {
+			using SpreadsheetDocument workbook = SpreadsheetDocument.Open(destination, false);
+			value = workbook.WorkbookPart!.WorksheetParts.Single().Worksheet.Descendants<Row>()
+				.Skip(1).Single().Elements<Cell>().Single().CellValue!.Text;
+		} else if (view == "json") {
+			using JsonDocument document = JsonDocument.Parse(await File.ReadAllTextAsync(destination));
+			value = document.RootElement[0].GetProperty("value").GetString()!;
+		} else {
+			value = (await File.ReadAllLinesAsync(destination))[1];
+		}
+		AllureApi.Step("Verify all 200 characters survived export", () => value.Should().Be(expected,
+			because: "file results must bypass the 40-character table display limit"));
+	}
+
+	[TestCase("json")]
+	[TestCase("table")]
+	[TestCase("csv")]
+	[TestCase("xlsx")]
+	[Description("An empty query result overwrites an older destination instead of leaving stale rows behind.")]
+	[AllureTag(ExecuteSqlScriptTool.ToolName)]
+	[AllureName("Empty SQL exports replace stale results")]
+	[AllureDescription("Seeds an existing output file, executes a zero-row SELECT through the real MCP server, and reads back an empty result in each format.")]
+	public async Task Execute_ShouldOverwriteOldResult_WhenQueryReturnsNoRows(string view) {
+		// Arrange
+		await using ArrangeContext context = Arrange();
+		string destination = Path.Combine(CreateFixtureDirectory("sql-empty"), "result." + view);
+		await File.WriteAllTextAsync(destination, "[{\"value\":\"stale\"}]");
+
+		// Act
+		CallToolResult result = await context.Session.CallToolAsync(ExecuteSqlScriptTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+				["environment-name"] = _environmentName, ["script"] = "SELECT 1 AS value WHERE 1 = 0",
+				["view"] = view, ["destination-path"] = destination, ["silent"] = true
+			}}, context.CancellationTokenSource.Token);
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(result);
+
+		// Assert
+		AllureApi.Step("Verify empty query succeeds", () => execution.ExitCode.Should().Be(0,
+			because: "zero rows is a successful query"));
+		if (view == "xlsx") {
+			using SpreadsheetDocument workbook = SpreadsheetDocument.Open(destination, false);
+			AllureApi.Step("Verify workbook has no data rows", () => workbook.WorkbookPart!.WorksheetParts.Single()
+				.Worksheet.Descendants<Row>().Skip(1).Should().BeEmpty(
+					because: "the new empty workbook must replace previous content"));
+		} else {
+			string content = await File.ReadAllTextAsync(destination);
+			AllureApi.Step("Verify stale rows were replaced", () => content.Trim().Should().Be(view == "json" ? "[]" : "",
+				because: "the exported result must describe this query, not the previous one"));
+		}
+	}
+
+	[TestCase("csv")]
+	[TestCase("xlsx")]
+	[Description("Rejects an export with no destination over real MCP before SQL can execute.")]
+	[AllureTag(ExecuteSqlScriptTool.ToolName)]
+	[AllureName("SQL export requires a destination")]
+	[AllureDescription("Uses an invalid environment to prove missing destination validation precedes environment resolution and SQL execution.")]
+	public async Task Execute_ShouldRejectMissingDestination_WhenFormatRequiresFile(string view) {
+		// Arrange
+		await using ArrangeContext context = Arrange();
+
+		// Act
+		CallToolResult result = await context.Session.CallToolAsync(ExecuteSqlScriptTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+				["environment-name"] = "missing-sql-export-environment", ["script"] = "SELECT 1", ["view"] = view
+			}}, context.CancellationTokenSource.Token);
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(result);
+
+		// Assert
+		AllureApi.Step("Verify validation failure", () => execution.ExitCode.Should().Be(1,
+			because: "a missing destination is an actionable input error"));
+		AllureApi.Step("Verify destination diagnostic", () => execution.Output.Should().Contain(
+			message => message.MessageType == LogDecoratorType.Error && message.Value!.Contains("destination-path"),
+			because: "the validation error must be returned before environment resolution"));
+	}
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("SQL and output-file failures remain visible in silent mode and never report a completed export.")]
+	[AllureTag(ExecuteSqlScriptTool.ToolName)]
+	[AllureName("SQL exports report execution failures")]
+	[AllureDescription("Exercises an invalid SQL query and a missing destination directory on the disposable instance, asserting failure and no output file.")]
+	public async Task Execute_ShouldReportFailure_WhenSqlOrDestinationIsInvalid(bool invalidSql) {
+		// Arrange
+		await using ArrangeContext context = Arrange();
+		string directory = CreateFixtureDirectory("sql-failure");
+		string destination = invalidSql ? Path.Combine(directory, "result.json")
+			: Path.Combine(directory, "missing", "result.json");
+
+		// Act
+		CallToolResult result = await context.Session.CallToolAsync(ExecuteSqlScriptTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = new Dictionary<string, object?> {
+				["environment-name"] = _environmentName,
+				["script"] = invalidSql ? "SELECT FROM" : "SELECT 1 AS value",
+				["view"] = "json", ["destination-path"] = destination, ["silent"] = true
+			}}, context.CancellationTokenSource.Token);
+		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(result);
+
+		// Assert
+		AllureApi.Step("Verify failure exit code", () => execution.ExitCode.Should().Be(1,
+			because: "SQL and file failures cannot count as successful exports"));
+		AllureApi.Step("Verify error remains visible", () => execution.Output.Should().Contain(
+			message => message.MessageType == LogDecoratorType.Error,
+			because: "silent mode suppresses results, not failures"));
+		AllureApi.Step("Verify no output file was created", () => File.Exists(destination).Should().BeFalse(
+			because: "failed queries and invalid destinations must not produce a successful-looking file"));
+	}
+}

--- a/clio.tests/Command/McpServer/ExecuteSqlScriptToolTests.cs
+++ b/clio.tests/Command/McpServer/ExecuteSqlScriptToolTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Clio.Command.McpServer.Tools;
+using Clio.Command.SqlScriptCommand;
+using Clio.Common;
+using FluentAssertions;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Command.McpServer;
+
+/// <summary>Contract and per-environment mapping tests for SQL exports.</summary>
+[Property("Module", "McpServer")]
+public sealed class ExecuteSqlScriptToolTests : BaseClioModuleTests {
+	private IToolCommandResolver _resolver;
+	private SqlScriptCommand _resolved;
+	private ExecuteSqlScriptTool _tool;
+
+	protected override void AdditionalRegistrations(IServiceCollection services) {
+		_resolver = Substitute.For<IToolCommandResolver>();
+		_resolved = Substitute.For<SqlScriptCommand>(Substitute.For<IApplicationClient>(),
+			EnvironmentSettings, Substitute.For<ISqlScriptExecutor>(), Substitute.For<ILogger>());
+		_resolver.Resolve<SqlScriptCommand>(Arg.Any<EnvironmentOptions>()).Returns(_resolved);
+		_resolver.Resolve<IRequiredPackageChecker>(Arg.Any<EnvironmentOptions>())
+			.Returns(Substitute.For<IRequiredPackageChecker>());
+		services.AddSingleton(_resolver);
+		services.AddTransient<ExecuteSqlScriptTool>();
+	}
+
+	public override void Setup() {
+		base.Setup();
+		_tool = Container.GetRequiredService<ExecuteSqlScriptTool>();
+	}
+
+	public override void TearDown() {
+		_resolver.ClearReceivedCalls();
+		_resolved.ClearReceivedCalls();
+		base.TearDown();
+	}
+
+	[TestCase(null, null, false)]
+	[TestCase("table", "result.txt", false)]
+	[TestCase("json", null, false)]
+	[TestCase("json", "result.json", true)]
+	[TestCase("csv", "result.csv", true)]
+	[TestCase("xlsx", "result.xlsx", true)]
+	[TestCase("JSON", "result.json", false)]
+	[Description("Maps format, destination and silent options into a command resolved for the requested environment.")]
+	public void Execute_ShouldMapOptions_WhenRequestIsValid(string view, string destination, bool silent) {
+		// Arrange
+		ExecuteSqlScriptArgs args = new("sql-env", Script: "SELECT 1", View: view,
+			DestinationPath: destination, Silent: silent);
+
+		// Act
+		CommandExecutionResult result = _tool.Execute(args);
+
+		// Assert
+		result.ExitCode.Should().Be(0, because: "the environment-scoped command succeeds");
+		ExecuteSqlScriptOptions options = _resolved.ReceivedCalls().Single(call =>
+			call.GetMethodInfo().Name == nameof(SqlScriptCommand.Execute)).GetArguments()[0]
+			as ExecuteSqlScriptOptions;
+		options.Should().BeEquivalentTo(new ExecuteSqlScriptOptions {
+			Environment = "sql-env", Script = "SELECT 1", ViewType = view?.ToLowerInvariant() ?? "table",
+			DestPath = destination, IsSilent = silent
+		}, because: "every output option must reach the resolved command without CLI parser defaults");
+	}
+
+	[TestCase(null)]
+	[TestCase(" ")]
+	[Description("Maps a SQL input file while preserving default table output and non-silent execution.")]
+	public void Execute_ShouldMapFile_WhenScriptIsOmitted(string script) {
+		// Arrange
+		ExecuteSqlScriptArgs args = new("sql-env", Script: script, File: "query.sql");
+
+		// Act
+		CommandExecutionResult result = _tool.Execute(args);
+
+		// Assert
+		result.ExitCode.Should().Be(0, because: "a file is a supported alternative SQL input");
+		_resolved.ReceivedCalls().Should().ContainSingle(call => call.GetArguments().OfType<ExecuteSqlScriptOptions>()
+			.Any(options => options.File == "query.sql" && options.Script == null && options.ViewType == "table"
+				&& !options.IsSilent), because: "file input and omitted output defaults must be forwarded");
+	}
+
+	[TestCase(null, null, "table", null, "script or file")]
+	[TestCase("SELECT 1", "query.sql", "json", null, "script or file")]
+	[TestCase("SELECT 1", null, "yaml", null, "view")]
+	[TestCase("SELECT 1", null, "csv", null, "destination-path")]
+	[TestCase("SELECT 1", null, "xlsx", " ", "destination-path")]
+	[Description("Rejects ambiguous or incomplete arguments before command resolution or SQL execution.")]
+	public void Execute_ShouldRejectBeforeResolution_WhenArgumentsAreInvalid(
+		string script, string file, string view, string destination, string diagnostic) {
+		// Arrange
+		ExecuteSqlScriptArgs args = new("sql-env", script, file, view, destination);
+
+		// Act
+		CommandExecutionResult result = _tool.Execute(args);
+
+		// Assert
+		result.ExitCode.Should().Be(1, because: "invalid arguments are actionable input errors");
+		result.Output.Should().Contain(message => message is ErrorMessage && message.Value.ToString().Contains(diagnostic),
+			because: "the result must name the invalid argument");
+		_resolver.ReceivedCalls().Should().BeEmpty(because: "invalid output options must never reach Creatio");
+	}
+
+	[Test]
+	[Description("Advertises SQL execution as destructive with a clear 40-character display limit and full-file export guidance.")]
+	public void Execute_ShouldAdvertiseSafetyAndExportGuidance_WhenDiscovered() {
+		// Arrange
+		MethodInfo method = typeof(ExecuteSqlScriptTool).GetMethod(nameof(ExecuteSqlScriptTool.Execute));
+
+		// Act
+		McpServerToolAttribute annotation = method.GetCustomAttribute<McpServerToolAttribute>();
+		string description = method.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>().Description;
+
+		// Assert
+		annotation.Name.Should().Be(ExecuteSqlScriptTool.ToolName, because: "discovery uses the stable tool name");
+		annotation.Destructive.Should().BeTrue(because: "arbitrary SQL and file exports can change data");
+		annotation.ReadOnly.Should().BeFalse(because: "the tool accepts more than SELECT queries");
+		annotation.Idempotent.Should().BeFalse(because: "repeating SQL can apply a write twice");
+		description.Should().ContainAll(["40", "destination-path", "view=json", "silent=true"],
+			because: "agents need the complete-content export route before executing");
+	}
+}

--- a/clio.tests/Command/McpServer/PassthroughToolClassificationRegistry.cs
+++ b/clio.tests/Command/McpServer/PassthroughToolClassificationRegistry.cs
@@ -303,6 +303,8 @@ internal static class PassthroughToolClassificationRegistry {
 			["find-entity-schema"] = PassthroughClassification.NotApplicable,
 			["finish-hotfix"] = PassthroughClassification.NotApplicable,
 			["generate-process-model"] = PassthroughClassification.NotApplicable,
+			// Uses the existing environment-scoped BaseTool resolver; outside the original passthrough audit.
+			[ExecuteSqlScriptTool.ToolName] = PassthroughClassification.NotApplicable,
 			["generate-source-code"] = PassthroughClassification.NotApplicable,
 			["get-browser-session"] = PassthroughClassification.NotApplicable,
 			["get-classic-list-columns"] = PassthroughClassification.NotApplicable,

--- a/clio.tests/Command/SqlScriptCommandTests.cs
+++ b/clio.tests/Command/SqlScriptCommandTests.cs
@@ -55,8 +55,7 @@ public class SqlScriptCommandTests : BaseCommandTests<ExecuteSqlScriptOptions> {
 
 	[TestCase("table", null)]
 	[TestCase("json", null)]
-	[TestCase("csv", "result.csv")]
-	[Description("Table and JSON still allow no destination, and CSV accepts a supplied destination.")]
+	[Description("Table and JSON allow execution without a destination file.")]
 	public void Execute_ShouldExecuteSql_WhenOutputOptionsAreValid(string view, string destination) {
 		// Arrange
 		var options = new ExecuteSqlScriptOptions {
@@ -73,5 +72,59 @@ public class SqlScriptCommandTests : BaseCommandTests<ExecuteSqlScriptOptions> {
 		_executor.ReceivedCalls().Should().ContainSingle(because: "SQL must execute exactly once");
 		_logger.ReceivedCalls().Select(call => call.GetArguments().FirstOrDefault()).Should()
 			.Equal(new object[] { "Done" }, because: "silent successful execution retains its completion message");
+	}
+
+	[Test]
+	[Description("Reports SQL server errors as failures instead of a successful Done message, including silent exports.")]
+	public void Execute_ShouldReturnFailure_WhenServerReportsSqlError() {
+		// Arrange
+		ExecuteSqlScriptOptions options = new() { Script = "invalid SQL", ViewType = "json", IsSilent = true };
+		_executor.Execute(options.Script, Arg.Any<IApplicationClient>(), Arg.Any<EnvironmentSettings>())
+			.Returns("ExecuteSQL ERROR: invalid query");
+
+		// Act
+		int exitCode = _sut.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(1, because: "SQL errors must not be reported as successful exports");
+		_logger.ReceivedCalls().Should().ContainSingle(call => call.GetMethodInfo().Name == nameof(ILogger.WriteError)
+			&& (string)call.GetArguments()[0] == "invalid query", because: "silent mode must retain the actionable error");
+		_logger.ReceivedCalls().Should().NotContain(call => call.GetArguments().Contains("Done"),
+			because: "failure must never include a success marker");
+	}
+
+	[TestCase("<html>Service unavailable</html>")]
+	[TestCase("{\"success\":false}")]
+	[Description("Rejects malformed or unexpected JSON export responses instead of reporting successful SQL execution.")]
+	public void Execute_ShouldRejectResponse_WhenJsonResultIsNotRowsOrCount(string response) {
+		// Arrange
+		ExecuteSqlScriptOptions options = new() { Script = "SELECT 1", ViewType = "json", IsSilent = true };
+		_executor.Execute(options.Script, Arg.Any<IApplicationClient>(), Arg.Any<EnvironmentSettings>()).Returns(response);
+
+		// Act
+		int exitCode = _sut.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(1, because: "an error page or unexpected object is not a SQL result");
+		_logger.ReceivedCalls().Should().ContainSingle(call => call.GetMethodInfo().Name == nameof(ILogger.WriteError),
+			because: "silent mode must not hide response validation errors");
+	}
+
+	[TestCase("table")]
+	[TestCase("csv")]
+	[TestCase("xlsx")]
+	[Description("Rejects a non-JSON affected-row-count export instead of reporting success without writing the requested file.")]
+	public void Execute_ShouldRejectCountExport_WhenFormatIsNotJson(string view) {
+		// Arrange
+		ExecuteSqlScriptOptions options = new() { Script = "UPDATE example", ViewType = view, DestPath = "unused", IsSilent = true };
+		_executor.Execute(options.Script, Arg.Any<IApplicationClient>(), Arg.Any<EnvironmentSettings>()).Returns("3");
+
+		// Act
+		int exitCode = _sut.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(1, because: "non-JSON count responses cannot satisfy the requested file format");
+		_logger.ReceivedCalls().Should().ContainSingle(call => call.GetMethodInfo().Name == nameof(ILogger.WriteError)
+			&& call.GetArguments()[0].ToString().Contains("-v json"), because: "the error must identify the supported count format");
 	}
 }

--- a/clio.tests/Common/SqlScriptExecutorTests.cs
+++ b/clio.tests/Common/SqlScriptExecutorTests.cs
@@ -1,0 +1,65 @@
+using Clio.Common;
+using Clio.Tests.Command;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+/// <summary>Guards SQL response decoding against changing JSON cell values.</summary>
+[Property("Module", "Common")]
+public sealed class SqlScriptExecutorTests : BaseClioModuleTests {
+	private IApplicationClient _client;
+	private ISqlScriptExecutor _executor;
+
+	protected override void AdditionalRegistrations(IServiceCollection services) {
+		_client = Substitute.For<IApplicationClient>();
+		services.AddSingleton(_client);
+	}
+
+	public override void Setup() {
+		base.Setup();
+		_executor = Container.GetRequiredService<ISqlScriptExecutor>();
+	}
+
+	public override void TearDown() {
+		_client.ClearReceivedCalls();
+		base.TearDown();
+	}
+
+	[TestCase(true)]
+	[TestCase(false)]
+	[Description("Preserves quotes, Unicode, newlines, tabs and backslashes inside JSON cell values with either transport shape.")]
+	public void Execute_ShouldPreserveJsonContent_WhenResponseContainsEscapes(bool wrapped) {
+		// Arrange
+		string expected = JsonConvert.SerializeObject(new[] { new { value = new string('X', 200) + "\"quoted\"\r\n\t\\path Привіт" } });
+		_client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>())
+			.Returns(wrapped ? JsonConvert.SerializeObject(expected) : expected);
+
+		// Act
+		string response = _executor.Execute("SELECT 1", _client, EnvironmentSettings);
+
+		// Assert
+		response.Should().Be(expected, because: "only the transport string should be decoded; inner JSON escapes are data");
+	}
+
+	[TestCase("[]", true)]
+	[TestCase("3", true)]
+	[TestCase("ExecuteSQL ERROR: invalid query", true)]
+	[TestCase("[]", false)]
+	[TestCase("3", false)]
+	[TestCase("ExecuteSQL ERROR: invalid query", false)]
+	[Description("Preserves empty results, row counts and errors in both wrapped and direct transport responses.")]
+	public void Execute_ShouldPreserveResult_WhenResponseIsNotARowSet(string expected, bool wrapped) {
+		// Arrange
+		_client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>())
+			.Returns(wrapped ? JsonConvert.SerializeObject(expected) : expected);
+
+		// Act
+		string response = _executor.Execute("SELECT 1", _client, EnvironmentSettings);
+
+		// Assert
+		response.Should().Be(expected, because: "error and count handling belongs to the command without transport changes");
+	}
+}

--- a/clio/Command/McpServer/Tools/ExecuteSqlScriptTool.cs
+++ b/clio/Command/McpServer/Tools/ExecuteSqlScriptTool.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Clio.Command.SqlScriptCommand;
+using Clio.Common;
+using ModelContextProtocol.Server;
+
+namespace Clio.Command.McpServer.Tools;
+
+/// <summary>Exposes SQL execution and existing result-file formats through MCP.</summary>
+[McpServerToolType]
+public sealed class ExecuteSqlScriptTool(
+	SqlScriptCommand.SqlScriptCommand command,
+	ILogger logger,
+	IToolCommandResolver commandResolver)
+	: BaseTool<ExecuteSqlScriptOptions>(command, logger, commandResolver) {
+
+	internal const string ToolName = "execute-sql-script";
+
+	/// <summary>Executes explicit SQL in the requested environment and optionally exports its result.</summary>
+	/// <param name="args">SQL input, environment, and output options.</param>
+	/// <returns>The command exit code and execution log.</returns>
+	[McpServerTool(Name = ToolName, ReadOnly = false, Destructive = true, Idempotent = false, OpenWorld = false)]
+	[McpToolExecution(
+		Location = McpToolExecutionLocation.Worker,
+		Lifetime = McpToolExecutionLifetime.PerCall,
+		OperationFamily = McpToolOperationFamily.None,
+		BudgetPolicy = McpToolBudgetPolicy.ParentKillDefault,
+		RequiresClientRequests = McpToolClientRequests.None,
+		SharedFileResource = McpToolSharedFileResource.None)]
+	[Description("Executes SQL through ClioGate in the specified Creatio environment. SQL can modify or delete data. Table output limits each displayed cell line to 40 characters and wraps longer values; do not use it to extract full cell content. For full content, set view=json (recommended), csv, or xlsx and destination-path to an output file on the MCP server host. Set silent=true to avoid returning the result body in the MCP response. Saving view=table retains the display formatting. Requires ClioGate 2.0.0.41 or later.")]
+	public CommandExecutionResult Execute([Required] ExecuteSqlScriptArgs args) {
+		if (args is null || string.IsNullOrWhiteSpace(args.EnvironmentName)) {
+			return CommandExecutionResult.FromValidationError("environment-name is required.");
+		}
+		if (string.IsNullOrWhiteSpace(args.Script) == string.IsNullOrWhiteSpace(args.File)) {
+			return CommandExecutionResult.FromValidationError("Provide exactly one of script or file.");
+		}
+		string view = (args.View ?? "table").ToLowerInvariant();
+		if (view is not ("table" or "json" or "csv" or "xlsx")) {
+			return CommandExecutionResult.FromValidationError("view must be table, json, csv, or xlsx.");
+		}
+		if ((view is "csv" or "xlsx") && string.IsNullOrWhiteSpace(args.DestinationPath)) {
+			return CommandExecutionResult.FromValidationError("destination-path is required for csv and xlsx.");
+		}
+		return InternalExecute<SqlScriptCommand.SqlScriptCommand>(new ExecuteSqlScriptOptions {
+			Environment = args.EnvironmentName,
+			Script = string.IsNullOrWhiteSpace(args.Script) ? null : args.Script,
+			File = string.IsNullOrWhiteSpace(args.File) ? null : args.File,
+			ViewType = view,
+			DestPath = args.DestinationPath,
+			IsSilent = args.Silent
+		});
+	}
+}
+
+/// <summary>Arguments for SQL execution and result export on the MCP server host.</summary>
+public sealed record ExecuteSqlScriptArgs(
+	[property: JsonPropertyName("environment-name"), Required]
+	[property: Description(McpToolDescriptions.EnvironmentName)]
+	string EnvironmentName,
+	[property: JsonPropertyName("script")]
+	[property: Description("SQL text. Supply either script or file, never both. SQL can modify or delete data.")]
+	string? Script = null,
+	[property: JsonPropertyName("file")]
+	[property: Description("Path to a SQL input file on the MCP server host; alternative to script.")]
+	string? File = null,
+	[property: JsonPropertyName("view")]
+	[property: Description("Output format: table (default; 40 characters per displayed cell line), json (recommended for full content), csv, or xlsx. CSV uses semicolons without escaping; prefer JSON for arbitrary text.")]
+	string? View = "table",
+	[property: JsonPropertyName("destination-path")]
+	[property: Description("Output file on the MCP server host, required for csv/xlsx. Use an absolute path for later inspection. Existing files are overwritten. Choose json/csv/xlsx for full cell values; table saves the formatted display.")]
+	string? DestinationPath = null,
+	[property: JsonPropertyName("silent")]
+	[property: Description("Suppress the result body in the MCP response (default false); use true with destination-path for large exports. Completion messages remain.")]
+	bool Silent = false);

--- a/clio/Command/SqlScriptCommand.cs
+++ b/clio/Command/SqlScriptCommand.cs
@@ -8,6 +8,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Clio.Command.SqlScriptCommand
 {
@@ -57,22 +58,25 @@ namespace Clio.Command.SqlScriptCommand
 
 		private static string GetSqlScriptResult(string serverResponse, string viewType, string filePath) {
 			
-			bool isError = TryGetError(serverResponse, out var errorMessage);
-			if (isError) {
-				return errorMessage;
-			}
-			
-			
-			if (serverResponse == "[]") {
-				return string.Empty;
+			viewType = viewType.ToLowerInvariant();
+			if (viewType == "json") {
+				JToken jsonResult = JToken.Parse(serverResponse);
+				if (jsonResult.Type is not (JTokenType.Array or JTokenType.Integer)) {
+					throw new InvalidOperationException("SQL response must contain a JSON row array or an affected-row count.");
+				}
+				if (filePath != null) {
+					File.WriteAllText(filePath, serverResponse);
+				}
+				return serverResponse;
 			}
 			if (int.TryParse(serverResponse, out var count)) {
+				if (filePath != null) {
+					throw new InvalidOperationException("Use -v json to export an affected-row count.");
+				}
 				return $"({count} rows affected)";
 			}
-			viewType = viewType.ToLower();
 			var dataTable = JsonConvert.DeserializeObject<DataTable>(serverResponse);
-			var table = CreateConsoleTable(dataTable);
-			string formatResult = table.ToString();
+			string formatResult = dataTable.Rows.Count == 0 ? string.Empty : CreateConsoleTable(dataTable).ToString();
 			if (viewType == "table") {
 				if (filePath != null) {
 					File.WriteAllText(filePath, formatResult);
@@ -170,7 +174,7 @@ namespace Clio.Command.SqlScriptCommand
 		/// Executes SQL and renders the result after validating the CSV destination.
 		/// </summary>
 		/// <param name="opts">SQL input, output format, and destination options.</param>
-		/// <returns>One when CSV has no destination; otherwise the command's execution result.</returns>
+		/// <returns>Zero on success; one for a missing CSV destination, SQL error, or export failure.</returns>
 		public override int Execute(ExecuteSqlScriptOptions opts) {
 			if (string.Equals(opts.ViewType, "csv", StringComparison.OrdinalIgnoreCase)
 				&& string.IsNullOrWhiteSpace(opts.DestPath)) {
@@ -183,7 +187,9 @@ namespace Clio.Command.SqlScriptCommand
 					result = _sqlScriptExecutor.Execute(opts.Script, ApplicationClient, EnvironmentSettings);
 				} else if (!string.IsNullOrEmpty(opts.File)) {
 					var script = File.ReadAllText(opts.File);
-					_logger.WriteLine(script);
+					if (!opts.IsSilent) {
+						_logger.WriteLine(script);
+					}
 					script = script.Replace(Environment.NewLine, "|nl|");
 					result = _sqlScriptExecutor.Execute(script, ApplicationClient, EnvironmentSettings);
 				} else {
@@ -191,16 +197,24 @@ namespace Clio.Command.SqlScriptCommand
 					var sc = Console.ReadLine();
 					result = _sqlScriptExecutor.Execute(sc, ApplicationClient, EnvironmentSettings);
 				}
+				if (TryGetError(result, out string errorMessage)) {
+					_logger.WriteError(errorMessage);
+					return 1;
+				}
 				result = GetSqlScriptResult(result, opts.ViewType, opts.DestPath);
+				if (opts.DestPath != null) {
+					_logger.WriteInfo($"Results saved to: {Path.GetFullPath(opts.DestPath)}");
+				}
 #pragma warning disable CLIO002
 				Console.OutputEncoding = System.Text.Encoding.UTF8;
 #pragma warning restore CLIO002
 				if (!opts.IsSilent) {
 					_logger.WriteLine(result);
 				}
-				_logger.WriteLine("Done");
+				_logger.WriteInfo("Done");
 			} catch (Exception e) {
 				_logger.WriteError(e.Message);
+				return 1;
 			}
 			return 0;
 		}

--- a/clio/Command/SqlScriptCommand.cs
+++ b/clio/Command/SqlScriptCommand.cs
@@ -60,14 +60,7 @@ namespace Clio.Command.SqlScriptCommand
 			
 			viewType = viewType.ToLowerInvariant();
 			if (viewType == "json") {
-				JToken jsonResult = JToken.Parse(serverResponse);
-				if (jsonResult.Type is not (JTokenType.Array or JTokenType.Integer)) {
-					throw new InvalidOperationException("SQL response must contain a JSON row array or an affected-row count.");
-				}
-				if (filePath != null) {
-					File.WriteAllText(filePath, serverResponse);
-				}
-				return serverResponse;
+				return GetJsonResult(serverResponse, filePath);
 			}
 			if (int.TryParse(serverResponse, out var count)) {
 				if (filePath != null) {
@@ -92,6 +85,17 @@ namespace Clio.Command.SqlScriptCommand
 				formatResult = serverResponse;
 			}
 			return formatResult;
+		}
+
+		private static string GetJsonResult(string serverResponse, string filePath) {
+			JToken jsonResult = JToken.Parse(serverResponse);
+			if (jsonResult.Type is not (JTokenType.Array or JTokenType.Integer)) {
+				throw new InvalidOperationException("SQL response must contain a JSON row array or an affected-row count.");
+			}
+			if (filePath != null) {
+				File.WriteAllText(filePath, serverResponse);
+			}
+			return serverResponse;
 		}
 
 		private static bool TryGetError(string json, out string errorMessage) {

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -377,7 +377,7 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 - [`download-configuration`](docs/commands/download-configuration.md) - Download configuration libraries from Creatio, `dconf`
 <a id="execute-sql-script"></a>
 <a id="sql"></a>
-- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio, with full request logging in ClioGate 2.0.0.53+, `sql`
+- [`execute-sql-script`](docs/commands/execute-sql-script.md) - Execute a SQL script in Creatio; table display uses 40 characters per cell line, with JSON/CSV/XLSX file exports for full content (also available through MCP), `sql`
 <a id="export-component-registry"></a>
 <a id="export-registry"></a>
 - [`export-component-registry`](docs/commands/export-component-registry.md) - Write the full Freedom UI component registry for a resolved platform version to a file, `export-registry`

--- a/clio/Common/ISqlScriptExecutor.cs
+++ b/clio/Common/ISqlScriptExecutor.cs
@@ -1,7 +1,13 @@
 ﻿namespace Clio.Common
 {
+	/// <summary>Executes SQL through ClioGate and decodes its transport response without changing cell content.</summary>
 	public interface ISqlScriptExecutor
 	{
+		/// <summary>Executes SQL once and unwraps a JSON string response when the transport wraps it.</summary>
+		/// <param name="sql">SQL text to execute.</param>
+		/// <param name="applicationClient">Authenticated client for the target environment.</param>
+		/// <param name="settings">Target environment settings.</param>
+		/// <returns>JSON rows, an affected-row count, or a server error, preserving embedded escapes.</returns>
 		string Execute(string sql, IApplicationClient applicationClient, EnvironmentSettings settings);
 	}
 }

--- a/clio/Common/SqlScriptExecutor.cs
+++ b/clio/Common/SqlScriptExecutor.cs
@@ -3,22 +3,12 @@ using Newtonsoft.Json;
 
 namespace Clio.Common
 {
+	/// <inheritdoc />
 	public class SqlScriptExecutor : ISqlScriptExecutor
 	{
 		private static string ExecuteSqlScriptUrl => @"/rest/CreatioApiGateway/ExecuteSqlScript";
 
-		private string CorrectJson(string body) {
-			body = body.Replace("\\\\r\\\\n", Environment.NewLine);
-			body = body.Replace("\\\\n", Environment.NewLine);
-			body = body.Replace("\\r\\n", Environment.NewLine);
-			body = body.Replace("\\n", Environment.NewLine);
-			body = body.Replace("\\\\t", Convert.ToChar(9).ToString());
-			body = body.Replace("\\\"", "\"");
-			body = body.Replace("\\\\", "\\");
-			body = body.Trim(new char[] { '\"' });
-			return body;
-		}
-
+		/// <inheritdoc />
 		public string Execute(string sql, IApplicationClient applicationClient, EnvironmentSettings settings) {
 			var scriptData = new {
 				script = sql
@@ -29,7 +19,9 @@ namespace Clio.Common
 				: settings.Uri + "/0" + ExecuteSqlScriptUrl;
 			string responseFormServer = applicationClient.ExecutePostRequest(endpointUri,
 				serializedRequestPayload);
-			return CorrectJson(responseFormServer);
+			return responseFormServer.TrimStart().StartsWith("\"", StringComparison.Ordinal)
+				? JsonConvert.DeserializeObject<string>(responseFormServer)
+				: responseFormServer;
 		}
 	}
 }

--- a/clio/docs/commands/execute-sql-script.md
+++ b/clio/docs/commands/execute-sql-script.md
@@ -11,8 +11,8 @@ execute-sql-script - Execute SQL script on a web application
 ## Description
 
 Executes custom SQL script on a web application. You can pass the script directly or via a file.
-Output can be formatted as a table, CSV, or XLSX, and saved to a file.
-Silent mode is supported to suppress console output.
+Output can be formatted as a table, JSON, CSV, or XLSX, and saved to a file.
+Table output limits each displayed cell line to 40 characters and wraps longer values. Do not extract full values from the formatted table. For full content, save JSON (recommended), CSV, or XLSX using -d/--destination-path. Saving table output retains the display formatting. Silent mode suppresses the result body; completion messages remain.
 
 This command requires cliogate version 2.0.0.41 or higher to be installed on the target Creatio environment.
 If cliogate is not installed or is an incompatible version, the command will display an error message and exit.
@@ -23,7 +23,7 @@ Install or update cliogate with `clio install-gate -e <ENVIRONMENT_NAME>`.
 ```bash
 Value (pos. 0)   Sql script to execute
 --File           -f          Path to the SQL script file
---View           -v          Output format: table, csv, xlsx (default: table)
+--View           -v          Output format: table, json, csv, xlsx (default: table)
 --destination-path -d         Path to save the result file
 --silent                     Suppress console output
 --uri            -u          Application uri
@@ -58,8 +58,11 @@ It retains complete statements, including literals. There is no automatic cleanu
 
 If both Script and File are omitted, the command prompts for SQL input.
 Output is shown in the console unless --silent is specified.
-Results can be saved to a file in the chosen format. CSV requires -d/--destination-path.
+Results can be saved to a file in the chosen format. CSV uses semicolons without quoting or escaping, so use JSON for arbitrary text containing delimiters or newlines. CSV requires -d/--destination-path.
 If the CSV destination is missing or blank, the command exits with code 1 before executing SQL.
+SQL and file-write failures also return exit code 1, including in silent mode.
+JSON exports preserve quotes, newlines, and backslashes, and empty queries overwrite the destination with `[]`.
+Use JSON when exporting an affected-row count from a SQL write. Successful exports report the absolute saved path.
 
 cliogate version 2.0.0.41 or higher must be installed on the target environment for this command to work.
 Install or update it with: clio install-gate -e <ENVIRONMENT_NAME>
@@ -69,3 +72,35 @@ Install or update it with: clio install-gate -e <ENVIRONMENT_NAME>
     https://github.com/Advance-Technologies-Foundation/clio
 
 - [Clio Command Reference](../../Commands.md#execute-sql-script)
+
+## MCP
+
+The `execute-sql-script` tool exposes `environment-name`, either `script` or `file`,
+`view` (table/json/csv/xlsx; default table), `destination-path`, and `silent` (default false).
+CSV and XLSX require a destination. Input and output paths refer to the MCP server host;
+use an absolute destination path to make later inspection unambiguous. Existing files are overwritten.
+The tool can execute SQL writes and is marked destructive and non-idempotent.
+
+For complete long values, call through `clio-run` with JSON export:
+
+```json
+{
+  "command": "execute-sql-script",
+  "args": {
+    "environment-name": "dev",
+    "script": "SELECT repeat('X', 200) AS value",
+    "view": "json",
+    "destination-path": "C:/exports/sql-result.json",
+    "silent": true
+  }
+}
+```
+
+Create the destination directory beforehand. Inspect the saved file for full content;
+table output is for display and uses 40 characters per cell line.
+
+Equivalent CLI invocation:
+
+```powershell
+clio execute-sql-script -e dev "SELECT repeat('X', 200) AS value" -v json -d C:/exports/sql-result.json --silent
+```

--- a/clio/help/en/execute-sql-script.txt
+++ b/clio/help/en/execute-sql-script.txt
@@ -5,10 +5,10 @@ NAME
     execute-sql-script - Execute SQL script on a web application
 
 DESCRIPTION
-    Executes custom SQL script on a web application. You can pass the script directly or via a file. 
-    Output can be formatted as a table, CSV, or XLSX, and saved to a file. 
+    Executes custom SQL script on a web application. You can pass the script directly or via a file.
+    Output can be formatted as a table, JSON, CSV, or XLSX, and saved to a file.
     Silent mode is supported to suppress console output.
-    
+
     This command requires cliogate version 2.0.0.41 or higher to be installed on the
     target Creatio environment. If cliogate is not installed or is an incompatible
     version, the command will display an error message and exit. Install or update it with:
@@ -17,7 +17,7 @@ DESCRIPTION
 OPTIONS
     Value (pos. 0)   Sql script to execute
     --File           -f          Path to the SQL script file
-    --View           -v          Output format: table, csv, xlsx (default: table)
+    --View           -v          Output format: table, json, csv, xlsx (default: table)
     --destination-path -d         Path to save the result file
     --silent                     Suppress console output
     --uri            -u          Application uri
@@ -44,10 +44,20 @@ NOTES
     Output is shown in the console unless --silent is specified.
     Results can be saved to a file in the chosen format. CSV requires -d/--destination-path.
     If the CSV destination is missing or blank, the command exits with code 1 before executing SQL.
-    
+
     cliogate version 2.0.0.41 or higher must be installed and compatible on the target
     environment for this command to work. Install or update it with:
         clio install-gate -e <ENVIRONMENT_NAME>
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio
+
+OUTPUT FILES
+    Table cells use 40 characters per displayed line and wrap longer values.
+    For full content, use -v json (recommended), csv, or xlsx with -d/--destination-path.
+    Use --silent to suppress the result body. Saving table output retains its formatting.
+    CSV uses semicolons without escaping; prefer JSON for arbitrary text.
+
+MCP
+    execute-sql-script exposes environment-name, script or file, view, destination-path, and silent.
+    CSV/XLSX require a destination. Paths are on the MCP server host; existing files are overwritten.

--- a/docs/McpCapabilityMap.md
+++ b/docs/McpCapabilityMap.md
@@ -109,6 +109,7 @@ Typical examples:
 - `update-page`
 - `delete-app`
 - `clear-redis-db-by-credentials`
+- `execute-sql-script` — executes explicit SQL through ClioGate; exposes `view`, `destination-path`, and `silent` for result export. Table cells wrap at 40 characters per displayed line. Use JSON file output for complete arbitrary text. SQL can modify data, and output files can be overwritten, so the tool is destructive and non-idempotent.
 - `restart-by-credentials`
 
 ### 3. Pure local mode

--- a/docs/knowledge/platform/execute-sql-script-reads-can-be-denied-while-writes-still-work.md
+++ b/docs/knowledge/platform/execute-sql-script-reads-can-be-denied-while-writes-still-work.md
@@ -10,7 +10,7 @@ date: 2026-09-11
 **What is true** — some Creatio stands refuse READ SQL through cliogate while still accepting writes. The server
 setting is `Terrasoft.Core.GlobalAppSettings.DenyCustomQueryApiUsage`; when it is on, `CustomQuery.ExecuteReader`
 throws and `clio execute-sql-script` reports
-`Usage of CustomQuery.ExecuteReader is denied by application security settings`. Lowercase, unindented writes are unaffected because
+`Usage of CustomQuery.ExecuteReader is denied by application security settings` as an error with exit code 1, including through MCP and in silent mode. Lowercase, unindented writes are unaffected because
 `SQLFunctions.ExecuteSQL` routes a script starting with `update` / `insert` / `delete` to `query.Execute()` and only
 everything else (i.e. `select`) to `ExecuteReader`.
 


### PR DESCRIPTION
## Result

Adds `execute-sql-script` to MCP with `environment-name`, `script` or `file`, `view`, `destination-path`, and `silent`. The description explains that table cells wrap at 40 characters per displayed line and directs full-content inspection to JSON/CSV/XLSX files. JSON is recommended for arbitrary text; successful exports return their absolute path.

Live validation exposed two existing export defects, fixed here: hand-written response unescaping corrupted quotes/newlines, and empty queries left stale destination files. JSON now preserves the original result, all empty exports replace their destination, and SQL/file errors return exit code 1 even in silent mode. Non-JSON affected-row-count exports now fail with guidance to use JSON instead of reporting success without writing a file.

Closes #1296.

## Validation

- `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit&(Module=Command|Module=McpServer|Module=Common)"` — 11,265 passed, 18 skipped. Final additional SQL tests: 42 passed, one existing skip. After the Sonar-driven JSON helper extraction, `dotnet test clio.tests/clio.tests.csproj -c Release --filter "Category=Unit&Module=Command"` passed 4,557 tests (13 skipped), and all 13 disposable-environment MCP tests passed again.
- Full `Category=Unit` suite — 12,680 passed, 25 skipped before the final command response-shape/test additions; final affected-module and SQL checks cover those additions.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Release -f net10.0 --filter "FullyQualifiedName~ExecuteSqlScriptToolE2ETests"` — 13 passed, zero skipped, through real stdio MCP on exclusive disposable `issue-1296` (Creatio 10.1.585, .NET 8, PostgreSQL). Verified persisted 200-character JSON/CSV/XLSX values, JSON quotes/newlines/backslashes, SQL-file input, silent output, absolute destination reporting, stale-file replacement in every format, and SQL/output errors. After merge, the Phase 3 uninstall succeeded. Independent checks verified the `issue-1296` Clio registration, IIS site/app pool, deployment directory, and PostgreSQL database are absent. The Phase 3 workspace is preserved at `F:\Projects\Issue-Workspaces\issue-1296`. Merge commit `3373ce58f24f2d4ab46903c5595e0740279fe603` was verified reachable from `origin/master`, and the task worktree/local branch were safely removed.
- Release build and Debug analyzer build passed; no new CLIO diagnostics in changed code.
- ClioRing compatibility reviewed: inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, and `clio-ring/ClioRing.Desktop/actions.json`; no existing Ring-consumed SQL contract changed. `dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release` — 157 passed. `dotnet publish clio-ring/ClioRing.Desktop/ClioRing.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishAot=true` — passed without IL2026/IL3050 warnings.
- Seven-perspective agentic review and focused Claude review `rev_f8f69826ac464f75` completed without remaining material findings. Reviewer suggestions for empty exports and whitespace input were fixed and covered.

## Contract and documentation

MCP added as an environment-aware BaseTool adapter with destructive/non-idempotent annotations and worker execution metadata. Updated discovery classification, unit/E2E coverage, command help, command index, detailed docs, capability map, and the affected platform knowledge note. No separate prompt/resource is needed. Wiki aliases and shipped workspace templates remain accurate. Reviewed clio-knowledge SQL references; no guidance change is required.

