### PR TITLE
Fix related-page responses to report the resolved entity identity

### DIFF
--- a/clio.mcp.e2e/RelatedPageIdentityToolE2ETests.cs
+++ b/clio.mcp.e2e/RelatedPageIdentityToolE2ETests.cs
@@ -47,6 +47,9 @@ public sealed class RelatedPageIdentityToolE2ETests {
 		};
 		var original = await ReadAsync(session, args, deadline.Token);
 		original.Success.Should().BeTrue(because: $"the existing binding must be captured before a write: {original.Error}");
+		original.Pages.Should().OnlyContain(page => string.IsNullOrWhiteSpace(page.Role)
+			|| page.RoleName == "All employees" || page.RoleName == "All external users",
+			because: "the fixture must be able to restore every original role before making any mutation");
 		// Use an existing page reference for a metadata persistence probe, including when mobile starts empty.
 		// This does not test page rendering; the disposable binding is restored below.
 		var web = schemaType == "web" ? original : await ReadAsync(session,

--- a/clio.mcp.e2e/RelatedPageIdentityToolE2ETests.cs
+++ b/clio.mcp.e2e/RelatedPageIdentityToolE2ETests.cs
@@ -1,0 +1,142 @@
+using Allure.Net.Commons;
+using Allure.NUnit.Attributes;
+using Clio.Command;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Mcp;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>Proves related-page identity and persistence on an explicitly selected disposable Marketing sandbox.</summary>
+[TestFixture]
+[Category("McpE2E.Sandbox")]
+[Category("McpE2E.Manual")]
+[Category("LocalOnly")]
+[Explicit("Clears and restores BulkEmail bindings and rebuilds static configuration; requires an exclusive Marketing sandbox.")]
+[NonParallelizable]
+// [AllureNUnit] is intentionally omitted. Its lifecycle hooks can deadlock fixtures with many sequential awaits.
+[AllureFeature(GetRelatedPageAddonTool.ToolName)]
+public sealed class RelatedPageIdentityToolE2ETests {
+	[TestCase("web")]
+	[TestCase("mobile")]
+	[Description("Keeps root identity stable across inherited/own-package reads, clear, restore, and missing-object errors.")]
+	[AllureTag(GetRelatedPageAddonTool.ToolName)]
+	[AllureTag(CreateRelatedPageAddonTool.ToolName)]
+	[AllureName("Related-page responses retain the persisted entity identity")]
+	[AllureDescription("Uses a SysSchema base-row oracle, exercises real MCP read/write, and restores the original semantic page set.")]
+	public async Task RelatedPages_ShouldKeepPersistedIdentity_WhenDesignerUsesReplacement(string schemaType) {
+		// Arrange
+		TeamCityRunGuard.IgnoreIfRunningUnderTeamCityOrGitHubActions("Related-page identity requires a disposable local sandbox.");
+		McpE2ESettings settings = TestConfiguration.Load();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("Set McpE2E__AllowDestructiveMcpTests=true for an exclusive disposable sandbox.");
+		}
+		TestConfiguration.EnsureSandboxIsConfigured(settings);
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		using CancellationTokenSource deadline = new(TimeSpan.FromMinutes(5));
+		var root = await AllureApi.Step("Read persisted base identity independently", () =>
+			RelatedPageIdentityReadback.ReadRootAsync(settings, "BulkEmail", deadline.Token));
+		string expected = root["UId"]!.GetValue<string>();
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, deadline.Token);
+		var args = new Dictionary<string, object?> {
+			["environment-name"] = settings.Sandbox.EnvironmentName,
+			["entity-schema-name"] = "BulkEmail", ["package-name"] = "Custom", ["schema-type"] = schemaType
+		};
+		var original = await ReadAsync(session, args, deadline.Token);
+		original.Success.Should().BeTrue(because: $"the existing binding must be captured before a write: {original.Error}");
+		// Use an existing page reference for a metadata persistence probe, including when mobile starts empty.
+		// This does not test page rendering; the disposable binding is restored below.
+		var web = schemaType == "web" ? original : await ReadAsync(session,
+			new Dictionary<string, object?>(args) { ["schema-type"] = "web" }, deadline.Token);
+		web.Success.Should().BeTrue(because: "the probe needs an existing page reference");
+		web.Pages.Should().NotBeEmpty(because: "the Marketing sandbox must contain a seeded BulkEmail web page");
+		string probePageUId = web.Pages[0].PageSchemaUId;
+
+		// Act / Assert: each stage has a separate result so a success envelope cannot hide a failed readback.
+		await AllureApi.Step("Repeated inherited-package reads equal the persisted root", async () => {
+			var repeated = await ReadAsync(session, args, deadline.Token);
+			repeated.Success.Should().BeTrue(because: "the unchanged read must succeed");
+			new[] { original.EntitySchemaUId, repeated.EntitySchemaUId }.Should().OnlyContain(
+				id => id == expected, because: "temporary designer IDs must never become the public identity");
+		});
+		await AllureApi.Step("Own-package read uses the same root", async () => {
+			var ownArgs = new Dictionary<string, object?>(args) { ["package-name"] = root["PackageName"]!.GetValue<string>() };
+			var own = await ReadAsync(session, ownArgs, deadline.Token);
+			own.Success.Should().BeTrue(because: "the entity's own package must resolve");
+			own.EntitySchemaUId.Should().Be(expected, because: "package context does not change the base identity");
+		});
+		try {
+			await AllureApi.Step("Write and independently read a nonempty page set", async () => {
+				var seed = new Dictionary<string, object?>(args) {
+					["pages"] = new[] { new Dictionary<string, object?> {
+						["page-schema-uid"] = probePageUId, ["is-default"] = true, ["is-add"] = true
+					} }
+				};
+				var seeded = await WriteAsync(session, seed, deadline.Token);
+				seeded.Success.Should().BeTrue(because: $"a nonempty binding must be saved: {seeded.Error}");
+				seeded.EntitySchemaUId.Should().Be(expected, because: "a nonempty write must report the persisted target");
+				var persisted = await ReadAsync(session, args, deadline.Token);
+				persisted.Success.Should().BeTrue(because: "the saved metadata must survive another request");
+				persisted.Pages.Should().ContainSingle(because: "a no-op save must not pass on an empty or multi-page baseline");
+				persisted.Pages[0].PageSchemaUId.Should().Be(probePageUId, because: "the requested page reference must persist");
+				persisted.Pages[0].IsDefault.Should().BeTrue(because: "the default flag must persist");
+				persisted.Pages[0].IsAdd.Should().BeTrue(because: "the add flag must persist");
+			});
+			await AllureApi.Step("Clear bindings and verify persisted empty set", async () => {
+				var clear = new Dictionary<string, object?>(args) { ["pages"] = Array.Empty<object>() };
+				var written = await WriteAsync(session, clear, deadline.Token);
+				written.Success.Should().BeTrue(because: $"the clear must save successfully: {written.Error}");
+				written.EntitySchemaUId.Should().Be(expected, because: "create reports the same resolved identity as get");
+				var cleared = await ReadAsync(session, args, deadline.Token);
+				cleared.Success.Should().BeTrue(because: "the persisted clear must be readable");
+				cleared.Pages.Should().BeEmpty(because: "the empty set must actually persist");
+				cleared.EntitySchemaUId.Should().Be(expected, because: "clearing pages cannot change entity identity");
+			});
+		} finally {
+			// A separate deadline lets restoration run even when the assertion deadline expired.
+			using CancellationTokenSource restoreDeadline = new(TimeSpan.FromMinutes(3));
+			var restore = new Dictionary<string, object?>(args) {
+				["type-column-uid"] = original.TypeColumnUId,
+				["pages"] = original.Pages.Select(page => new Dictionary<string, object?> {
+					["page-schema-uid"] = page.PageSchemaUId, ["is-default"] = page.IsDefault,
+					["is-add"] = page.IsAdd, ["is-ssp-default"] = page.IsSspDefault,
+					["role"] = page.Role, ["type-column-value"] = page.TypeColumnValue
+				}).ToArray()
+			};
+			await AllureApi.Step("Restore and verify original binding semantics", async () => {
+				var restored = await WriteAsync(session, restore, restoreDeadline.Token);
+				restored.Success.Should().BeTrue(because: $"the original configuration must be restored: {restored.Error}");
+				restored.EntitySchemaUId.Should().Be(expected, because: "restore is another create using the same root");
+				var after = await ReadAsync(session, args, restoreDeadline.Token);
+				after.Success.Should().BeTrue(because: "the restoration must survive readback");
+				after.Pages.Should().BeEquivalentTo(original.Pages, because: "the reporting fix must preserve page binding behavior");
+				after.TypeColumnUId.Should().Be(original.TypeColumnUId, because: "restoration must preserve the type discriminator");
+			});
+		}
+		await AllureApi.Step("Missing object fails without changing the real binding", async () => {
+			var missing = new Dictionary<string, object?>(args) { ["entity-schema-name"] = "UsrMissing" + Guid.NewGuid().ToString("N") };
+			var failed = await ReadAsync(session, missing, deadline.Token);
+			failed.Success.Should().BeFalse(because: "a missing entity must not resolve to a parent's binding");
+			failed.Error.Should().Contain("not found", because: "the error must explain the missing object");
+			var unchanged = await ReadAsync(session, args, deadline.Token);
+			unchanged.Pages.Should().BeEquivalentTo(original.Pages, because: "the failed lookup must not affect an existing binding");
+		});
+	}
+
+	private static async Task<GetRelatedPageAddonResponse> ReadAsync(McpServerSession session, Dictionary<string, object?> args, CancellationToken token) {
+		var result = await session.CallToolAsync(GetRelatedPageAddonTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = args }, token);
+		result.IsError.Should().NotBeTrue(because: "the read must use the structured command result");
+		return EntitySchemaStructuredResultParser.Extract<GetRelatedPageAddonResponse>(result);
+	}
+
+	private static async Task<CreateRelatedPageAddonResponse> WriteAsync(McpServerSession session, Dictionary<string, object?> args, CancellationToken token) {
+		var result = await session.CallToolAsync(CreateRelatedPageAddonTool.ToolName,
+			new Dictionary<string, object?> { ["args"] = args }, token);
+		result.IsError.Should().NotBeTrue(because: "the write must use the structured command result");
+		return EntitySchemaStructuredResultParser.Extract<CreateRelatedPageAddonResponse>(result);
+	}
+}

--- a/clio.mcp.e2e/Support/Creatio/RelatedPageIdentityReadback.cs
+++ b/clio.mcp.e2e/Support/Creatio/RelatedPageIdentityReadback.cs
@@ -23,7 +23,11 @@ internal static class RelatedPageIdentityReadback {
 				"DataService/json/SyncReply/SelectQuery", "-b", query.ToJsonString()], cancellationToken: token);
 		result.ExitCode.Should().Be(0, because: $"the independent SysSchema query must succeed: {result.StandardOutput}");
 		string output = result.StandardOutput;
-		JsonObject response = JsonNode.Parse(output[output.IndexOf('{')..(output.LastIndexOf('}') + 1)])!.AsObject();
+		int start = output.IndexOf('{');
+		int end = output.LastIndexOf('}');
+		start.Should().BeGreaterThanOrEqualTo(0, because: "the successful oracle call must include a JSON response");
+		end.Should().BeGreaterThan(start, because: "the oracle response must include a complete JSON object");
+		JsonObject response = JsonNode.Parse(output[start..(end + 1)])!.AsObject();
 		response["success"]!.GetValue<bool>().Should().BeTrue(because: "the identity oracle must be a successful persisted read");
 		JsonArray rows = response["rows"]!.AsArray();
 		rows.Should().ContainSingle(because: "the named entity must have exactly one base row, independently of replacements");

--- a/clio.mcp.e2e/Support/Creatio/RelatedPageIdentityReadback.cs
+++ b/clio.mcp.e2e/Support/Creatio/RelatedPageIdentityReadback.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Nodes;
+using Clio.Mcp.E2E.Support.Configuration;
+using FluentAssertions;
+
+namespace Clio.Mcp.E2E.Support.Creatio;
+
+/// <summary>Independent persisted entity identity oracle for related-page tests.</summary>
+internal static class RelatedPageIdentityReadback {
+	internal static async Task<JsonObject> ReadRootAsync(McpE2ESettings settings, string entity, CancellationToken token) {
+		JsonObject query = JsonNode.Parse("""
+			{"rootSchemaName":"SysSchema","columns":{"items":{
+			"UId":{"expression":{"expressionType":0,"columnPath":"UId"}},
+			"PackageName":{"expression":{"expressionType":0,"columnPath":"SysPackage.Name"}}}},
+			"filters":{"filterType":6,"logicalOperation":0,"items":{
+			"name":{"filterType":1,"comparisonType":3,"leftExpression":{"expressionType":0,"columnPath":"Name"},"rightExpression":{"expressionType":2,"parameter":{"dataValueType":1,"value":""}}},
+			"manager":{"filterType":1,"comparisonType":3,"leftExpression":{"expressionType":0,"columnPath":"ManagerName"},"rightExpression":{"expressionType":2,"parameter":{"dataValueType":1,"value":"EntitySchemaManager"}}},
+			"root":{"filterType":1,"comparisonType":3,"leftExpression":{"expressionType":0,"columnPath":"ExtendParent"},"rightExpression":{"expressionType":2,"parameter":{"dataValueType":12,"value":false}}}
+			}}}
+			""")!.AsObject();
+		query["filters"]!["items"]!["name"]!["rightExpression"]!["parameter"]!["value"] = entity;
+		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(settings,
+			["call-service", "-e", settings.Sandbox.EnvironmentName!, "--service-path",
+				"DataService/json/SyncReply/SelectQuery", "-b", query.ToJsonString()], cancellationToken: token);
+		result.ExitCode.Should().Be(0, because: $"the independent SysSchema query must succeed: {result.StandardOutput}");
+		string output = result.StandardOutput;
+		JsonObject response = JsonNode.Parse(output[output.IndexOf('{')..(output.LastIndexOf('}') + 1)])!.AsObject();
+		response["success"]!.GetValue<bool>().Should().BeTrue(because: "the identity oracle must be a successful persisted read");
+		JsonArray rows = response["rows"]!.AsArray();
+		rows.Should().ContainSingle(because: "the named entity must have exactly one base row, independently of replacements");
+		return rows[0]!.AsObject();
+	}
+}

--- a/clio.tests/Command/AddonSchemaDesignerClientTests.cs
+++ b/clio.tests/Command/AddonSchemaDesignerClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using Clio.Command.AddonSchemaDesigner;
 using Clio.Common;
 using FluentAssertions;
@@ -44,6 +45,35 @@ public sealed class AddonSchemaDesignerClientTests {
 			TargetSchemaManagerName = "EntitySchemaManager",
 			UseFullHierarchy = true
 		};
+
+	[Test]
+	[Description("Preserves the target identity and unknown fields in the real add-on deserialize/save round trip.")]
+	public void SaveSchema_ShouldPreserveExtensionData_WhenSchemaWasFetched() {
+		// Arrange
+		const string target = "11111111-1111-1111-1111-111111111111";
+		string savedBody = null;
+		_applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(call => {
+				if (call.ArgAt<string>(0).EndsWith("/GetSchema", StringComparison.Ordinal)) {
+					return $$$"""{"success":true,"schema":{"targetSchemaUId":"{{{target}}}","futureField":{"enabled":true},"metaData":"{}","resources":[]}}""";
+				}
+				savedBody = call.ArgAt<string>(1);
+				return """{"success":true,"value":true}""";
+			});
+
+		// Act
+		AddonSchemaDto schema = _client.GetSchema(SampleGetRequest());
+		_client.SaveSchema(schema);
+
+		// Assert
+		using JsonDocument saved = JsonDocument.Parse(savedBody);
+		saved.RootElement.GetProperty("targetSchemaUId").GetString().Should().Be(target,
+			because: "the identity must be passed back unchanged rather than lost or renamed");
+		saved.RootElement.GetProperty("futureField").GetProperty("enabled").GetBoolean().Should().BeTrue(
+			because: "unknown server metadata must survive the same serialization path");
+		saved.RootElement.EnumerateObject().Should().ContainSingle(field => field.Name == "targetSchemaUId",
+			because: "the save payload must not duplicate the identity field");
+	}
 
 	[Test]
 	[Description("Deserializes raw add-on designer responses directly when the service returns valid JSON.")]

--- a/clio.tests/Command/RelatedPageAddonServiceTests.cs
+++ b/clio.tests/Command/RelatedPageAddonServiceTests.cs
@@ -3,6 +3,7 @@ namespace Clio.Tests.Command;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Clio.Command;
 using Clio.Command.AddonSchemaDesigner;
@@ -47,7 +48,7 @@ public sealed class RelatedPageAddonServiceTests {
 			.Returns(callInfo => PageHierarchy(PageUIdForName(callInfo.Arg<string>())));
 		_serviceUrlBuilder.Build("/DataService/json/SyncReply/SelectQuery").Returns(SelectQueryUrl);
 		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>())
-			.Returns(new AddonSchemaDto { MetaData = """{"Pages":[],"TypeColumnUId":null}""" });
+			.Returns(new AddonSchemaDto { AdditionalData = TargetData(), MetaData = """{"Pages":[],"TypeColumnUId":null}""" });
 		_addonSchemaDesignerClient
 			.When(client => client.SaveSchema(Arg.Any<AddonSchemaDto>()))
 			.Do(callInfo => _savedSchema = callInfo.Arg<AddonSchemaDto>());
@@ -89,7 +90,88 @@ public sealed class RelatedPageAddonServiceTests {
 
 	private void StubAddonMetadata(string metaData) =>
 		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>())
-			.Returns(new AddonSchemaDto { MetaData = metaData });
+			.Returns(new AddonSchemaDto { AdditionalData = TargetData(), MetaData = metaData });
+
+	private static Dictionary<string, JsonElement> TargetData() => new() {
+		["targetSchemaUId"] = JsonSerializer.SerializeToElement(EntityUId)
+	};
+
+	[TestCase(RelatedPageSchemaType.Web)]
+	[TestCase(RelatedPageSchemaType.Mobile)]
+	[Description("Reports the add-on target across changing designer IDs and preserves its wire metadata on save.")]
+	public void GetAndCreate_ShouldReturnPersistedTarget_WhenDesignerCreatesTemporarySchemas(RelatedPageSchemaType type) {
+		// Arrange
+		StubSelectQueue(Rows(PackageUId), Rows(PackageUId), Rows(PackageUId));
+		var payload = TargetData();
+		payload["futureField"] = JsonSerializer.SerializeToElement(new { enabled = true });
+		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>())
+			.Returns(new AddonSchemaDto { AdditionalData = payload, MetaData = "{}" });
+		_entitySchemaDesignerClient.GetSchemaDesignItem(Arg.Any<GetSchemaDesignItemRequestDto>(), Arg.Any<RemoteCommandOptions>())
+			.Returns(_ => new Clio.Command.EntitySchemaDesigner.DesignerResponse<EntityDesignSchemaDto> {
+				Success = true, Schema = new EntityDesignSchemaDto {
+					UId = Guid.NewGuid(), Name = "UsrDeliveryItem",
+					ParentSchema = new EntityDesignSchemaDto { UId = Guid.Parse(EntityUId) }
+				}
+			});
+
+		// Act
+		var first = _service.Get(new RelatedPageAddonReadRequest("Custom", "UsrDeliveryItem", type));
+		var created = _service.Create(new RelatedPageAddonRequest("Custom", "UsrDeliveryItem", [], null, type));
+		var last = _service.Get(new RelatedPageAddonReadRequest("Custom", "UsrDeliveryItem", type));
+
+		// Assert
+		new[] { first.EntitySchemaUId, created.EntitySchemaUId, last.EntitySchemaUId }.Should().OnlyContain(
+			id => id == EntityUId, because: "the stable add-on target is the entity identity, not the temporary design item");
+		_savedSchema.AdditionalData.Should().BeSameAs(payload, because: "reading the identity must not rewrite the save payload");
+		_savedSchema.AdditionalData["futureField"].GetProperty("enabled").GetBoolean().Should().BeTrue(
+			because: "unknown platform fields must survive the save");
+	}
+
+	[TestCase(null)]
+	[TestCase("null")]
+	[TestCase("42")]
+	[TestCase("{}")]
+	[TestCase("\"invalid\"")]
+	[TestCase("\"00000000-0000-0000-0000-000000000000\"")]
+	[Description("Rejects absent or malformed target identity consistently before any save or refresh.")]
+	public void GetAndCreate_ShouldRejectInvalidTarget_WhenAddonResponseHasNoUsableIdentity(string json) {
+		// Arrange
+		StubSelectQueue(Rows(PackageUId), Rows(PackageUId));
+		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>()).Returns(new AddonSchemaDto {
+			AdditionalData = json == null ? null : new Dictionary<string, JsonElement> {
+				["targetSchemaUId"] = JsonSerializer.Deserialize<JsonElement>(json)
+			}, MetaData = "{}"
+		});
+
+		// Act
+		Action read = () => _service.Get(new RelatedPageAddonReadRequest("Custom", "UsrDeliveryItem"));
+		Action write = () => _service.Create(Request());
+
+		// Assert
+		read.Should().Throw<InvalidOperationException>().WithMessage("*targetSchemaUId*", because: "a read cannot report an invented identity");
+		write.Should().Throw<InvalidOperationException>().WithMessage("*targetSchemaUId*", because: "identity must be validated before saving");
+		_addonSchemaDesignerClient.ReceivedCalls().Should().OnlyContain(
+			call => call.GetMethodInfo().Name == nameof(IAddonSchemaDesignerClient.GetSchema),
+			because: "invalid identity must prevent both the durable save and the subsequent refreshes");
+	}
+
+	[Test]
+	[Description("Reads case-insensitive extension keys and normalizes the returned GUID without changing the payload.")]
+	public void Get_ShouldNormalizeTargetIdentity_WhenWireCasingAndGuidFormatDiffer() {
+		// Arrange
+		StubSelectQueue(Rows(PackageUId));
+		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>()).Returns(new AddonSchemaDto {
+			AdditionalData = new Dictionary<string, JsonElement> {
+				["TargetSchemaUId"] = JsonSerializer.SerializeToElement(Guid.Parse(EntityUId).ToString("B").ToUpperInvariant())
+			}, MetaData = "{}"
+		});
+
+		// Act
+		var result = _service.Get(new RelatedPageAddonReadRequest("Custom", "UsrDeliveryItem"));
+
+		// Assert
+		result.EntitySchemaUId.Should().Be(EntityUId, because: "the public GUID format stays canonical regardless of wire casing");
+	}
 
 	private static RelatedPageAddonRequest Request(params RelatedPageSpec[] pages) =>
 		new("Custom", "UsrDeliveryItem", pages, null);
@@ -613,6 +695,7 @@ public sealed class RelatedPageAddonServiceTests {
 		// Arrange — GetSchema returns a pre-existing config (a stale page and a stale type column).
 		_addonSchemaDesignerClient.GetSchema(Arg.Any<AddonGetRequestDto>())
 			.Returns(new AddonSchemaDto {
+				AdditionalData = TargetData(),
 				MetaData = """{"Pages":[{"UId":"old","PageSchemaUId":"99999999-9999-9999-9999-999999999999","IsDefault":true}],"TypeColumnUId":"88888888-8888-8888-8888-888888888888"}"""
 			});
 		StubSelectQueue(Rows(PackageUId), Rows(PageAUId));

--- a/clio/Command/McpServer/Tools/CreateRelatedPageAddonTool.cs
+++ b/clio/Command/McpServer/Tools/CreateRelatedPageAddonTool.cs
@@ -27,7 +27,7 @@ public sealed class CreateRelatedPageAddonTool(
 		BudgetPolicy = McpToolBudgetPolicy.ParentKillDefault,
 		RequiresClientRequests = McpToolClientRequests.None,
 		SharedFileResource = McpToolSharedFileResource.None)]
-	[Description("Configure the RelatedPage add-on for an object (entity schema): which Freedom UI pages open by default and for adding records, optionally per audience and per type. " +
+	[Description("Configure the RelatedPage add-on for an object (entity schema): which Freedom UI pages open by default and for adding records, optionally per audience and per type.  Returns entitySchemaUId as the base/root entity identity resolved by Creatio, shared across replacing layers." +
 		"Per-page role-name 'All external users' binds the PORTAL (self-service) audience and 'All employees' the internal one. " +
 		"Writes the RelatedPage add-on via AddonSchemaDesignerService and rebuilds static content. " +
 		"The pages list fully REPLACES the object's current related-page configuration; an EMPTY pages list clears all bindings (reset to inline — the effective delete). " +

--- a/clio/Command/McpServer/Tools/GetRelatedPageAddonTool.cs
+++ b/clio/Command/McpServer/Tools/GetRelatedPageAddonTool.cs
@@ -25,7 +25,7 @@ public sealed class GetRelatedPageAddonTool(
 		BudgetPolicy = McpToolBudgetPolicy.ParentKillDefault,
 		RequiresClientRequests = McpToolClientRequests.None,
 		SharedFileResource = McpToolSharedFileResource.None)]
-	[Description("Read an object's current RelatedPage configuration: which Freedom UI pages are bound as the default and the add page, per audience (role) and per record type. " +
+	[Description("Read an object's current RelatedPage configuration: which Freedom UI pages are bound as the default and the add page, per audience (role) and per record type.  Returns entitySchemaUId as the base/root entity identity resolved by Creatio, shared across replacing layers." +
 		"Returns each entry's page-schema-uid + resolved page-schema-name, the role uid + resolved role-name (for the standard 'All employees' / 'All external users' audiences), the is-default / is-add / is-ssp-default flags, and any type-column-value, plus the top-level type-column-uid. " +
 		"Read-only — makes no changes. Use this BEFORE create-related-page-addon for a safe read-modify-write: create REPLACES the whole configuration, so read the current pages first, modify, then send the full set back (otherwise the omitted entries are lost). " +
 		"Prefer environment-name; keep direct connection args for emergency fallback only.")]

--- a/clio/Command/RelatedPages/RelatedPageAddonMessages.cs
+++ b/clio/Command/RelatedPages/RelatedPageAddonMessages.cs
@@ -8,6 +8,8 @@ namespace Clio.Command.RelatedPages;
 /// </summary>
 internal static class RelatedPageAddonMessages {
 	internal const string EntitySchemaNameRequired = "entity-schema-name is required.";
+	internal const string TargetSchemaUIdInvalid =
+		"The related-page add-on response is missing a valid targetSchemaUId. No related-page configuration was saved.";
 	internal const string PackageNameRequired = "package-name is required.";
 
 	// The pages list itself. Shared by the MCP tool's argument guard and the service's ValidateRequest, which

--- a/clio/Command/RelatedPages/RelatedPageAddonMessages.cs
+++ b/clio/Command/RelatedPages/RelatedPageAddonMessages.cs
@@ -9,7 +9,7 @@ namespace Clio.Command.RelatedPages;
 internal static class RelatedPageAddonMessages {
 	internal const string EntitySchemaNameRequired = "entity-schema-name is required.";
 	internal const string TargetSchemaUIdInvalid =
-		"The related-page add-on response is missing a valid targetSchemaUId. No related-page configuration was saved.";
+		"The related-page add-on response is missing a valid targetSchemaUId.";
 	internal const string PackageNameRequired = "package-name is required.";
 
 	// The pages list itself. Shared by the MCP tool's argument guard and the service's ValidateRequest, which

--- a/clio/Command/RelatedPages/RelatedPageAddonService.cs
+++ b/clio/Command/RelatedPages/RelatedPageAddonService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Clio.Command.AddonSchemaDesigner;
 using Clio.Command.EntitySchemaDesigner;
@@ -51,6 +52,8 @@ public sealed record RelatedPageAddonRequest(
 /// <summary>
 /// Outcome of a <see cref="IRelatedPageAddonService.Create"/> call.
 /// </summary>
+/// <param name="EntitySchemaUId">The base/root entity UId resolved by the add-on service, shared across
+/// replacing layers, rather than an unsaved designer or replacing schema's UId.</param>
 public sealed record RelatedPageAddonResult(
 	string EntitySchemaUId,
 	string PackageUId,
@@ -73,6 +76,8 @@ public sealed record RelatedPageAddonReadRequest(
 /// read the existing page set before a (replace-not-merge) <see cref="IRelatedPageAddonService.Create"/>,
 /// so a single page can be added or removed without losing the rest.
 /// </summary>
+/// <param name="EntitySchemaUId">The base/root entity UId resolved by the add-on service, shared across
+/// replacing layers, rather than an unsaved designer or replacing schema's UId.</param>
 public sealed record RelatedPageAddonReadResult(
 	string EntitySchemaName,
 	string EntitySchemaUId,
@@ -415,6 +420,7 @@ internal sealed class RelatedPageAddonService(
 		string addonName = AddonNameFor(request.SchemaType);
 		AddonGetRequestDto addonRequest = BuildAddonGetRequest(entitySchema, packageId, addonName);
 		AddonSchemaDto schema = addonSchemaDesignerClient.GetSchema(addonRequest);
+		string entitySchemaUId = ReadTargetSchemaUId(schema);
 		// Start from the FETCHED metadata and replace only the two keys this tool owns (Pages, TypeColumnUId), so
 		// any OTHER top-level field survives the write. The RelatedPage MetaData is exactly
 		// {"Pages":[...],"TypeColumnUId":...} today (verified backend contract), but preserving unknown top-level
@@ -441,7 +447,7 @@ internal sealed class RelatedPageAddonService(
 		string buildWarning = addonSchemaDesignerClient.BuildConfiguration();
 
 		return new RelatedPageAddonResult(
-			entitySchema.UId.ToString("D"), packageUId, pages.Count, addonName,
+			entitySchemaUId, packageUId, pages.Count, addonName,
 			CombineWarnings(typeColumnWarning, resetWarning, buildWarning));
 	}
 
@@ -461,11 +467,29 @@ internal sealed class RelatedPageAddonService(
 		AddonGetRequestDto addonRequest = BuildAddonGetRequest(entitySchema, packageId, addonName);
 		// Read-only: GetSchema returns the (server auto-provisioned) add-on with its current metadata; no save.
 		AddonSchemaDto schema = addonSchemaDesignerClient.GetSchema(addonRequest);
+		string entitySchemaUId = ReadTargetSchemaUId(schema);
 		IReadOnlyList<RelatedPageEntry> pages = DecodePages(schema.MetaData, out string typeColumnUId);
 
 		return new RelatedPageAddonReadResult(
-			request.EntitySchemaName, entitySchema.UId.ToString("D"), request.PackageName, packageUId,
+			request.EntitySchemaName, entitySchemaUId, request.PackageName, packageUId,
 			addonName, typeColumnUId, pages.Count, pages);
+	}
+
+	// Keep the fetched wire payload intact: the designer UId may identify an unsaved replacement,
+	// whereas the add-on service has already resolved its persisted root target.
+	private static string ReadTargetSchemaUId(AddonSchemaDto schema) {
+		if (schema.AdditionalData != null) {
+			foreach (var field in schema.AdditionalData) {
+				if (string.Equals(field.Key, "targetSchemaUId", StringComparison.OrdinalIgnoreCase)
+					&& field.Value.ValueKind == JsonValueKind.String
+					&& Guid.TryParse(field.Value.GetString(), out Guid targetUId)
+					&& targetUId != Guid.Empty) {
+					return targetUId.ToString("D");
+				}
+			}
+		}
+		throw new InvalidOperationException(
+			RelatedPageAddonMessages.TargetSchemaUIdInvalid);
 	}
 
 	/// <summary>

--- a/clio/Commands.md
+++ b/clio/Commands.md
@@ -774,3 +774,9 @@ Use `clio help` for the terminal overview and `clio <command> --help` for comman
 - [`set-app-version`](docs/commands/set-app-version.md) - Set application version, `appversion`
 <a id="unregister"></a>
 - [`unregister`](docs/commands/unregister.md) - Remove clio shell integrations
+
+### Related-page response identity
+
+`get-related-page-addon` and `create-related-page-addon` report `entitySchemaUId` as
+the base/root entity UId resolved by Creatio for the add-on, shared across replacing
+layers. A temporary designer schema or an individual replacing row is not that identity.

--- a/clio/docs/commands/create-related-page-addon.md
+++ b/clio/docs/commands/create-related-page-addon.md
@@ -78,3 +78,10 @@ clio create-related-page-addon -e dev --entity-schema-name UsrRequest --package-
   manage the **mobile** related-page add-on (`MobileRelatedPage`) instead — the page the Creatio Mobile app
   opens for a record. The two add-ons are independent: a write to one (including an empty-clear reset) is
   neither read nor written against the other, so it never affects the other surface's page configuration.
+
+## Response identity
+
+`entitySchemaUId` is the base/root entity schema UId resolved by Creatio for the add-on.
+It is shared across replacing layers, not the UId of a particular replacing row or an
+unsaved designer schema. The same entity therefore reports the same identity on repeated
+reads and writes. A missing or invalid target identity fails before saving.

--- a/clio/docs/commands/get-related-page-addon.md
+++ b/clio/docs/commands/get-related-page-addon.md
@@ -47,3 +47,10 @@ clio get-related-page-addon -e dev --entity-schema-name UsrDeliveryItem --packag
 
 - Aliases: `related-page-addon-get`, `get-related-pages`.
 - Pairs with [`create-related-page-addon`](create-related-page-addon.md): read → modify → `create` (which replaces the full set). Raw page/role UIds are always returned so the modified set can be sent back exactly.
+
+## Response identity
+
+`entitySchemaUId` is the base/root entity schema UId resolved by Creatio for the add-on.
+It is shared across replacing layers, not the UId of a particular replacing row or an
+unsaved designer schema. The same entity therefore reports the same identity on repeated
+reads and writes. A missing or invalid target identity fails before saving.

--- a/clio/help/en/create-related-page-addon.txt
+++ b/clio/help/en/create-related-page-addon.txt
@@ -94,3 +94,8 @@ NOTES
     manage the MOBILE related-page add-on (MobileRelatedPage) instead - the page the Creatio Mobile app opens
     for a record. The two add-ons are independent: a write to one (including an empty reset) is neither read
     nor written against the other, so it never affects the other surface's page configuration.
+
+RESPONSE IDENTITY
+    entitySchemaUId is the base/root entity UId resolved by Creatio for the add-on,
+    shared across replacing layers. It is not a temporary designer or replacing-row UId.
+    A missing or invalid target identity fails before saving.

--- a/clio/help/en/get-related-page-addon.txt
+++ b/clio/help/en/get-related-page-addon.txt
@@ -43,3 +43,8 @@ NOTES
     Aliases: related-page-addon-get, get-related-pages.
 
     Pairs with create-related-page-addon: read -> modify -> create (which replaces the full set).
+
+RESPONSE IDENTITY
+    entitySchemaUId is the base/root entity UId resolved by Creatio for the add-on,
+    shared across replacing layers. It is not a temporary designer or replacing-row UId.
+    A missing or invalid target identity fails before saving.

--- a/docs/knowledge/Command/related-page-designer-uid-can-be-temporary.md
+++ b/docs/knowledge/Command/related-page-designer-uid-can-be-temporary.md
@@ -1,0 +1,24 @@
+---
+description: GetSchemaDesignItem can synthesize an unsaved replacing entity; use the add-on response targetSchemaUId for related-page identity
+applies-to:
+  - clio/Command/RelatedPages/RelatedPageAddonService.cs
+  - clio/Command/AddonSchemaDesigner/AddonSchemaDesignerDtos.cs
+ticket: GH-1302
+date: 2026-09-12
+---
+
+**What is true** — When an entity is inherited into the requested package, Creatio's
+`EntitySchemaDesignerService.GetSchemaDesignItem` may return a new unsaved replacing schema
+on every read. Its `uId` is not a persisted entity identity. The add-on service resolves the
+parent and returns the base/root target in `schema.targetSchemaUId`. Verified with BulkEmail
+in Custom on Creatio 10.0.0.858 (.NET Framework, PostgreSQL), against persisted SysSchema rows.
+
+**Why it is this way** — This is the designer's normal preparation of an editable schema,
+not an entity-identity lookup. `AddonSchemaDesignerService.GetAddonInfo` resolves the supplied
+target or parent through the entity manager and canonicalizes the target by name. Keep that
+request path: replacing it with a flat SysSchema name query is ambiguous across replacing rows.
+
+**What breaks if you ignore it** — Reads and successful writes report different invented
+entity IDs even while their bindings persist correctly. Read the existing add-on extension
+data without rewriting it; validate the target before saving so a malformed response cannot
+turn an already committed write into an apparent failure.

--- a/spec/related-page-identity/related-page-identity-qa.md
+++ b/spec/related-page-identity/related-page-identity-qa.md
@@ -1,0 +1,26 @@
+# Related-page identity validation
+
+The fix reports the target Creatio already resolved. It does not change entity resolution,
+add-on requests, save metadata, or cache refresh behavior.
+
+Unit tests cover varying designer IDs, stable target identity, malformed/missing identity,
+case normalization, web/mobile, clearing, and extension-data serialization preservation.
+
+`RelatedPageIdentityToolE2ETests` is an explicit local fixture: it requires an exclusive
+Marketing sandbox containing BulkEmail and Custom. It clears and restores bindings and
+rebuilds static configuration, so it cannot run on a shared CI stand. Its independent
+identity oracle is SysSchema filtered by Name, EntitySchemaManager and ExtendParent=false.
+It verifies repeated reads, own-package reads, clear/readback, restore/readback, and a
+missing-object failure. The original semantic page set is restored in a finally block.
+
+Run against a disposable environment with:
+
+```powershell
+$env:McpE2E__AllowDestructiveMcpTests = 'true'
+$env:McpE2E__Sandbox__EnvironmentName = '<exclusive-environment>'
+dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net10.0 --filter 'FullyQualifiedName~RelatedPageIdentityToolE2ETests'
+```
+
+These tools return structured response DTOs rather than CommandExecutionResult logs, so
+the fixture checks success/IsError, diagnostics, identity and actual persisted side effects.
+There is no Info/Error execution-log collection in these two response contracts.


### PR DESCRIPTION
## Problem and change

When the entity is inherited into the requested package, Creatio can return a fresh unsaved replacement from its entity designer. Clio exposed that temporary UId as `entitySchemaUId`, so unchanged reads and successful writes appeared to target different objects.

Both related-page commands now return the `targetSchemaUId` already resolved by Creatio's add-on service. The designer request, fetched save payload, page metadata and refresh flow are preserved. Missing or malformed target identity fails before saving. No new endpoint, lookup, ClioGate package or Creatio behavior workaround is introduced.

Fixes #1302.

## Local validation

- `dotnet test clio.tests/clio.tests.csproj -c Debug --filter "Category=Unit&(Module=Command|Module=McpServer)"`: **9,748 passed**, 15 existing skips.
- `dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net10.0 --filter "FullyQualifiedName~RelatedPageIdentityToolE2ETests"`: **2 passed on each** disposable Creatio 10.0.0.858 PostgreSQL environment (.NET Framework 4.8 and .NET 8.0.31).
- Real MCP coverage includes an independent SysSchema base-row oracle, repeated inherited/own-package reads, a nonempty page write/readback, clear/readback, original configuration restoration/readback, and missing-object errors. Web and mobile are both exercised; this proves metadata persistence, not mobile page rendering.
- Installed unpatched Clio returned two changing IDs on the same fresh stand; the patched binary returned the correct root twice with unchanged page data. A saved replacement package also resolved to that root.
- Both disposable environments were removed, with registration, IIS site/pool, deployment directory and database absence independently verified.

## Contract and review

Docs updated: command help, command pages and index document base/root identity across replacing layers. MCP descriptions updated; existing argument names, DTO shape and destructive semantics are preserved. Prompts, resources, templates and wiki aliases reviewed, no update required. The current related-page knowledge guide makes no conflicting response-identity claim; no downstream knowledge repair is needed.

ClioRing compatibility reviewed, no Ring-consumed contract changed: inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing/ViewModels/ClioIpcViewModel.cs` and `clio-ring/ClioRing.Desktop/actions.json`; no related-page invocation or entitySchemaUId interpretation exists. Generic raw-result presentation is unchanged.

Comprehensive seven-perspective agentic review completed. Its empty-mobile-test finding was fixed with nonempty seed/readback and independently rechecked. Final comprehensive review of tree `75e61f258b74d7afda0dc11197efcf7b6a4e20b1` found no actionable issues across all seven perspectives. Claude implementation review `rev_c45241aff03d4526` found no blockers; its diagnostic and fixture-safety notes are addressed. The final Command-module rerun passed 4,567 tests with 13 existing skips. The earlier Claude design review also agreed with this approach.

Validation boundary: both reported Creatio runtimes were exercised on 10.0.0.858; older releases were not tested.

