### PR TITLE
Redact credentials in the CLI readable-message renderer (#1505)

### DIFF
--- a/clio.tests/Command/McpServer/SensitiveErrorTextRedactorTests.cs
+++ b/clio.tests/Command/McpServer/SensitiveErrorTextRedactorTests.cs
@@ -804,6 +804,69 @@ public sealed class SensitiveErrorTextRedactorTests {
 			because: "no cut is needed, so no ellipsis may appear");
 	}
 
+	[Test]
+	[Category("Unit")]
+	[Description("RedactCredentials keeps a URI without userinfo byte-identical, host, port, path and query included (#1505).")]
+	[TestCase("Cannot connect to http://ts1-core-dev04:88/sae_m_seeenu_16009960_0914/0/DataService")]
+	[TestCase("Probe https://ts1-core-dev04:88?u=john@acme.com answered 404")]
+	[TestCase("Endpoint https://host.example.com has no path")]
+	public void RedactCredentials_ShouldLeaveAUriWithoutUserInfo_Untouched(string text) {
+		// Act
+		string result = SensitiveErrorTextRedactor.RedactCredentials(text);
+
+		// Assert
+		result.Should().Be(text,
+			because: "the console variant redacts credentials only; the operator's own endpoint is the diagnosis, not a leak - and an '@' inside the query must not be mistaken for userinfo");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("RedactCredentials removes only the userinfo of a URI and keeps the host - including a password that contains '@' (#1505).")]
+	[TestCase("Request to https://user:pw@host.example.com/x failed", "Request to https://[redacted]@host.example.com/x failed")]
+	[TestCase("Request to https://user:p@ss@host.example.com/x failed", "Request to https://[redacted]@host.example.com/x failed")]
+	[TestCase("Request to https://user@host.example.com/x failed", "Request to https://[redacted]@host.example.com/x failed")]
+	public void RedactCredentials_ShouldStripUriUserInfo_AndKeepTheHost(string text, string expected) {
+		// Act
+		string result = SensitiveErrorTextRedactor.RedactCredentials(text);
+
+		// Assert
+		result.Should().Be(expected,
+			because: "the authority ends at the first '/', '?' or '#', and the last '@' inside the authority is the userinfo delimiter, so a password containing '@' is still removed whole");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("RedactCredentials leaves local paths, host:port pairs and e-mail addresses alone - only the console's own reader sees them (#1505).")]
+	public void RedactCredentials_ShouldLeaveLocalPathsHostPortsAndEmails_Untouched() {
+		// Arrange
+		const string text = "Could not find a part of the path '/Users/x/y.json'. Connection refused (localhost:1616). Contact john.doe@acme.com.";
+
+		// Act
+		string result = SensitiveErrorTextRedactor.RedactCredentials(text);
+
+		// Assert
+		result.Should().Be(text,
+			because: "the path, host:port and e-mail rules are deliberately not part of the console variant");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("RedactCredentials is idempotent: the AggregateException arm of the CLI renderer scrubs twice (#1505).")]
+	public void RedactCredentials_ShouldBeIdempotent() {
+		// Arrange
+		const string text = "SelectQuery failed: password=s3cr3t token Bearer eyJabc.def.ghi at https://user:pw@host/x";
+
+		// Act
+		string once = SensitiveErrorTextRedactor.RedactCredentials(text);
+		string twice = SensitiveErrorTextRedactor.RedactCredentials(once);
+
+		// Assert
+		once.Should().NotContain("s3cr3t").And.NotContain("eyJabc").And.NotContain("user:pw",
+			because: "the credential pair, the bearer token and the URI userinfo are the console variant's whole job");
+		twice.Should().Be(once,
+			because: "a second pass must find nothing new to replace");
+	}
+
 	private static int CountOccurrences(string text, string token) {
 		int count = 0;
 		int index = text.IndexOf(token, StringComparison.OrdinalIgnoreCase);

--- a/clio.tests/ExceptionReadableMessageExtension.Tests.cs
+++ b/clio.tests/ExceptionReadableMessageExtension.Tests.cs
@@ -323,6 +323,61 @@ public class ExceptionReadableMessageExtensionTestCase
 			because: "a secret-free line must not be altered, re-wrapped or truncated by the redaction wrapper");
 	}
 
+	[Test]
+	[Description(
+		"Issue #1505 follow-up: a local absolute path in clio's OWN prose must survive verbatim - the full "
+		+ "Redact turned `clio compress <missing dir>` into \"Could not find a part of the path "
+		+ "'[redacted-path]'.\", an error that names nothing.")]
+	public void GetReadableMessageException_ShouldKeepLocalPath_WhenMessageQuotesAnAbsolutePath() {
+		// Arrange
+		const string message = "Could not find a part of the path '/Users/x/y.json'.";
+		var exception = new InvalidOperationException(message);
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().Be(message,
+			because: "a path on the operator's own terminal is the diagnosis, not a secret to hide from them");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505 follow-up: the operator's own environment URL and host:port must survive verbatim, so a "
+		+ "connectivity error still names the environment that could not be reached.")]
+	public void GetReadableMessageException_ShouldKeepEnvironmentUrl_WhenMessageQuotesAnEndpoint() {
+		// Arrange
+		const string message = "Cannot connect to http://ts1-core-dev04:88/site";
+		var exception = new InvalidOperationException(message);
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().Be(message,
+			because: "a credential-free URL naming the operator's own stand must not be replaced by a placeholder");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505 follow-up: a credential embedded in a URL authority is still a credential - the userinfo "
+		+ "is removed while the host survives, so the line stays diagnosable.")]
+	public void GetReadableMessageException_ShouldRedactUriUserInfoOnly_WhenUrlCarriesCredentials() {
+		// Arrange
+		var exception = new InvalidOperationException("Request to https://user:pw@host.example.com/x failed");
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().NotContain("user:pw",
+			because: "credentials embedded in a URL authority must never reach the console in the clear");
+		result.Should().Contain("host.example.com/x",
+			because: "the host and path must survive so the operator still knows which endpoint failed");
+		result.Should().Contain("[redacted]@",
+			because: "only the userinfo prefix is replaced, by the redactor's stable placeholder");
+	}
+
 	/// <summary>
 	/// Builds a real <see cref="HttpWebResponse"/> carrying the supplied status code without opening a
 	/// socket. On modern .NET <see cref="HttpWebResponse"/> has no usable public constructor and its

--- a/clio.tests/ExceptionReadableMessageExtension.Tests.cs
+++ b/clio.tests/ExceptionReadableMessageExtension.Tests.cs
@@ -215,6 +215,114 @@ public class ExceptionReadableMessageExtensionTestCase
 			because: "the wrapped WebException status must be reported even when the wrapper is an InvalidOperationException");
 	}
 
+	[Test]
+	[Description(
+		"Issue #1505: the SelectQuery failure path (SelectQueryHelper / DataServiceSelectResponse) throws a "
+		+ "plain InvalidOperationException carrying the server's errorInfo.message, so the credential the "
+		+ "server echoed must be redacted while clio's own 'SelectQuery failed:' prefix survives.")]
+	public void GetReadableMessageException_ShouldRedactServerCredentials_WhenSelectQueryFailureIsRendered() {
+		// Arrange
+		var exception = new InvalidOperationException(
+			"SelectQuery failed: Configuration service failed: backend echoed "
+			+ "password=s3cr3t server=db.internal");
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().StartWith("SelectQuery failed: Configuration service failed:",
+			because: "clio's own diagnosis must survive redaction, otherwise the operator loses the reason");
+		result.Should().NotContain("s3cr3t",
+			because: "a credential the server echoed must never reach the console in the clear");
+		result.Should().NotContain("db.internal",
+			because: "the connection-string host the server echoed must be redacted like the password");
+		result.Should().Contain("password=[redacted]",
+			because: "the key is kept so the line still reads sensibly while the value is replaced");
+		result.Should().Contain("server=[redacted]",
+			because: "the same placeholder policy as the MCP path (ClioRunTool.RedactFailureContent) applies");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505: the InvalidOperationException arm prefers the inner message, so a bearer token in an "
+		+ "INNER exception must be redacted too - the arm that is actually taken is the one that has to scrub.")]
+	public void GetReadableMessageException_ShouldRedactBearerToken_WhenInvalidOperationExceptionWrapsInner() {
+		// Arrange
+		var inner = new Exception("Request rejected with Authorization: Bearer eyJhbGciOi.eyJzdWIiOi.c2lnbmF0dXJl");
+		var exception = new InvalidOperationException("SelectQuery failed", inner);
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().NotContain("eyJhbGciOi",
+			because: "a JWT surfaced by an inner exception must not reach the console in the clear");
+		result.Should().Contain("[redacted]",
+			because: "the token has to be replaced by the redactor's stable placeholder");
+		result.Should().StartWith("Request rejected with",
+			because: "redaction must not change which arm is taken nor the surrounding prose");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505: redaction is applied to the COMPOSED line, so the WebException enrichment that CI reads "
+		+ "must still be appended while a credential inside the exception message is replaced.")]
+	public void GetReadableMessageException_ShouldKeepWebExceptionEnrichment_WhenMessageCarriesCredential() {
+		// Arrange
+		using HttpWebResponse response = CreateHttpWebResponse(HttpStatusCode.Unauthorized);
+		var exception = new WebException(
+			"The remote server rejected password=s3cr3t",
+			null,
+			WebExceptionStatus.ProtocolError,
+			response);
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().NotContain("s3cr3t",
+			because: "the credential must be redacted even on the WebException arm");
+		result.Should().Contain("(WebException: ProtocolError (HTTP 401 Unauthorized))",
+			because: "the enrichment arm's structure must survive the redaction wrapper unchanged");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505: the debug path must stay exception.ToString() verbatim - --debug is the bridge back to "
+		+ "the raw server text, so redaction must not be applied there.")]
+	public void GetReadableMessageException_ShouldNotRedact_WhenDebugIsRequested() {
+		// Arrange
+		var exception = new InvalidOperationException(
+			"SelectQuery failed: backend echoed password=s3cr3t server=db.internal");
+
+		// Act
+		string result = exception.GetReadableMessageException(true);
+
+		// Assert
+		result.Should().Be(exception.ToString(),
+			because: "the debug render is unchanged by this issue and must remain the raw ToString()");
+		result.Should().Contain("password=s3cr3t",
+			because: "--debug deliberately keeps the raw text so an operator can diagnose the fault");
+	}
+
+	[Test]
+	[Description(
+		"Issue #1505: a message with no secret shapes must come back byte-identical - Scrub replaces known "
+		+ "secret shapes only, and does not flatten or clamp clio's own multi-line prose.")]
+	public void GetReadableMessageException_ShouldReturnMessageUnchanged_WhenNothingIsSensitive() {
+		// Arrange
+		string message = "Package 'MyPackage' was not found." + Environment.NewLine
+			+ "Run list-packages to see what is installed. " + new string('x', 400);
+		var exception = new InvalidOperationException(message);
+
+		// Act
+		string result = exception.GetReadableMessageException();
+
+		// Assert
+		result.Should().Be(message,
+			because: "a secret-free line must not be altered, re-wrapped or truncated by the redaction wrapper");
+	}
+
 	/// <summary>
 	/// Builds a real <see cref="HttpWebResponse"/> carrying the supplied status code without opening a
 	/// socket. On modern .NET <see cref="HttpWebResponse"/> has no usable public constructor and its

--- a/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
+++ b/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -359,6 +359,61 @@ internal static partial class SensitiveErrorTextRedactor {
 			result = CredentialPairRegex().Replace(result, match => $"{match.Groups[1].Value}={RedactedValue}");
 			return result;
 		});
+	}
+
+	/// <summary>
+	/// The CONSOLE-facing variant of <see cref="Redact"/> for text whose PROSE clio itself wrote: it runs
+	/// the credential rules only - embedded URI userinfo, JWTs, <c>Bearer</c> values and
+	/// <c>key=value</c> secret pairs - and deliberately leaves absolute paths, scheme-less
+	/// <c>host:port</c> endpoints, e-mail addresses and plain URLs intact.
+	/// </summary>
+	/// <remarks>
+	/// Issue #1505. Wrapping <see cref="ExceptionReadableMessageExtension"/>'s non-carrier arms in the full
+	/// <see cref="Redact"/> also scrubbed the operator's OWN local paths and endpoints, which are not
+	/// secrets on their own terminal and are the entire content of the diagnosis. Measured:
+	/// <c>clio compress /Users/&lt;user&gt;/nope1505dir -d /tmp/x.gz</c> printed
+	/// <c>Could not find a part of the path '[redacted-path]'.</c> - an error that names nothing.
+	/// <para>
+	/// The full <see cref="Redact"/> stays the rule for text a SERVER authored and for anything copied into
+	/// an MCP envelope, a log an operator pastes into a ticket, or a third-party LLM's context: there a path
+	/// or a host IS a leak. This variant is only for a line whose sole reader is the person who typed the
+	/// command.
+	/// </para>
+	/// <para>
+	/// <see cref="UriRegex"/> is reused rather than duplicated, with a match evaluator that removes only the
+	/// <c>user:pass@</c> authority prefix and keeps the host - so <c>https://user:pw@host/x</c> loses the
+	/// credential and stays diagnosable. A matched URI that cannot be parsed but whose authority carries an
+	/// <c>@</c> is replaced whole: this path must fail closed on an embedded credential.
+	/// </para>
+	/// </remarks>
+	/// <param name="text">The raw text of a console line clio composed itself.</param>
+	/// <returns>The text with credential shapes replaced; <see cref="string.Empty"/> for null/empty input.</returns>
+	public static string RedactCredentials(string? text) {
+		if (string.IsNullOrEmpty(text)) {
+			return string.Empty;
+		}
+		return ExecuteRegex(() => {
+			string result = UriRegex().Replace(text, StripUriUserInfo);
+			result = JwtRegex().Replace(result, RedactedValue);
+			result = BearerTokenRegex().Replace(result, RedactedValue);
+			return CredentialPairRegex().Replace(result, match => $"{match.Groups[1].Value}={RedactedValue}");
+		});
+	}
+
+	/// <summary>
+	/// Returns a matched URI unchanged unless its authority carries userinfo, in which case only the
+	/// <c>user:pass@</c> prefix is replaced and the host, port and path survive.
+	/// </summary>
+	private static string StripUriUserInfo(Match match) {
+		string value = match.Value;
+		int authorityStart = value.IndexOf("://", StringComparison.Ordinal) + 3;
+		int authorityEnd = value.IndexOf('/', authorityStart);
+		string authority = authorityEnd < 0 ? value[authorityStart..] : value[authorityStart..authorityEnd];
+		int at = authority.LastIndexOf('@');
+		if (at < 0) {
+			return value;
+		}
+		return string.Concat(value.AsSpan(0, authorityStart), RedactedValue, "@", value.AsSpan(authorityStart + at + 1));
 	}
 
 	internal static string ExecuteRegex(Func<string> operation) {

--- a/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
+++ b/clio/Command/McpServer/SensitiveErrorTextRedactor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -382,8 +382,8 @@ internal static partial class SensitiveErrorTextRedactor {
 	/// <para>
 	/// <see cref="UriRegex"/> is reused rather than duplicated, with a match evaluator that removes only the
 	/// <c>user:pass@</c> authority prefix and keeps the host - so <c>https://user:pw@host/x</c> loses the
-	/// credential and stays diagnosable. A matched URI that cannot be parsed but whose authority carries an
-	/// <c>@</c> is replaced whole: this path must fail closed on an embedded credential.
+	/// credential and stays diagnosable. A matched URI whose authority carries no <c>@</c> is returned
+	/// untouched, host, port, path and query included.
 	/// </para>
 	/// </remarks>
 	/// <param name="text">The raw text of a console line clio composed itself.</param>
@@ -402,18 +402,29 @@ internal static partial class SensitiveErrorTextRedactor {
 
 	/// <summary>
 	/// Returns a matched URI unchanged unless its authority carries userinfo, in which case only the
-	/// <c>user:pass@</c> prefix is replaced and the host, port and path survive.
+	/// <c>user:pass@</c> prefix is replaced and the host, port, path and query survive.
 	/// </summary>
+	/// <remarks>
+	/// The authority ends at the first <c>/</c>, <c>?</c> or <c>#</c>. Cutting at <c>/</c> alone was wrong
+	/// on a measured input: <c>https://host:88?u=john@acme.com</c> has no <c>/</c> at all, so the authority
+	/// ran into the query, the <c>@</c> of an e-mail was taken for userinfo, and the host was replaced
+	/// instead - leaving <c>https://[redacted]@acme.com</c>, which names the wrong endpoint.
+	/// <c>LastIndexOf</c> is searched inside those bounds because a password may itself contain <c>@</c>.
+	/// A raw <c>/</c> inside userinfo is not a valid URI (RFC 3986 requires it percent-encoded) and is not
+	/// handled: such a value ends the authority early and the pair is returned unchanged.
+	/// </remarks>
 	private static string StripUriUserInfo(Match match) {
 		string value = match.Value;
 		int authorityStart = value.IndexOf("://", StringComparison.Ordinal) + 3;
-		int authorityEnd = value.IndexOf('/', authorityStart);
-		string authority = authorityEnd < 0 ? value[authorityStart..] : value[authorityStart..authorityEnd];
-		int at = authority.LastIndexOf('@');
+		int authorityEnd = value.IndexOfAny(['/', '?', '#'], authorityStart);
+		if (authorityEnd < 0) {
+			authorityEnd = value.Length;
+		}
+		int at = value.LastIndexOf('@', authorityEnd - 1, authorityEnd - authorityStart);
 		if (at < 0) {
 			return value;
 		}
-		return string.Concat(value.AsSpan(0, authorityStart), RedactedValue, "@", value.AsSpan(authorityStart + at + 1));
+		return string.Concat(value.AsSpan(0, authorityStart), RedactedValue, "@", value.AsSpan(at + 1));
 	}
 
 	internal static string ExecuteRegex(Func<string> operation) {

--- a/clio/Common/UntrustedText.cs
+++ b/clio/Common/UntrustedText.cs
@@ -49,4 +49,15 @@ public static class UntrustedText {
 	/// </summary>
 	/// <param name="text">The raw, possibly-sensitive text.</param>
 	public static string Scrub(string text) => SensitiveErrorTextRedactor.Redact(text);
+
+	/// <summary>
+	/// The CONSOLE rendering for text whose PROSE clio itself wrote: credential shapes only - embedded URI
+	/// userinfo, JWT and <c>Bearer</c> values, <c>key=value</c> secret pairs. Absolute paths, scheme-less
+	/// <c>host:port</c> endpoints, e-mail addresses and plain URLs are left intact, because on the
+	/// operator's own terminal they are the diagnosis rather than a leak (issue #1505). Use
+	/// <see cref="Scrub"/> instead for text a server authored, or for anything an MCP envelope, a log or a
+	/// third-party model will read.
+	/// </summary>
+	/// <param name="text">The raw text of a console line clio composed itself.</param>
+	public static string ScrubCredentials(string text) => SensitiveErrorTextRedactor.RedactCredentials(text);
 }

--- a/clio/ExceptionReadableMessageExtension.cs
+++ b/clio/ExceptionReadableMessageExtension.cs
@@ -36,17 +36,19 @@ internal static class ExceptionReadableMessageExtension
 		// (ClioRunTool.RedactFailureContent) redacted the same text. So the composed non-debug line goes
 		// through the redactor once, here, for every arm.
 		//
-		// Scrub (= SensitiveErrorTextRedactor.Redact), NOT UntrustedText.ForConsole: ForConsole is the
-		// rendering for text that is ENTIRELY server-authored - it also flattens line breaks and clamps at
-		// 300 characters, which is right for a platform fault excerpt and wrong here, where most of what
-		// this renderer prints is clio's own multi-line prose for ~20 commands. Scrub replaces the known
-		// secret shapes and nothing else, so a message with no secrets comes back byte-identical. It is
-		// also exactly what the MCP path applies, which is the parity the issue asks for.
+		// ScrubCredentials, NOT Scrub and NOT ForConsole. The other two are the renderings for text a SERVER
+		// authored: ForConsole additionally flattens line breaks and clamps at 300 characters, and both
+		// scrub absolute paths, host:port endpoints and e-mail addresses. That is right for an excerpt
+		// bound for an MCP envelope, a log pasted into a ticket or a third-party model - and wrong here,
+		// where the reader is the person who typed the command and the path IS the diagnosis. Measured
+		// while this wrapper was still Scrub: `clio compress /Users/<user>/nope1505dir -d /tmp/x.gz`
+		// printed "Could not find a part of the path '[redacted-path]'." - an error naming nothing.
+		// ScrubCredentials runs the credential rules only (URI userinfo, JWT, Bearer, key=value secret
+		// pairs), so the server-echoed password above is still replaced and a secret-free line comes back
+		// byte-identical.
 		//
-		// The debug path above is untouched on purpose: --debug is the #1333 bridge back to the raw text,
-		// and it is the reason redacting an absolute path out of, say, a FileNotFoundException line here
-		// costs the operator nothing they cannot get back.
-		return UntrustedText.Scrub(exception switch
+		// The debug path above is untouched on purpose: --debug is the #1333 bridge back to the raw text.
+		return UntrustedText.ScrubCredentials(exception switch
 		{
 			AggregateException ex when ex.InnerException != null
 				=> ex.InnerException.GetReadableMessageException(debug),

--- a/clio/ExceptionReadableMessageExtension.cs
+++ b/clio/ExceptionReadableMessageExtension.cs
@@ -27,7 +27,26 @@ internal static class ExceptionReadableMessageExtension
 			return RenderServerDetailCarrier(carrier, exception, debug);
 		}
 		if (debug) return exception.ToString();
-		return exception switch
+		// Issue #1505: the non-carrier arms below render text whose CONTENT a server can influence -
+		// measured with `clio list-packages -e <env>` against a DataService answering HTTP 500 with
+		// {"success":false,"errorInfo":{"message":"Configuration service failed: backend echoed
+		// password=s3cr3t server=db.internal"}}: SelectQueryHelper throws
+		// InvalidOperationException("SelectQuery failed: <that prose>"), the IOE arm returned it verbatim,
+		// and the console printed the credential in the clear - while the MCP path
+		// (ClioRunTool.RedactFailureContent) redacted the same text. So the composed non-debug line goes
+		// through the redactor once, here, for every arm.
+		//
+		// Scrub (= SensitiveErrorTextRedactor.Redact), NOT UntrustedText.ForConsole: ForConsole is the
+		// rendering for text that is ENTIRELY server-authored - it also flattens line breaks and clamps at
+		// 300 characters, which is right for a platform fault excerpt and wrong here, where most of what
+		// this renderer prints is clio's own multi-line prose for ~20 commands. Scrub replaces the known
+		// secret shapes and nothing else, so a message with no secrets comes back byte-identical. It is
+		// also exactly what the MCP path applies, which is the parity the issue asks for.
+		//
+		// The debug path above is untouched on purpose: --debug is the #1333 bridge back to the raw text,
+		// and it is the reason redacting an absolute path out of, say, a FileNotFoundException line here
+		// costs the operator nothing they cannot get back.
+		return UntrustedText.Scrub(exception switch
 		{
 			AggregateException ex when ex.InnerException != null
 				=> ex.InnerException.GetReadableMessageException(debug),
@@ -43,7 +62,7 @@ internal static class ExceptionReadableMessageExtension
 				=> $"{exception.Message} ({DescribeWebException(nestedWebException)})",
 			InvalidOperationException ex => ex.InnerException?.Message ?? ex.Message,
 			_ => exception.Message
-		};
+		});
 	}
 
 	/// <summary>

--- a/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
+++ b/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
@@ -32,6 +32,18 @@ same treatment, and it also renders a carrier's OWN message rather than an inner
 `InvalidOperationException` arm that preferred `InnerException.Message` was printing the raw parser
 fault instead of the composed diagnosis.
 
+Since issue #1505 the rule covers that renderer's **non-carrier** arms too: a failure with no
+`IServerDetailCarrier` can still carry server prose (`SelectQueryHelper` /
+`DataServiceSelectResponse` throw a plain `InvalidOperationException("SelectQuery failed: " +
+errorInfo.message)`), and the arms returned it verbatim while the MCP path redacted the same text.
+The whole composed non-debug line now goes through `UntrustedText.Scrub` once. That variant, not
+`ForConsole`: these arms render mostly clio-authored, often multi-line prose for ~20 commands, and
+`ForConsole` additionally flattens line breaks and clamps at 300 characters — right for an excerpt
+that is entirely server-authored, wrong for a composed CLI line. `Scrub` replaces the known secret
+shapes only, so a secret-free message is byte-identical. The debug path stays `exception.ToString()`
+unredacted, which is what makes redacting an absolute path out of, for example, a
+`FileNotFoundException` line cost the operator nothing.
+
 The single exception is a plain `Success == false` whose `ErrorMessage` is the platform's own
 validation prose ("Column 'Name' is required") — no fixed sentence can replace it without destroying
 the diagnosis. That one is kept, but passed through

--- a/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
+++ b/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
@@ -9,6 +9,7 @@ applies-to:
   - clio/Command/SysSettingsCommand.cs
   - clio/Command/McpServer/SensitiveErrorTextRedactor.cs
   - clio/ExceptionReadableMessageExtension.cs
+  - clio/Common/UntrustedText.cs
   - clio/Common/ServerReportedFailureText.cs
 ticket: GH-1333
 date: 2026-09-03
@@ -39,9 +40,11 @@ errorInfo.message)`), and the arms returned it verbatim while the MCP path redac
 The whole composed non-debug line now goes through `UntrustedText.ScrubCredentials` once.
 
 **Credentials only, and deliberately so.** That line is composed mostly of clio's OWN prose for ~20
-commands, and its only reader is the person who typed the command — for whom their own local path,
+commands, and its primary reader is the person who typed the command — for whom their own local path,
 their own environment URL, their own `host:port` and their own e-mail address are the diagnosis, not
-a leak. The first attempt used the full `Scrub`, and `clio compress /Users/<user>/nope1505dir -d
+a leak. (The same `WriteError` buffer can reach `CommandExecutionResult.Messages` on the trusted
+stdio MCP path; full fidelity there is by design, and the passthrough path applies the full `Redact`
+separately.) The first attempt used the full `Scrub`, and `clio compress /Users/<user>/nope1505dir -d
 /tmp/x.gz` printed `Could not find a part of the path '[redacted-path]'.` — an error that names
 nothing. `ForConsole` is wrong here for a second reason on top of that: it also flattens line breaks
 and clamps at 300 characters, which is right for a platform fault excerpt and wrong for a composed

--- a/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
+++ b/docs/knowledge/Common/server-prose-never-reaches-a-non-debug-diagnostic-field.md
@@ -36,13 +36,25 @@ Since issue #1505 the rule covers that renderer's **non-carrier** arms too: a fa
 `IServerDetailCarrier` can still carry server prose (`SelectQueryHelper` /
 `DataServiceSelectResponse` throw a plain `InvalidOperationException("SelectQuery failed: " +
 errorInfo.message)`), and the arms returned it verbatim while the MCP path redacted the same text.
-The whole composed non-debug line now goes through `UntrustedText.Scrub` once. That variant, not
-`ForConsole`: these arms render mostly clio-authored, often multi-line prose for ~20 commands, and
-`ForConsole` additionally flattens line breaks and clamps at 300 characters — right for an excerpt
-that is entirely server-authored, wrong for a composed CLI line. `Scrub` replaces the known secret
-shapes only, so a secret-free message is byte-identical. The debug path stays `exception.ToString()`
-unredacted, which is what makes redacting an absolute path out of, for example, a
-`FileNotFoundException` line cost the operator nothing.
+The whole composed non-debug line now goes through `UntrustedText.ScrubCredentials` once.
+
+**Credentials only, and deliberately so.** That line is composed mostly of clio's OWN prose for ~20
+commands, and its only reader is the person who typed the command — for whom their own local path,
+their own environment URL, their own `host:port` and their own e-mail address are the diagnosis, not
+a leak. The first attempt used the full `Scrub`, and `clio compress /Users/<user>/nope1505dir -d
+/tmp/x.gz` printed `Could not find a part of the path '[redacted-path]'.` — an error that names
+nothing. `ForConsole` is wrong here for a second reason on top of that: it also flattens line breaks
+and clamps at 300 characters, which is right for a platform fault excerpt and wrong for a composed
+CLI line.
+
+So the third rendering exists: `UntrustedText.ScrubCredentials` →
+`SensitiveErrorTextRedactor.RedactCredentials`, which runs `UriRegex` (through a match evaluator that
+removes only `user:pass@` and keeps the host), `JwtRegex`, `BearerTokenRegex` and
+`CredentialPairRegex`, and does NOT run the path, `host:port` or e-mail rules. A secret-free message
+is byte-identical. The distinction is the SINK, not the text: the moment the same line is copied into
+an MCP envelope, a log an operator pastes into a ticket, or a third-party model's context, a path and
+a host ARE a leak and the full `Scrub`/`Fenced` rules apply. The debug path stays
+`exception.ToString()` unredacted.
 
 The single exception is a plain `Success == false` whose `ErrorMessage` is the platform's own
 validation prose ("Column 'Name' is required") — no fixed sentence can replace it without destroying
@@ -76,7 +88,8 @@ So a failure composed from server prose carries **both** renderings and each sin
 | Rendering | Produced by | Read by |
 | --- | --- | --- |
 | fenced | `UntrustedText.Fenced` → `SensitiveErrorTextRedactor.RedactUntrustedOrNull` | MCP envelope fields, `WriteDebug` (which MCP mode still captures) |
-| unfenced | `UntrustedText.ForConsole` → `SensitiveErrorTextRedactor.RedactForConsoleOrNull` | `ILogger.WriteError` lines that are not MCP-visible, `GetReadableMessageException` at default verbosity |
+| unfenced | `UntrustedText.ForConsole` → `SensitiveErrorTextRedactor.RedactForConsoleOrNull` | `ILogger.WriteError` lines that are not MCP-visible, a carrier's `ConsoleMessage` |
+| credentials only | `UntrustedText.ScrubCredentials` → `SensitiveErrorTextRedactor.RedactCredentials` | `GetReadableMessageException`'s non-carrier arms at default verbosity (issue #1505) |
 
 `ServerReportedFailureText.ConsoleCause` / `ComposeConsoleMessage` and
 `IConsoleRenderedFailure.ConsoleMessage` (implemented by `DataProviderFailureException`) are the seams.


### PR DESCRIPTION
🔗 **Issue:** [#1505](https://github.com/Advance-Technologies-Foundation/clio/issues/1505)

## What

The CLI top-level exception renderer (`ExceptionReadableMessageExtension.GetReadableMessageException`, used by `Program` and ~20 commands' `catch` blocks) printed server-authored text verbatim. Measured through a local HTTP relay in front of a real .NET Framework stand, answering `SelectQuery` with HTTP 500 and an `errorInfo.message` carrying credentials:

```
before: [ERR] - SelectQuery failed: Configuration service failed: backend echoed password=s3cr3t server=db.internal token Bearer eyJabc.def.ghi
after:  [ERR] - SelectQuery failed: Configuration service failed: backend echoed password=[redacted] server=[redacted] token [redacted]
```

The MCP path (`ClioRunTool.RedactFailureContent`) already redacted the same text; the CLI now matches it.

- The non-carrier, non-debug arms of the renderer pass their result through a new `SensitiveErrorTextRedactor.RedactCredentials` (exposed as `UntrustedText.ScrubCredentials`): credential pairs, bearer tokens, JWTs, and the `user:pass@` userinfo of a URI (host, port, path and query are kept).
- **Credentials only, deliberately.** The first cut used the full `Redact`, and `clio compress /Users/<user>/nope -d x.gz` printed `Could not find a part of the path '[redacted-path]'` — the operator's own local path, environment URL, `host:port` and e-mail are the diagnosis on their own console, not a leak. Those rules are not part of the console variant; the three local-path probes (`compress`, `push-pkg`, `restore-workspace`) print byte-identical lines to master.
- The debug path (`--debug`, `exception.ToString()`) and the server-detail carrier path (#1333) are unchanged.
- Known, documented limit: a raw `/` inside URI userinfo is not a valid URI and is not handled.

## Verification

- `dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&(Module=Core|Module=Common|Module=Command|Module=McpServer)"` — 11510 passed / 25 failed (the macOS-only baseline; the failing name set is identical on master) / 33 skipped. Renderer fixture 24/24, redactor fixture incl. 4 new direct `RedactCredentials` tests.
- Stand `ts1-core-dev04:88/sae_m_seeenu_16009960_0914` via relay: before/after lines above. Local-path probes: identical to master.

## Review

Small diff → single combined lens (correctness + security + quality); its two Medium findings (authority bound at `/` only; no direct tests for the new entry point) are fixed in the third commit. Codex CLI is out of credits.

Docs reviewed, no update required (renderer only; no option or verb changed). MCP reviewed, no update required (MCP already redacted this text; CLI now matches). ClioRing compatibility reviewed, no Ring-consumed contract changed (Ring receives failure content through `clio-run`, which already passed `Redact`; redaction is idempotent, bytes unchanged).

Knowledge record `server-prose-never-reaches-a-non-debug-diagnostic-field.md` extended with the console renderer rule and why it scrubs credentials only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
