### PR TITLE
Cut Team_Atf_ClioMcpE2eTests duration by removing duplicated e2e work

### DIFF
--- a/clio.mcp.e2e/AddItemModelToolE2ETests.cs
+++ b/clio.mcp.e2e/AddItemModelToolE2ETests.cs
@@ -74,29 +74,10 @@ public sealed class AddItemModelToolE2ETests {
 		return new AddItemModelArrangeContext(rootDirectory, outputFolderPath, environmentName, session, cancellationTokenSource);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"add-item-model MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			$"add-item-model MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static async Task<AddItemModelActResult> ActAsync(
 		McpServerSession session,

--- a/clio.mcp.e2e/AddItemModelToolE2ETests.cs
+++ b/clio.mcp.e2e/AddItemModelToolE2ETests.cs
@@ -19,7 +19,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature("add-item-model")]
 [NonParallelizable]
-public sealed class AddItemModelToolE2ETests {
+public sealed class AddItemModelToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = AddItemModelTool.AddItemModelToolName;
 	private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
@@ -63,14 +63,14 @@ public sealed class AddItemModelToolE2ETests {
 				because: "model generation should create at least one model class file in addition to the shared helper");
 	}
 
-	private static async Task<AddItemModelArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
+	private async Task<AddItemModelArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(10));
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		await ClioCliCommandRunner.EnsureCliogateInstalledAsync(settings, environmentName, cancellationTokenSource.Token);
 		string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-add-item-model-e2e-{Guid.NewGuid():N}");
 		string outputFolderPath = Path.Combine(rootDirectory, "Models");
 		Directory.CreateDirectory(rootDirectory);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new AddItemModelArrangeContext(rootDirectory, outputFolderPath, environmentName, session, cancellationTokenSource);
 	}
 
@@ -136,12 +136,12 @@ public sealed class AddItemModelToolE2ETests {
 		string EnvironmentName,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -18,7 +18,7 @@ namespace Clio.Mcp.E2E;
 [TestFixture]
 [AllureNUnit]
 [NonParallelizable]
-public sealed class ApplicationSectionMaintenanceToolE2ETests {
+public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtureBase {
 	private const string SectionListToolName = ApplicationSectionGetListTool.ApplicationSectionGetListToolName;
 	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
@@ -310,19 +310,10 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 	/// <param name="settings">Settings for the child process.</param>
 	/// <param name="cancellationToken">Bounds the start.</param>
 	/// <returns>The shared session.</returns>
-	private static async Task<McpServerSession> GetOrStartSharedSessionAsync(
+	private Task<McpServerSession> GetOrStartSharedSessionAsync(
 		McpE2ESettings settings,
 		CancellationToken cancellationToken) =>
-		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
+		Task.FromResult(Session);
 
-	private static McpServerSession? _sharedSession;
-
-	[OneTimeTearDown]
-	public static async Task StopSharedSessionAsync() {
-		if (_sharedSession is not null) {
-			await _sharedSession.DisposeAsync();
-			_sharedSession = null;
-		}
-	}
 
 }

--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -37,7 +37,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -72,7 +72,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session,
 			cancellationTokenSource.Token,
@@ -121,7 +121,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -166,7 +166,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 
 		string caption = $"E2E Del {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		string? createdSectionCode = null;
 		try {
 			// Act 1: create a new section in the seeded application
@@ -289,4 +289,40 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 			callResult.Content
 		});
 	}
+
+	/// <summary>
+	/// Returns this fixture's single MCP server process, starting it on first use.
+	/// </summary>
+	/// <remarks>
+	/// Each test used to start its own child server. TeamCity bills only test bodies, so those process
+	/// lifecycles — roughly 1.8 s to start and 0.5 s to tear down apiece — were invisible while still
+	/// being paid on every run. The tests here share one read/create workload against one environment
+	/// and none of them mutates server state at startup, so a single process serves them all. The
+	/// fixture is <c>[NonParallelizable]</c>, so the lazy start needs no lock. It is lazy rather than
+	/// <c>[OneTimeSetUp]</c> on purpose: an <c>Assert.Ignore</c> raised from one-time setup skips the
+	/// WHOLE fixture, which would hide the tests that need no reachable stand.
+	/// <para>
+	/// A test that needs its OWN session — different client capabilities, or a deliberate restart — must
+	/// keep calling <see cref="McpServerSession.StartAsync(McpE2ESettings, CancellationToken)"/> directly
+	/// and dispose what it started.
+	/// </para>
+	/// </remarks>
+	/// <param name="settings">Settings for the child process.</param>
+	/// <param name="cancellationToken">Bounds the start.</param>
+	/// <returns>The shared session.</returns>
+	private static async Task<McpServerSession> GetOrStartSharedSessionAsync(
+		McpE2ESettings settings,
+		CancellationToken cancellationToken) =>
+		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
+
+	private static McpServerSession? _sharedSession;
+
+	[OneTimeTearDown]
+	public static async Task StopSharedSessionAsync() {
+		if (_sharedSession is not null) {
+			await _sharedSession.DisposeAsync();
+			_sharedSession = null;
+		}
+	}
+
 }

--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -277,35 +277,10 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests {
 		return ApplicationResultParser.ExtractSectionList(callResult);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static string DescribeCallResult(CallToolResult callResult) {
 		return JsonSerializer.Serialize(new {

--- a/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionMaintenanceToolE2ETests.cs
@@ -37,7 +37,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtu
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -72,7 +72,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtu
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		ApplicationListItemEnvelope installedApplication = await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session,
 			cancellationTokenSource.Token,
@@ -121,7 +121,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtu
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -166,7 +166,7 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtu
 
 		string caption = $"E2E Del {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		string? createdSectionCode = null;
 		try {
 			// Act 1: create a new section in the seeded application
@@ -289,31 +289,5 @@ public sealed class ApplicationSectionMaintenanceToolE2ETests : McpContractFixtu
 			callResult.Content
 		});
 	}
-
-	/// <summary>
-	/// Returns this fixture's single MCP server process, starting it on first use.
-	/// </summary>
-	/// <remarks>
-	/// Each test used to start its own child server. TeamCity bills only test bodies, so those process
-	/// lifecycles — roughly 1.8 s to start and 0.5 s to tear down apiece — were invisible while still
-	/// being paid on every run. The tests here share one read/create workload against one environment
-	/// and none of them mutates server state at startup, so a single process serves them all. The
-	/// fixture is <c>[NonParallelizable]</c>, so the lazy start needs no lock. It is lazy rather than
-	/// <c>[OneTimeSetUp]</c> on purpose: an <c>Assert.Ignore</c> raised from one-time setup skips the
-	/// WHOLE fixture, which would hide the tests that need no reachable stand.
-	/// <para>
-	/// A test that needs its OWN session — different client capabilities, or a deliberate restart — must
-	/// keep calling <see cref="McpServerSession.StartAsync(McpE2ESettings, CancellationToken)"/> directly
-	/// and dispose what it started.
-	/// </para>
-	/// </remarks>
-	/// <param name="settings">Settings for the child process.</param>
-	/// <param name="cancellationToken">Bounds the start.</param>
-	/// <returns>The shared session.</returns>
-	private Task<McpServerSession> GetOrStartSharedSessionAsync(
-		McpE2ESettings settings,
-		CancellationToken cancellationToken) =>
-		Task.FromResult(Session);
-
 
 }

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -902,35 +902,10 @@ public sealed class ApplicationSectionToolE2ETests {
 		}
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static string DescribeCallResult(CallToolResult callResult) {
 		return JsonSerializer.Serialize(new {

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -23,7 +23,6 @@ namespace Clio.Mcp.E2E;
 [NonParallelizable]
 public sealed class ApplicationSectionToolE2ETests {
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
-	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string ApplicationCode = "AutoTestClioMcp";
 
 	/// <summary>
@@ -517,54 +516,34 @@ public sealed class ApplicationSectionToolE2ETests {
 		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		string? createdSectionCode = null;
-		try {
-			// Act
-			CallToolResult callResult = await session.CallToolAsync(
-				SectionCreateToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["caption"] = caption,
-						["entity-schema-name"] = platformEntitySchemaName
-					}
-				},
-				cancellationTokenSource.Token);
-			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
-
-			// Assert
-			callResult.IsError.Should().NotBeTrue(
-				because: $"create-app-section with a platform entity should not throw an MCP-level error. Actual: {DescribeCallResult(callResult)}");
-			response.Success.Should().BeTrue(
-				because: $"create-app-section with entity-schema-name:{platformEntitySchemaName} must return success:true. " +
-					"Creatio stores Code = EntitySchemaName for platform entity sections, so the readback poll must match " +
-					$"by entity schema name, not the caption-derived code sent in the INSERT. Error: {response.Error}");
-			response.Section.Should().NotBeNull(
-				because: "a successful create-app-section must include the created section metadata in the readback");
-			response.Section!.EntitySchemaName.Should().Be(platformEntitySchemaName,
-				because: "the readback must preserve the platform entity schema name provided in the create request");
-
-			createdSectionCode = response.Section.Code;
-		} finally {
-			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = createdSectionCode
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+		// The stand is deployed fresh for every build and torn down with it, so the created section is not
+		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
+		// section list checks membership of its own section — none reads a total count.
+		// Act
+		CallToolResult callResult = await session.CallToolAsync(
+			SectionCreateToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = ApplicationCode,
+					["caption"] = caption,
+					["entity-schema-name"] = platformEntitySchemaName
 				}
-			}
-		}
+			},
+			cancellationTokenSource.Token);
+		ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: $"create-app-section with a platform entity should not throw an MCP-level error. Actual: {DescribeCallResult(callResult)}");
+		response.Success.Should().BeTrue(
+			because: $"create-app-section with entity-schema-name:{platformEntitySchemaName} must return success:true. " +
+				"Creatio stores Code = EntitySchemaName for platform entity sections, so the readback poll must match " +
+				$"by entity schema name, not the caption-derived code sent in the INSERT. Error: {response.Error}");
+		response.Section.Should().NotBeNull(
+			because: "a successful create-app-section must include the created section metadata in the readback");
+		response.Section!.EntitySchemaName.Should().Be(platformEntitySchemaName,
+			because: "the readback must preserve the platform entity schema name provided in the create request");
 	}
 
 	[Category("McpE2E.Sandbox")]
@@ -754,61 +733,44 @@ public sealed class ApplicationSectionToolE2ETests {
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		List<string> createdSectionCodes = new();
-		try {
-			// Act — fire every create-app-section call concurrently against the SAME application, on one
-			// long-lived MCP server, exactly reproducing the parallel batch that produced the contention.
-			Task<CallToolResult>[] calls = captions
-				.Select(caption => session.CallToolAsync(
-					SectionCreateToolName,
-					new Dictionary<string, object?> {
-						["args"] = new Dictionary<string, object?> {
-							["environment-name"] = environmentName,
-							["application-code"] = ApplicationCode,
-							["caption"] = caption
-						}
-					},
-					cancellationTokenSource.Token))
-				.ToArray();
-			CallToolResult[] results = await Task.WhenAll(calls);
+		// The stand is deployed fresh for every build and torn down with it, so the created section is not
+		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
+		// section list checks membership of its own section — none reads a total count.
+		// Act — fire every create-app-section call concurrently against the SAME application, on one
+		// long-lived MCP server, exactly reproducing the parallel batch that produced the contention.
+		Task<CallToolResult>[] calls = captions
+			.Select(caption => session.CallToolAsync(
+				SectionCreateToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = environmentName,
+						["application-code"] = ApplicationCode,
+						["caption"] = caption
+					}
+				},
+				cancellationTokenSource.Token))
+			.ToArray();
+		CallToolResult[] results = await Task.WhenAll(calls);
 
-			// Assert
-			for (int i = 0; i < results.Length; i++) {
-				CallToolResult callResult = results[i];
-				callResult.IsError.Should().NotBeTrue(
-					because: $"concurrent create-app-section '{captions[i]}' must not surface as an MCP-level error. Actual: {DescribeCallResult(callResult)}");
-				ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
-				response.ErrorClass.Should().NotBe("contention",
-					because: $"the in-process serialization guard plus verify+retry must prevent a spurious contention failure for '{captions[i]}' (ENG-93089)");
-				(response.Error ?? string.Empty).Should().NotContain("InsertQuery failed",
-					because: $"concurrent creation against one app must not abort with the opaque 'InsertQuery failed' for '{captions[i]}'");
-				response.Success.Should().BeTrue(
-					because: $"every serialized concurrent create-app-section must ultimately succeed. Error: {response.Error}");
-				if (!string.IsNullOrWhiteSpace(response.Section?.Code)) {
-					createdSectionCodes.Add(response.Section!.Code);
-				}
-			}
-
-			createdSectionCodes.Should().HaveCount(concurrentCount,
-				because: "each concurrently-requested section must be created exactly once, with no duplicate and no contention loss");
-		} finally {
-			foreach (string code in createdSectionCodes) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = code
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{code}' failed: {ex.Message}");
-				}
+		// Assert
+		for (int i = 0; i < results.Length; i++) {
+			CallToolResult callResult = results[i];
+			callResult.IsError.Should().NotBeTrue(
+				because: $"concurrent create-app-section '{captions[i]}' must not surface as an MCP-level error. Actual: {DescribeCallResult(callResult)}");
+			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
+			response.ErrorClass.Should().NotBe("contention",
+				because: $"the in-process serialization guard plus verify+retry must prevent a spurious contention failure for '{captions[i]}' (ENG-93089)");
+			(response.Error ?? string.Empty).Should().NotContain("InsertQuery failed",
+				because: $"concurrent creation against one app must not abort with the opaque 'InsertQuery failed' for '{captions[i]}'");
+			response.Success.Should().BeTrue(
+				because: $"every serialized concurrent create-app-section must ultimately succeed. Error: {response.Error}");
+			if (!string.IsNullOrWhiteSpace(response.Section?.Code)) {
+				createdSectionCodes.Add(response.Section!.Code);
 			}
 		}
+
+		createdSectionCodes.Should().HaveCount(concurrentCount,
+			because: "each concurrently-requested section must be created exactly once, with no duplicate and no contention loss");
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
@@ -864,69 +826,49 @@ public sealed class ApplicationSectionToolE2ETests {
 		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		string? createdSectionCode = null;
-		try {
-			// Act — the call answers within seconds; the section is created afterwards, or not at all.
-			CallToolResult createResult = await session.CallToolAsync(
-				SectionCreateToolName,
+		// The stand is deployed fresh for every build and torn down with it, so the created section is not
+		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
+		// section list checks membership of its own section — none reads a total count.
+		// Act — the call answers within seconds; the section is created afterwards, or not at all.
+		CallToolResult createResult = await session.CallToolAsync(
+			SectionCreateToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = ApplicationCode,
+					["caption"] = caption
+				}
+			},
+			cancellationTokenSource.Token);
+		ApplicationSectionContextResponseEnvelope createResponse =
+			ApplicationResultParser.ExtractSectionCreate(createResult);
+
+		// Assert — first half of the contract: the classified in-progress envelope.
+		createResponse.SectionCreated.Should().Be("in-progress",
+			because: $"a 50 ms deadline cannot outlast a real section insert, so the tool must answer in-progress. Actual: {DescribeCallResult(createResult)}");
+
+		// Assert — second half: the work the envelope promised is still running must actually land.
+		// Polling is what the retry-guidance tells an agent to do, so the test does exactly that.
+		ApplicationSectionEnvelope? createdSection = null;
+		for (int attempt = 0; attempt < DetachedWorkPollAttempts && createdSection is null; attempt++) {
+			await Task.Delay(DetachedWorkPollInterval, cancellationTokenSource.Token);
+			CallToolResult listResult = await session.CallToolAsync(
+				SectionListToolName,
 				new Dictionary<string, object?> {
 					["args"] = new Dictionary<string, object?> {
 						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["caption"] = caption
+						["application-code"] = ApplicationCode
 					}
 				},
 				cancellationTokenSource.Token);
-			ApplicationSectionContextResponseEnvelope createResponse =
-				ApplicationResultParser.ExtractSectionCreate(createResult);
-
-			// Assert — first half of the contract: the classified in-progress envelope.
-			createResponse.SectionCreated.Should().Be("in-progress",
-				because: $"a 50 ms deadline cannot outlast a real section insert, so the tool must answer in-progress. Actual: {DescribeCallResult(createResult)}");
-
-			// Assert — second half: the work the envelope promised is still running must actually land.
-			// Polling is what the retry-guidance tells an agent to do, so the test does exactly that.
-			ApplicationSectionEnvelope? createdSection = null;
-			for (int attempt = 0; attempt < DetachedWorkPollAttempts && createdSection is null; attempt++) {
-				await Task.Delay(DetachedWorkPollInterval, cancellationTokenSource.Token);
-				CallToolResult listResult = await session.CallToolAsync(
-					SectionListToolName,
-					new Dictionary<string, object?> {
-						["args"] = new Dictionary<string, object?> {
-							["environment-name"] = environmentName,
-							["application-code"] = ApplicationCode
-						}
-					},
-					cancellationTokenSource.Token);
-				createdSection = ApplicationResultParser.ExtractSectionList(listResult).Sections
-					?.FirstOrDefault(section => string.Equals(section.Caption, caption, StringComparison.Ordinal));
-			}
-
-			createdSection.Should().NotBeNull(
-				because: $"the in-progress envelope promised the section was still being created server-side, so after {DetachedWorkPollAttempts * DetachedWorkPollInterval.TotalSeconds:0}s of the polling that envelope itself prescribes it must exist — a section that never appears makes the guidance unfollowable (clio#1421)");
-			createdSection!.Code.Should().NotBeNullOrWhiteSpace(
-				because: "the section the detached work created must be fully readable, not a partial record");
-
-			createdSectionCode = createdSection.Code;
-		} finally {
-			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = createdSectionCode
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
-				}
-			}
+			createdSection = ApplicationResultParser.ExtractSectionList(listResult).Sections
+				?.FirstOrDefault(section => string.Equals(section.Caption, caption, StringComparison.Ordinal));
 		}
+
+		createdSection.Should().NotBeNull(
+			because: $"the in-progress envelope promised the section was still being created server-side, so after {DetachedWorkPollAttempts * DetachedWorkPollInterval.TotalSeconds:0}s of the polling that envelope itself prescribes it must exist — a section that never appears makes the guidance unfollowable (clio#1421)");
+		createdSection!.Code.Should().NotBeNullOrWhiteSpace(
+			because: "the section the detached work created must be fully readable, not a partial record");
 	}
 
 	/// <summary>
@@ -1016,44 +958,17 @@ public sealed class ApplicationSectionToolE2ETests {
 			progress,
 			cancellationTokenSource.Token);
 		ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
-		_customEntitySectionEnvironmentName = environmentName;
-		_customEntitySectionCode = response.Section?.Code;
 		cancellationTokenSource.Dispose();
 		_customEntitySection = new SharedCustomEntitySection(callResult, response, [.. progress.Messages]);
 		return _customEntitySection;
 	}
 
 	private static SharedCustomEntitySection? _customEntitySection;
-	private static string? _customEntitySectionCode;
-	private static string? _customEntitySectionEnvironmentName;
 
 	private sealed record SharedCustomEntitySection(
 		CallToolResult CallResult,
 		ApplicationSectionContextResponseEnvelope Response,
 		IReadOnlyList<string> ProgressMessages);
 
-	[OneTimeTearDown]
-	public static async Task RemoveSharedCustomEntitySectionAsync() {
-		if (string.IsNullOrWhiteSpace(_customEntitySectionCode) || _sharedSession is null) {
-			return;
-		}
-		string sectionCode = _customEntitySectionCode;
-		_customEntitySectionCode = null;
-		try {
-			using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-			await _sharedSession.CallToolAsync(
-				SectionDeleteToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = _customEntitySectionEnvironmentName,
-						["application-code"] = ApplicationCode,
-						["section-code"] = sectionCode
-					}
-				},
-				cleanupCts.Token);
-		} catch (Exception exception) {
-			TestContext.Out.WriteLine($"[cleanup] failed to remove shared section '{sectionCode}': {exception.Message}");
-		}
-	}
 
 }

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -171,7 +171,11 @@ public sealed class ApplicationSectionToolE2ETests {
 			settings.ClioProcessPath,
 			settings.ProcessEnvironmentVariables);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		// A COLD session on purpose: this test asserts on behaviour that only appears while the first
+		// call is still slow — an unmet response deadline, or progress arriving during a long call.
+		// The fixture-wide session has its connection and login already warm, which lets the call
+		// finish before the condition under test can occur.
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 
 		try {
 			// Act
@@ -780,7 +784,11 @@ public sealed class ApplicationSectionToolE2ETests {
 		// inside the interval and this test observes zero notifications while the relay is working perfectly.
 		settings.ProcessEnvironmentVariables[McpProgressHeartbeat.IntervalOverrideEnvVar] = "0.05";
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		// A COLD session on purpose: this test asserts on behaviour that only appears while the first
+		// call is still slow — an unmet response deadline, or progress arriving during a long call.
+		// The fixture-wide session has its connection and login already warm, which lets the call
+		// finish before the condition under test can occur.
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		MessageCollectingProgress progress = new();
 
 		// Act — list-app-sections is read-only and always performs a backend round-trip, so the
@@ -952,7 +960,11 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		string caption = $"E2E Deadline {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(12));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		// A COLD session on purpose: this test asserts on behaviour that only appears while the first
+		// call is still slow — an unmet response deadline, or progress arriving during a long call.
+		// The fixture-wide session has its connection and login already warm, which lets the call
+		// finish before the condition under test can occur.
+		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		string? createdSectionCode = null;

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -22,6 +22,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [NonParallelizable]
 public sealed class ApplicationSectionToolE2ETests {
+	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
 	private const string ApplicationCode = "AutoTestClioMcp";
 
@@ -516,9 +517,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		// The stand is deployed fresh for every build and torn down with it, so the created section is not
-		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
-		// section list checks membership of its own section — none reads a total count.
+		// Created sections are removed once per fixture, not per test — see RemoveCreatedSectionsAsync.
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
 			SectionCreateToolName,
@@ -544,6 +543,7 @@ public sealed class ApplicationSectionToolE2ETests {
 			because: "a successful create-app-section must include the created section metadata in the readback");
 		response.Section!.EntitySchemaName.Should().Be(platformEntitySchemaName,
 			because: "the readback must preserve the platform entity schema name provided in the create request");
+		RecordCreatedSection(response.Section.Code, environmentName);
 	}
 
 	[Category("McpE2E.Sandbox")]
@@ -733,9 +733,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		List<string> createdSectionCodes = new();
-		// The stand is deployed fresh for every build and torn down with it, so the created section is not
-		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
-		// section list checks membership of its own section — none reads a total count.
+		// Created sections are removed once per fixture, not per test — see RemoveCreatedSectionsAsync.
 		// Act — fire every create-app-section call concurrently against the SAME application, on one
 		// long-lived MCP server, exactly reproducing the parallel batch that produced the contention.
 		Task<CallToolResult>[] calls = captions
@@ -766,6 +764,7 @@ public sealed class ApplicationSectionToolE2ETests {
 				because: $"every serialized concurrent create-app-section must ultimately succeed. Error: {response.Error}");
 			if (!string.IsNullOrWhiteSpace(response.Section?.Code)) {
 				createdSectionCodes.Add(response.Section!.Code);
+					RecordCreatedSection(response.Section.Code, environmentName);
 			}
 		}
 
@@ -826,9 +825,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		// The stand is deployed fresh for every build and torn down with it, so the created section is not
-		// deleted here: the cleanup cost about 18s per test, and every assertion that reads the application's
-		// section list checks membership of its own section — none reads a total count.
+		// Created sections are removed once per fixture, not per test — see RemoveCreatedSectionsAsync.
 		// Act — the call answers within seconds; the section is created afterwards, or not at all.
 		CallToolResult createResult = await session.CallToolAsync(
 			SectionCreateToolName,
@@ -867,6 +864,7 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		createdSection.Should().NotBeNull(
 			because: $"the in-progress envelope promised the section was still being created server-side, so after {DetachedWorkPollAttempts * DetachedWorkPollInterval.TotalSeconds:0}s of the polling that envelope itself prescribes it must exist — a section that never appears makes the guidance unfollowable (clio#1421)");
+		RecordCreatedSection(createdSection?.Code, environmentName);
 		createdSection!.Code.Should().NotBeNullOrWhiteSpace(
 			because: "the section the detached work created must be fully readable, not a partial record");
 	}
@@ -897,6 +895,59 @@ public sealed class ApplicationSectionToolE2ETests {
 		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
 
 	private static McpServerSession? _sharedSession;
+
+	/// <summary>
+	/// Every section code this fixture created, removed once in one-time teardown.
+	/// </summary>
+	/// <remarks>
+	/// The stand is disposable per build, so nothing here has to be cleaned up for the stand's sake — the
+	/// per-test cleanup this replaced cost about 18s a time and was pure waste. It is done once per fixture
+	/// for a different reason: sections left in the shared <c>AutoTestClioMcp</c> application each add a
+	/// Form and a List page, and <c>MobilePageConversionGuideSandboxE2ETests</c> enumerates EVERY page of
+	/// that application and requires each eligible one to convert. Letting them accumulate across fixtures
+	/// would hand that fixture a growing set of pages to convert — more time and a wider failure surface,
+	/// which is the opposite of what this change is for.
+	/// </remarks>
+	private static readonly List<string> CreatedSectionCodes = [];
+
+	private static void RecordCreatedSection(string? sectionCode, string environmentName) {
+		if (string.IsNullOrWhiteSpace(sectionCode)) {
+			return;
+		}
+		_createdSectionEnvironmentName = environmentName;
+		CreatedSectionCodes.Add(sectionCode);
+	}
+
+	[OneTimeTearDown]
+	public static async Task RemoveCreatedSectionsAsync() {
+		if (CreatedSectionCodes.Count == 0 || _sharedSession is null || _createdSectionEnvironmentName is null) {
+			return;
+		}
+		string[] codes = [.. CreatedSectionCodes];
+		CreatedSectionCodes.Clear();
+		foreach (string code in codes) {
+			try {
+				using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+				await _sharedSession.CallToolAsync(
+					SectionDeleteToolName,
+					new Dictionary<string, object?> {
+						["args"] = new Dictionary<string, object?> {
+							["environment-name"] = _createdSectionEnvironmentName,
+							["application-code"] = ApplicationCode,
+							["section-code"] = code
+						}
+					},
+					cleanupCts.Token);
+			} catch (Exception exception) {
+				// Best effort: the stand goes away with the build, so a failed removal must not fail a
+				// green fixture. It only matters to the fixtures that read this application's pages.
+				TestContext.Out.WriteLine($"[cleanup] failed to remove section '{code}': {exception.Message}");
+			}
+		}
+	}
+
+	private static string? _createdSectionEnvironmentName;
+
 
 	[OneTimeTearDown]
 	public static async Task StopSharedSessionAsync() {
@@ -959,6 +1010,7 @@ public sealed class ApplicationSectionToolE2ETests {
 			cancellationTokenSource.Token);
 		ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
 		cancellationTokenSource.Dispose();
+		RecordCreatedSection(response.Section?.Code, environmentName);
 		_customEntitySection = new SharedCustomEntitySection(callResult, response, [.. progress.Messages]);
 		return _customEntitySection;
 	}

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -834,7 +834,11 @@ public sealed class ApplicationSectionToolE2ETests {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
 		}
 
-		const int concurrentCount = 3;
+		// Two is what the property needs: contention is a property of MORE THAN ONE call arriving at the
+		// same application, and a third adds another full serialized section (~33 s on CI) without
+		// exercising anything the second does not already cover. This was the most expensive test in the
+		// suite at 102 s, and all of that was the platform compiling sections one after another.
+		const int concurrentCount = 2;
 		string runId = Guid.NewGuid().ToString("N")[..8];
 		string[] captions = Enumerable.Range(1, concurrentCount)
 			.Select(index => $"E2E Conc {runId} {index}")

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -85,7 +85,7 @@ public sealed class ApplicationSectionToolE2ETests {
 			settings.ClioProcessPath,
 			settings.ProcessEnvironmentVariables);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		try {
 			// Act
@@ -171,7 +171,7 @@ public sealed class ApplicationSectionToolE2ETests {
 			settings.ClioProcessPath,
 			settings.ProcessEnvironmentVariables);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		try {
 			// Act
@@ -339,7 +339,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		IReadOnlyCollection<string> reachableToolNames = await session.ListReachableToolNamesAsync(cancellationTokenSource.Token);
 		reachableToolNames.Should().Contain(SectionCreateToolName,
 			because: "create-app-section must be discoverable via the get-tool-contract compact index before the end-to-end validation calls can run");
@@ -378,7 +378,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -414,7 +414,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -459,7 +459,7 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		string? createdSectionCode = null;
@@ -533,7 +533,7 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		string caption = $"E2E Progress {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		MessageCollectingProgress progress = new();
@@ -613,7 +613,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		const string platformEntitySchemaName = "Contact";
 		string caption = $"E2E Contact {Guid.NewGuid():N}"[..23];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		string? createdSectionCode = null;
@@ -684,7 +684,7 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		const string nonLatinCaption = "Контакти";
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -730,7 +730,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		string missingEntitySchemaName = $"UsrMissing{Guid.NewGuid():N}"[..24];
 		string caption = $"E2E Missing {Guid.NewGuid():N}"[..22];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -780,7 +780,7 @@ public sealed class ApplicationSectionToolE2ETests {
 		// inside the interval and this test observes zero notifications while the relay is working perfectly.
 		settings.ProcessEnvironmentVariables[McpProgressHeartbeat.IntervalOverrideEnvVar] = "0.05";
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		MessageCollectingProgress progress = new();
 
 		// Act — list-app-sections is read-only and always performs a backend round-trip, so the
@@ -841,7 +841,7 @@ public sealed class ApplicationSectionToolE2ETests {
 			.ToArray();
 		// Sections are serialized (~90-100s each), so allow a generous ceiling for the whole batch.
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(15));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		List<string> createdSectionCodes = new();
@@ -948,7 +948,7 @@ public sealed class ApplicationSectionToolE2ETests {
 
 		string caption = $"E2E Deadline {Guid.NewGuid():N}"[..24];
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(12));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		await SeededApplicationResolver.ResolveOrIgnoreAsync(
 			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
 		string? createdSectionCode = null;
@@ -1015,4 +1015,40 @@ public sealed class ApplicationSectionToolE2ETests {
 			}
 		}
 	}
+
+	/// <summary>
+	/// Returns this fixture's single MCP server process, starting it on first use.
+	/// </summary>
+	/// <remarks>
+	/// Each test used to start its own child server. TeamCity bills only test bodies, so those process
+	/// lifecycles — roughly 1.8 s to start and 0.5 s to tear down apiece — were invisible while still
+	/// being paid on every run. The tests here share one read/create workload against one environment
+	/// and none of them mutates server state at startup, so a single process serves them all. The
+	/// fixture is <c>[NonParallelizable]</c>, so the lazy start needs no lock. It is lazy rather than
+	/// <c>[OneTimeSetUp]</c> on purpose: an <c>Assert.Ignore</c> raised from one-time setup skips the
+	/// WHOLE fixture, which would hide the tests that need no reachable stand.
+	/// <para>
+	/// A test that needs its OWN session — different client capabilities, or a deliberate restart — must
+	/// keep calling <see cref="McpServerSession.StartAsync(McpE2ESettings, CancellationToken)"/> directly
+	/// and dispose what it started.
+	/// </para>
+	/// </remarks>
+	/// <param name="settings">Settings for the child process.</param>
+	/// <param name="cancellationToken">Bounds the start.</param>
+	/// <returns>The shared session.</returns>
+	private static async Task<McpServerSession> GetOrStartSharedSessionAsync(
+		McpE2ESettings settings,
+		CancellationToken cancellationToken) =>
+		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
+
+	private static McpServerSession? _sharedSession;
+
+	[OneTimeTearDown]
+	public static async Task StopSharedSessionAsync() {
+		if (_sharedSession is not null) {
+			await _sharedSession.DisposeAsync();
+			_sharedSession = null;
+		}
+	}
+
 }

--- a/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionToolE2ETests.cs
@@ -450,152 +450,49 @@ public sealed class ApplicationSectionToolE2ETests {
 	[Description("Creates a section with a brand-new custom entity in a known installed application and verifies the structured read-back data including the created section metadata.")]
 	public async Task ApplicationSectionCreate_WithCustomEntity_Should_Return_Structured_Readback_Data() {
 		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		string? environmentName = settings.Sandbox.EnvironmentName;
-		if (!settings.AllowDestructiveMcpTests) {
-			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
-		}
+		SharedCustomEntitySection created = await GetOrCreateCustomEntitySectionAsync();
 
-		if (string.IsNullOrWhiteSpace(environmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
-		}
-
-		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
-		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
-		await SeededApplicationResolver.ResolveOrIgnoreAsync(
-			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		string? createdSectionCode = null;
-		try {
-			// Act
-			CallToolResult callResult = await session.CallToolAsync(
-				SectionCreateToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["caption"] = caption
-					}
-				},
-				cancellationTokenSource.Token);
-			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
-
-			// Assert
-			callResult.IsError.Should().NotBeTrue(
-				because: $"create-app-section with a custom entity should not throw an MCP-level error. Actual: {DescribeCallResult(callResult)}");
-			response.Success.Should().BeTrue(
-				because: $"create-app-section without entity-schema-name must succeed and auto-create the entity schema. Error: {response.Error}");
-			response.Section.Should().NotBeNull(
-				because: "a successful create-app-section must include the created section metadata in the readback");
-			response.Section!.Code.Should().NotBeNullOrWhiteSpace(
-				because: "the readback must expose the generated section code");
-			response.Section.EntitySchemaName.Should().NotBeNullOrWhiteSpace(
-				because: "the readback must expose the auto-created entity schema name");
-
-			createdSectionCode = response.Section.Code;
-		} finally {
-			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = createdSectionCode
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
-				}
-			}
-		}
+		// Assert
+		created.CallResult.IsError.Should().NotBeTrue(
+			because: $"create-app-section with a custom entity should not throw an MCP-level error. Actual: {DescribeCallResult(created.CallResult)}");
+		created.Response.Success.Should().BeTrue(
+			because: $"create-app-section without entity-schema-name must succeed and auto-create the entity schema. Error: {created.Response.Error}");
+		created.Response.Section.Should().NotBeNull(
+			because: "a successful create-app-section must include the created section metadata in the readback");
+		created.Response.Section!.Code.Should().NotBeNullOrWhiteSpace(
+			because: "the readback must expose the generated section code");
+		created.Response.Section.EntitySchemaName.Should().NotBeNullOrWhiteSpace(
+			because: "the readback must expose the auto-created entity schema name");
 	}
 
 	[Category("McpE2E.Sandbox")]
 	[Test]
-	[Description("Creates a section through the progress-capable overload and verifies the client observes the per-phase stage markers 'loading application info', 'creating section', and 'loading created section' (ENG-93087).")]
+	[Description("Verifies the client observes the per-phase stage markers 'loading application info', 'creating section', and 'loading created section' streamed by the create-app-section the readback test also asserts on (ENG-93087).")]
 	[AllureFeature(SectionCreateToolName)]
 	[AllureTag(SectionCreateToolName)]
 	[AllureName("Application section create streams per-phase progress markers")]
-	[AllureDescription("Uses the real clio MCP server to call create-app-section with an IProgress sink and asserts the client observed the service-level stage markers 'loading application info', 'creating section', and 'loading created section', proving the per-phase progress path is wired end to end (ENG-93087).")]
+	[AllureDescription("Asserts the client observed the service-level stage markers 'loading application info', 'creating section', and 'loading created section' on the fixture's single create-app-section call, proving the per-phase progress path is wired end to end (ENG-93087).")]
 	public async Task ApplicationSectionCreate_Should_Stream_PerPhase_Progress_Markers() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		string? environmentName = settings.Sandbox.EnvironmentName;
-		if (!settings.AllowDestructiveMcpTests) {
-			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section progress-marker test.");
+		// Arrange — the same create the readback test asserts on; its progress stream was captured then.
+		SharedCustomEntitySection created = await GetOrCreateCustomEntitySectionAsync();
+
+		// Diagnostic: surface the exact progress stream the client received so a failure shows the markers.
+		foreach (string progressMessage in created.ProgressMessages) {
+			TestContext.Out.WriteLine($"[progress] {progressMessage}");
 		}
 
-		if (string.IsNullOrWhiteSpace(environmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
-		}
-
-		string caption = $"E2E Progress {Guid.NewGuid():N}"[..24];
-		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
-		await SeededApplicationResolver.ResolveOrIgnoreAsync(
-			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
-		MessageCollectingProgress progress = new();
-		string? createdSectionCode = null;
-		try {
-			// Act — invoke create-app-section through the progress-capable overload so the client observes
-			// the service-level stage markers the tool streams as notifications/progress.
-			CallToolResult callResult = await session.CallToolAsync(
-				SectionCreateToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["caption"] = caption
-					}
-				},
-				progress,
-				cancellationTokenSource.Token);
-
-			// Diagnostic: surface the exact progress stream the client received so a failure shows the markers.
-			foreach (string progressMessage in progress.Messages) {
-				TestContext.Out.WriteLine($"[progress] {progressMessage}");
-			}
-
-			ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
-			createdSectionCode = response.Section?.Code;
-
-			// Assert
-			callResult.IsError.Should().NotBeTrue(
-				because: $"a valid create-app-section request should return a structured payload. Actual: {DescribeCallResult(callResult)}");
-			progress.Messages.Should().Contain(
-				message => message.Contains("loading application info", StringComparison.Ordinal),
-				because: "create-app-section must stream the 'loading application info' stage marker so the client can show the app-resolution phase (ENG-93087)");
-			progress.Messages.Should().Contain(
-				message => message.Contains("creating section", StringComparison.Ordinal),
-				because: "create-app-section must stream the 'creating section' stage marker so the client can show the section-creation phase (ENG-93087)");
-			progress.Messages.Should().Contain(
-				message => message.Contains("loading created section", StringComparison.Ordinal),
-				because: "create-app-section must stream the 'loading created section' stage marker so the client can show the readback phase (ENG-93087)");
-		} finally {
-			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = createdSectionCode
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
-				}
-			}
-		}
+		// Assert
+		created.CallResult.IsError.Should().NotBeTrue(
+			because: $"the progress-marker create must itself succeed before its markers can be judged. Actual: {DescribeCallResult(created.CallResult)}");
+		created.ProgressMessages.Should().Contain(
+			message => message.Contains(SectionCreatePhaseMarkers[0], StringComparison.OrdinalIgnoreCase),
+			because: $"create-app-section must stream the '{SectionCreatePhaseMarkers[0]}' phase marker so the client can show progress");
+		created.ProgressMessages.Should().Contain(
+			message => message.Contains(SectionCreatePhaseMarkers[1], StringComparison.OrdinalIgnoreCase),
+			because: $"create-app-section must stream the '{SectionCreatePhaseMarkers[1]}' phase marker so the client can show progress");
+		created.ProgressMessages.Should().Contain(
+			message => message.Contains(SectionCreatePhaseMarkers[2], StringComparison.OrdinalIgnoreCase),
+			because: $"create-app-section must stream the '{SectionCreatePhaseMarkers[2]}' phase marker so the client can show progress");
 	}
 
 	[Category("McpE2E.Sandbox")]
@@ -1064,6 +961,98 @@ public sealed class ApplicationSectionToolE2ETests {
 		if (_sharedSession is not null) {
 			await _sharedSession.DisposeAsync();
 			_sharedSession = null;
+		}
+	}
+
+
+	/// <summary>Phase markers create-app-section streams while it works.</summary>
+	private static readonly string[] SectionCreatePhaseMarkers = [
+		"loading application info",
+		"creating section",
+		"loading created section"
+	];
+
+	/// <summary>
+	/// Creates — once for this fixture — one section from a custom entity, capturing the progress stream
+	/// of that same create, and removes it in one-time teardown.
+	/// </summary>
+	/// <remarks>
+	/// The structured-readback test and the progress-marker test each used to create a section of their
+	/// own. A create-app-section is a real Creatio compile (~30 s on CI), and the second create existed
+	/// only so the progress-capable overload could watch it — the readback create streams exactly the
+	/// same markers. Capturing them once serves both. The tests stay separate, so a failure still names
+	/// whether the readback or the progress stream broke.
+	/// </remarks>
+	/// <returns>The shared create's result, envelope and captured progress.</returns>
+	private static async Task<SharedCustomEntitySection> GetOrCreateCustomEntitySectionAsync() {
+		if (_customEntitySection is not null) {
+			return _customEntitySection;
+		}
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping destructive create-app-section test.");
+		}
+		string? environmentName = settings.Sandbox.EnvironmentName;
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to point at the seeded sandbox before running this test.");
+		}
+
+		string caption = $"E2E Custom {Guid.NewGuid():N}"[..24];
+		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
+		await SeededApplicationResolver.ResolveOrIgnoreAsync(
+			session, cancellationTokenSource.Token, environmentName!, ApplicationCode);
+		MessageCollectingProgress progress = new();
+		CallToolResult callResult = await session.CallToolAsync(
+			SectionCreateToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = ApplicationCode,
+					["caption"] = caption
+				}
+			},
+			progress,
+			cancellationTokenSource.Token);
+		ApplicationSectionContextResponseEnvelope response = ApplicationResultParser.ExtractSectionCreate(callResult);
+		_customEntitySectionEnvironmentName = environmentName;
+		_customEntitySectionCode = response.Section?.Code;
+		cancellationTokenSource.Dispose();
+		_customEntitySection = new SharedCustomEntitySection(callResult, response, [.. progress.Messages]);
+		return _customEntitySection;
+	}
+
+	private static SharedCustomEntitySection? _customEntitySection;
+	private static string? _customEntitySectionCode;
+	private static string? _customEntitySectionEnvironmentName;
+
+	private sealed record SharedCustomEntitySection(
+		CallToolResult CallResult,
+		ApplicationSectionContextResponseEnvelope Response,
+		IReadOnlyList<string> ProgressMessages);
+
+	[OneTimeTearDown]
+	public static async Task RemoveSharedCustomEntitySectionAsync() {
+		if (string.IsNullOrWhiteSpace(_customEntitySectionCode) || _sharedSession is null) {
+			return;
+		}
+		string sectionCode = _customEntitySectionCode;
+		_customEntitySectionCode = null;
+		try {
+			using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+			await _sharedSession.CallToolAsync(
+				SectionDeleteToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = _customEntitySectionEnvironmentName,
+						["application-code"] = ApplicationCode,
+						["section-code"] = sectionCode
+					}
+				},
+				cleanupCts.Token);
+		} catch (Exception exception) {
+			TestContext.Out.WriteLine($"[cleanup] failed to remove shared section '{sectionCode}': {exception.Message}");
 		}
 	}
 

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -22,6 +22,7 @@ namespace Clio.Mcp.E2E;
 public sealed class ApplicationSectionUpdateToolE2ETests {
 	private const string SectionUpdateToolName = ApplicationSectionUpdateTool.ApplicationSectionUpdateToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
+	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string ApplicationCode = "AutoTestClioMcp";
 
 	[Category("McpE2E.Sandbox")]
@@ -202,9 +203,9 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		string? createdSectionCode = null;
-		// The stand is deployed fresh for every build and torn down with it, so the created section is not
-		// deleted here: the cleanup cost about 18s, and every assertion that reads the application's section
-		// list checks membership of its own section — none reads a total count.
+		// The created section is removed once, in one-time teardown: the stand is disposable per build, but
+		// a section left in the shared application adds pages that MobilePageConversionGuideSandboxE2ETests
+		// then has to convert.
 		// Act 1: create a section with the initial caption
 		CallToolResult createResult = await session.CallToolAsync(
 			SectionCreateToolName,
@@ -228,6 +229,8 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 			because: "the readback must expose the created section code so update-app-section can target it");
 
 		createdSectionCode = createResponse.Section.Code;
+		_createdSectionCode = createdSectionCode;
+		_createdSectionEnvironmentName = environmentName;
 
 		// Act 2: update the section's caption and description
 		CallToolResult updateResult = await session.CallToolAsync(
@@ -407,11 +410,52 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 
 	private static McpServerSession? _sharedSession;
 
+	private static string? _createdSectionCode;
+	private static string? _createdSectionEnvironmentName;
+
 	[OneTimeTearDown]
 	public static async Task StopSharedSessionAsync() {
-		if (_sharedSession is not null) {
-			await _sharedSession.DisposeAsync();
-			_sharedSession = null;
+		try {
+			await RemoveCreatedSectionAsync();
+		} finally {
+			if (_sharedSession is not null) {
+				await _sharedSession.DisposeAsync();
+				_sharedSession = null;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Removes the section this fixture created — once, not per test.
+	/// </summary>
+	/// <remarks>
+	/// The stand is disposable per build, so the removal is not owed to the stand. It is owed to
+	/// <c>MobilePageConversionGuideSandboxE2ETests</c>, which enumerates every page of the shared
+	/// <c>AutoTestClioMcp</c> application and requires each eligible one to convert: a section left behind
+	/// adds a Form and a List page to that set.
+	/// </remarks>
+	private static async Task RemoveCreatedSectionAsync() {
+		if (string.IsNullOrWhiteSpace(_createdSectionCode) || _sharedSession is null) {
+			return;
+		}
+		string sectionCode = _createdSectionCode;
+		_createdSectionCode = null;
+		try {
+			using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
+			await _sharedSession.CallToolAsync(
+				SectionDeleteToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["environment-name"] = _createdSectionEnvironmentName,
+						["application-code"] = ApplicationCode,
+						["section-code"] = sectionCode
+					}
+				},
+				cleanupCts.Token);
+		} catch (Exception exception) {
+			// Best effort: the stand goes away with the build, so a failed removal must not fail a green
+			// fixture. It only matters to the fixtures that read this application's pages.
+			TestContext.Out.WriteLine($"[cleanup] failed to remove section '{sectionCode}': {exception.Message}");
 		}
 	}
 

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -385,35 +385,10 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		}
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"application section MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static string DescribeCallResult(CallToolResult callResult) {
 		return JsonSerializer.Serialize(new {

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -38,7 +38,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -75,7 +75,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -112,7 +112,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -149,7 +149,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 
 		// Act
 		CallToolResult callResult = await session.CallToolAsync(
@@ -201,7 +201,7 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		string updatedCaption = $"E2E UpdAfter {Guid.NewGuid():N}"[..24];
 		const string updatedDescription = "E2E update lifecycle";
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		string? createdSectionCode = null;
 		try {
 			// Act 1: create a section with the initial caption
@@ -397,4 +397,40 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 			callResult.Content
 		});
 	}
+
+	/// <summary>
+	/// Returns this fixture's single MCP server process, starting it on first use.
+	/// </summary>
+	/// <remarks>
+	/// Each test used to start its own child server. TeamCity bills only test bodies, so those process
+	/// lifecycles — roughly 1.8 s to start and 0.5 s to tear down apiece — were invisible while still
+	/// being paid on every run. The tests here share one read/create workload against one environment
+	/// and none of them mutates server state at startup, so a single process serves them all. The
+	/// fixture is <c>[NonParallelizable]</c>, so the lazy start needs no lock. It is lazy rather than
+	/// <c>[OneTimeSetUp]</c> on purpose: an <c>Assert.Ignore</c> raised from one-time setup skips the
+	/// WHOLE fixture, which would hide the tests that need no reachable stand.
+	/// <para>
+	/// A test that needs its OWN session — different client capabilities, or a deliberate restart — must
+	/// keep calling <see cref="McpServerSession.StartAsync(McpE2ESettings, CancellationToken)"/> directly
+	/// and dispose what it started.
+	/// </para>
+	/// </remarks>
+	/// <param name="settings">Settings for the child process.</param>
+	/// <param name="cancellationToken">Bounds the start.</param>
+	/// <returns>The shared session.</returns>
+	private static async Task<McpServerSession> GetOrStartSharedSessionAsync(
+		McpE2ESettings settings,
+		CancellationToken cancellationToken) =>
+		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
+
+	private static McpServerSession? _sharedSession;
+
+	[OneTimeTearDown]
+	public static async Task StopSharedSessionAsync() {
+		if (_sharedSession is not null) {
+			await _sharedSession.DisposeAsync();
+			_sharedSession = null;
+		}
+	}
+
 }

--- a/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationSectionUpdateToolE2ETests.cs
@@ -22,7 +22,6 @@ namespace Clio.Mcp.E2E;
 public sealed class ApplicationSectionUpdateToolE2ETests {
 	private const string SectionUpdateToolName = ApplicationSectionUpdateTool.ApplicationSectionUpdateToolName;
 	private const string SectionCreateToolName = ApplicationSectionCreateTool.ApplicationSectionCreateToolName;
-	private const string SectionDeleteToolName = ApplicationSectionDeleteTool.ApplicationSectionDeleteToolName;
 	private const string ApplicationCode = "AutoTestClioMcp";
 
 	[Category("McpE2E.Sandbox")]
@@ -203,84 +202,67 @@ public sealed class ApplicationSectionUpdateToolE2ETests {
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		string? createdSectionCode = null;
-		try {
-			// Act 1: create a section with the initial caption
-			CallToolResult createResult = await session.CallToolAsync(
-				SectionCreateToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["caption"] = initialCaption
-					}
-				},
-				cancellationTokenSource.Token);
-			ApplicationSectionContextResponseEnvelope createResponse = ApplicationResultParser.ExtractSectionCreate(createResult);
-
-			createResult.IsError.Should().NotBeTrue(
-				because: $"create-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(createResult)}");
-			createResponse.Success.Should().BeTrue(
-				because: $"create-app-section must succeed before the update lifecycle can be verified. Error: {createResponse.Error}");
-			createResponse.Section.Should().NotBeNull(
-				because: "create-app-section readback must include the created section metadata");
-			createResponse.Section!.Code.Should().NotBeNullOrWhiteSpace(
-				because: "the readback must expose the created section code so update-app-section can target it");
-
-			createdSectionCode = createResponse.Section.Code;
-
-			// Act 2: update the section's caption and description
-			CallToolResult updateResult = await session.CallToolAsync(
-				SectionUpdateToolName,
-				new Dictionary<string, object?> {
-					["args"] = new Dictionary<string, object?> {
-						["environment-name"] = environmentName,
-						["application-code"] = ApplicationCode,
-						["section-code"] = createdSectionCode,
-						["caption"] = updatedCaption,
-						["description"] = updatedDescription
-					}
-				},
-				cancellationTokenSource.Token);
-			ApplicationSectionUpdateContextResponseEnvelope updateResponse = ApplicationResultParser.ExtractSectionUpdate(updateResult);
-
-			// Assert
-			updateResult.IsError.Should().NotBeTrue(
-				because: $"update-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(updateResult)}");
-			updateResponse.Success.Should().BeTrue(
-				because: $"update-app-section must succeed for the freshly created section. Error: {updateResponse.Error}");
-			updateResponse.PreviousSection.Should().NotBeNull(
-				because: "update-app-section must include the pre-update section snapshot so callers can diff before-and-after");
-			updateResponse.PreviousSection!.Code.Should().Be(createdSectionCode,
-				because: "the previous-section snapshot must identify the same section that was updated");
-			updateResponse.PreviousSection.Caption.Should().Be(initialCaption,
-				because: "the previous-section snapshot must preserve the caption that existed before update-app-section was invoked");
-			updateResponse.Section.Should().NotBeNull(
-				because: "update-app-section must include the post-update section state for the caller to confirm the new values landed");
-			updateResponse.Section!.Code.Should().Be(createdSectionCode,
-				because: "the post-update section must report the same code as the previous-section snapshot");
-			updateResponse.Section.Caption.Should().Be(updatedCaption,
-				because: "the post-update section must reflect the new caption that update-app-section was asked to apply");
-			updateResponse.Section.Description.Should().Be(updatedDescription,
-				because: "the post-update section must reflect the new description that update-app-section was asked to apply");
-		} finally {
-			if (!string.IsNullOrWhiteSpace(createdSectionCode)) {
-				try {
-					using CancellationTokenSource cleanupCts = new(TimeSpan.FromMinutes(1));
-					await session.CallToolAsync(
-						SectionDeleteToolName,
-						new Dictionary<string, object?> {
-							["args"] = new Dictionary<string, object?> {
-								["environment-name"] = environmentName,
-								["application-code"] = ApplicationCode,
-								["section-code"] = createdSectionCode
-							}
-						},
-						cleanupCts.Token);
-				} catch (Exception ex) {
-					await Console.Error.WriteLineAsync($"[cleanup] delete-app-section '{createdSectionCode}' failed: {ex.Message}");
+		// The stand is deployed fresh for every build and torn down with it, so the created section is not
+		// deleted here: the cleanup cost about 18s, and every assertion that reads the application's section
+		// list checks membership of its own section — none reads a total count.
+		// Act 1: create a section with the initial caption
+		CallToolResult createResult = await session.CallToolAsync(
+			SectionCreateToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = ApplicationCode,
+					["caption"] = initialCaption
 				}
-			}
-		}
+			},
+			cancellationTokenSource.Token);
+		ApplicationSectionContextResponseEnvelope createResponse = ApplicationResultParser.ExtractSectionCreate(createResult);
+
+		createResult.IsError.Should().NotBeTrue(
+			because: $"create-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(createResult)}");
+		createResponse.Success.Should().BeTrue(
+			because: $"create-app-section must succeed before the update lifecycle can be verified. Error: {createResponse.Error}");
+		createResponse.Section.Should().NotBeNull(
+			because: "create-app-section readback must include the created section metadata");
+		createResponse.Section!.Code.Should().NotBeNullOrWhiteSpace(
+			because: "the readback must expose the created section code so update-app-section can target it");
+
+		createdSectionCode = createResponse.Section.Code;
+
+		// Act 2: update the section's caption and description
+		CallToolResult updateResult = await session.CallToolAsync(
+			SectionUpdateToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = environmentName,
+					["application-code"] = ApplicationCode,
+					["section-code"] = createdSectionCode,
+					["caption"] = updatedCaption,
+					["description"] = updatedDescription
+				}
+			},
+			cancellationTokenSource.Token);
+		ApplicationSectionUpdateContextResponseEnvelope updateResponse = ApplicationResultParser.ExtractSectionUpdate(updateResult);
+
+		// Assert
+		updateResult.IsError.Should().NotBeTrue(
+			because: $"update-app-section should not throw an MCP-level error. Actual: {DescribeCallResult(updateResult)}");
+		updateResponse.Success.Should().BeTrue(
+			because: $"update-app-section must succeed for the freshly created section. Error: {updateResponse.Error}");
+		updateResponse.PreviousSection.Should().NotBeNull(
+			because: "update-app-section must include the pre-update section snapshot so callers can diff before-and-after");
+		updateResponse.PreviousSection!.Code.Should().Be(createdSectionCode,
+			because: "the previous-section snapshot must identify the same section that was updated");
+		updateResponse.PreviousSection.Caption.Should().Be(initialCaption,
+			because: "the previous-section snapshot must preserve the caption that existed before update-app-section was invoked");
+		updateResponse.Section.Should().NotBeNull(
+			because: "update-app-section must include the post-update section state for the caller to confirm the new values landed");
+		updateResponse.Section!.Code.Should().Be(createdSectionCode,
+			because: "the post-update section must report the same code as the previous-section snapshot");
+		updateResponse.Section.Caption.Should().Be(updatedCaption,
+			because: "the post-update section must reflect the new caption that update-app-section was asked to apply");
+		updateResponse.Section.Description.Should().Be(updatedDescription,
+			because: "the post-update section must reflect the new description that update-app-section was asked to apply");
 	}
 
 	[Category("McpE2E.NoEnvironment")]

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -904,8 +904,38 @@ public sealed class ApplicationToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		CancellationTokenSource cancellationTokenSource = new(timeout);
 		string environmentName = await ResolveReachableEnvironmentAsync(settings);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = await GetOrStartSharedSessionAsync(settings, cancellationTokenSource.Token);
 		return new ApplicationArrangeContext(environmentName, session, cancellationTokenSource);
+	}
+
+	/// <summary>
+	/// Returns this fixture's single MCP server process, starting it on first use.
+	/// </summary>
+	/// <remarks>
+	/// Every test here used to start its own child server: 16 process lifecycles for one fixture, each
+	/// costing roughly 1.8 s to start and 0.5 s to tear down, none of which TeamCity bills to a test.
+	/// The tests share a read/create workload against one environment and none of them mutates server
+	/// state at startup, so one process serves them all. The fixture is <c>[NonParallelizable]</c>, so
+	/// the lazy start needs no lock. Started lazily rather than in <c>[OneTimeSetUp]</c> on purpose: an
+	/// <c>Assert.Ignore</c> raised from one-time setup skips the WHOLE fixture, which would hide the
+	/// tests that need no reachable stand.
+	/// </remarks>
+	/// <param name="settings">Settings for the child process.</param>
+	/// <param name="cancellationToken">Bounds the start.</param>
+	/// <returns>The shared session.</returns>
+	private static async Task<McpServerSession> GetOrStartSharedSessionAsync(
+		McpE2ESettings settings,
+		CancellationToken cancellationToken) =>
+		_sharedSession ??= await McpServerSession.StartAsync(settings, cancellationToken);
+
+	private static McpServerSession? _sharedSession;
+
+	[OneTimeTearDown]
+	public static async Task StopSharedSessionAsync() {
+		if (_sharedSession is not null) {
+			await _sharedSession.DisposeAsync();
+			_sharedSession = null;
+		}
 	}
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
@@ -1375,9 +1405,14 @@ public sealed class ApplicationToolE2ETests {
 		string EnvironmentName,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		/// <summary>
+		/// Releases only what this test owns. The session is the fixture's, shared by every test here and
+		/// disposed once in <c>[OneTimeTearDown]</c>; disposing it per test is what made the fixture pay
+		/// 16 process lifecycles.
+		/// </summary>
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -1015,18 +1015,27 @@ public sealed class ApplicationToolE2ETests {
 		string? iconBackground,
 		string? optionalTemplateDataJson,
 		bool withMobilePages = true) {
-		CallToolResult callResult = await CallCreateAsync(
-			session,
-			cancellationToken,
-			environmentName,
-			name,
-			code,
-			description,
-			templateCode,
-			iconId,
-			iconBackground,
-			optionalTemplateDataJson,
-			withMobilePages);
+		// create-app is answered with "Creatio is currently rebuilding the OData library" whenever an
+		// earlier test's schema publish is still finishing on the shared stand — a condition that outlives
+		// the command that started it and therefore cannot be serialized away (see
+		// docs/knowledge/Tests/the-parallel-pool-cannot-disturb-the-shared-stand.md). The gate is the
+		// repository's existing answer to exactly that window, and it deliberately refuses to retry a
+		// create that may already have happened, so a real failure still fails.
+		CallToolResult callResult = await TransientPlatformConditionRetryGate.InvokeWithRetryAsync(
+			async attemptToken => await CallCreateAsync(
+				session,
+				attemptToken,
+				environmentName,
+				name,
+				code,
+				description,
+				templateCode,
+				iconId,
+				iconBackground,
+				optionalTemplateDataJson,
+				withMobilePages),
+			reauthenticateAsync: null,
+			cancellationToken);
 		ApplicationContextResponseEnvelope result;
 		try {
 			result = ApplicationResultParser.ExtractInfo(callResult);

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -530,24 +530,9 @@ public sealed class ApplicationToolE2ETests {
 		}
 
 		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		await using ApplicationArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(10));
-		string suffix = Guid.NewGuid().ToString("N")[..8];
-		string createdApplicationCode = $"UsrWeb{suffix}";
-		string applicationName = $"Web Only E2E {suffix}";
 
 		// Act
-		ApplicationInfoActResult actResult = await ActCreateAsync(
-			arrangeContext.Session,
-			arrangeContext.CancellationTokenSource.Token,
-			arrangeContext.EnvironmentName,
-			applicationName,
-			createdApplicationCode,
-			description: null,
-			ApplicationTemplateCode,
-			ApplicationIconId,
-			ApplicationIconBackground,
-			optionalTemplateDataJson: null,
-			withMobilePages: false);
+		ApplicationInfoActResult actResult = await GetOrCreateWebOnlyAutoIconApplicationAsync(settings);
 
 		// Assert
 		actResult.CallResult.IsError.Should().NotBeTrue(
@@ -865,21 +850,9 @@ public sealed class ApplicationToolE2ETests {
 		}
 
 		TestConfiguration.EnsureSandboxIsConfigured(settings);
-		await using ApplicationArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(10));
-		string suffix = Guid.NewGuid().ToString("N")[..8];
 
 		// Act
-		ApplicationInfoActResult actResult = await ActCreateAsync(
-			arrangeContext.Session,
-			arrangeContext.CancellationTokenSource.Token,
-			arrangeContext.EnvironmentName,
-			name: $"Codex Auto Icon {suffix}",
-			code: $"UsrAutoIcon{suffix}",
-			description: null,
-			templateCode: ApplicationTemplateCode,
-			iconId: "auto",
-			iconBackground: ApplicationIconBackground,
-			optionalTemplateDataJson: null);
+		ApplicationInfoActResult actResult = await GetOrCreateWebOnlyAutoIconApplicationAsync(settings);
 		// Diagnostic: dump the create payload before anything asserts on it, so a create that failed on the
 		// environment is visible in the run output even when the assertion below is the first thing to notice.
 		TestContext.Out.WriteLine($"[create payload] {DescribeCallResult(actResult.CallResult)}");
@@ -1423,4 +1396,52 @@ public sealed class ApplicationToolE2ETests {
 	private sealed record ApplicationInfoActResult(
 		CallToolResult CallResult,
 		ApplicationContextResponseEnvelope Result);
+
+	/// <summary>
+	/// Creates — once for this fixture — one application with <c>icon-id='auto'</c> and
+	/// <c>with-mobile-pages=false</c>, and returns that single create's result to every test that asserts
+	/// on it.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The auto-icon test and the web-only test each used to create an application of their own. A
+	/// create-app is a real Creatio compile — roughly 40 s each on CI — and the two options are
+	/// orthogonal: resolving an icon has nothing to do with suppressing mobile pages, so one create
+	/// carrying both exercises both paths without weakening either assertion. The tests stay separate,
+	/// so a failure still names which property broke.
+	/// </para>
+	/// <para>
+	/// Lazy rather than <c>[OneTimeSetUp]</c>: the destructive-tests gate and the sandbox check are
+	/// per-test <c>Assert.Ignore</c>s, and an ignore raised from one-time setup would skip the whole
+	/// fixture. The fixture is <c>[NonParallelizable]</c>, so the lazy create needs no lock.
+	/// </para>
+	/// </remarks>
+	/// <param name="settings">Settings for the MCP session.</param>
+	/// <returns>The shared create-app result.</returns>
+	private static async Task<ApplicationInfoActResult> GetOrCreateWebOnlyAutoIconApplicationAsync(
+		McpE2ESettings settings) {
+		if (_webOnlyAutoIconApplication is not null) {
+			return _webOnlyAutoIconApplication;
+		}
+		ApplicationArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(10));
+		await using (arrangeContext) {
+			string suffix = Guid.NewGuid().ToString("N")[..8];
+			_webOnlyAutoIconApplication = await ActCreateAsync(
+				arrangeContext.Session,
+				arrangeContext.CancellationTokenSource.Token,
+				arrangeContext.EnvironmentName,
+				name: $"Codex Auto Icon Web Only {suffix}",
+				code: $"UsrAutoIconWeb{suffix}",
+				description: null,
+				templateCode: ApplicationTemplateCode,
+				iconId: "auto",
+				iconBackground: ApplicationIconBackground,
+				optionalTemplateDataJson: null,
+				withMobilePages: false);
+		}
+		return _webOnlyAutoIconApplication;
+	}
+
+	private static ApplicationInfoActResult? _webOnlyAutoIconApplication;
+
 }

--- a/clio.mcp.e2e/ApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/ApplicationToolE2ETests.cs
@@ -908,35 +908,10 @@ public sealed class ApplicationToolE2ETests {
 		return new ApplicationArrangeContext(environmentName, session, cancellationTokenSource);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"application MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"application MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static async Task<ApplicationListActResult> ActListAsync(
 		McpServerSession session,
@@ -1386,7 +1361,6 @@ public sealed class ApplicationToolE2ETests {
 			Content = callResult.Content
 		});
 	}
-
 
 	private sealed record ApplicationArrangeContext(
 		string EnvironmentName,

--- a/clio.mcp.e2e/AssertInfrastructureToolE2ETests.cs
+++ b/clio.mcp.e2e/AssertInfrastructureToolE2ETests.cs
@@ -23,8 +23,7 @@ namespace Clio.Mcp.E2E;
 [Category("McpE2E.NoEnvironment")]
 [AllureNUnit]
 [AllureFeature("assert")]
-public sealed class AssertInfrastructureToolE2ETests
-{
+public sealed class AssertInfrastructureToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = AssertInfrastructureTool.AssertInfrastructureToolName;
 
 	[Test]
@@ -47,13 +46,13 @@ public sealed class AssertInfrastructureToolE2ETests
 		AssertDatabaseCandidatesAreNormalized(actResult);
 	}
 
-	private static async Task<AssertInfrastructureArrangeContext> ArrangeAsync()
+	private async Task<AssertInfrastructureArrangeContext> ArrangeAsync()
 	{
 		return await AllureApi.Step("Arrange assert-infrastructure MCP session", async () =>
 		{
 			McpE2ESettings settings = TestConfiguration.Load();
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new AssertInfrastructureArrangeContext(session, cancellationTokenSource);
 		});
 	}
@@ -135,10 +134,10 @@ public sealed class AssertInfrastructureToolE2ETests
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable
 	{
-		public async ValueTask DisposeAsync()
+		public ValueTask DisposeAsync()
 		{
-			await Session.DisposeAsync();
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/ClearBrowserSessionToolE2ETests.cs
+++ b/clio.mcp.e2e/ClearBrowserSessionToolE2ETests.cs
@@ -103,7 +103,9 @@ public sealed class ClearBrowserSessionToolE2ETests : McpContractFixtureBase {
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
 		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			"Configure McpE2E:Sandbox:EnvironmentName to run clear-browser-session MCP E2E tests.");
+			$"clear-browser-session MCP E2E requires a reachable environment. Configure McpE2E:Sandbox:EnvironmentName; "
+			+ $"configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback "
+			+ $"environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/ClearBrowserSessionToolE2ETests.cs
+++ b/clio.mcp.e2e/ClearBrowserSessionToolE2ETests.cs
@@ -100,25 +100,10 @@ public sealed class ClearBrowserSessionToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run clear-browser-session MCP E2E tests.");
-		}
-
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore($"clear-browser-session MCP E2E requires a reachable sandbox environment. '{configuredEnvironmentName}' was not reachable.");
-		}
-
-		return configuredEnvironmentName!;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			"Configure McpE2E:Sandbox:EnvironmentName to run clear-browser-session MCP E2E tests.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/ClearRedisToolE2ETests.cs
+++ b/clio.mcp.e2e/ClearRedisToolE2ETests.cs
@@ -29,7 +29,7 @@ namespace Clio.Mcp.E2E;
 [TestFixture]
 [AllureNUnit]
 [AllureFeature("clear-redis-db")]
-public sealed class ClearRedisToolE2ETests {
+public sealed class ClearRedisToolE2ETests : McpContractFixtureBase {
 	private const string EnvironmentToolName = ClearRedisTool.ClearRedisByEnvironmentName;
 	private const string CredentialsToolName = ClearRedisTool.ClearRedisByCredentialsToolName;
 
@@ -98,7 +98,7 @@ public sealed class ClearRedisToolE2ETests {
 				RedisConnectionString: string.Empty,
 				DatabaseConnectionString: string.Empty);
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new ClearRedisArrangeContext(sandboxContext, session, cancellationTokenSource);
 		});
 	}
@@ -199,9 +199,9 @@ public sealed class ClearRedisToolE2ETests {
 		SandboxEnvironmentContext SandboxContext,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/ComponentInfoToolVersionResolutionSandboxE2ETests.cs
+++ b/clio.mcp.e2e/ComponentInfoToolVersionResolutionSandboxE2ETests.cs
@@ -28,7 +28,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(ComponentInfoTool.ToolName)]
 [NonParallelizable]
-public sealed class ComponentInfoToolVersionResolutionSandboxE2ETests {
+public sealed class ComponentInfoToolVersionResolutionSandboxE2ETests : McpContractFixtureBase {
 
 	private const string ToolName = ComponentInfoTool.ToolName;
 
@@ -80,7 +80,7 @@ public sealed class ComponentInfoToolVersionResolutionSandboxE2ETests {
 		return EntitySchemaStructuredResultParser.Extract<ComponentInfoResponse>(callResult);
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync() {
+	private async Task<ArrangeContext> ArrangeAsync() {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
@@ -91,17 +91,17 @@ public sealed class ComponentInfoToolVersionResolutionSandboxE2ETests {
 			Assert.Ignore($"get-component-info version-resolution MCP E2E requires a reachable configured sandbox environment. '{environmentName}' was not reachable.");
 		}
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource,
 		string? EnvironmentName) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/CreateIntegrationTestProjectToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateIntegrationTestProjectToolE2ETests.cs
@@ -13,7 +13,7 @@ namespace Clio.Mcp.E2E;
 [TestFixture, Category("McpE2E.NoEnvironment"), AllureNUnit]
 [AllureFeature(CreateIntegrationTestProjectTool.ToolName)]
 [NonParallelizable]
-public sealed class CreateIntegrationTestProjectToolE2ETests {
+public sealed class CreateIntegrationTestProjectToolE2ETests : McpContractFixtureBase {
 	[Test]
 	[Description("Starts the real MCP server, creates a portable integration-test project in a temporary clio workspace, and verifies its files and solution registrations.")]
 	[AllureName("Integration-test scaffold is generated end to end")]
@@ -27,7 +27,7 @@ public sealed class CreateIntegrationTestProjectToolE2ETests {
 		await File.WriteAllTextAsync(Path.Combine(workspace, ".clio", "workspaceSettings.json"),
 			"{\"Packages\":[\"Acme\"],\"ApplicationVersion\":\"8.1.0\"}", cancellation.Token);
 		try {
-			await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellation.Token);
+			McpServerSession session = Session;
 
 			// Act
 			CallToolResult callResult = await session.CallToolAsync(

--- a/clio.mcp.e2e/CreateRelatedPageAddonToolE2ETests.cs
+++ b/clio.mcp.e2e/CreateRelatedPageAddonToolE2ETests.cs
@@ -19,7 +19,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(CreateRelatedPageAddonTool.ToolName)]
 [NonParallelizable]
-public sealed class CreateRelatedPageAddonToolE2ETests {
+public sealed class CreateRelatedPageAddonToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = CreateRelatedPageAddonTool.ToolName;
 
 	[Test]
@@ -286,20 +286,20 @@ public sealed class CreateRelatedPageAddonToolE2ETests {
 			because: "the structured response should explain that a null pages entry is not allowed");
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
+	private async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		CancellationTokenSource cancellationTokenSource = new(timeout);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new ArrangeContext(session, cancellationTokenSource);
 	}
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/DataBindingDbFixtureBase.cs
+++ b/clio.mcp.e2e/DataBindingDbFixtureBase.cs
@@ -162,12 +162,8 @@ public abstract class DataBindingDbFixtureBase : McpContractFixtureBase {
 		return string.Empty;
 	}
 
-	private protected static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private protected static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	/// <summary>
 	/// Polls odata-read until the schema that was just published answers, or the window closes.

--- a/clio.mcp.e2e/DataBindingToolE2ETests.cs
+++ b/clio.mcp.e2e/DataBindingToolE2ETests.cs
@@ -343,29 +343,10 @@ public sealed class DataBindingToolE2ETests : McpContractFixtureBase {
 			cancellationTokenSource);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"Data-binding MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			$"Data-binding MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private static async Task<CommandExecutionActResult> ActCommandAsync(
 		DataBindingArrangeContext arrangeContext,

--- a/clio.mcp.e2e/DataForgeToolE2ETests.cs
+++ b/clio.mcp.e2e/DataForgeToolE2ETests.cs
@@ -608,25 +608,10 @@ public sealed class DataForgeToolE2ETests {
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run Data Forge MCP E2E tests.");
-		}
-
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore($"Data Forge MCP E2E requires a reachable sandbox environment. '{configuredEnvironmentName}' was not reachable.");
-		}
-
-		return configuredEnvironmentName!;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			"Configure McpE2E:Sandbox:EnvironmentName to run Data Forge MCP E2E tests.");
 
 	private sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/DataForgeToolE2ETests.cs
+++ b/clio.mcp.e2e/DataForgeToolE2ETests.cs
@@ -39,7 +39,7 @@ namespace Clio.Mcp.E2E;
 // The clio-side exception->Success=false mapping is unit-tested in DataForgeToolTests.cs. Because the
 // reads skip on any non-wired stand, the positive (Success=true) assertions run only in a DataForge-
 // wired lane, NOT the default CI lane; table similarity search additionally depends on ENG-87092.
-public sealed class DataForgeToolE2ETests {
+public sealed class DataForgeToolE2ETests : McpContractFixtureBase {
 	private const string StatusToolName = DataForgeTool.DataForgeStatusToolName;
 	private const string FindTablesToolName = DataForgeTool.DataForgeFindTablesToolName;
 	private const string FindLookupsToolName = DataForgeTool.DataForgeFindLookupsToolName;
@@ -490,7 +490,7 @@ public sealed class DataForgeToolE2ETests {
 	/// multiplied across the three reads. The skip-vs-fail decision is taken after the read by
 	/// <see cref="AssertServiceServedReadOrSkipByStateAsync"/> from the observed service state (ENG-92557).
 	/// </summary>
-	private static async Task EnsureSimilarityIndexReadyAsync(McpE2ESettings settings, ArrangeContext arrangeContext) {
+	private async Task EnsureSimilarityIndexReadyAsync(McpE2ESettings settings, ArrangeContext arrangeContext) {
 		if (!settings.DataForge.InitializeAndWait) {
 			return;
 		}
@@ -596,12 +596,12 @@ public sealed class DataForgeToolE2ETests {
 		}
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync(
+	private async Task<ArrangeContext> ArrangeAsync(
 		McpE2ESettings settings,
 		TimeSpan timeout,
 		bool requireReachableEnvironment) {
 		CancellationTokenSource cancellationTokenSource = new(timeout);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		string? environmentName = requireReachableEnvironment
 			? await ResolveReachableEnvironmentAsync(settings)
 			: settings.Sandbox.EnvironmentName;
@@ -613,13 +613,13 @@ public sealed class DataForgeToolE2ETests {
 			settings,
 			"Configure McpE2E:Sandbox:EnvironmentName to run Data Forge MCP E2E tests.");
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource,
 		string? EnvironmentName) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/DbTemplatePruneToolE2ETests.cs
+++ b/clio.mcp.e2e/DbTemplatePruneToolE2ETests.cs
@@ -16,7 +16,7 @@ namespace Clio.Mcp.E2E;
 [Category("McpE2E.NoEnvironment")]
 [AllureNUnit]
 [AllureFeature("database template pruning")]
-public sealed class DbTemplatePruneToolE2ETests {
+public sealed class DbTemplatePruneToolE2ETests : McpContractFixtureBase {
 	[Test]
 	[Description("Discovers both template-pruning tools and returns a structured configuration failure for an unknown server.")]
 	[AllureTag(DbTemplatePruneTool.ListDbTemplatesToolName)]
@@ -27,8 +27,7 @@ public sealed class DbTemplatePruneToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(2));
-		await using McpServerSession session = await AllureApi.Step("Arrange MCP server session", async () =>
-			await McpServerSession.StartAsync(settings, cancellation.Token));
+		McpServerSession session = Session;
 
 		// Act
 		IReadOnlyCollection<string> names = await AllureApi.Step("Act by discovering reachable tools", async () =>
@@ -62,8 +61,7 @@ public sealed class DbTemplatePruneToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(2));
-		await using McpServerSession session = await AllureApi.Step("Arrange MCP server session", async () =>
-			await McpServerSession.StartAsync(settings, cancellation.Token));
+		McpServerSession session = Session;
 
 		// Act
 		CallToolResult result = await AllureApi.Step("Act by calling destructive tool through raw name", async () =>
@@ -92,8 +90,7 @@ public sealed class DbTemplatePruneToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(2));
-		await using McpServerSession session = await AllureApi.Step("Arrange MCP server session", async () =>
-			await McpServerSession.StartAsync(settings, cancellation.Token));
+		McpServerSession session = Session;
 
 		// Act
 		CallToolResult result = await AllureApi.Step("Act by calling approved executor with empty selection", async () =>
@@ -119,7 +116,7 @@ public sealed class DbTemplatePruneToolE2ETests {
 [NonParallelizable]
 [AllureNUnit]
 [AllureFeature("database template pruning")]
-public sealed class DbTemplatePruneSandboxE2ETests {
+public sealed class DbTemplatePruneSandboxE2ETests : McpContractFixtureBase {
 	[Test]
 	[Description("Inventories and deletes an explicitly named managed template through the approved MCP path on an opt-in PostgreSQL sandbox.")]
 	[AllureTag(DbTemplatePruneTool.PruneDbTemplatesToolName)]
@@ -146,7 +143,7 @@ public sealed class DbTemplatePruneSandboxE2ETests {
 				await CreateManagedTemplateAsync(builder.ConnectionString, gatedName);
 			});
 			using CancellationTokenSource cancellation = new(TimeSpan.FromMinutes(3));
-			await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellation.Token);
+			McpServerSession session = Session;
 			DbTemplateInventoryResult inventory = await AllureApi.Step("Act by inventorying sandbox templates", async () => {
 				CallToolResult result = await session.CallToolAsync(DbTemplatePruneTool.ListDbTemplatesToolName,
 					new Dictionary<string, object?> {

--- a/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/EntityBusinessRuleToolE2ETests.cs
@@ -1020,34 +1020,10 @@ public sealed class EntityBusinessRuleToolE2ETests : McpContractFixtureBase {
 			? "Custom"
 			: settings.Sandbox.PackageName;
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("create-entity-business-rule MCP E2E requires McpE2E:Sandbox:EnvironmentName for destructive tests.");
-			return string.Empty;
-		}
-
-		if (await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"create-entity-business-rule MCP E2E requires a reachable configured sandbox environment. Environment '{configuredEnvironmentName}' was not reachable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			"create-entity-business-rule MCP E2E requires McpE2E:Sandbox:EnvironmentName for destructive tests.");
 
 	private static IReadOnlyDictionary<string, object?> CreateContactEntityRule(string caption) =>
 		new Dictionary<string, object?> {

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -506,7 +506,11 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		const string localizedColumnName = LocalizedTextColumnName;
 
 		// Act
-		CommandExecutionEnvelope addResult = await ActSharedBatchAddColumnsAsync(arrangeContext);
+		// Deliberately NOT the shared batch. This is the fixture's only witness that a SECOND
+		// update-entity-schema succeeds against a schema an earlier batch already changed and
+		// recompiled, and its "the add emitted progress" assertion only means something while the
+		// envelope belongs to one operation rather than six.
+		CommandExecutionEnvelope addResult = await ActBatchAddLocalizedTextColumnAsync(arrangeContext, localizedColumnName);
 		CommandExecutionEnvelope modifyResult =
 			await ActModifyLocalizedTextColumnWithStructuredSettingsDefaultAsync(arrangeContext, localizedColumnName);
 		EntitySchemaColumnPropertiesInfo columnProperties =
@@ -1602,14 +1606,37 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	/// schema four times — about 25s apiece — to add columns that never interact. The batch is the tool's
 	/// own supported shape, so nothing about the operation under test changes; each test still reads back
 	/// and asserts only its own column. The trade-off is deliberate: a column type that fails to add now
-	/// fails all four tests at once rather than one, which is the cost of paying for the compile once.
+	/// fails all three tests at once rather than one, which is the cost of paying for the compile once.
+	/// The localized-text column stays outside this batch on purpose — see its test.
 	/// </remarks>
-	private static async Task<CommandExecutionEnvelope> ActSharedBatchAddColumnsAsync(
+	private static async Task<CommandExecutionEnvelope> ActBatchAddLocalizedTextColumnAsync(
+		EntitySchemaArrangeContext arrangeContext,
+		string columnName) {
+		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for a localized text column", async () => {
+			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
+				arrangeContext.Session,
+				arrangeContext.EnvironmentName,
+				arrangeContext.PackageName,
+				arrangeContext.SchemaName,
+				arrangeContext.CancellationTokenSource.Token,
+				[
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = columnName,
+						["type"] = "Text",
+						["title-localizations"] = BuildLocalizations("Status")
+					}
+				]);
+			return McpCommandExecutionParser.Extract(callResult);
+		});
+	}
+
+	private async Task<CommandExecutionEnvelope> ActSharedBatchAddColumnsAsync(
 		EntitySchemaArrangeContext arrangeContext) {
 		if (_sharedBatchAddResult is not null) {
 			return _sharedBatchAddResult;
 		}
-		_sharedBatchAddResult = await AllureApi.Step(
+		CommandExecutionEnvelope batchResult = await AllureApi.Step(
 			"Act by invoking update-entity-schema through MCP for the fixture's shared column batch", async () => {
 			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
 				arrangeContext.Session,
@@ -1644,12 +1671,6 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 					},
 					new Dictionary<string, object?> {
 						["action"] = "add",
-						["column-name"] = LocalizedTextColumnName,
-						["type"] = "Text",
-						["title-localizations"] = BuildLocalizations("Status")
-					},
-					new Dictionary<string, object?> {
-						["action"] = "add",
 						["column-name"] = BatchUsageColumnName,
 						["type"] = "ShortText",
 						["title-localizations"] = BuildLocalizations("Batch usage column"),
@@ -1658,10 +1679,16 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 				]);
 			return McpCommandExecutionParser.Extract(callResult);
 		});
+		if (batchResult.ExitCode != 0) {
+			// Not cached: replaying one bad round trip to the other callers reports it as several broken
+			// tests and hides that a rerun of the batch would have succeeded.
+			return batchResult;
+		}
+		_sharedBatchAddResult = batchResult;
 		return _sharedBatchAddResult;
 	}
 
-	private static CommandExecutionEnvelope? _sharedBatchAddResult;
+	private CommandExecutionEnvelope? _sharedBatchAddResult;
 
 	private const string BinaryColumnName = "UsrPayload";
 	private const string ImageColumnName = "UsrPreview";

--- a/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/EntitySchemaToolE2ETests.cs
@@ -438,12 +438,12 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	public async Task UpdateEntitySchema_Should_Add_BinaryLike_Columns_And_Read_Back_Friendly_Types() {
 		// Arrange
 		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSharedSchemaAsync();
-		const string binaryColumnName = "UsrPayload";
-		const string imageColumnName = "UsrPreview";
-		const string fileColumnName = "UsrDocument";
+		const string binaryColumnName = BinaryColumnName;
+		const string imageColumnName = ImageColumnName;
+		const string fileColumnName = FileColumnName;
 
 		// Act
-		CommandExecutionEnvelope updateResult = await ActBatchAddBinaryLikeColumnsAsync(arrangeContext, binaryColumnName, imageColumnName, fileColumnName);
+		CommandExecutionEnvelope updateResult = await ActSharedBatchAddColumnsAsync(arrangeContext);
 		EntitySchemaPropertiesInfo schemaProperties = await ActGetSchemaPropertiesAsync(arrangeContext);
 		EntitySchemaColumnPropertiesInfo binaryColumnProperties = await ActGetColumnPropertiesAsync(arrangeContext, binaryColumnName);
 		EntitySchemaColumnPropertiesInfo imageColumnProperties = await ActGetColumnPropertiesAsync(arrangeContext, imageColumnName);
@@ -472,10 +472,10 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	public async Task UpdateEntitySchema_Should_Add_ImageLookup_Column_Referencing_SysImage() {
 		// Arrange
 		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSharedSchemaAsync();
-		const string imageLookupColumnName = "UsrPhoto";
+		const string imageLookupColumnName = ImageLookupColumnName;
 
 		// Act
-		CommandExecutionEnvelope updateResult = await ActBatchAddImageLookupColumnAsync(arrangeContext, imageLookupColumnName);
+		CommandExecutionEnvelope updateResult = await ActSharedBatchAddColumnsAsync(arrangeContext);
 		EntitySchemaPropertiesInfo schemaProperties = await ActGetSchemaPropertiesAsync(arrangeContext);
 		EntitySchemaColumnPropertiesInfo imageLookupColumnProperties = await ActGetColumnPropertiesAsync(arrangeContext, imageLookupColumnName);
 
@@ -503,10 +503,10 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	public async Task UpdateEntitySchema_Should_Keep_Localized_Column_Valid_For_Later_DefaultValueConfig_Modify() {
 		// Arrange
 		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSharedSchemaAsync();
-		const string localizedColumnName = "UsrStatus";
+		const string localizedColumnName = LocalizedTextColumnName;
 
 		// Act
-		CommandExecutionEnvelope addResult = await ActBatchAddLocalizedTextColumnAsync(arrangeContext, localizedColumnName);
+		CommandExecutionEnvelope addResult = await ActSharedBatchAddColumnsAsync(arrangeContext);
 		CommandExecutionEnvelope modifyResult =
 			await ActModifyLocalizedTextColumnWithStructuredSettingsDefaultAsync(arrangeContext, localizedColumnName);
 		EntitySchemaColumnPropertiesInfo columnProperties =
@@ -729,10 +729,10 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 	public async Task UpdateEntitySchema_Should_Apply_UsageType_Through_Mcp() {
 		// Arrange
 		await using EntitySchemaArrangeContext arrangeContext = await ArrangeSharedSchemaAsync();
-		const string batchUsageColumnName = "UsrBatchUsage";
+		const string batchUsageColumnName = BatchUsageColumnName;
 
 		// Act
-		CommandExecutionEnvelope batchResult = await ActBatchAddColumnWithUsageTypeAsync(arrangeContext, batchUsageColumnName, "Advanced");
+		CommandExecutionEnvelope batchResult = await ActSharedBatchAddColumnsAsync(arrangeContext);
 		EntitySchemaColumnPropertiesInfo columnProperties = await ActGetColumnPropertiesAsync(arrangeContext, batchUsageColumnName);
 
 		// Assert
@@ -1593,11 +1593,24 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 		});
 	}
 
-	private static async Task<CommandExecutionEnvelope> ActBatchAddColumnWithUsageTypeAsync(
-		EntitySchemaArrangeContext arrangeContext,
-		string columnName,
-		string usageType) {
-		return await AllureApi.Step("Act by invoking update-entity-schema through MCP to add a column with a usage-type", async () => {
+	/// <summary>
+	/// Adds every plain "add a column and read it back" fixture column in ONE update-entity-schema batch,
+	/// once per fixture, and hands the same envelope to each test that asserts on one of them.
+	/// </summary>
+	/// <remarks>
+	/// Four tests each ran their own batch against the one shared schema, so the stand compiled the same
+	/// schema four times — about 25s apiece — to add columns that never interact. The batch is the tool's
+	/// own supported shape, so nothing about the operation under test changes; each test still reads back
+	/// and asserts only its own column. The trade-off is deliberate: a column type that fails to add now
+	/// fails all four tests at once rather than one, which is the cost of paying for the compile once.
+	/// </remarks>
+	private static async Task<CommandExecutionEnvelope> ActSharedBatchAddColumnsAsync(
+		EntitySchemaArrangeContext arrangeContext) {
+		if (_sharedBatchAddResult is not null) {
+			return _sharedBatchAddResult;
+		}
+		_sharedBatchAddResult = await AllureApi.Step(
+			"Act by invoking update-entity-schema through MCP for the fixture's shared column batch", async () => {
 			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
 				arrangeContext.Session,
 				arrangeContext.EnvironmentName,
@@ -1607,15 +1620,55 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 				[
 					new Dictionary<string, object?> {
 						["action"] = "add",
-						["column-name"] = columnName,
+						["column-name"] = BinaryColumnName,
+						["type"] = "Binary",
+						["title-localizations"] = BuildLocalizations("Payload")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = ImageColumnName,
+						["type"] = "Image",
+						["title-localizations"] = BuildLocalizations("Preview")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = FileColumnName,
+						["type"] = "File",
+						["title-localizations"] = BuildLocalizations("Document")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = ImageLookupColumnName,
+						["type"] = "ImageLookup",
+						["title-localizations"] = BuildLocalizations("Photo")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = LocalizedTextColumnName,
+						["type"] = "Text",
+						["title-localizations"] = BuildLocalizations("Status")
+					},
+					new Dictionary<string, object?> {
+						["action"] = "add",
+						["column-name"] = BatchUsageColumnName,
 						["type"] = "ShortText",
 						["title-localizations"] = BuildLocalizations("Batch usage column"),
-						["usage-type"] = usageType
+						["usage-type"] = "Advanced"
 					}
 				]);
 			return McpCommandExecutionParser.Extract(callResult);
 		});
+		return _sharedBatchAddResult;
 	}
+
+	private static CommandExecutionEnvelope? _sharedBatchAddResult;
+
+	private const string BinaryColumnName = "UsrPayload";
+	private const string ImageColumnName = "UsrPreview";
+	private const string FileColumnName = "UsrDocument";
+	private const string ImageLookupColumnName = "UsrPhoto";
+	private const string LocalizedTextColumnName = "UsrStatus";
+	private const string BatchUsageColumnName = "UsrBatchUsage";
 
 	private static async Task<EntitySchemaColumnPropertiesInfo> ActGetColumnPropertiesAsync(
 		EntitySchemaArrangeContext arrangeContext,
@@ -1629,86 +1682,6 @@ public sealed class EntitySchemaToolE2ETests : McpContractFixtureBase {
 				columnName ?? arrangeContext.AddedColumnName,
 				arrangeContext.CancellationTokenSource.Token);
 			return EntitySchemaStructuredResultParser.Extract<EntitySchemaColumnPropertiesInfo>(callResult);
-		});
-	}
-
-	private static async Task<CommandExecutionEnvelope> ActBatchAddBinaryLikeColumnsAsync(
-		EntitySchemaArrangeContext arrangeContext,
-		string binaryColumnName,
-		string imageColumnName,
-		string fileColumnName) {
-		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for binary-like columns", async () => {
-			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
-				arrangeContext.Session,
-				arrangeContext.EnvironmentName,
-				arrangeContext.PackageName,
-				arrangeContext.SchemaName,
-				arrangeContext.CancellationTokenSource.Token,
-				[
-					new Dictionary<string, object?> {
-						["action"] = "add",
-						["column-name"] = binaryColumnName,
-						["type"] = "Binary",
-						["title-localizations"] = BuildLocalizations("Payload")
-					},
-					new Dictionary<string, object?> {
-						["action"] = "add",
-						["column-name"] = imageColumnName,
-						["type"] = "Image",
-						["title-localizations"] = BuildLocalizations("Preview")
-					},
-					new Dictionary<string, object?> {
-						["action"] = "add",
-						["column-name"] = fileColumnName,
-						["type"] = "File",
-						["title-localizations"] = BuildLocalizations("Document")
-					}
-				]);
-			return McpCommandExecutionParser.Extract(callResult);
-		});
-	}
-
-	private static async Task<CommandExecutionEnvelope> ActBatchAddImageLookupColumnAsync(
-		EntitySchemaArrangeContext arrangeContext,
-		string imageLookupColumnName) {
-		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for an ImageLookup column", async () => {
-			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
-				arrangeContext.Session,
-				arrangeContext.EnvironmentName,
-				arrangeContext.PackageName,
-				arrangeContext.SchemaName,
-				arrangeContext.CancellationTokenSource.Token,
-				[
-					new Dictionary<string, object?> {
-						["action"] = "add",
-						["column-name"] = imageLookupColumnName,
-						["type"] = "ImageLookup",
-						["title-localizations"] = BuildLocalizations("Photo")
-					}
-				]);
-			return McpCommandExecutionParser.Extract(callResult);
-		});
-	}
-
-	private static async Task<CommandExecutionEnvelope> ActBatchAddLocalizedTextColumnAsync(
-		EntitySchemaArrangeContext arrangeContext,
-		string columnName) {
-		return await AllureApi.Step("Act by invoking update-entity-schema through MCP for a localized text column", async () => {
-			CallToolResult callResult = await CallUpdateEntitySchemaAsync(
-				arrangeContext.Session,
-				arrangeContext.EnvironmentName,
-				arrangeContext.PackageName,
-				arrangeContext.SchemaName,
-				arrangeContext.CancellationTokenSource.Token,
-				[
-					new Dictionary<string, object?> {
-						["action"] = "add",
-						["column-name"] = columnName,
-						["type"] = "Text",
-						["title-localizations"] = BuildLocalizations("Status")
-					}
-				]);
-			return McpCommandExecutionParser.Extract(callResult);
 		});
 	}
 

--- a/clio.mcp.e2e/FindAppToolE2ETests.cs
+++ b/clio.mcp.e2e/FindAppToolE2ETests.cs
@@ -23,7 +23,7 @@ namespace Clio.Mcp.E2E;
 // its NUnit lifecycle hooks can deadlock async MCP flows. The Allure metadata attributes
 // below are still safe because they do not install lifecycle hooks.
 [NonParallelizable]
-public sealed class FindAppToolE2ETests {
+public sealed class FindAppToolE2ETests : McpContractFixtureBase {
 	private const string FindAppToolName = FindAppTool.FindAppToolName;
 
 	[Category("McpE2E.Sandbox")]
@@ -38,7 +38,7 @@ public sealed class FindAppToolE2ETests {
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		TestConfiguration.EnsureSandboxIsConfigured(settings);
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 
 		// Act
 		CallToolResult callResult = await CallFindAppAsync(
@@ -71,7 +71,7 @@ public sealed class FindAppToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		await using McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		string invalidEnvironmentName = $"missing-find-app-env-{Guid.NewGuid():N}";
 
 		// Act

--- a/clio.mcp.e2e/FlatArgsProgressTokenE2ETests.cs
+++ b/clio.mcp.e2e/FlatArgsProgressTokenE2ETests.cs
@@ -51,7 +51,12 @@ namespace Clio.Mcp.E2E;
 [Category("McpE2E.NoEnvironment")]
 [AllureNUnit]
 [AllureFeature("mcp-flat-argument-normalization")]
-[NonParallelizable]
+// Parallelizable on purpose. The single test here spends about 100s waiting on a loopback listener that
+// accepts the connection and never answers — that wait IS the assertion, so it cannot be shortened. As
+// [NonParallelizable] it stopped every other worker for those 100s; the fixture owns everything it
+// touches (its own MCP child with an isolated CLIO_HOME, its own ephemeral-port listener, no stand), so
+// the wait can overlap with other fixtures instead.
+[Parallelizable(ParallelScope.Self)]
 public sealed class FlatArgsProgressTokenE2ETests : McpContractFixtureBase {
 	private const string ToolName = ApplicationSectionGetListTool.ApplicationSectionGetListToolName;
 	private const string StallingEnvironmentName = "mcp-e2e-flat-args-progress-stall";

--- a/clio.mcp.e2e/GenerateProcessModelToolE2ETests.cs
+++ b/clio.mcp.e2e/GenerateProcessModelToolE2ETests.cs
@@ -109,12 +109,8 @@ public sealed class GenerateProcessModelToolE2ETests {
 			cancellationTokenSource);
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static async Task<GenerateProcessModelActResult> ActAsync(
 		McpServerSession session,

--- a/clio.mcp.e2e/GenerateProcessModelToolE2ETests.cs
+++ b/clio.mcp.e2e/GenerateProcessModelToolE2ETests.cs
@@ -18,7 +18,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature("generate-process-model")]
 [NonParallelizable]
-public sealed class GenerateProcessModelToolE2ETests {
+public sealed class GenerateProcessModelToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = GenerateProcessModelTool.GenerateProcessModelToolName;
 
 	[Category("McpE2E.Sandbox")]
@@ -59,7 +59,7 @@ public sealed class GenerateProcessModelToolE2ETests {
 			because: "the generated file should define a class named after the requested process code");
 	}
 
-	private static async Task<GenerateProcessModelArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
+	private async Task<GenerateProcessModelArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
 		string? environmentName = settings.Sandbox.EnvironmentName;
 		string? processCode = settings.Sandbox.ProcessCode;
 		if (string.IsNullOrWhiteSpace(environmentName) || string.IsNullOrWhiteSpace(processCode)) {
@@ -77,7 +77,7 @@ public sealed class GenerateProcessModelToolE2ETests {
 		string generatedFilePath = Path.Combine(process.WorkingDirectory, destinationPath);
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 		Directory.CreateDirectory(rootDirectory);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new GenerateProcessModelArrangeContext(
 			rootDirectory,
 			destinationPath,
@@ -89,7 +89,7 @@ public sealed class GenerateProcessModelToolE2ETests {
 			cancellationTokenSource);
 	}
 
-	private static async Task<GenerateProcessModelArrangeContext> ArrangeFailureAsync(McpE2ESettings settings) {
+	private async Task<GenerateProcessModelArrangeContext> ArrangeFailureAsync(McpE2ESettings settings) {
 		ClioProcessDescriptor process = ClioExecutableResolver.Resolve(settings);
 		string rootDirectory = Path.Combine(process.WorkingDirectory, $"gpm-invalid-e2e-{Guid.NewGuid():N}");
 		string destinationPath = Path.Combine(Path.GetFileName(rootDirectory), "generated", "missing-process-model.cs");
@@ -97,7 +97,7 @@ public sealed class GenerateProcessModelToolE2ETests {
 		string generatedFilePath = Path.Combine(process.WorkingDirectory, destinationPath);
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
 		Directory.CreateDirectory(rootDirectory);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new GenerateProcessModelArrangeContext(
 			rootDirectory,
 			destinationPath,
@@ -147,12 +147,12 @@ public sealed class GenerateProcessModelToolE2ETests {
 		string EnvironmentName,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/GetBrowserSessionToolE2ETests.cs
+++ b/clio.mcp.e2e/GetBrowserSessionToolE2ETests.cs
@@ -130,7 +130,9 @@ public sealed class GetBrowserSessionToolE2ETests : McpContractFixtureBase {
 	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
 		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			"Configure McpE2E:Sandbox:EnvironmentName to run get-browser-session MCP E2E tests.");
+			$"get-browser-session MCP E2E requires a reachable environment. Configure McpE2E:Sandbox:EnvironmentName; "
+			+ $"configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback "
+			+ $"environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/GetBrowserSessionToolE2ETests.cs
+++ b/clio.mcp.e2e/GetBrowserSessionToolE2ETests.cs
@@ -127,25 +127,10 @@ public sealed class GetBrowserSessionToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run get-browser-session MCP E2E tests.");
-		}
-
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore($"get-browser-session MCP E2E requires a reachable sandbox environment. '{configuredEnvironmentName}' was not reachable.");
-		}
-
-		return configuredEnvironmentName!;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			"Configure McpE2E:Sandbox:EnvironmentName to run get-browser-session MCP E2E tests.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/GetClassicListColumnsToolE2ETests.cs
+++ b/clio.mcp.e2e/GetClassicListColumnsToolE2ETests.cs
@@ -264,32 +264,10 @@ public sealed class GetClassicListColumnsToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(Session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? environmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(environmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run get-classic-list-columns MCP E2E.");
-			return string.Empty;
-		}
-		if (await CanReachEnvironmentAsync(settings, environmentName)) {
-			return environmentName;
-		}
-		Assert.Ignore($"Configured MCP sandbox environment '{environmentName}' is not reachable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cancellationTokenSource.Token);
-			return result.ExitCode == 0;
-		}
-		catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			"Configure McpE2E:Sandbox:EnvironmentName to run get-classic-list-columns MCP E2E.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
+++ b/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
@@ -34,44 +34,31 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 	// A base-product classic page present on every stand and replaced across many packages (multi-layer).
 	private const string MultiLayerPage = "ContactPageV2";
 
+	private SharedPageSources? _sharedPageSources;
+
 	[Test]
 	[Description("Assembles a real multi-layer classic page's sources via clio-run and writes an engine-consumable manifest to disk.")]
 	[AllureTag(ToolName)]
 	[AllureName("get-classic-page-sources assembles and writes an engine-consumable manifest")]
 	[AllureDescription("Uses the real clio MCP server to invoke the long-tail get-classic-page-sources tool through clio-run for ContactPageV2, then verifies the manifest was written to disk with a base->top schemas chain in the shape the migration engine folds.")]
 	public async Task GetPageSources_Should_Assemble_And_Write_EngineConsumable_Manifest() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
-		string outputDirectory = CreateFixtureDirectory("classic-page-sources");
-		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-
-		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		GetClassicPageSourcesResponse response =
-			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// Arrange & Act — every assertion in this fixture that reads a SUCCESSFUL ContactPageV2 manifest
+		// shares one collection. The five callers passed identical arguments to the same read-only tool and
+		// differed only in what they asserted, so each repetition cost a full ~25s round trip for nothing.
+		SharedPageSources shared = await GetOrCollectSharedPageSourcesAsync();
+		GetClassicPageSourcesResponse response = shared.Response;
 
 		// Assert — the tool reported success and a manifest path
-		callResult.IsError.Should().NotBeTrue(
+		shared.IsError.Should().NotBeTrue(
 			because: "the routed MCP call must return a structured payload");
 		response.Success.Should().BeTrue(
 			because: $"the page sources must assemble for the multi-layer page '{MultiLayerPage}'. Error: {response.Error}");
-		response.ManifestPath.Should().Be(outputFile,
+		response.ManifestPath.Should().Be(shared.OutputFile,
 			because: "an explicit absolute output-file must be echoed as the manifest location");
 
 		// Assert — the manifest on disk is in the engine's contract shape (bodies live here, not in the response)
 		File.Exists(response.ManifestPath).Should().BeTrue(because: "the manifest must be written to disk");
-		using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(response.ManifestPath));
+		using JsonDocument manifest = JsonDocument.Parse(shared.ManifestJson);
 		manifest.RootElement.TryGetProperty("schemas", out JsonElement schemas).Should().BeTrue(
 			because: "the manifest must carry the replacing-schema layer chain");
 		schemas.ValueKind.Should().Be(JsonValueKind.Array,
@@ -90,26 +77,11 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 	[AllureName("get-classic-page-sources resolves the section from SysModule metadata")]
 	[AllureDescription("Collects the ContactPageV2 sources on a real stand and verifies the section chain was gathered through the SysModule binding (not only the naming convention) and that the response carries no warnings — a broken metadata query would degrade to the conventions and surface a warning instead.")]
 	public async Task GetPageSources_Should_Resolve_Section_Through_SysModule_Metadata() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
-		string outputDirectory = CreateFixtureDirectory("classic-page-sources-section");
-		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-
-		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		GetClassicPageSourcesResponse response =
-			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// Arrange & Act — every assertion in this fixture that reads a SUCCESSFUL ContactPageV2 manifest
+		// shares one collection. The five callers passed identical arguments to the same read-only tool and
+		// differed only in what they asserted, so each repetition cost a full ~25s round trip for nothing.
+		SharedPageSources shared = await GetOrCollectSharedPageSourcesAsync();
+		GetClassicPageSourcesResponse response = shared.Response;
 
 		// Assert — the section resolved, so the caller gets no incompleteness warning
 		response.Success.Should().BeTrue(
@@ -127,7 +99,7 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 				"conventions and report the reason here");
 
 		// Assert — the manifest carries the section bodies the engine folds into the Freedom List page
-		using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(response.ManifestPath));
+		using JsonDocument manifest = JsonDocument.Parse(shared.ManifestJson);
 		manifest.RootElement.TryGetProperty("section", out JsonElement section).Should().BeTrue(
 			because: "a resolved section must reach the manifest, not just the response counter");
 		section.GetArrayLength().Should().Be(response.SectionLayerCount,
@@ -140,33 +112,18 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 	[AllureName("get-classic-page-sources reports a detail count consistent with its manifest and no truncation")]
 	[AllureDescription("Live witness that the response counter and the manifest agree and that no cap/truncation warning is reported. Deliberately product-agnostic — the detail count of a given page differs per installed product (Studio ContactPageV2 gathers 9, a Sales product far more), so this asserts CONSISTENCY and the absence of truncation rather than any specific number. It does NOT by itself prove the caps are gone: on a narrow (Studio) stand the page stays under the retired caps, so that claim rests on the unit regression tests (250/250/120/30).")]
 	public async Task GetPageSources_Should_Report_DetailCount_ConsistentWithManifest_AndNoTruncation() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(5));
-		string outputDirectory = CreateFixtureDirectory("classic-page-sources-uncapped");
-		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-
-		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		GetClassicPageSourcesResponse response =
-			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// Arrange & Act — every assertion in this fixture that reads a SUCCESSFUL ContactPageV2 manifest
+		// shares one collection. The five callers passed identical arguments to the same read-only tool and
+		// differed only in what they asserted, so each repetition cost a full ~25s round trip for nothing.
+		SharedPageSources shared = await GetOrCollectSharedPageSourcesAsync();
+		GetClassicPageSourcesResponse response = shared.Response;
 
 		// Assert — the whole unit was collected. The count itself is product-dependent (Studio gathers far fewer
 		// details for the same page than a Sales product), so the invariant asserted here is that the response
 		// counter and the manifest agree EXACTLY: a cap would have shortened one without the other noticing.
 		response.Success.Should().BeTrue(
 			because: $"the page sources must assemble for '{MultiLayerPage}'. Error: {response.Error}");
-		using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(response.ManifestPath));
+		using JsonDocument manifest = JsonDocument.Parse(shared.ManifestJson);
 		int manifestDetailCount = manifest.RootElement.TryGetProperty("detailSchemas", out JsonElement detailSchemas)
 			? detailSchemas.EnumerateObject().Count()
 			: 0; // the block is omitted (never null-filled) when the page resolved no details on this product
@@ -188,26 +145,11 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 	[AllureName("get-classic-page-sources populates childPageSchemas from SysModuleEdit")]
 	[AllureDescription("Collects the ContactPageV2 sources on a real stand and verifies the child pages each detail's entity registers in SysModuleEdit reached the manifest. Before ENG-94401 child pages were resolved by scanning detail bodies for a getEditPageName token, which matches nothing on a stock product (0 of 845 page-detail pairs), so childPageSchemas was structurally always empty and a migration plan silently omitted every child page.")]
 	public async Task GetPageSources_Should_Populate_ChildPageSchemas_From_SysModuleEdit() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(5));
-		string outputDirectory = CreateFixtureDirectory("classic-page-sources-child-pages");
-		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-
-		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		GetClassicPageSourcesResponse response =
-			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// Arrange & Act — every assertion in this fixture that reads a SUCCESSFUL ContactPageV2 manifest
+		// shares one collection. The five callers passed identical arguments to the same read-only tool and
+		// differed only in what they asserted, so each repetition cost a full ~25s round trip for nothing.
+		SharedPageSources shared = await GetOrCollectSharedPageSourcesAsync();
+		GetClassicPageSourcesResponse response = shared.Response;
 
 		// Assert — the page has details, and their entities' registered pages were resolved
 		response.Success.Should().BeTrue(
@@ -219,7 +161,7 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 				"route regressed back to the body scan that matches nothing on a stock product");
 
 		// Assert — the child pages are real nested manifests on disk, not just a counter
-		using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(response.ManifestPath));
+		using JsonDocument manifest = JsonDocument.Parse(shared.ManifestJson);
 		manifest.RootElement.TryGetProperty("childPageSchemas", out JsonElement childPages).Should().BeTrue(
 			because: "resolved child pages must reach the manifest the engine folds, not only the response counter");
 		childPages.EnumerateObject().Count().Should().Be(response.ChildPageCount,
@@ -311,26 +253,11 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 	[AllureName("get-classic-page-sources echoes the stand's own enumVocabulary")]
 	[AllureDescription("Collects ContactPageV2 sources on a real stand and verifies enumVocabulary was measured from the stand's own sysenums.js — not merely present, but carrying plausible member counts for ViewItemType/ContentType/DataValueType — so the engine's enum-drift guard receives a genuine, stand-specific input on every real run rather than a hardcoded copy of its own pinned tables.")]
 	public async Task GetPageSources_Should_Echo_EnumVocabulary_From_Stand() {
-		// Arrange
-		McpE2ESettings settings = TestConfiguration.Load();
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(3));
-		string outputDirectory = CreateFixtureDirectory("classic-page-sources-enum-vocabulary");
-		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-
-		// Act
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
-			arrangeContext.CancellationTokenSource.Token);
-		GetClassicPageSourcesResponse response =
-			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// Arrange & Act — every assertion in this fixture that reads a SUCCESSFUL ContactPageV2 manifest
+		// shares one collection. The five callers passed identical arguments to the same read-only tool and
+		// differed only in what they asserted, so each repetition cost a full ~25s round trip for nothing.
+		SharedPageSources shared = await GetOrCollectSharedPageSourcesAsync();
+		GetClassicPageSourcesResponse response = shared.Response;
 
 		// Assert — the stand served its own sysenums.js and all three DRIFT_TABLES enums were measured from it
 		response.Success.Should().BeTrue(
@@ -340,7 +267,7 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 				"(ViewItemType/ContentType/DataValueType); a lower count means the fetch or parse degraded and must " +
 				"be visible here rather than silently passing as success");
 
-		using JsonDocument manifest = JsonDocument.Parse(await File.ReadAllTextAsync(response.ManifestPath));
+		using JsonDocument manifest = JsonDocument.Parse(shared.ManifestJson);
 		manifest.RootElement.TryGetProperty("enumVocabulary", out JsonElement enumVocabulary).Should().BeTrue(
 			because: "the stand-measured enum tables must reach the manifest the engine folds, not only the response counter");
 		foreach (string enumName in new[] { "ViewItemType", "ContentType", "DataValueType" }) {
@@ -354,6 +281,48 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 			}
 		}
 	}
+
+	/// <summary>
+	/// Collects ContactPageV2 once per fixture and hands every successful-path test the same response and the
+	/// same manifest text. The tool is read-only and its result does not depend on the caller, so repeating the
+	/// call per test bought nothing and cost a full round trip against the stand each time.
+	/// </summary>
+	private async Task<SharedPageSources> GetOrCollectSharedPageSourcesAsync() {
+		if (_sharedPageSources is not null) {
+			return _sharedPageSources;
+		}
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(5));
+		string outputDirectory = CreateFixtureDirectory("classic-page-sources");
+		string outputFile = Path.Combine(outputDirectory, "manifest.json");
+		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = MultiLayerPage,
+					["environment-name"] = arrangeContext.EnvironmentName,
+					["output-file"] = outputFile
+				}
+			},
+			arrangeContext.CancellationTokenSource.Token);
+		GetClassicPageSourcesResponse response =
+			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
+		// The manifest is read here, while the fixture directory is known to exist, and handed on as text: a
+		// JsonDocument cannot be shared across tests because each test disposes the one it parses.
+		string manifestJson = response.Success && response.ManifestPath is not null && File.Exists(response.ManifestPath)
+			? await File.ReadAllTextAsync(response.ManifestPath)
+			: string.Empty;
+		_sharedPageSources = new SharedPageSources(callResult.IsError, response, manifestJson, outputFile);
+		return _sharedPageSources;
+	}
+
+	/// <summary>One collection of ContactPageV2 sources, reused by every successful-path test in this fixture.</summary>
+	private sealed record SharedPageSources(
+		bool? IsError,
+		GetClassicPageSourcesResponse Response,
+		string ManifestJson,
+		string OutputFile);
 
 	private async Task<ArrangeContext> ArrangeAsync(McpE2ESettings settings, TimeSpan timeout) {
 		CancellationTokenSource cancellationTokenSource = new(timeout);

--- a/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
+++ b/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
@@ -296,15 +296,21 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 		await using ArrangeContext arrangeContext = await ArrangeAsync(settings, TimeSpan.FromMinutes(5));
 		string outputDirectory = CreateFixtureDirectory("classic-page-sources");
 		string outputFile = Path.Combine(outputDirectory, "manifest.json");
-		CallToolResult callResult = await arrangeContext.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = MultiLayerPage,
-					["environment-name"] = arrangeContext.EnvironmentName,
-					["output-file"] = outputFile
-				}
-			},
+		// Behind the retry gate, and cached only on success: one shared collection now carries five
+		// tests, so a single transient platform condition would otherwise fail all five at once and be
+		// replayed from the cache instead of retried.
+		CallToolResult callResult = await TransientPlatformConditionRetryGate.InvokeWithRetryAsync(
+			async token => await arrangeContext.Session.CallToolAsync(
+				ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["schema-name"] = MultiLayerPage,
+						["environment-name"] = arrangeContext.EnvironmentName,
+						["output-file"] = outputFile
+					}
+				},
+				token),
+			reauthenticateAsync: null,
 			arrangeContext.CancellationTokenSource.Token);
 		GetClassicPageSourcesResponse response =
 			EntitySchemaStructuredResultParser.Extract<GetClassicPageSourcesResponse>(callResult);
@@ -313,7 +319,13 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 		string manifestJson = response.Success && response.ManifestPath is not null && File.Exists(response.ManifestPath)
 			? await File.ReadAllTextAsync(response.ManifestPath)
 			: string.Empty;
-		_sharedPageSources = new SharedPageSources(callResult.IsError, response, manifestJson, outputFile);
+		SharedPageSources collected = new(callResult.IsError, response, manifestJson, outputFile);
+		if (!response.Success) {
+			// Not cached: a failure replayed to the other four tests reports one bad round trip as five
+			// broken assertions, and hides the fact that a retry would have succeeded.
+			return collected;
+		}
+		_sharedPageSources = collected;
 		return _sharedPageSources;
 	}
 

--- a/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
+++ b/clio.mcp.e2e/GetClassicPageSourcesToolE2ETests.cs
@@ -361,36 +361,11 @@ public sealed class GetClassicPageSourcesToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(Session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
 			$"get-classic-page-sources MCP E2E requires a reachable environment. Configured sandbox environment " +
-			$"'{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+			$"'{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/GetClientUnitSchemaToolE2ETests.cs
+++ b/clio.mcp.e2e/GetClientUnitSchemaToolE2ETests.cs
@@ -162,36 +162,11 @@ public sealed class GetClientUnitSchemaToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(Session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
 			$"get-client-unit-schema MCP E2E requires a reachable environment. Configured sandbox environment " +
-			$"'{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+			$"'{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/GetPkgListToolE2ETests.cs
+++ b/clio.mcp.e2e/GetPkgListToolE2ETests.cs
@@ -19,7 +19,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature("list-packages")]
 [NonParallelizable]
-public sealed class GetPkgListToolE2ETests {
+public sealed class GetPkgListToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = GetPkgListTool.GetPkgListToolName;
 
 	[Test]
@@ -46,19 +46,19 @@ public sealed class GetPkgListToolE2ETests {
 		AssertStructuredPagesReturned(actResult);
 	}
 
-	private static async Task<GetPkgListArrangeContext> ArrangeAsync(McpE2ESettings settings) {
+	private async Task<GetPkgListArrangeContext> ArrangeAsync(McpE2ESettings settings) {
 		return await AllureApi.Step("Arrange list-packages MCP session", async () => {
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(5));
 			await ClioCliCommandRunner.EnsureCliogateInstalledAsync(
 				settings,
 				settings.Sandbox.EnvironmentName!,
 				cancellationTokenSource.Token);
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new GetPkgListArrangeContext(session, cancellationTokenSource);
 		});
 	}
 
-	private static async Task<GetPkgListActResult> ActAsync(GetPkgListArrangeContext arrangeContext, string environmentName) {
+	private async Task<GetPkgListActResult> ActAsync(GetPkgListArrangeContext arrangeContext, string environmentName) {
 		return await AllureApi.Step("Act by invoking list-packages through MCP", async () => {
 			IList<McpClientTool> tools = await arrangeContext.Session.ListToolsAsync(arrangeContext.CancellationTokenSource.Token);
 			tools.Select(tool => tool.Name).Should().Contain(ToolName,
@@ -177,9 +177,9 @@ public sealed class GetPkgListToolE2ETests {
 	private sealed record GetPkgListArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/GetProcessSignatureToolE2ETests.cs
+++ b/clio.mcp.e2e/GetProcessSignatureToolE2ETests.cs
@@ -59,12 +59,8 @@ public sealed class GetProcessSignatureToolE2ETests : McpContractFixtureBase {
 			because: "a successful signature must always carry a parameters collection (possibly empty)");
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static async Task<GetProcessSignatureEnvelope> ActAsync(
 		ArrangeContext arrangeContext,

--- a/clio.mcp.e2e/GetRelatedPageAddonToolE2ETests.cs
+++ b/clio.mcp.e2e/GetRelatedPageAddonToolE2ETests.cs
@@ -18,7 +18,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(GetRelatedPageAddonTool.ToolName)]
 [NonParallelizable]
-public sealed class GetRelatedPageAddonToolE2ETests {
+public sealed class GetRelatedPageAddonToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = GetRelatedPageAddonTool.ToolName;
 
 	[Test]
@@ -140,20 +140,20 @@ public sealed class GetRelatedPageAddonToolE2ETests {
 			because: "the structured response should name the missing required field");
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
+	private async Task<ArrangeContext> ArrangeAsync(TimeSpan timeout) {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		CancellationTokenSource cancellationTokenSource = new(timeout);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new ArrangeContext(session, cancellationTokenSource);
 	}
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/InstallApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/InstallApplicationToolE2ETests.cs
@@ -19,7 +19,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature("install-application")]
 [NonParallelizable]
-public sealed class InstallApplicationToolE2ETests {
+public sealed class InstallApplicationToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = InstallApplicationTool.InstallApplicationToolName;
 
 	[Test]
@@ -93,7 +93,7 @@ public sealed class InstallApplicationToolE2ETests {
 			because: "invalid environment failures must not create the requested report file");
 	}
 
-	private static async Task<InstallApplicationArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
+	private async Task<InstallApplicationArrangeContext> ArrangeSuccessAsync(McpE2ESettings settings) {
 		string? environmentName = settings.Sandbox.EnvironmentName;
 		// Fall back to the bundled minimal package fixture so the success path is self-contained on a
 		// reachable sandbox without requiring McpE2E:Sandbox:ApplicationPackagePath to be configured.
@@ -117,7 +117,7 @@ public sealed class InstallApplicationToolE2ETests {
 		string reportPath = Path.Combine(rootDirectory, "install-application.log");
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(10));
 		Directory.CreateDirectory(rootDirectory);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new InstallApplicationArrangeContext(
 			rootDirectory,
 			reportPath,
@@ -127,13 +127,13 @@ public sealed class InstallApplicationToolE2ETests {
 			cancellationTokenSource);
 	}
 
-	private static async Task<InstallApplicationArrangeContext> ArrangeFailureAsync(McpE2ESettings settings) {
+	private async Task<InstallApplicationArrangeContext> ArrangeFailureAsync(McpE2ESettings settings) {
 		ClioProcessDescriptor process = ClioExecutableResolver.Resolve(settings);
 		string rootDirectory = Path.Combine(process.WorkingDirectory, $"install-application-invalid-e2e-{Guid.NewGuid():N}");
 		string reportPath = Path.Combine(rootDirectory, "install-application.log");
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
 		Directory.CreateDirectory(rootDirectory);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new InstallApplicationArrangeContext(
 			rootDirectory,
 			reportPath,
@@ -181,12 +181,12 @@ public sealed class InstallApplicationToolE2ETests {
 		string EnvironmentName,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/InstallApplicationToolE2ETests.cs
+++ b/clio.mcp.e2e/InstallApplicationToolE2ETests.cs
@@ -147,12 +147,8 @@ public sealed class InstallApplicationToolE2ETests {
 	private static string ResolveBundledFixturePackagePath() =>
 		Path.Combine(AppContext.BaseDirectory, "Assets", "ClioMcpE2EFixture.gz");
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static async Task<InstallApplicationActResult> ActAsync(
 		McpServerSession session,

--- a/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
+++ b/clio.mcp.e2e/LastCompilationLogToolE2ETests.cs
@@ -165,14 +165,6 @@ public sealed class LastCompilationLogToolE2ETests : McpContractFixtureBase {
 		return string.Empty;
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings, ["ping-app", "-e", environmentName], cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 }

--- a/clio.mcp.e2e/LinkFromRepositoryToolE2ETests.cs
+++ b/clio.mcp.e2e/LinkFromRepositoryToolE2ETests.cs
@@ -23,7 +23,7 @@ namespace Clio.Mcp.E2E;
 // attribute restores normal execution.
 [AllureFeature("link-from-repository")]
 [NonParallelizable]
-public sealed class LinkFromRepositoryToolE2ETests {
+public sealed class LinkFromRepositoryToolE2ETests : McpContractFixtureBase {
 	private const string EnvironmentToolName = LinkFromRepositoryTool.LinkFromRepositoryByEnvironmentToolName;
 	private const string EnvPkgPathToolName = LinkFromRepositoryTool.LinkFromRepositoryByEnvPackagePathToolName;
 
@@ -141,7 +141,7 @@ public sealed class LinkFromRepositoryToolE2ETests {
 
 	[AllureStep("Arrange link-from-repository MCP sandbox")]
 	[AllureDescription("Arrange by creating temporary repository and Creatio package directories, seeding a package folder, and starting a real clio MCP server session")]
-	private static async Task<LinkFromRepositoryArrangeContext> ArrangeAsync() {
+	private async Task<LinkFromRepositoryArrangeContext> ArrangeAsync() {
 		McpE2ESettings settings = TestConfiguration.Load();
 		if (!settings.AllowDestructiveMcpTests) {
 			Assert.Ignore("Set McpE2E:AllowDestructiveMcpTests=true to run destructive MCP end-to-end tests.");
@@ -169,7 +169,7 @@ public sealed class LinkFromRepositoryToolE2ETests {
 		await File.WriteAllTextAsync(Path.Combine(secondEnvironmentPackagePath, "env.txt"), "environment");
 
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new LinkFromRepositoryArrangeContext(
 			rootDirectory,
 			environmentPackagesPath,
@@ -364,13 +364,13 @@ public sealed class LinkFromRepositoryToolE2ETests {
 		string RepositoryRootPath,
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 
 			if (Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
+++ b/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Clio.Command.McpServer.Tools.MobilePageConverter;
 using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Diagnostics;
 using Clio.Mcp.E2E.Support.Mcp;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -73,6 +74,8 @@ public sealed class McpSharedHomeSetUpFixture {
 
 	[OneTimeTearDown]
 	public void RestoreSharedClioHome() {
+		// Runs last in the assembly, so every fixture's arrange cost has already been recorded.
+		E2ETimingProbe.WriteReportToProcessStandardOutput();
 		TestConfiguration.ClearSharedClioHome();
 		DeleteSensitiveSettingsFile();
 		if (!string.IsNullOrWhiteSpace(_sharedClioHome) && Directory.Exists(_sharedClioHome)) {

--- a/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
+++ b/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
@@ -74,8 +74,14 @@ public sealed class McpSharedHomeSetUpFixture {
 
 	[OneTimeTearDown]
 	public async Task RestoreSharedClioHomeAsync() {
-		await McpContractFixtureBase.ReleaseProcessWideSessionAsync();
-		RestoreSharedClioHome();
+		// finally, not a plain sequence: releasing the shared session kills a process tree, and a child
+		// that already exited makes that throw. RestoreSharedClioHome deletes the settings file holding
+		// the stand password in clear text, so it must run even then.
+		try {
+			await McpContractFixtureBase.ReleaseProcessWideSessionAsync();
+		} finally {
+			RestoreSharedClioHome();
+		}
 	}
 
 	private void RestoreSharedClioHome() {

--- a/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
+++ b/clio.mcp.e2e/McpSharedHomeSetUpFixture.cs
@@ -73,7 +73,12 @@ public sealed class McpSharedHomeSetUpFixture {
 	}
 
 	[OneTimeTearDown]
-	public void RestoreSharedClioHome() {
+	public async Task RestoreSharedClioHomeAsync() {
+		await McpContractFixtureBase.ReleaseProcessWideSessionAsync();
+		RestoreSharedClioHome();
+	}
+
+	private void RestoreSharedClioHome() {
 		// Runs last in the assembly, so every fixture's arrange cost has already been recorded.
 		E2ETimingProbe.WriteReportToProcessStandardOutput();
 		TestConfiguration.ClearSharedClioHome();

--- a/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
+++ b/clio.mcp.e2e/MobilePageConversionGuideSandboxE2ETests.cs
@@ -1296,29 +1296,10 @@ public sealed class MobilePageConversionGuideSandboxE2ETests : McpContractFixtur
 	}
 
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore(
-				"mobile-page-conversion MCP E2E requires a configured sandbox environment: set Sandbox.EnvironmentName "
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			"mobile-page-conversion MCP E2E requires a configured sandbox environment: set Sandbox.EnvironmentName "
 				+ "in the MCP E2E settings to a registered clio environment that hosts the seed application.");
-		}
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore(
-				$"mobile-page-conversion MCP E2E requires a reachable environment: configured sandbox environment "
-				+ $"'{configuredEnvironmentName}' did not answer ping-app. Start it or point Sandbox.EnvironmentName at a reachable environment.");
-		}
-		return configuredEnvironmentName!;
-	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings, ["ping-app", "-e", environmentName], cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
 }

--- a/clio.mcp.e2e/PackageFileToolE2ETests.cs
+++ b/clio.mcp.e2e/PackageFileToolE2ETests.cs
@@ -18,7 +18,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(PackageFileTool.ListPackageFilesToolName)]
 [NonParallelizable]
-public sealed class PackageFileToolE2ETests {
+public sealed class PackageFileToolE2ETests : McpContractFixtureBase {
 	private const string CompiledPackageName = "IntegrationV2";
 	private const string CompiledSourcePath = "cs/EmailClient.cs";
 
@@ -33,9 +33,7 @@ public sealed class PackageFileToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await AllureApi.Step(
-			"Arrange the real clio MCP server session",
-			async () => await McpServerSession.StartAsync(settings, cancellationTokenSource.Token));
+		McpServerSession session = Session;
 		string environmentName = await AllureApi.Step(
 			"Arrange a reachable registered Creatio sandbox",
 			async () => await ResolveReachableEnvironmentAsync(settings));
@@ -114,9 +112,7 @@ public sealed class PackageFileToolE2ETests {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		await using McpServerSession session = await AllureApi.Step(
-			"Arrange the real clio MCP server session for invalid input",
-			async () => await McpServerSession.StartAsync(settings, cancellationTokenSource.Token));
+		McpServerSession session = Session;
 		string environmentName = await AllureApi.Step(
 			"Arrange a reachable registered Creatio sandbox for invalid input",
 			async () => await ResolveReachableEnvironmentAsync(settings));

--- a/clio.mcp.e2e/PackageFileToolE2ETests.cs
+++ b/clio.mcp.e2e/PackageFileToolE2ETests.cs
@@ -154,16 +154,8 @@ public sealed class PackageFileToolE2ETests {
 				because: "the tool must stop before its companion project read"));
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? environmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(environmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run package file MCP E2E tests.");
-		}
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings, ["ping-app", "-e", environmentName]);
-		if (result.ExitCode != 0) {
-			Assert.Ignore($"Package file MCP E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
-		}
-		return environmentName!;
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			"Configure McpE2E:Sandbox:EnvironmentName to run package file MCP E2E tests.");
 }

--- a/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
+++ b/clio.mcp.e2e/PageBusinessRuleToolE2ETests.cs
@@ -886,34 +886,10 @@ public sealed class PageBusinessRuleToolE2ETests : McpContractFixtureBase {
 			? "Custom"
 			: settings.Sandbox.PackageName;
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("create-page-business-rule MCP E2E requires McpE2E:Sandbox:EnvironmentName for destructive tests.");
-			return string.Empty;
-		}
-
-		if (await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"create-page-business-rule MCP E2E requires a reachable configured sandbox environment. Environment '{configuredEnvironmentName}' was not reachable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			"create-page-business-rule MCP E2E requires McpE2E:Sandbox:EnvironmentName for destructive tests.");
 
 	private static async Task<PageRuleTarget> ResolvePageRuleTargetAsync(
 		McpServerSession session,

--- a/clio.mcp.e2e/PageCreateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageCreateToolE2ETests.cs
@@ -421,34 +421,9 @@ public sealed class PageCreateToolE2ETests : McpContractFixtureBase {
 		}
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"create-page MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"create-page MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 }

--- a/clio.mcp.e2e/PageGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageGetToolE2ETests.cs
@@ -506,35 +506,10 @@ public sealed class PageGetToolE2ETests : McpContractFixtureBase {
 		return (callResult, response);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"page MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"page MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/PageHierarchyGetToolE2ETests.cs
+++ b/clio.mcp.e2e/PageHierarchyGetToolE2ETests.cs
@@ -195,16 +195,8 @@ public sealed class PageHierarchyGetToolE2ETests : McpContractFixtureBase {
 		return string.Empty;
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings, ["ping-app", "-e", environmentName], cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static async Task<string> ResolveSeededPageSchemaOrIgnoreAsync(
 		McpServerSession session,

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -504,7 +504,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages validation E2E.");
 		}
-		if (!await CanReachEnvironmentAsync(settings, environmentName!)) {
+		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
 			Assert.Ignore($"sync-pages validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
 		}
 
@@ -824,22 +824,10 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		}
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"sync-pages MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"sync-pages MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	[Test]
 	[Description("ENG-91317: sync-pages surfaces a per-page conflict for a stale-baseline page after an out-of-band modification, and the per-page force flag overwrites it deliberately (restoring the seed body).")]
@@ -1227,7 +1215,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages semantic validation E2E.");
 		}
-		if (!await CanReachEnvironmentAsync(settings, environmentName!)) {
+		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
 			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
 		}
 
@@ -1286,7 +1274,7 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages semantic validation E2E.");
 		}
-		if (!await CanReachEnvironmentAsync(settings, environmentName!)) {
+		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
 			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
 		}
 
@@ -1332,13 +1320,6 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 			.And.Contain("max")
 			.And.Contain("maxLength",
 				because: "the failure should identify both the wrong param and the required param name");
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
 	}
 
 	private async Task<ArrangeContext> ArrangeAsync() {

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -1330,10 +1330,11 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		string workspaceName = $"workspace-{Guid.NewGuid():N}";
 		string workspacePath = Path.Combine(rootDirectory, workspaceName);
 		CancellationTokenSource cancellationTokenSource = new(System.TimeSpan.FromMinutes(5));
-		await ClioCliCommandRunner.RunAndAssertSuccessAsync(
-			settings,
-			["create-workspace", workspaceName, "--empty", "--directory", rootDirectory],
-			cancellationToken: cancellationTokenSource.Token);
+		// No create-workspace here. Every test in this fixture calls sync-pages with an explicit
+		// environment-name and page bodies; none reads WorkspacePath and none pushes or restores a
+		// workspace, so the clio CLI round trip that used to build one per test (25 invocations, about
+		// 43s of the run) produced a directory nothing then looked at.
+		Directory.CreateDirectory(workspacePath);
 		McpServerSession session = Session;
 		return new ArrangeContext(rootDirectory, workspacePath, session, cancellationTokenSource);
 	}

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -504,8 +504,12 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages validation E2E.");
 		}
-		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
-			Assert.Ignore($"sync-pages validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
+		// The resolver may fall back to another registered stand, so its ANSWER is the environment
+		// the test must use. Discarding it and keeping the configured name sent the call to a stand
+		// already known to be unreachable, turning a skip into a failure.
+		environmentName = await ReachableSandboxEnvironment.ResolveAsync(settings);
+		if (environmentName is null) {
+			Assert.Ignore($"sync-pages validation E2E requires a reachable sandbox environment. '{settings.Sandbox.EnvironmentName}' was not reachable.");
 		}
 
 		await using ArrangeContext context = await ArrangeAsync();
@@ -1215,8 +1219,12 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages semantic validation E2E.");
 		}
-		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
-			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
+		// The resolver may fall back to another registered stand, so its ANSWER is the environment
+		// the test must use. Discarding it and keeping the configured name sent the call to a stand
+		// already known to be unreachable, turning a skip into a failure.
+		environmentName = await ReachableSandboxEnvironment.ResolveAsync(settings);
+		if (environmentName is null) {
+			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{settings.Sandbox.EnvironmentName}' was not reachable.");
 		}
 
 		await using ArrangeContext context = await ArrangeAsync();
@@ -1274,8 +1282,12 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sync-pages semantic validation E2E.");
 		}
-		if (await ReachableSandboxEnvironment.ResolveAsync(settings) is null) {
-			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{environmentName}' was not reachable.");
+		// The resolver may fall back to another registered stand, so its ANSWER is the environment
+		// the test must use. Discarding it and keeping the configured name sent the call to a stand
+		// already known to be unreachable, turning a skip into a failure.
+		environmentName = await ReachableSandboxEnvironment.ResolveAsync(settings);
+		if (environmentName is null) {
+			Assert.Ignore($"sync-pages semantic validation E2E requires a reachable sandbox environment. '{settings.Sandbox.EnvironmentName}' was not reachable.");
 		}
 
 		await using ArrangeContext context = await ArrangeAsync();

--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -1483,22 +1483,10 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 		}
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"update-page MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"update-page MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	[Test]
 	[Description("Rejects a mobile JSON body that contains a 'validators' section without making any remote call.")]
@@ -1660,19 +1648,6 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 			because: "a valid mobile body should produce a structured result even when dry-run fails because the schema doesn't exist");
 		response.Error.Should().NotContain("SCHEMA_",
 			because: "AMD marker errors must not appear when the body is a mobile JSON object");
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
 	}
 
 	private sealed class DesignerPresenceListener : IAsyncDisposable {

--- a/clio.mcp.e2e/ProcessPageFactsToolE2ETests.cs
+++ b/clio.mcp.e2e/ProcessPageFactsToolE2ETests.cs
@@ -112,29 +112,12 @@ public sealed class ProcessPageFactsToolE2ETests : McpContractFixtureBase {
 	/// Resolves an environment the sandbox can actually reach, ignoring the test rather than failing it when none
 	/// is available — the same policy the other environment-dependent E2E fixtures follow.
 	/// </summary>
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName)
-			&& await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-		Assert.Ignore(
-			$"get-process-page-facts MCP E2E requires a reachable environment. Configured sandbox environment "
-			+ $"'{configuredEnvironmentName}' was not reachable, and fallback environment "
-			+ $"'{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			$"get-process-page-facts MCP E2E requires a reachable environment. Configured sandbox environment "
+			+ $"'{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment "
+			+ $"'{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/RemovePackageDependencyToolE2ETests.cs
+++ b/clio.mcp.e2e/RemovePackageDependencyToolE2ETests.cs
@@ -18,7 +18,7 @@ namespace Clio.Mcp.E2E;
 [Category("McpE2E.NoEnvironment")]
 [AllureNUnit]
 [AllureFeature("remove-package-dependency")]
-public sealed class RemovePackageDependencyToolE2ETests {
+public sealed class RemovePackageDependencyToolE2ETests : McpContractFixtureBase {
 
 	private const string ToolName = RemovePackageDependencyTool.RemovePackageDependencyToolName;
 
@@ -61,10 +61,10 @@ public sealed class RemovePackageDependencyToolE2ETests {
 		AssertFailureMentionsEnvironment(actResult, invalidEnvironmentName);
 	}
 
-	private static async Task<RemovePackageDependencyArrangeContext> ArrangeAsync(McpE2ESettings settings) {
+	private async Task<RemovePackageDependencyArrangeContext> ArrangeAsync(McpE2ESettings settings) {
 		return await AllureApi.Step("Arrange MCP server session", async () => {
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new RemovePackageDependencyArrangeContext(session, cancellationTokenSource);
 		});
 	}
@@ -127,9 +127,9 @@ public sealed class RemovePackageDependencyToolE2ETests {
 	private sealed record RemovePackageDependencyArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/RequestInfoToolVersionResolutionSandboxE2ETests.cs
+++ b/clio.mcp.e2e/RequestInfoToolVersionResolutionSandboxE2ETests.cs
@@ -28,7 +28,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(RequestInfoTool.ToolName)]
 [NonParallelizable]
-public sealed class RequestInfoToolVersionResolutionSandboxE2ETests {
+public sealed class RequestInfoToolVersionResolutionSandboxE2ETests : McpContractFixtureBase {
 
 	private const string ToolName = RequestInfoTool.ToolName;
 
@@ -80,7 +80,7 @@ public sealed class RequestInfoToolVersionResolutionSandboxE2ETests {
 		return EntitySchemaStructuredResultParser.Extract<RequestInfoResponse>(callResult);
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync() {
+	private async Task<ArrangeContext> ArrangeAsync() {
 		McpE2ESettings settings = TestConfiguration.Load();
 		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 		string? environmentName = settings.Sandbox.EnvironmentName;
@@ -91,17 +91,17 @@ public sealed class RequestInfoToolVersionResolutionSandboxE2ETests {
 			Assert.Ignore($"get-request-info version-resolution MCP E2E requires a reachable configured sandbox environment. '{environmentName}' was not reachable.");
 		}
 		CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource,
 		string? EnvironmentName) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/RunProcessToolE2ETests.cs
+++ b/clio.mcp.e2e/RunProcessToolE2ETests.cs
@@ -118,10 +118,6 @@ public sealed class RunProcessToolE2ETests : McpContractFixtureBase {
 				+ "cannot show");
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 }

--- a/clio.mcp.e2e/SchemaCreateToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaCreateToolE2ETests.cs
@@ -168,34 +168,9 @@ public sealed class SchemaCreateToolE2ETests : McpContractFixtureBase {
 		duplicateResponse.Error.Should().Contain(schemaName).And.Contain("already exists");
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"create-schema MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
+			settings,
+			$"create-schema MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
 
 }

--- a/clio.mcp.e2e/SchemaNamePrefixToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaNamePrefixToolE2ETests.cs
@@ -19,7 +19,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature(SchemaNamePrefixTool.GetSchemaNamePrefixToolName)]
 [NonParallelizable]
-public sealed class SchemaNamePrefixToolE2ETests {
+public sealed class SchemaNamePrefixToolE2ETests : McpContractFixtureBase {
 
 	private const string ToolName = SchemaNamePrefixTool.GetSchemaNamePrefixToolName;
 
@@ -214,12 +214,12 @@ public sealed class SchemaNamePrefixToolE2ETests {
 			arrangeContext.CancellationTokenSource.Token);
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync(
+	private async Task<ArrangeContext> ArrangeAsync(
 		McpE2ESettings settings,
 		TimeSpan timeout,
 		bool requireReachableEnvironment) {
 		CancellationTokenSource cancellationTokenSource = new(timeout);
-		McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+		McpServerSession session = Session;
 		string? environmentName = requireReachableEnvironment
 			? await ResolveReachableEnvironmentAsync(settings)
 			: settings.Sandbox.EnvironmentName;
@@ -231,13 +231,13 @@ public sealed class SchemaNamePrefixToolE2ETests {
 			settings,
 			"Configure McpE2E:Sandbox:EnvironmentName to run SchemaNamePrefix MCP E2E tests.");
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource,
 		string? EnvironmentName) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 }

--- a/clio.mcp.e2e/SchemaNamePrefixToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaNamePrefixToolE2ETests.cs
@@ -226,25 +226,10 @@ public sealed class SchemaNamePrefixToolE2ETests {
 		return new ArrangeContext(session, cancellationTokenSource, environmentName);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run SchemaNamePrefix MCP E2E tests.");
-		}
-
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore($"SchemaNamePrefix MCP E2E requires a reachable sandbox environment. '{configuredEnvironmentName}' was not reachable.");
-		}
-
-		return configuredEnvironmentName!;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			"Configure McpE2E:Sandbox:EnvironmentName to run SchemaNamePrefix MCP E2E tests.");
 
 	private sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -1274,33 +1274,11 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 
 	private static async Task<string> ResolveReachableEnvironmentAsync(
 		McpE2ESettings settings,
-		CancellationToken cancellationToken) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName) &&
-			await CanReachEnvironmentAsync(settings, configuredEnvironmentName, cancellationToken)) {
-			return configuredEnvironmentName;
-		}
-
-		const string fallbackEnvironmentName = "d2";
-		if (await CanReachEnvironmentAsync(settings, fallbackEnvironmentName, cancellationToken)) {
-			return fallbackEnvironmentName;
-		}
-
-		Assert.Ignore(
-			$"sync-schemas MCP E2E requires a reachable environment. Configured sandbox environment '{configuredEnvironmentName}' was not reachable, and fallback environment '{fallbackEnvironmentName}' was also unavailable.");
-		return string.Empty;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(
-		McpE2ESettings settings,
-		string environmentName,
-		CancellationToken cancellationToken) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+		CancellationToken cancellationToken) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName, "--timeout", "30000"],
-			cancellationToken: cancellationToken);
-		return result.ExitCode == 0;
-	}
+			$"sync-schemas MCP E2E requires a reachable environment. Configured sandbox environment '{settings.Sandbox.EnvironmentName}' was not reachable, and fallback environment '{ReachableSandboxEnvironment.FallbackEnvironmentName}' was also unavailable.");
+
 
 	private static async Task CreateEmptyWorkspaceAsync(
 		McpE2ESettings settings,

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -16,6 +16,7 @@ using Clio.Mcp.E2E.Support.Creatio;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
+using ModelContextProtocol;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
 using NUnit.Framework;
@@ -322,14 +323,8 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		await using ArrangeContext context = await ArrangeAsync(requireEnvironment: true);
 
 		// Act
-		CallToolResult callResult = await CallSchemaSyncAsync(
-			context.Session,
-			context.EnvironmentName!,
-			context.PackageName!,
-			context.EntitySchemaName!,
-			context.LookupSchemaName!,
-			context.LookupColumnName,
-			context.CancellationTokenSource.Token);
+		SharedCompositeBatch batch = await GetOrRunCompositeBatchAsync(context);
+		CallToolResult callResult = batch.CallResult;
 		callResult.IsError.Should().NotBeTrue(
 			because: "sync-schemas should return a structured success payload for a valid sandbox package");
 		JsonElement response = ExtractSchemaSyncResponse(callResult);
@@ -339,27 +334,27 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 			because: $"the composite batch should succeed on the reachable sandbox environment. Payload: {responsePayload}");
 		results.Should().HaveCount(4,
 			because: $"create-entity, create-lookup, seed-data, and update-entity should each produce one result. Payload: {responsePayload}");
-		JsonElement createLookupResult = FindResult(results, "create-lookup", context.LookupSchemaName!);
-		JsonElement seedResult = FindResult(results, "seed-data", context.LookupSchemaName!);
-		JsonElement updateResult = FindResult(results, "update-entity", context.EntitySchemaName!);
+		JsonElement createLookupResult = FindResult(results, "create-lookup", batch.LookupSchemaName);
+		JsonElement seedResult = FindResult(results, "seed-data", batch.LookupSchemaName);
+		JsonElement updateResult = FindResult(results, "update-entity", batch.EntitySchemaName);
 		string[] createLookupMessages = GetMessageValues(createLookupResult);
 		string[] seedMessages = GetMessageValues(seedResult);
 		string[] updateMessages = GetMessageValues(updateResult);
 		EntitySchemaPropertiesInfo lookupProperties = await GetSchemaPropertiesAsync(
 			context.Session,
-			context.EnvironmentName!,
-			context.PackageName!,
-			context.LookupSchemaName!,
+			batch.EnvironmentName,
+			batch.PackageName,
+			batch.LookupSchemaName,
 			context.CancellationTokenSource.Token);
 		LookupRegistrationSnapshot registrationSnapshot = LookupRegistrationProbe.Read(
-			context.EnvironmentName!,
-			context.PackageName!,
-			context.LookupSchemaName!);
+			batch.EnvironmentName,
+			batch.PackageName,
+			batch.LookupSchemaName);
 		EntitySchemaColumnPropertiesInfo columnProperties = await GetColumnPropertiesAsync(
 			context.Session,
-			context.EnvironmentName!,
-			context.PackageName!,
-			context.EntitySchemaName!,
+			batch.EnvironmentName,
+			batch.PackageName,
+			batch.EntitySchemaName,
 			context.LookupColumnName,
 			context.CancellationTokenSource.Token);
 
@@ -367,7 +362,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		results.Select(result => result.GetProperty("type").GetString()).Should().OnlyContain(type =>
 				!string.IsNullOrWhiteSpace(type),
 			because: "sync-schemas should expose the canonical type field on every result");
-		createLookupMessages.Should().Contain(message => message.Contains(context.LookupSchemaName!, StringComparison.Ordinal),
+		createLookupMessages.Should().Contain(message => message.Contains(batch.LookupSchemaName, StringComparison.Ordinal),
 			because: "create-lookup should keep its schema creation message on its own result");
 		createLookupMessages.Should().NotContain(message => message.Contains("Created row:", StringComparison.Ordinal),
 			because: "seed-data messages must not leak into the create-lookup result");
@@ -381,7 +376,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 			because: "schema creation messages must not leak into the seed-data result");
 		seedMessages.Should().NotContain(message => message.Contains(context.LookupColumnName, StringComparison.Ordinal),
 			because: "update-entity messages must not leak into the seed-data result");
-		updateMessages.Should().Contain(message => message.Contains(context.EntitySchemaName!, StringComparison.Ordinal),
+		updateMessages.Should().Contain(message => message.Contains(batch.EntitySchemaName, StringComparison.Ordinal),
 			because: "update-entity should keep its column mutation message on its own result");
 		updateMessages.Should().Contain(message => message.Contains(context.LookupColumnName, StringComparison.Ordinal),
 			because: "update-entity should report the added lookup column");
@@ -415,43 +410,17 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 	[AllureName("sync-schemas streams per-operation stage markers")]
 	[AllureDescription("Runs sync-schemas with two operations through the real clio MCP server with an IProgress sink and asserts the client observed a per-operation stage marker naming the operation index and type — proving the tool-level progress path is wired end to end (ENG-93087). Batch success is asserted before the markers and the raw tool result is dumped, so an operation that failed on the environment is reported as that failure instead of as a missing marker.")]
 	public async Task SchemaSyncTool_Should_Stream_Per_Operation_Progress_Markers() {
-		// Arrange
+		// Arrange & Act — the composite batch this fixture already runs for its message-alignment test.
+		// The markers and the message alignment are two properties of ONE batch, so it is run once with a
+		// progress sink attached instead of twice. Its first two operations are still create-entity and
+		// create-lookup, in that order, which is what this test's marker expectations name.
 		await using ArrangeContext context = await ArrangeAsync(requireEnvironment: true);
-		MessageCollectingProgress progress = new();
-
-		// Act — a two-operation batch; each operation must push a stage marker before it runs.
-		CallToolResult callResult = await context.Session.CallToolAsync(
-			ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["environment-name"] = context.EnvironmentName!,
-					["package-name"] = context.PackageName!,
-					["operations"] = new object?[] {
-						new Dictionary<string, object?> {
-							["type"] = "create-entity",
-							["schema-name"] = context.EntitySchemaName!,
-							["title-localizations"] = BuildLocalizations("Schema Sync Entity"),
-							["columns"] = new object?[] {
-								new Dictionary<string, object?> {
-									["name"] = "UsrTitle",
-									["type"] = "Text",
-									["title-localizations"] = BuildLocalizations("Title")
-								}
-							}
-						},
-						new Dictionary<string, object?> {
-							["type"] = "create-lookup",
-							["schema-name"] = context.LookupSchemaName!,
-							["title-localizations"] = BuildLocalizations("Schema Sync Lookup")
-						}
-					}
-				}
-			},
-			progress,
-			context.CancellationTokenSource.Token);
+		SharedCompositeBatch batch = await GetOrRunCompositeBatchAsync(context);
+		CallToolResult callResult = batch.CallResult;
+		IReadOnlyList<string> progressMessages = batch.ProgressMessages;
 
 		// Diagnostic: surface the exact progress stream the client received (markers + heartbeats).
-		foreach (string progressMessage in progress.Messages) {
+		foreach (string progressMessage in progressMessages) {
 			TestContext.Out.WriteLine($"[progress] {progressMessage}");
 		}
 
@@ -473,13 +442,13 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		// operation that actually broke instead of reporting a missing marker as if the progress path were at fault.
 		response.GetProperty("success").GetBoolean().Should().BeTrue(
 			because: $"every operation in the batch must succeed before the per-operation markers can be judged — a failed operation aborts the batch and suppresses the markers of the operations after it. Payload: {responsePayload}");
-		progress.Messages.Should().Contain(
+		progressMessages.Should().Contain(
 			message => message.Contains("1/", StringComparison.Ordinal) && message.Contains("create-entity", StringComparison.Ordinal),
 			because: $"sync-schemas must stream a per-operation stage marker naming the operation index and type so the client can show which operation is running. Payload: {responsePayload}");
-		progress.Messages.Should().Contain(
+		progressMessages.Should().Contain(
 			message => message.Contains("2/", StringComparison.Ordinal) && message.Contains("create-lookup", StringComparison.Ordinal),
 			because: $"sync-schemas must also stream a marker for the second operation naming its index and type. Payload: {responsePayload}");
-		List<string> orderedMessages = progress.Messages.ToList();
+		List<string> orderedMessages = progressMessages.ToList();
 		int firstOperationMarkerIndex = orderedMessages.FindIndex(message => message.Contains("1/", StringComparison.Ordinal));
 		int secondOperationMarkerIndex = orderedMessages.FindIndex(message => message.Contains("2/", StringComparison.Ordinal));
 		firstOperationMarkerIndex.Should().BeLessThan(secondOperationMarkerIndex,
@@ -1322,6 +1291,53 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 			cancellationToken: cancellationToken);
 	}
 
+	/// <summary>
+	/// Runs the fixture's composite sync-schemas batch (create-entity, create-lookup with seed rows,
+	/// update-entity) once, with a progress sink attached, and hands the same result and progress stream to
+	/// every test that asserts on it.
+	/// </summary>
+	/// <remarks>
+	/// The per-operation progress markers and the per-operation message alignment are two properties of one
+	/// and the same batch, but each was verified by its own run against the stand — about 100s together on a
+	/// slow agent. Attaching the sink to the composite call costs nothing and lets the marker test read the
+	/// stream the message test already produced. The marker test keeps its own expectations: the composite
+	/// batch's first two operations are still create-entity and create-lookup, in that order.
+	/// </remarks>
+	private static async Task<SharedCompositeBatch> GetOrRunCompositeBatchAsync(ArrangeContext context) {
+		if (_sharedCompositeBatch is not null) {
+			return _sharedCompositeBatch;
+		}
+		MessageCollectingProgress progress = new();
+		CallToolResult callResult = await CallSchemaSyncAsync(
+			context.Session,
+			context.EnvironmentName!,
+			context.PackageName!,
+			context.EntitySchemaName!,
+			context.LookupSchemaName!,
+			context.LookupColumnName,
+			context.CancellationTokenSource.Token,
+			progress);
+		_sharedCompositeBatch = new SharedCompositeBatch(
+			callResult,
+			[.. progress.Messages],
+			context.EnvironmentName!,
+			context.PackageName!,
+			context.EntitySchemaName!,
+			context.LookupSchemaName!);
+		return _sharedCompositeBatch;
+	}
+
+	private static SharedCompositeBatch? _sharedCompositeBatch;
+
+	/// <summary>One run of the fixture's composite sync-schemas batch, shared by the tests that assert on it.</summary>
+	private sealed record SharedCompositeBatch(
+		CallToolResult CallResult,
+		IReadOnlyList<string> ProgressMessages,
+		string EnvironmentName,
+		string PackageName,
+		string EntitySchemaName,
+		string LookupSchemaName);
+
 	private static async Task<CallToolResult> CallSchemaSyncAsync(
 		McpServerSession session,
 		string environmentName,
@@ -1329,7 +1345,8 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		string entitySchemaName,
 		string lookupSchemaName,
 		string lookupColumnName,
-		CancellationToken cancellationToken) {
+		CancellationToken cancellationToken,
+		IProgress<ProgressNotificationValue>? progress = null) {
 		IReadOnlyCollection<string> reachableToolNames = await session.ListReachableToolNamesAsync(cancellationToken);
 		reachableToolNames.Should().Contain(ToolName,
 			because: "sync-schemas must be discoverable via the get-tool-contract compact index before the end-to-end call can be executed");
@@ -1387,6 +1404,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 					}
 				}
 			},
+			progress,
 			cancellationToken);
 	}
 

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -2165,8 +2165,14 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 				}
 			}
 		};
-		CallToolResult firstResult = await context.Session.CallToolAsync(
-			ToolName, batchArgs, context.CancellationTokenSource.Token);
+		// This first call is arrange, not the subject: the test is about what the REPLAY reports. An
+		// OData rebuild left running by an earlier test on the shared stand would fail it here for a
+		// reason that has nothing to do with replay semantics, so it goes through the retry gate. The
+		// batch is convergent by construction (no seed-rows), which is exactly what makes a repeat safe.
+		CallToolResult firstResult = await TransientPlatformConditionRetryGate.InvokeWithRetryAsync(
+			async attemptToken => await context.Session.CallToolAsync(ToolName, batchArgs, attemptToken),
+			reauthenticateAsync: null,
+			context.CancellationTokenSource.Token);
 		ExtractSchemaSyncResponse(firstResult).GetProperty("success").GetBoolean().Should().BeTrue(
 			because: "the initial convergent batch must apply before the identical replay");
 		EntitySchemaPropertiesInfo afterFirst = await GetSchemaPropertiesAsync(

--- a/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/SchemaSyncToolE2ETests.cs
@@ -1303,7 +1303,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 	/// stream the message test already produced. The marker test keeps its own expectations: the composite
 	/// batch's first two operations are still create-entity and create-lookup, in that order.
 	/// </remarks>
-	private static async Task<SharedCompositeBatch> GetOrRunCompositeBatchAsync(ArrangeContext context) {
+	private async Task<SharedCompositeBatch> GetOrRunCompositeBatchAsync(ArrangeContext context) {
 		if (_sharedCompositeBatch is not null) {
 			return _sharedCompositeBatch;
 		}
@@ -1317,6 +1317,20 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 			context.LookupColumnName,
 			context.CancellationTokenSource.Token,
 			progress);
+		// Waited for, not snapshotted. Progress delivery and call completion are independent SDK
+		// continuations, so a marker can land microseconds after the result — and the collector of this
+		// batch is the message-alignment test, which does not read progress at all. Freezing the list the
+		// instant the call returned would drop a late "2/4 create-lookup" permanently and fail the marker
+		// test with no regression behind it. An elapsed wait is not an error here: the condition is
+		// re-checked by the caller's own assertions, which report the real gap.
+		try {
+			await progress.WaitForMessagesAsync(
+				messages => messages.Any(m => m.Contains("1/", StringComparison.Ordinal))
+					&& messages.Any(m => m.Contains("2/", StringComparison.Ordinal)),
+				TimeSpan.FromSeconds(10),
+				context.CancellationTokenSource.Token);
+		} catch (OperationCanceledException) {
+		}
 		_sharedCompositeBatch = new SharedCompositeBatch(
 			callResult,
 			[.. progress.Messages],
@@ -1327,7 +1341,7 @@ public sealed class SchemaSyncToolE2ETests : McpContractFixtureBase {
 		return _sharedCompositeBatch;
 	}
 
-	private static SharedCompositeBatch? _sharedCompositeBatch;
+	private SharedCompositeBatch? _sharedCompositeBatch;
 
 	/// <summary>One run of the fixture's composite sync-schemas batch, shared by the tests that assert on it.</summary>
 	private sealed record SharedCompositeBatch(

--- a/clio.mcp.e2e/ShowPassingInfrastructureToolE2ETests.cs
+++ b/clio.mcp.e2e/ShowPassingInfrastructureToolE2ETests.cs
@@ -20,8 +20,7 @@ namespace Clio.Mcp.E2E;
 [Category("McpE2E.NoEnvironment")]
 [AllureNUnit]
 [AllureFeature("show-passing-infrastructure")]
-public sealed class ShowPassingInfrastructureToolE2ETests
-{
+public sealed class ShowPassingInfrastructureToolE2ETests : McpContractFixtureBase {
 	private const string ToolName = ShowPassingInfrastructureTool.ShowPassingInfrastructureToolName;
 
 	[Test]
@@ -57,13 +56,13 @@ public sealed class ShowPassingInfrastructureToolE2ETests
 		AssertRecommendationShape(actResult.Execution.RecommendedByEngine.Mssql);
 	}
 
-	private static async Task<ArrangeContext> ArrangeAsync()
+	private async Task<ArrangeContext> ArrangeAsync()
 	{
 		return await AllureApi.Step("Arrange show-passing-infrastructure MCP session", async () =>
 		{
 			McpE2ESettings settings = TestConfiguration.Load();
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new ArrangeContext(session, cancellationTokenSource);
 		});
 	}
@@ -150,14 +149,14 @@ public sealed class ShowPassingInfrastructureToolE2ETests
 			because: "deploy-creatio recommendations should only expose an optional local redis-server-name argument");
 	}
 
-	private sealed record ArrangeContext(
+	private new sealed record ArrangeContext(
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource) : IAsyncDisposable
 	{
-		public async ValueTask DisposeAsync()
+		public ValueTask DisposeAsync()
 		{
-			await Session.DisposeAsync();
 			CancellationTokenSource.Dispose();
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
@@ -113,12 +114,58 @@ internal static class ClioCliCommandRunner {
 		McpE2ESettings settings,
 		string environmentName,
 		CancellationToken cancellationToken = default) {
-		ClioCliCommandResult result = await RunAsync(
-			settings,
-			["ping-app", "-e", environmentName],
-			cancellationToken: cancellationToken);
-		return result.ExitCode == 0;
+		if (ReachedEnvironments.ContainsKey(environmentName)) {
+			return true;
+		}
+		// The probe carries its own ceiling so no caller can hang the run on an environment that accepts
+		// the connection and never answers. A caller-supplied token still applies; this only adds a bound.
+		using CancellationTokenSource probeCancellation =
+			CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		probeCancellation.CancelAfter(ReachabilityProbeTimeout);
+		bool isReachable;
+		try {
+			ClioCliCommandResult result = await RunAsync(
+				settings,
+				["ping-app", "-e", environmentName],
+				cancellationToken: probeCancellation.Token,
+				timingKey: "ping-app (reachability)");
+			isReachable = result.ExitCode == 0;
+		} catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+			return false;
+		}
+		if (isReachable) {
+			ReachedEnvironments[environmentName] = true;
+		}
+		return isReachable;
 	}
+
+	/// <summary>
+	/// Ceiling for one reachability probe. An unreachable stand must cost a bounded wait, never a hang.
+	/// </summary>
+	private static readonly TimeSpan ReachabilityProbeTimeout = TimeSpan.FromSeconds(30);
+
+	/// <summary>
+	/// Environments already proven reachable in this process.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The probe is an out-of-process clio start plus a real authenticated round trip to Creatio, and
+	/// dozens of fixtures ran it inside their own arrange — once per test — against the single stand the
+	/// build deploys and removes around the run. Once an environment has answered, every repeat probe is
+	/// pure cost, so a success is remembered for the rest of the process.
+	/// </para>
+	/// <para>
+	/// A FAILURE is deliberately not remembered. A transient refusal during the stand's warm-up would
+	/// otherwise be frozen for the whole run and silently turn every sandbox fixture into a skip, which
+	/// reads as a green build with no coverage. Re-probing after a failure costs one extra CLI start on a
+	/// stand that is genuinely down, and such a run has no sandbox coverage to lose anyway.
+	/// </para>
+	/// <para>
+	/// A fixture that deliberately makes an environment unreachable must not use this probe to observe
+	/// that transition; call <see cref="RunAsync"/> directly instead.
+	/// </para>
+	/// </remarks>
+	private static readonly ConcurrentDictionary<string, bool> ReachedEnvironments = new();
 
 	/// <summary>
 	/// Waits for Creatio to finish the delayed recycle triggered by package installation or hot-fix changes.

--- a/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+++ b/clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using Clio.Common;
+using Clio.Mcp.E2E.Support.Diagnostics;
 using Clio.Mcp.E2E.Support.Mcp;
 using FluentAssertions;
 
@@ -56,7 +57,8 @@ internal static class ClioCliCommandRunner {
 		McpE2ESettings settings,
 		IReadOnlyList<string> arguments,
 		string? workingDirectory = null,
-		CancellationToken cancellationToken = default) {
+		CancellationToken cancellationToken = default,
+		string? timingKey = null) {
 		ClioProcessDescriptor command = ClioExecutableResolver.Resolve(settings, arguments.ToArray());
 		ProcessStartInfo startInfo = new() {
 			FileName = command.Command,
@@ -76,6 +78,7 @@ internal static class ClioCliCommandRunner {
 		}
 
 		using Process process = new() { StartInfo = startInfo };
+		long startedAt = Stopwatch.GetTimestamp();
 		process.Start();
 		Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(CancellationToken.None);
 		Task<string> stderrTask = process.StandardError.ReadToEndAsync(CancellationToken.None);
@@ -88,6 +91,10 @@ internal static class ClioCliCommandRunner {
 			}
 			throw;
 		}
+
+		E2ETimingProbe.RecordCliInvocation(
+			timingKey ?? (arguments.Count == 0 ? "(none)" : arguments[0]),
+			Stopwatch.GetElapsedTime(startedAt));
 
 		return new ClioCliCommandResult(
 			process.ExitCode,

--- a/clio.mcp.e2e/Support/Configuration/ReachableSandboxEnvironment.cs
+++ b/clio.mcp.e2e/Support/Configuration/ReachableSandboxEnvironment.cs
@@ -1,0 +1,78 @@
+namespace Clio.Mcp.E2E.Support.Configuration;
+
+/// <summary>
+/// Resolves — once per run — which registered environment the sandbox fixtures should talk to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The probe itself is a <c>ping-app</c>: an out-of-process clio start plus a real authenticated round
+/// trip to Creatio. Fixtures used to run it inside their own arrange, so a suite of N sandbox tests
+/// paid for N identical probes against the one stand the build deploys. The answer cannot change
+/// during a run — the stand is created by the build's own deploy step and removed after it — so only
+/// the first probe carries information.
+/// </para>
+/// <para>
+/// Only a SUCCESSFUL resolution is cached. A transient refusal during the stand's warm-up must not be
+/// frozen for the whole run — that would silently turn every sandbox fixture into a skip, which reads
+/// as a green build with no coverage. A fixture that finds no reachable environment still calls
+/// <see cref="Assert.Ignore(string)"/> itself, so the fixture-specific skip message is preserved and a
+/// skipped fixture is still reported as skipped.
+/// </para>
+/// </remarks>
+internal static class ReachableSandboxEnvironment {
+
+	/// <summary>
+	/// Environment probed when the configured sandbox environment is absent or unreachable. Kept for
+	/// developer machines, where the shared dev stand is registered under this name.
+	/// </summary>
+	public const string FallbackEnvironmentName = "d2";
+
+	private static readonly SemaphoreSlim ResolutionGate = new(1, 1);
+	private static string? _resolvedEnvironmentName;
+
+	/// <summary>
+	/// Returns the name of the reachable environment for this run, or <see langword="null"/> when
+	/// neither the configured sandbox environment nor the fallback answered.
+	/// </summary>
+	/// <param name="settings">Settings carrying the configured sandbox environment name.</param>
+	/// <returns>The reachable environment name, or <see langword="null"/>.</returns>
+	public static async Task<string?> ResolveAsync(McpE2ESettings settings) {
+		if (_resolvedEnvironmentName is not null) {
+			return _resolvedEnvironmentName;
+		}
+		await ResolutionGate.WaitAsync();
+		try {
+			_resolvedEnvironmentName ??= await ProbeAsync(settings);
+			return _resolvedEnvironmentName;
+		} finally {
+			ResolutionGate.Release();
+		}
+	}
+
+	/// <summary>
+	/// Returns the reachable environment for this run, or ignores the calling test with
+	/// <paramref name="ignoreMessage"/> when no environment answered.
+	/// </summary>
+	/// <param name="settings">Settings carrying the configured sandbox environment name.</param>
+	/// <param name="ignoreMessage">Fixture-specific message explaining what the test needed.</param>
+	/// <returns>The reachable environment name.</returns>
+	public static async Task<string> ResolveOrIgnoreAsync(McpE2ESettings settings, string ignoreMessage) {
+		string? environmentName = await ResolveAsync(settings);
+		if (string.IsNullOrWhiteSpace(environmentName)) {
+			Assert.Ignore(ignoreMessage);
+		}
+		return environmentName!;
+	}
+
+	private static async Task<string?> ProbeAsync(McpE2ESettings settings) {
+		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
+		if (!string.IsNullOrWhiteSpace(configuredEnvironmentName)
+				&& await CanReachAsync(settings, configuredEnvironmentName)) {
+			return configuredEnvironmentName;
+		}
+		return await CanReachAsync(settings, FallbackEnvironmentName) ? FallbackEnvironmentName : null;
+	}
+
+	private static async Task<bool> CanReachAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
+}

--- a/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
+++ b/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
@@ -47,6 +47,26 @@ internal static class E2ETimingProbe {
 	}
 
 	/// <summary>
+	/// Records one MCP tool call made through the harness.
+	/// </summary>
+	/// <remarks>
+	/// A handful of tool names cost a real Creatio compile — create-app, create-app-section, every
+	/// schema mutation that publishes — and those calls, not the harness, are what the run's remaining
+	/// time is made of. Counting them by name is the only way to answer "how many compiles does one run
+	/// pay for" without reading every fixture.
+	/// </remarks>
+	/// <param name="toolName">Name of the tool invoked.</param>
+	/// <param name="elapsed">Wall time the call took.</param>
+	public static void RecordToolCall(string toolName, TimeSpan elapsed) {
+		ToolCalls.AddOrUpdate(
+			toolName,
+			_ => (1, (long)elapsed.TotalMilliseconds),
+			(_, existing) => (existing.Count + 1, existing.Milliseconds + (long)elapsed.TotalMilliseconds));
+	}
+
+	private static readonly ConcurrentDictionary<string, (int Count, long Milliseconds)> ToolCalls = new();
+
+	/// <summary>
 	/// Renders the collected counters as a human-readable block plus TeamCity build statistics, so the
 	/// numbers are both visible in the build log and comparable across builds.
 	/// </summary>
@@ -72,6 +92,17 @@ internal static class E2ETimingProbe {
 		report.AppendLine(Statistic("e2eCliInvocations", cliCount));
 		report.AppendLine(Statistic("e2eCliMs", cliTotal));
 		report.AppendLine(Statistic("e2eFixedCostMs", overall));
+		report.AppendLine("[e2e-timing] MCP tool calls, most expensive first");
+		long toolTotal = 0;
+		int toolCount = 0;
+		foreach ((string toolName, (int Count, long Milliseconds) value) in ToolCalls.OrderByDescending(entry => entry.Value.Milliseconds)) {
+			report.AppendLine(Line($"tool {toolName}", value.Count, value.Milliseconds));
+			toolTotal += value.Milliseconds;
+			toolCount += value.Count;
+		}
+		report.AppendLine(Line("tool calls total", toolCount, toolTotal));
+		report.AppendLine(Statistic("e2eToolCalls", toolCount));
+		report.AppendLine(Statistic("e2eToolMs", toolTotal));
 		return report.ToString();
 	}
 

--- a/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
+++ b/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+
+namespace Clio.Mcp.E2E.Support.Diagnostics;
+
+/// <summary>
+/// Counts the two fixed costs the suite pays outside test logic — MCP server process lifecycles and
+/// out-of-process clio CLI invocations — and reports them once at the end of the run.
+/// </summary>
+/// <remarks>
+/// The per-test durations TeamCity records cover only test bodies, so the arrange cost of the suite
+/// (a server process per fixture, a <c>ping-app</c> per test) is invisible in the build statistics and
+/// can only be estimated. These counters make it a measured number, which is what any decision about
+/// restructuring the fixtures has to be based on.
+/// </remarks>
+internal static class E2ETimingProbe {
+
+	private static int _sessionStarts;
+	private static long _sessionStartMilliseconds;
+	private static int _sessionDisposals;
+	private static long _sessionDisposeMilliseconds;
+	private static readonly ConcurrentDictionary<string, (int Count, long Milliseconds)> CliInvocations = new();
+
+	/// <summary>Records one completed MCP server process start.</summary>
+	/// <param name="elapsed">Wall time the start took.</param>
+	public static void RecordSessionStart(TimeSpan elapsed) {
+		Interlocked.Increment(ref _sessionStarts);
+		Interlocked.Add(ref _sessionStartMilliseconds, (long)elapsed.TotalMilliseconds);
+	}
+
+	/// <summary>Records one completed MCP server process disposal.</summary>
+	/// <param name="elapsed">Wall time the disposal took.</param>
+	public static void RecordSessionDispose(TimeSpan elapsed) {
+		Interlocked.Increment(ref _sessionDisposals);
+		Interlocked.Add(ref _sessionDisposeMilliseconds, (long)elapsed.TotalMilliseconds);
+	}
+
+	/// <summary>Records one out-of-process clio CLI invocation.</summary>
+	/// <param name="verb">The first CLI argument, used as the grouping key.</param>
+	/// <param name="elapsed">Wall time the invocation took.</param>
+	public static void RecordCliInvocation(string verb, TimeSpan elapsed) {
+		CliInvocations.AddOrUpdate(
+			verb,
+			_ => (1, (long)elapsed.TotalMilliseconds),
+			(_, existing) => (existing.Count + 1, existing.Milliseconds + (long)elapsed.TotalMilliseconds));
+	}
+
+	/// <summary>
+	/// Renders the collected counters as a human-readable block plus TeamCity build statistics, so the
+	/// numbers are both visible in the build log and comparable across builds.
+	/// </summary>
+	/// <returns>The report text.</returns>
+	public static string BuildReport() {
+		StringBuilder report = new();
+		report.AppendLine("[e2e-timing] fixed arrange cost of this run");
+		report.AppendLine(Line("mcp server starts", _sessionStarts, _sessionStartMilliseconds));
+		report.AppendLine(Line("mcp server disposals", _sessionDisposals, _sessionDisposeMilliseconds));
+		long cliTotal = 0;
+		int cliCount = 0;
+		foreach ((string verb, (int Count, long Milliseconds) value) in CliInvocations.OrderByDescending(entry => entry.Value.Milliseconds)) {
+			report.AppendLine(Line($"cli {verb}", value.Count, value.Milliseconds));
+			cliTotal += value.Milliseconds;
+			cliCount += value.Count;
+		}
+		report.AppendLine(Line("cli total", cliCount, cliTotal));
+		long overall = _sessionStartMilliseconds + _sessionDisposeMilliseconds + cliTotal;
+		report.AppendLine(Line("fixed cost total", _sessionStarts + _sessionDisposals + cliCount, overall));
+		report.AppendLine(Statistic("e2eMcpSessionStarts", _sessionStarts));
+		report.AppendLine(Statistic("e2eMcpSessionStartMs", _sessionStartMilliseconds));
+		report.AppendLine(Statistic("e2eMcpSessionDisposeMs", _sessionDisposeMilliseconds));
+		report.AppendLine(Statistic("e2eCliInvocations", cliCount));
+		report.AppendLine(Statistic("e2eCliMs", cliTotal));
+		report.AppendLine(Statistic("e2eFixedCostMs", overall));
+		return report.ToString();
+	}
+
+	/// <summary>
+	/// Writes the report to the test host's REAL standard output, bypassing the <see cref="Console"/>
+	/// writer NUnit substitutes during a run — otherwise the text is swallowed and never reaches the
+	/// build log, which is the only place the TeamCity service messages are read from.
+	/// </summary>
+	public static void WriteReportToProcessStandardOutput() {
+		string report = Environment.NewLine + BuildReport();
+		using (Stream standardOutput = Console.OpenStandardOutput()) {
+			byte[] payload = Encoding.UTF8.GetBytes(report);
+			standardOutput.Write(payload, 0, payload.Length);
+			standardOutput.Flush();
+		}
+		// stdout of the test host is not always relayed by `dotnet test`; the file next to the test
+		// assembly is the channel that always survives and can be published as a build artifact.
+		try {
+			File.WriteAllText(
+				Path.Combine(AppContext.BaseDirectory, "e2e-timing.txt"),
+				report);
+		} catch (IOException) {
+		} catch (UnauthorizedAccessException) {
+		}
+	}
+
+	private static string Line(string label, long count, long milliseconds) =>
+		string.Format(
+			CultureInfo.InvariantCulture,
+			"[e2e-timing]   {0,-24} count={1,5}  total={2,8:F1}s  mean={3,6:F0}ms",
+			label,
+			count,
+			milliseconds / 1000d,
+			count == 0 ? 0 : milliseconds / (double)count);
+
+	private static string Statistic(string key, long value) =>
+		string.Format(CultureInfo.InvariantCulture, "##teamcity[buildStatisticValue key='{0}' value='{1}']", key, value);
+}

--- a/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
+++ b/clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
@@ -113,11 +113,13 @@ internal static class E2ETimingProbe {
 	/// </summary>
 	public static void WriteReportToProcessStandardOutput() {
 		string report = Environment.NewLine + BuildReport();
-		using (Stream standardOutput = Console.OpenStandardOutput()) {
-			byte[] payload = Encoding.UTF8.GetBytes(report);
-			standardOutput.Write(payload, 0, payload.Length);
-			standardOutput.Flush();
-		}
+		// Deliberately NOT disposed: this stream wraps the test host's own stdout handle, which the
+		// host keeps using after this teardown runs — `dotnet test` still has its run summary and the
+		// TeamCity service messages to write. Closing it here would send all of that to a dead handle.
+		Stream standardOutput = Console.OpenStandardOutput();
+		byte[] payload = Encoding.UTF8.GetBytes(report);
+		standardOutput.Write(payload, 0, payload.Length);
+		standardOutput.Flush();
 		// stdout of the test host is not always relayed by `dotnet test`; the file next to the test
 		// assembly is the channel that always survives and can be published as a build artifact.
 		try {

--- a/clio.mcp.e2e/Support/Mcp/McpContractFixtureBase.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpContractFixtureBase.cs
@@ -28,18 +28,69 @@ public abstract class McpContractFixtureBase {
 			: Path.GetFullPath(settings.ClioProcessPath);
 		ConfigureMcpServerSettings(settings);
 		using CancellationTokenSource startupCts = new(TimeSpan.FromMinutes(5));
-		_session = await McpServerSession.StartAsync(settings, startupCts.Token);
+		if (CustomizesServerSettings) {
+			_ownedSession = await McpServerSession.StartAsync(settings, startupCts.Token);
+			_session = _ownedSession;
+			return;
+		}
+		_session = ProcessWideSession ??= await McpServerSession.StartAsync(settings, startupCts.Token);
 	}
 
 	[OneTimeTearDown]
 	public async Task StopSharedMcpServerAsync() {
 		try {
-			if (_session is not null) {
-				await _session.DisposeAsync();
+			// Only a session this fixture STARTED is disposed here. The process-wide one outlives every
+			// fixture and is disposed once, by ReleaseProcessWideSessionAsync at the end of the run.
+			if (_ownedSession is not null) {
+				await _ownedSession.DisposeAsync();
+				_ownedSession = null;
 			}
 		} finally {
+			_session = null;
 			CleanupFixtureDirectories();
 		}
+	}
+
+	/// <summary>
+	/// Server process shared by every contract fixture that does not customize the child's settings.
+	/// </summary>
+	/// <remarks>
+	/// A fixture-scoped server was already a large improvement over a per-test one, but the suite has
+	/// roughly a hundred contract fixtures, and starting a child process for each costs about 1.8 s to
+	/// start plus half a second to tear down — time TeamCity bills to no test, so it was invisible until
+	/// the run-level counters made it measurable. These fixtures exercise a read-only, stateless tool
+	/// surface against one identical configuration, so one process answers all of them.
+	/// <para>
+	/// A fixture that overrides <see cref="ConfigureMcpServerSettings"/> is excluded automatically: its
+	/// child differs (an isolated CLIO_HOME, a loopback stub, a specific client identity), so sharing
+	/// would silently give it the wrong server. That check is by declaration, not by a flag somebody has
+	/// to remember to set.
+	/// </para>
+	/// </remarks>
+	private static McpServerSession? ProcessWideSession;
+
+	private McpServerSession? _ownedSession;
+
+	private bool CustomizesServerSettings =>
+		GetType()
+			.GetMethod(
+				nameof(ConfigureMcpServerSettings),
+				System.Reflection.BindingFlags.Instance
+					| System.Reflection.BindingFlags.NonPublic
+					| System.Reflection.BindingFlags.Public)
+			?.DeclaringType != typeof(McpContractFixtureBase);
+
+	/// <summary>
+	/// Disposes the process-wide contract server. Called once, after every fixture has finished.
+	/// </summary>
+	/// <returns>A task that completes when the shared child has exited.</returns>
+	internal static async Task ReleaseProcessWideSessionAsync() {
+		if (ProcessWideSession is null) {
+			return;
+		}
+		McpServerSession session = ProcessWideSession;
+		ProcessWideSession = null;
+		await session.DisposeAsync();
 	}
 
 	/// <summary>

--- a/clio.mcp.e2e/Support/Mcp/McpContractFixtureBase.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpContractFixtureBase.cs
@@ -33,7 +33,18 @@ public abstract class McpContractFixtureBase {
 			_session = _ownedSession;
 			return;
 		}
-		_session = ProcessWideSession ??= await McpServerSession.StartAsync(settings, startupCts.Token);
+		// Not `ProcessWideSession ??= await StartAsync(...)`: that reads, awaits and assigns as three
+		// steps. 26 fixtures carry [Parallelizable(ParallelScope.Self)] and the run uses two NUnit
+		// workers, so two of their [OneTimeSetUp] bodies do overlap — both would see null, both would
+		// start a child, and only the last assignment would ever be disposed, leaking a clio process
+		// onto the agent for the rest of the build.
+		await ProcessWideSessionGate.WaitAsync(startupCts.Token);
+		try {
+			ProcessWideSession ??= await McpServerSession.StartAsync(settings, startupCts.Token);
+			_session = ProcessWideSession;
+		} finally {
+			ProcessWideSessionGate.Release();
+		}
 	}
 
 	[OneTimeTearDown]
@@ -68,6 +79,8 @@ public abstract class McpContractFixtureBase {
 	/// </para>
 	/// </remarks>
 	private static McpServerSession? ProcessWideSession;
+
+	private static readonly SemaphoreSlim ProcessWideSessionGate = new(1, 1);
 
 	private McpServerSession? _ownedSession;
 

--- a/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Clio.Command.McpServer.Knowledge;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Diagnostics;
 using Clio.Mcp.E2E.Support.Results;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModelContextProtocol;
@@ -70,8 +71,13 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			WorkingDirectory = process.WorkingDirectory,
 			EnvironmentVariables = settings.ProcessEnvironmentVariables,
 			Name = "clio-mcp-e2e",
-			// SDK waits the full window on dispose even after the child exits (~0.05s measured on CI); 40x margin.
-			ShutdownTimeout = TimeSpan.FromSeconds(2),
+			// The SDK never closes the child's stdin on dispose: StdioClientTransport.DisposeProcess goes
+			// straight to KillTree(ShutdownTimeout), so this window is spent in full on EVERY disposal
+			// regardless of how fast the server would have exited on its own (measured: 2035ms out of a
+			// 2s setting, 280ms out of 250ms). clio's own EOF shutdown is not the bottleneck — a manual
+			// stdin close makes the server exit in 0.27s. The window therefore only has to cover
+			// KillTree itself, so keep it small; raising it costs the whole delta on every fixture.
+			ShutdownTimeout = TimeSpan.FromMilliseconds(500),
 			StandardErrorLines = standardErrorLines
 		}, NullLoggerFactory.Instance);
 
@@ -89,11 +95,13 @@ internal sealed class McpServerSession : IAsyncDisposable {
 			options.Handlers = new McpClientHandlers { ElicitationHandler = elicitationHandler };
 		}
 
+		long startedAt = Stopwatch.GetTimestamp();
 		McpClient client = await McpClient.CreateAsync(
 			transport,
 			options,
 			NullLoggerFactory.Instance,
 			cancellationToken);
+		E2ETimingProbe.RecordSessionStart(Stopwatch.GetElapsedTime(startedAt));
 
 		return new McpServerSession(client, transport);
 	}
@@ -513,6 +521,8 @@ internal sealed class McpServerSession : IAsyncDisposable {
 		if (_logCaptureRegistration is not null) {
 			await _logCaptureRegistration.DisposeAsync();
 		}
+		long startedAt = Stopwatch.GetTimestamp();
 		await Client.DisposeAsync();
+		E2ETimingProbe.RecordSessionDispose(Stopwatch.GetElapsedTime(startedAt));
 	}
 }

--- a/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+++ b/clio.mcp.e2e/Support/Mcp/McpServerSession.cs
@@ -343,13 +343,18 @@ internal sealed class McpServerSession : IAsyncDisposable {
 		string toolName,
 		IReadOnlyDictionary<string, object?> arguments,
 		CancellationToken cancellationToken) {
-		if (await IsToolAdvertisedAsync(toolName, cancellationToken)) {
-			return await Client.CallToolAsync(toolName, arguments, cancellationToken: cancellationToken);
+		long startedAt = Stopwatch.GetTimestamp();
+		try {
+			if (await IsToolAdvertisedAsync(toolName, cancellationToken)) {
+				return await Client.CallToolAsync(toolName, arguments, cancellationToken: cancellationToken);
+			}
+			return await Client.CallToolAsync(
+				ClioRunTool.ToolName,
+				BuildClioRunArguments(toolName, arguments),
+				cancellationToken: cancellationToken);
+		} finally {
+			E2ETimingProbe.RecordToolCall(toolName, Stopwatch.GetElapsedTime(startedAt));
 		}
-		return await Client.CallToolAsync(
-			ClioRunTool.ToolName,
-			BuildClioRunArguments(toolName, arguments),
-			cancellationToken: cancellationToken);
 	}
 
 	/// <summary>
@@ -366,14 +371,19 @@ internal sealed class McpServerSession : IAsyncDisposable {
 		IReadOnlyDictionary<string, object?> arguments,
 		IProgress<ProgressNotificationValue> progress,
 		CancellationToken cancellationToken) {
-		if (await IsToolAdvertisedAsync(toolName, cancellationToken)) {
-			return await Client.CallToolAsync(toolName, arguments, progress: progress, cancellationToken: cancellationToken);
+		long startedAt = Stopwatch.GetTimestamp();
+		try {
+			if (await IsToolAdvertisedAsync(toolName, cancellationToken)) {
+				return await Client.CallToolAsync(toolName, arguments, progress: progress, cancellationToken: cancellationToken);
+			}
+			return await Client.CallToolAsync(
+				ClioRunTool.ToolName,
+				BuildClioRunArguments(toolName, arguments),
+				progress: progress,
+				cancellationToken: cancellationToken);
+		} finally {
+			E2ETimingProbe.RecordToolCall(toolName, Stopwatch.GetElapsedTime(startedAt));
 		}
-		return await Client.CallToolAsync(
-			ClioRunTool.ToolName,
-			BuildClioRunArguments(toolName, arguments),
-			progress: progress,
-			cancellationToken: cancellationToken);
 	}
 
 	/// <summary>

--- a/clio.mcp.e2e/SysSettingsToolE2ETests.cs
+++ b/clio.mcp.e2e/SysSettingsToolE2ETests.cs
@@ -382,23 +382,10 @@ public sealed class SysSettingsToolE2ETests : McpContractFixtureBase {
 		return new ArrangeContext(session, cancellationTokenSource, environmentName, settings);
 	}
 
-	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) {
-		string? configuredEnvironmentName = settings.Sandbox.EnvironmentName;
-		if (string.IsNullOrWhiteSpace(configuredEnvironmentName)) {
-			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run sys-settings MCP E2E tests.");
-		}
-		if (!await CanReachEnvironmentAsync(settings, configuredEnvironmentName!)) {
-			Assert.Ignore($"Sys-settings MCP E2E requires a reachable sandbox environment. '{configuredEnvironmentName}' was not reachable.");
-		}
-		return configuredEnvironmentName!;
-	}
-
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
+	private static async Task<string> ResolveReachableEnvironmentAsync(McpE2ESettings settings) =>
+		await ReachableSandboxEnvironment.ResolveOrIgnoreAsync(
 			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+			"Configure McpE2E:Sandbox:EnvironmentName to run sys-settings MCP E2E tests.");
 
 	private new sealed record ArrangeContext(
 		McpServerSession Session,

--- a/clio.mcp.e2e/ThemingSandboxE2ETests.cs
+++ b/clio.mcp.e2e/ThemingSandboxE2ETests.cs
@@ -471,8 +471,7 @@ public sealed class ThemingSandboxE2ETests : McpContractFixtureBase {
 		if (string.IsNullOrWhiteSpace(environmentName)) {
 			Assert.Ignore("Configure McpE2E:Sandbox:EnvironmentName to run the theming sandbox E2E tests.");
 		}
-		ClioCliCommandResult ping = await ClioCliCommandRunner.RunAsync(settings, ["ping-app", "-e", environmentName!]);
-		if (ping.ExitCode != 0) {
+		if (!await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName!)) {
 			Assert.Ignore($"The theming sandbox E2E tests require a reachable sandbox environment; '{environmentName}' was not reachable.");
 		}
 		return environmentName!;

--- a/clio.mcp.e2e/ValidateProcessGraphToolE2ETests.cs
+++ b/clio.mcp.e2e/ValidateProcessGraphToolE2ETests.cs
@@ -304,18 +304,8 @@ public sealed class ValidateProcessGraphToolE2ETests {
 		return environmentName!;
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		using CancellationTokenSource cts = new(TimeSpan.FromSeconds(30));
-		try {
-			ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-				settings,
-				["ping-app", "-e", environmentName],
-				cancellationToken: cts.Token);
-			return result.ExitCode == 0;
-		} catch (OperationCanceledException) {
-			return false;
-		}
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static Dictionary<string, object?> Node(string name, string type) =>
 		new() { ["name"] = name, ["type"] = type };

--- a/clio.mcp.e2e/WatchCompilationToolE2ETests.cs
+++ b/clio.mcp.e2e/WatchCompilationToolE2ETests.cs
@@ -93,8 +93,10 @@ public sealed class WatchCompilationToolE2ETests {
 
 		// Act
 		// A short give-up-after keeps this bounded even if the sandbox happens to be mid-compile from
-		// an unrelated concurrent test run; the fast-idle path is what this test actually verifies.
-		CallToolResult callResult = await CallToolAsync(arrangeContext, environmentName!, giveUpAfterSeconds: 30);
+		// an unrelated concurrent test run; the fast-idle path is what this test actually verifies. An
+		// idle stand settles in well under a second, so this number is only the ceiling paid when the
+		// stand is busy — and on CI it IS busy, which made the test cost its whole budget every run.
+		CallToolResult callResult = await CallToolAsync(arrangeContext, environmentName!, giveUpAfterSeconds: 10);
 		CommandExecutionEnvelope execution = McpCommandExecutionParser.Extract(callResult);
 
 		// Assert

--- a/clio.mcp.e2e/WatchCompilationToolE2ETests.cs
+++ b/clio.mcp.e2e/WatchCompilationToolE2ETests.cs
@@ -113,12 +113,8 @@ public sealed class WatchCompilationToolE2ETests {
 		return new ArrangeContext(session, cancellationTokenSource);
 	}
 
-	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) {
-		ClioCliCommandResult result = await ClioCliCommandRunner.RunAsync(
-			settings,
-			["ping-app", "-e", environmentName]);
-		return result.ExitCode == 0;
-	}
+	private static async Task<bool> CanReachEnvironmentAsync(McpE2ESettings settings, string environmentName) =>
+		await ClioCliCommandRunner.IsEnvironmentReachableAsync(settings, environmentName);
 
 	private static async Task<CallToolResult> CallToolAsync(
 		ArrangeContext arrangeContext, string environmentName, int? giveUpAfterSeconds) {

--- a/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/WorkspaceSyncToolE2ETests.cs
@@ -21,7 +21,7 @@ namespace Clio.Mcp.E2E;
 [AllureNUnit]
 [AllureFeature("workspace-sync")]
 [NonParallelizable]
-public sealed class WorkspaceSyncToolE2ETests {
+public sealed class WorkspaceSyncToolE2ETests : McpContractFixtureBase {
 	private const string PushToolName = PushWorkspaceTool.PushWorkspaceToolName;
 	private const string RestoreToolName = RestoreWorkspaceTool.RestoreWorkspaceToolName;
 	private const string PackageListToolName = GetPkgListTool.GetPkgListToolName;
@@ -153,7 +153,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 		AssertGateDidNotRefuse(restoreResult, "cliogate");
 	}
 
-	private static async Task<WorkspaceSyncArrangeContext> ArrangeInvalidEnvironmentAsync(string toolPrefix) {
+	private async Task<WorkspaceSyncArrangeContext> ArrangeInvalidEnvironmentAsync(string toolPrefix) {
 		return await AllureApi.Step("Arrange workspace-sync invalid-environment MCP session", async () => {
 			string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-{toolPrefix}-mcp-e2e-{Guid.NewGuid():N}");
 			string workspacePath = Path.Combine(rootDirectory, "workspace");
@@ -164,7 +164,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 			McpE2ESettings settings = TestConfiguration.Load();
 			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
 			CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(2));
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new WorkspaceSyncArrangeContext(
 				settings,
 				rootDirectory,
@@ -181,7 +181,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 		});
 	}
 
-	private static async Task<WorkspaceSyncArrangeContext> ArrangeSandboxWorkspaceAsync(bool includePackage = true) {
+	private async Task<WorkspaceSyncArrangeContext> ArrangeSandboxWorkspaceAsync(bool includePackage = true) {
 		return await AllureApi.Step("Arrange workspace-sync sandbox lifecycle", async () => {
 			McpE2ESettings settings = TestConfiguration.Load();
 			settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
@@ -211,7 +211,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 				packageMetadata = ReadPackageMetadata(workspacePath, packageName);
 			}
 
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new WorkspaceSyncArrangeContext(
 				settings,
 				rootDirectory,
@@ -243,7 +243,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 			string testRootDirectory = Path.Combine(Path.GetTempPath(), $"clio-workspace-restore-e2e-{Guid.NewGuid():N}");
 			string testWorkspacePath = Path.Combine(testRootDirectory, Path.GetFileName(_sharedWorkspacePath!));
 			CopyDirectory(_sharedWorkspacePath!, testWorkspacePath);
-			McpServerSession session = await McpServerSession.StartAsync(settings, cancellationTokenSource.Token);
+			McpServerSession session = Session;
 			return new WorkspaceSyncArrangeContext(
 				settings,
 				testRootDirectory,
@@ -573,8 +573,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 		McpServerSession Session,
 		CancellationTokenSource CancellationTokenSource,
 		bool OwnsRootDirectory) : IAsyncDisposable {
-		public async ValueTask DisposeAsync() {
-			await Session.DisposeAsync();
+		public ValueTask DisposeAsync() {
 			CancellationTokenSource.Dispose();
 
 			// Restore-test contexts reuse the shared fixture workspace (see EnsureSharedRestoreWorkspaceAsync),
@@ -582,6 +581,7 @@ public sealed class WorkspaceSyncToolE2ETests {
 			if (OwnsRootDirectory && Directory.Exists(RootDirectory)) {
 				Directory.Delete(RootDirectory, recursive: true);
 			}
+			return ValueTask.CompletedTask;
 		}
 	}
 

--- a/docs/knowledge/Tests/the-mcp-shutdown-window-is-spent-in-full-on-every-session.md
+++ b/docs/knowledge/Tests/the-mcp-shutdown-window-is-spent-in-full-on-every-session.md
@@ -1,0 +1,38 @@
+---
+description: the harness ShutdownTimeout is burned in full on every MCP session disposal because the SDK kills the child without closing stdin, and the suite opens 274 sessions per run
+applies-to:
+  - clio.mcp.e2e/Support/Mcp/McpServerSession.cs
+  - clio.mcp.e2e/Support/Diagnostics/E2ETimingProbe.cs
+  - clio.mcp.e2e/Support/Configuration/ReachableSandboxEnvironment.cs
+  - clio.mcp.e2e/Support/Configuration/ClioCliCommandRunner.cs
+ticket: none
+date: 2026-09-11
+---
+
+**What is true** — `StdioClientTransportOptions.ShutdownTimeout` is not a ceiling, it is a bill. The
+SDK's `StdioClientTransport.DisposeProcess` (ModelContextProtocol 2.2.0) never closes the child's
+standard input; it goes straight to `KillTree(ShutdownTimeout)`. Measured with a stopwatch around
+`McpServerSession.DisposeAsync`: **2035 ms at a 2 s setting, 529 ms at 500 ms, 280 ms at 250 ms**.
+clio's own EOF shutdown is healthy and is NOT the cost — closing stdin by hand over a FIFO makes the
+server exit in **0.27 s**.
+
+The multiplier is large and was invisible before `E2ETimingProbe` existed: a full CI run opens
+**274 MCP server sessions** and made **184 `ping-app` reachability probes** (1.16 s each) before
+those were collapsed into one probe per run. TeamCity bills only test bodies, so none of this
+appeared in `AllTestsDuration` or in any per-test duration.
+
+**Why it is this way** — the suite must start the server under test as a real external process
+(`clio.mcp.e2e/AGENTS.md`, "Decisions"), so every fixture that needs an isolated server pays a full
+process lifecycle. The 2 s value was itself a fix for a 10 s one and was recorded as "resolved",
+which hid the fact that the window is spent unconditionally rather than only on a stuck child.
+
+**What breaks if you ignore it** — raising the window "to be safe" costs `274 x delta` per run with
+no safety gained, because the time is spent whether or not the child would have exited. A direct
+A/B on TeamCity, both builds started within six seconds of each other on different agents:
+master **56.3 min** vs branch **50.4 min** (test step 3004 s vs 2638 s). Lowering it does not orphan
+processes — the kill still happens; the window only bounds `KillTree` itself.
+
+The counters are permanent: `e2eMcpSessionStarts`, `e2eMcpSessionDisposeMs`, `e2eCliInvocations`,
+`e2eFixedCostMs` are published as TeamCity build statistics and written to `e2e-timing.txt` beside
+the test assembly. Read them before claiming any e2e timing change; the fixed arrange cost they
+report was **17.2 min out of a 45 min test step** before these two changes.


### PR DESCRIPTION
🔗 **Issue:** [#1513](https://github.com/Advance-Technologies-Foundation/clio/issues/1513)

Closes #1513

## Result

**[Build 16016827](https://teamcity-rnd.bpmonline.com/build/16016827) — 39.0 minutes end to end, SUCCESS.** 865 passed, 22 ignored, 10 muted, no unmuted failure. Master's last four runs of one and the same commit took 62.2, 62.7, 91.9 and 101.0 minutes.

| Run | Duration |
|---|---|
| **this branch — [16016827](https://teamcity-rnd.bpmonline.com/build/16016827)** | **39.0 min** |
| this branch — [16016226](https://teamcity-rnd.bpmonline.com/build/16016226) | 56.5 min |
| master — [16016005](https://teamcity-rnd.bpmonline.com/build/16016005) | 62.2 min |
| master — [16016208](https://teamcity-rnd.bpmonline.com/build/16016208) | 62.7 min |
| master — [16016205](https://teamcity-rnd.bpmonline.com/build/16016205) | 91.9 min |
| master — [16016209](https://teamcity-rnd.bpmonline.com/build/16016209) | 101.0 min |

The two distributions do not overlap: the branch's **slowest** run is still faster than master's **fastest**. Stated conservatively that is −9%. The midpoints differ by far more, but four master runs of one commit spanning 62 to 101 minutes is exactly why a midpoint would be agent luck rather than a result — the spread is recorded in #1513 so the next person does not measure this the wrong way.

Counters that do not depend on which agent picked the build up, same branch before and after the work:

| Counter | Before | After |
|---|---|---|
| `e2eMcpSessionStarts` | 174 | **127** |
| `e2eCliInvocations` | 169 | **144** |
| `e2eFixedCostMs` | 1153s | **501s** |

No production code changes — the diff is the e2e suite plus one knowledge record.

## Where the time went

A timing probe added to the suite (`E2ETimingProbe`) emits per-run TeamCity statistics, which is how the targets were chosen rather than guessed. On build 16013607, whose 4353s of test execution sat inside a 79-minute build:

| | seconds | share |
|---|---|---|
| Sum of all test durations | 3964 | 91% |
| — the 34 slowest tests | 1950 | **49%** |
| Fixed arrange cost (174 server starts + 174 disposals + 169 CLI invocations) | 1153 | 26% |
| 499 tests costing 0.0s each | 0 | 0% |

## What changed

| Change | Before | After |
|---|---|---|
| `get-classic-page-sources` — five tests sent an identical request to the same read-only tool and differed only in assertions | 7 calls | 3 calls |
| 21 sandbox fixtures started their own `clio mcp-server` per test while passing unmodified settings | 57 of the run's 174 starts | shared process |
| `EntitySchemaToolE2ETests` — four separate `update-entity-schema` batches against one shared schema | 4 compiles | 2 |
| `sync-schemas` — the per-operation markers and the per-operation message alignment are two properties of one batch | 2 runs | 1 |
| `delete-app-section` cleanup on a stand that is disposable per build | 9 calls, per test | 3, per fixture |
| `PageSyncToolE2ETests` built a workspace per test that no test reads | 25 `create-workspace` | 0 |
| `FlatArgsProgressTokenE2ETests` waits ~100s on a deliberately silent loopback listener — that wait is the assertion | `[NonParallelizable]` | `[Parallelizable]` |

## Pre-PR review

Full three-lens review over the complete diff; every Blocker and High is fixed in `9aeadb3`.

- **Blocker, found independently by two reviewers** — `ProcessWideSession ??= await StartAsync(...)` reads, awaits and assigns as three steps. 26 fixtures carry `[Parallelizable(ParallelScope.Self)]` and the run uses two NUnit workers, so two `[OneTimeSetUp]` bodies overlap: both start a child, only the last assignment is ever disposed, and a clio process leaks onto the agent for the rest of the build. Now serialized.
- **Blocker** — `E2ETimingProbe` wrote its report inside `using (Console.OpenStandardOutput())`, closing the host's stdout while `dotnet test` still had its summary and the TeamCity service messages to write.
- **High** — the shared `sync-schemas` progress stream was snapshotted the instant the call returned. Progress delivery and call completion are independent SDK continuations, so a late marker would be dropped permanently and fail the marker test with no regression behind it. Now waited for.
- **Coverage restored in two places the merge had genuinely narrowed:** the localized-text column got its own `update-entity-schema` call back (the fixture's only witness that a second batch succeeds against an already-recompiled schema), and created sections are removed once per fixture because `MobilePageConversionGuideSandboxE2ETests` converts every page of the shared application.

Plus six smaller fixes listed in that commit, including three `sync-pages` skip guards that discarded the resolver's answer and called an environment already known to be unreachable.

## Verification

- TeamCity [16016827](https://teamcity-rnd.bpmonline.com/build/16016827) is green. The four tests the review fixes were meant to protect all pass: `SchemaSyncTool_Should_Stream_Per_Operation_Progress_Markers`, `UpdateEntitySchema_Should_Keep_Localized_Column_Valid_For_Later_DefaultValueConfig_Modify`, all 7 `GetPageSources_*`, all 34 `ApplicationSection*`.
- The 10 muted failures are `ExecuteSqlScript` + `DownloadSysSettingFile`, which fail on every master run and are tracked separately in #1509.
- `dotnet test clio.mcp.e2e --filter "TestCategory=McpE2E.NoEnvironment"` — 504 passed, 4 skipped, 2 failures (`CuratedKnowledgeGitStartup`, `CuratedKnowledgeArtifactStartup`) that are pre-existing local startup-budget flakes, present on master and untouched by this diff.
- Test count unchanged at every step: the suite discovers the same set before and after.

## Not in scope

Sharding across stands (explicitly rejected) and a 30-minute target — `Deploy Application` and `Prepare site` cost ~11.5 minutes outside the tests, so 30 minutes is not reachable on one stand.

docs reviewed, no update required. MCP reviewed, no update required — no tool contract, argument, description or dispatch path changed. ClioRing compatibility reviewed, no Ring-consumed contract changed: the diff touches only `clio.mcp.e2e/**` and `docs/knowledge/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

