### PR TITLE
Run the MCP fixture-cleanup guards in the unit lane and gate the destructive arrange behaviourally (#1319)

### DIFF
--- a/clio.mcp.e2e/DataBindingDbFixtureBase.cs
+++ b/clio.mcp.e2e/DataBindingDbFixtureBase.cs
@@ -65,21 +65,42 @@ public abstract class DataBindingDbFixtureBase : McpContractFixtureBase {
 			.Should().Contain(text => text.Contains(expected), because: because);
 	}
 
+	/// <summary>
+	/// The production wiring of the destructive-opt-in gate: the real decision, NUnit's ignore, the
+	/// freshly built clio executable and the stand-pinging environment resolver.
+	/// </summary>
+	/// <remarks>
+	/// The arrange step routes every stand-touching call through <see cref="DestructiveArrangeGate"/>,
+	/// so the "opt-in first" order is executable code rather than the order in which the calls happen to
+	/// appear in this file; <c>Clio.Tests.McpDestructiveArrangeGateTests</c> runs it off-stand.
+	/// </remarks>
+	private static DestructiveArrangeSteps ProductionArrangeSteps() =>
+		new(
+			DestructiveStandAuthorization.IsAuthorized,
+			message => Assert.Ignore(message),
+			TestConfiguration.ResolveFreshClioProcessPath,
+			ResolveReachableEnvironmentAsync);
+
 	private protected async Task<DataBindingDbArrangeContext> ArrangeAsync(bool requireEnvironment) {
 		McpE2ESettings settings = TestConfiguration.Load();
-		//The destructive opt-in is checked here, before anything else, because everything past
-		//this line touches the configured stand: push-workspace, pkg-hotfix, the schema this
-		//fixture publishes, and the remote package the teardown deletes. [Explicit] and the CI
-		//guard only stop automatic selection - a developer selecting the fixture by hand reaches
-		//this code with the opt-in off.
-		if (!DestructiveStandAuthorization.IsAuthorized(requireEnvironment, settings.AllowDestructiveMcpTests)) {
-			Assert.Ignore(DestructiveStandAuthorization.MissingOptInMessage);
-		}
-		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
-		string? environmentName = requireEnvironment
-			? await ResolveReachableEnvironmentAsync(settings)
-			: null;
+		//The destructive opt-in is checked by the gate, before anything else, because everything past it
+		//touches the configured stand: the environment probe, push-workspace, pkg-hotfix, the schema this
+		//fixture publishes, and the remote package the teardown deletes. [Explicit] and the CI guard only
+		//stop automatic selection - a developer selecting the fixture by hand reaches this code with the
+		//opt-in off.
+		return await DestructiveArrangeGate.RunAsync(
+			settings,
+			requireEnvironment,
+			ProductionArrangeSteps(),
+			environmentName => CreateWorkspaceAndPackageAsync(settings, requireEnvironment, environmentName));
+	}
 
+	/// <summary>
+	/// Creates the temporary workspace and the fixture package, and pushes them to the stand when the
+	/// fixture needs one. Runs only after <see cref="DestructiveArrangeGate"/> authorized the arrange step.
+	/// </summary>
+	private async Task<DataBindingDbArrangeContext> CreateWorkspaceAndPackageAsync(
+		McpE2ESettings settings, bool requireEnvironment, string? environmentName) {
 		string rootDirectory = Path.Combine(Path.GetTempPath(), $"clio-db-binding-e2e-{System.Guid.NewGuid():N}");
 		Directory.CreateDirectory(rootDirectory);
 		string workspaceName = $"workspace-{System.Guid.NewGuid():N}";

--- a/clio.mcp.e2e/DestructiveStandAuthorization.cs
+++ b/clio.mcp.e2e/DestructiveStandAuthorization.cs
@@ -8,7 +8,8 @@ namespace Clio.Mcp.E2E;
 /// but neither of them stops a developer who selects such a fixture by hand while
 /// <c>McpE2E__AllowDestructiveMcpTests=false</c>. The decision is a pure function so the invariant
 /// - a stand-touching arrange runs only under the explicit opt-in - is covered off-stand by
-/// <c>Clio.Tests.McpFixturePolicyTests</c> rather than only by the fixtures that never run in CI.
+/// <c>Clio.Tests.McpFixturePolicyTests</c> and <c>Clio.Tests.McpDestructiveArrangeGateTests</c> rather
+/// than only by the fixtures that never run in CI.
 /// </remarks>
 public static class DestructiveStandAuthorization {
 

--- a/clio.mcp.e2e/Support/DestructiveArrangeGate.cs
+++ b/clio.mcp.e2e/Support/DestructiveArrangeGate.cs
@@ -1,0 +1,72 @@
+using System.Threading.Tasks;
+using Clio.Mcp.E2E.Support.Configuration;
+
+namespace Clio.Mcp.E2E.Support;
+
+/// <summary>
+/// The destructive-opt-in decision, normally <see cref="DestructiveStandAuthorization.IsAuthorized"/>.
+/// </summary>
+/// <remarks>
+/// A named delegate rather than <c>Func&lt;bool, bool, bool&gt;</c>: two positional booleans swap silently at
+/// the call site, and swapping these two turns a denial into a permission to mutate the stand.
+/// </remarks>
+/// <param name="touchesStand">Whether the arrange step reaches a Creatio environment at all.</param>
+/// <param name="allowDestructiveMcpTests">The <c>McpE2E:AllowDestructiveMcpTests</c> setting.</param>
+internal delegate bool DestructiveAuthorizationDecision(bool touchesStand, bool allowDestructiveMcpTests);
+
+/// <summary>
+/// The steps a stand-touching arrange step runs, in the order the destructive opt-in has to gate them.
+/// </summary>
+/// <param name="IsAuthorized">The destructive-opt-in decision.</param>
+/// <param name="Deny">What to do when the opt-in is off, normally <c>Assert.Ignore</c>.</param>
+/// <param name="ResolveClioProcessPath">Resolves the clio executable the arrange step will spawn.</param>
+/// <param name="ResolveEnvironmentAsync">
+/// Resolves the sandbox environment; it pings the stand, so it must never run before the gate.
+/// </param>
+internal sealed record DestructiveArrangeSteps(
+	DestructiveAuthorizationDecision IsAuthorized,
+	Action<string> Deny,
+	Func<string> ResolveClioProcessPath,
+	Func<McpE2ESettings, Task<string>> ResolveEnvironmentAsync);
+
+/// <summary>
+/// Runs a stand-touching arrange step behind the destructive opt-in.
+/// </summary>
+/// <remarks>
+/// The ordering this helper enforces is the whole point: <c>[Explicit]</c> and the CI guard only stop
+/// automatic selection, so a developer selecting such a fixture by hand reaches the arrange code with the
+/// opt-in off. Everything past the gate touches the configured stand - resolving the environment pings it,
+/// and the remaining steps push a package and publish configuration. Keeping the gate, the resolvers and
+/// the remaining steps inside one helper makes the order a property of code an environment-free test can
+/// execute, instead of the order in which the calls happen to appear in the fixture source.
+/// </remarks>
+internal static class DestructiveArrangeGate {
+	/// <summary>
+	/// Checks the destructive opt-in and, only when it passes, resolves the clio executable and the
+	/// environment and runs <paramref name="remainingSteps"/>.
+	/// </summary>
+	/// <param name="settings">The e2e settings; its <c>ClioProcessPath</c> is filled in here.</param>
+	/// <param name="touchesStand">Whether this arrange step reaches a Creatio environment at all.</param>
+	/// <param name="steps">The injectable seam; production passes the real implementations.</param>
+	/// <param name="remainingSteps">
+	/// The rest of arrange, receiving the resolved environment name (<c>null</c> when the step needs none).
+	/// </param>
+	internal static async Task<TContext> RunAsync<TContext>(
+		McpE2ESettings settings,
+		bool touchesStand,
+		DestructiveArrangeSteps steps,
+		Func<string?, Task<TContext>> remainingSteps) {
+		if (!steps.IsAuthorized(touchesStand, settings.AllowDestructiveMcpTests)) {
+			steps.Deny(DestructiveStandAuthorization.MissingOptInMessage);
+			//Deny normally ends the test by throwing (Assert.Ignore does). Throwing here as well keeps the
+			//guarantee independent of that: a deny hook that returns must still not reach the stand.
+			throw new InvalidOperationException(DestructiveStandAuthorization.MissingOptInMessage);
+		}
+
+		settings.ClioProcessPath = steps.ResolveClioProcessPath();
+		string? environmentName = touchesStand
+			? await steps.ResolveEnvironmentAsync(settings)
+			: null;
+		return await remainingSteps(environmentName);
+	}
+}

--- a/clio.mcp.e2e/clio.mcp.e2e.csproj
+++ b/clio.mcp.e2e/clio.mcp.e2e.csproj
@@ -37,6 +37,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<!-- The environment-free guards over this project's fixture-support helpers live in clio.tests,
+		     because the always-on GitHub unit lane runs clio.tests only; this project is driven from
+		     TeamCity and needs a stood-up stand, so it does not gate every pull request. -->
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>clio.tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\clio\clio.csproj" />
 		<ProjectReference Include="..\clio.process.fixture\clio.process.fixture.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>

--- a/clio.tests/McpDestructiveArrangeGateTests.cs
+++ b/clio.tests/McpDestructiveArrangeGateTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Clio.Mcp.E2E;
+using Clio.Mcp.E2E.Support;
+using Clio.Mcp.E2E.Support.Configuration;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Clio.Tests;
+
+/// <summary>
+/// Behavioural guard over the destructive-opt-in gate the DB-first data-binding arrange step runs
+/// through: with the opt-in off nothing that reaches a Creatio stand may be invoked.
+/// </summary>
+/// <remarks>
+/// This replaces a source-text ordering assertion over <c>DataBindingDbFixtureBase.cs</c>. That guard
+/// matched comments and string literals too, so an implementation that moved the real check after the
+/// first stand touch while leaving a matching comment in front of it still passed. Here the gate is
+/// executed with recording delegates instead, so the order is measured rather than read.
+/// </remarks>
+[TestFixture]
+[Category("Unit")]
+public sealed class McpDestructiveArrangeGateTests {
+
+	private const string DeniedMarker = "denied";
+
+	[Test]
+	[Description("With the destructive opt-in off, the gate denies the run and invokes neither the clio-executable resolver, nor the stand-pinging environment resolver, nor the remaining arrange steps.")]
+	public async Task RunAsync_ShouldTouchNothing_WhenTheDestructiveOptInIsOff() {
+		// Arrange
+		McpE2ESettings settings = new() { AllowDestructiveMcpTests = false };
+		List<string> calls = [];
+		DestructiveArrangeSteps steps = RecordingSteps(calls, denyThrows: true);
+
+		// Act
+		Func<Task> act = () => DestructiveArrangeGate.RunAsync(
+			settings,
+			touchesStand: true,
+			steps,
+			environmentName => {
+				calls.Add("remaining-steps");
+				return Task.FromResult("context");
+			});
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*" + DeniedMarker + "*",
+				because: "the gate has to end the run through the injected deny hook instead of returning a context");
+		calls.Should().Equal(["is-authorized", "deny"],
+			because: "nothing that reaches the stand - not the clio-executable resolver, not the ping-app environment probe, not the arrange commands - may run while the opt-in is off");
+		settings.ClioProcessPath.Should().BeNull(
+			because: "resolving the executable builds clio locally in preparation for spawning it against the stand, so it belongs after the gate too");
+	}
+
+	[Test]
+	[Description("The gate still fails closed when the injected deny hook returns instead of throwing, so the guarantee does not depend on Assert.Ignore's behaviour.")]
+	public async Task RunAsync_ShouldStillFailClosed_WhenTheDenyHookReturns() {
+		// Arrange
+		McpE2ESettings settings = new() { AllowDestructiveMcpTests = false };
+		List<string> calls = [];
+		DestructiveArrangeSteps steps = RecordingSteps(calls, denyThrows: false);
+
+		// Act
+		Func<Task> act = () => DestructiveArrangeGate.RunAsync(
+			settings,
+			touchesStand: true,
+			steps,
+			environmentName => {
+				calls.Add("remaining-steps");
+				return Task.FromResult("context");
+			});
+
+		// Assert
+		await act.Should().ThrowAsync<InvalidOperationException>()
+			.WithMessage("*AllowDestructiveMcpTests*",
+				because: "a deny hook that returns must not let the arrange step fall through to the stand, and the failure has to name the switch that turns the run on");
+		calls.Should().Equal(["is-authorized", "deny"],
+			because: "the denial is final regardless of what the deny hook does");
+		settings.ClioProcessPath.Should().BeNull(
+			because: "nothing that prepares a clio process may run once the gate denied the arrange step");
+	}
+
+	[Test]
+	[Description("With the destructive opt-in on, the gate authorizes first and only then resolves the executable, the environment and the remaining arrange steps.")]
+	public async Task RunAsync_ShouldAuthorizeBeforeEveryStandTouch_WhenTheOptInIsOn() {
+		// Arrange
+		McpE2ESettings settings = new() { AllowDestructiveMcpTests = true };
+		List<string> calls = [];
+		DestructiveArrangeSteps steps = RecordingSteps(calls, denyThrows: true);
+		string? environmentPassedOn = null;
+
+		// Act
+		string context = await DestructiveArrangeGate.RunAsync(
+			settings,
+			touchesStand: true,
+			steps,
+			environmentName => {
+				calls.Add("remaining-steps");
+				environmentPassedOn = environmentName;
+				return Task.FromResult("context");
+			});
+
+		// Assert
+		context.Should().Be("context",
+			because: "an authorized arrange step returns the context its caller owns from here on");
+		calls.Should().Equal(["is-authorized", "resolve-clio-process-path", "resolve-environment", "remaining-steps"],
+			because: "the opt-in decision has to precede the executable lookup, the ping-app probe and the first clio command");
+		environmentPassedOn.Should().Be("sandbox-environment",
+			because: "the remaining arrange steps run against the environment the gate resolved");
+		settings.ClioProcessPath.Should().Be("clio-process-path",
+			because: "the arrange step spawns the freshly resolved executable, so the gate writes it back into the settings it hands on");
+	}
+
+	[Test]
+	[Description("An arrange step that never reaches a stand skips the environment probe and receives no environment name.")]
+	public async Task RunAsync_ShouldSkipTheEnvironmentProbe_WhenTheArrangeStepNeverReachesAStand() {
+		// Arrange
+		McpE2ESettings settings = new() { AllowDestructiveMcpTests = false };
+		List<string> calls = [];
+		DestructiveArrangeSteps steps = RecordingSteps(calls, denyThrows: true);
+		string? environmentPassedOn = "not-assigned";
+
+		// Act
+		string context = await DestructiveArrangeGate.RunAsync(
+			settings,
+			touchesStand: false,
+			steps,
+			environmentName => {
+				calls.Add("remaining-steps");
+				environmentPassedOn = environmentName;
+				return Task.FromResult("context");
+			});
+
+		// Assert
+		context.Should().Be("context",
+			because: "an arrange step that never reaches a stand needs no opt-in and runs to completion");
+		calls.Should().Equal(["is-authorized", "resolve-clio-process-path", "remaining-steps"],
+			because: "pinging an environment is itself a stand touch, so it must not happen for a stand-free arrange step");
+		environmentPassedOn.Should().BeNull(
+			because: "there is no environment to hand on when none was resolved");
+	}
+
+	private static DestructiveArrangeSteps RecordingSteps(List<string> calls, bool denyThrows) =>
+		new(
+			(touchesStand, allowDestructiveMcpTests) => {
+				calls.Add("is-authorized");
+				return DestructiveStandAuthorization.IsAuthorized(touchesStand, allowDestructiveMcpTests);
+			},
+			message => {
+				calls.Add("deny");
+				if (denyThrows) {
+					//Assert.Ignore throws; a test double that throws its own exception keeps this fixture
+					//out of the Skipped bucket the pre-merge lane gate counts.
+					throw new InvalidOperationException(DeniedMarker + ": " + message);
+				}
+			},
+			() => {
+				calls.Add("resolve-clio-process-path");
+				return "clio-process-path";
+			},
+			_ => {
+				calls.Add("resolve-environment");
+				return Task.FromResult("sandbox-environment");
+			});
+}

--- a/clio.tests/McpFixtureCleanupOwnershipTests.cs
+++ b/clio.tests/McpFixtureCleanupOwnershipTests.cs
@@ -1,9 +1,12 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Clio.Mcp.E2E.Support;
 using FluentAssertions;
+using NUnit.Framework;
 
-namespace Clio.Mcp.E2E.Support;
+namespace Clio.Tests;
 
 /// <summary>
 /// Pins the two teardown guarantees the DB-first data-binding fixtures rely on: a cleanup command can never
@@ -11,8 +14,8 @@ namespace Clio.Mcp.E2E.Support;
 /// arrange step already created.
 /// </summary>
 [TestFixture]
-[Category("McpE2E.NoEnvironment")]
-public sealed class FixtureCleanupOwnershipTests {
+[Category("Unit")]
+public sealed class McpFixtureCleanupOwnershipTests {
 	[Test]
 	[Description("A cleanup command that never returns is cancelled by its own bounded token instead of hanging the E2E worker.")]
 	public async Task BoundedCleanup_Should_Cancel_A_Hung_Cleanup_Command() {
@@ -57,14 +60,17 @@ public sealed class FixtureCleanupOwnershipTests {
 	[Test]
 	[Description("A non-zero exit code is reported, and a successful cleanup produces no diagnostics at all.")]
 	public async Task BoundedCleanup_Should_Report_Only_A_Failing_Exit_Code() {
+		// Arrange
+		TimeSpan timeout = TimeSpan.FromSeconds(5);
+
 		// Act
 		string? failed = await BoundedCleanup.RunAsync(
 			_ => Task.FromResult(1),
-			TimeSpan.FromSeconds(5),
+			timeout,
 			"Deleting the fixture package");
 		string? succeeded = await BoundedCleanup.RunAsync(
 			_ => Task.FromResult(0),
-			TimeSpan.FromSeconds(5),
+			timeout,
 			"Deleting the fixture package");
 
 		// Assert

--- a/clio.tests/McpFixturePolicyTests.cs
+++ b/clio.tests/McpFixturePolicyTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Clio.Mcp.E2E;
+using Clio.Mcp.E2E.Support;
 using Clio.Tests.Command;
 using Clio.Tests.Command.ProcessModel;
 using Clio.Tests.Common;
@@ -31,7 +32,6 @@ public sealed class McpFixturePolicyTests {
 	/// </summary>
 	private static readonly string RepositoryRoot =
 		Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
-
 
 	[Test]
 	[Description("Verifies that every fixture containing Sandbox tests is class-level NonParallelizable.")]
@@ -241,32 +241,74 @@ public sealed class McpFixturePolicyTests {
 	}
 
 	[Test]
-	[Description("Proves the DB-first data-binding arrange consults the destructive opt-in before it resolves the environment or runs any clio command, so a hand-selected fixture cannot mutate the stand while the opt-in is false.")]
-	public void DataBindingDbArrange_ShouldCheckDestructiveOptIn_BeforeItRunsAnyCommand() {
+	[Description("Proves the DB-first data-binding arrange wires the real destructive-opt-in decision and NUnit's ignore into the gate, so the injectable seam cannot be wired to something that always authorizes.")]
+	public void DataBindingDbArrange_ShouldWireTheRealAuthorizationDecision() {
+		// Arrange
+		MethodInfo? productionSteps = typeof(DataBindingDbFixtureBase)
+			.GetMethod("ProductionArrangeSteps", BindingFlags.Static | BindingFlags.NonPublic);
+		productionSteps.Should().NotBeNull(
+			because: "the arrange step reaches the stand only through the gate's seam; a rename must fail here rather than leave this guard pinning nothing");
+
+		// Act
+		DestructiveArrangeSteps steps = (DestructiveArrangeSteps)productionSteps!.Invoke(null, null)!;
+
+		// Assert
+		steps.IsAuthorized.Method.Should().BeSameAs(
+			typeof(DestructiveStandAuthorization).GetMethod(nameof(DestructiveStandAuthorization.IsAuthorized)),
+			because: "the seam must carry the real decision; wiring it to a delegate that always returns true would let a hand-selected fixture mutate the stand with the opt-in off");
+		Assert.Throws<IgnoreException>(() => steps.Deny("denied"),
+			"the deny hook must still end the run the way NUnit skips a test, not return and let the caller continue");
+		//The resolvers are deliberately not invoked here: one builds clio, the other pings the stand.
+	}
+
+	[Test]
+	[Description("Keeps the DB-first data-binding arrange free of any stand-touching call of its own, so everything it does to a Creatio stand goes through the destructive-opt-in gate whose ordering McpDestructiveArrangeGateTests proves.")]
+	public void DataBindingDbArrange_ShouldDelegateEveryStandTouchToTheGate() {
 		// Arrange
 		string fixtureSourcePath = Path.Combine(
 			RepositoryRoot, "clio.mcp.e2e", "DataBindingDbFixtureBase.cs");
 		File.Exists(fixtureSourcePath).Should().BeTrue(
 			because: $"this guard reads the arrange step from {fixtureSourcePath}; a moved file must fail here rather than pass on a missing source");
-		string source = File.ReadAllText(fixtureSourcePath);
 
 		// Act
-		int authorizationIndex = source.IndexOf(
-			nameof(DestructiveStandAuthorization) + "." + nameof(DestructiveStandAuthorization.IsAuthorized),
-			StringComparison.Ordinal);
-		int[] standTouchingIndexes = [
-			source.IndexOf("ResolveReachableEnvironmentAsync(settings)", StringComparison.Ordinal),
-			source.IndexOf("ClioCliCommandRunner.RunAndAssertSuccessAsync", StringComparison.Ordinal),
-			source.IndexOf("ResolveFreshClioProcessPath", StringComparison.Ordinal)
+		string arrangeBody = ReadMethodBodyWithoutComments(fixtureSourcePath,
+			"private protected async Task<DataBindingDbArrangeContext> ArrangeAsync(bool requireEnvironment) {");
+		string[] standTouchingCalls = [
+			"ResolveReachableEnvironmentAsync",
+			"ResolveFreshClioProcessPath",
+			"ClioCliCommandRunner."
 		];
 
 		// Assert
-		authorizationIndex.Should().BeGreaterThan(-1,
-			because: "the arrange step must consult DestructiveStandAuthorization.IsAuthorized; without it a hand-selected fixture pushes a package and publishes a schema on the configured stand with the opt-in off");
-		standTouchingIndexes.Should().OnlyContain(index => index > -1,
-			because: "this guard pins the order against the calls that actually reach the stand; if they were renamed the guard would silently pin nothing");
-		standTouchingIndexes.Should().OnlyContain(index => index > authorizationIndex,
-			because: "the opt-in has to be checked before the environment is resolved and before the first clio process is spawned, otherwise the guard runs after the damage");
+		arrangeBody.Should().Contain("DestructiveArrangeGate.RunAsync(",
+			because: "the arrange step must hand its work to the gate; without that call the gate's own tests guard a seam nobody uses");
+		standTouchingCalls.Should().OnlyContain(call => !arrangeBody.Contains(call, StringComparison.Ordinal),
+			because: "a stand-touching call made by the arrange step itself would bypass the opt-in, and unlike the previous guard this one reads the method body with its comments stripped, so a comment can no longer satisfy it");
+	}
+
+	/// <summary>
+	/// Returns the body of the method whose declaration line is <paramref name="declaration"/>, with
+	/// <c>//</c> comment lines removed, so a guard over it cannot be satisfied by prose.
+	/// </summary>
+	private static string ReadMethodBodyWithoutComments(string sourcePath, string declaration) {
+		string[] lines = File.ReadAllLines(sourcePath);
+		int declarationIndex = Array.FindIndex(lines, line => line.Trim() == declaration);
+		declarationIndex.Should().BeGreaterThan(-1,
+			because: $"the guard locates the method by its declaration '{declaration}'; a changed signature must fail here rather than scan nothing");
+
+		List<string> body = [];
+		int depth = 0;
+		for (int index = declarationIndex; index < lines.Length; index++) {
+			string line = lines[index];
+			depth += line.Count(character => character == '{') - line.Count(character => character == '}');
+			if (index > declarationIndex && !line.TrimStart().StartsWith("//", StringComparison.Ordinal)) {
+				body.Add(line);
+			}
+			if (index > declarationIndex && depth == 0) {
+				break;
+			}
+		}
+		return string.Join(Environment.NewLine, body);
 	}
 
 	private static bool HasCategory(IEnumerable<CategoryAttribute> attributes, string category) =>


### PR DESCRIPTION
🔗 **Issue:** [#1319](https://github.com/Advance-Technologies-Foundation/clio/issues/1319)

Closes #1319

## Summary

Both test-harness follow-ups deferred out of #1250: the cleanup-ownership tests now run in a blocking lane, and the authorization-order guard is behavioural instead of a source-text search.

## Root cause

**Item 1.** `clio.mcp.e2e/Support/FixtureCleanupOwnershipTests.cs` (`McpE2E.NoEnvironment`) pinned two real safety invariants — a bounded, never-throwing teardown and arrange-ownership transfer — but the always-on GitHub unit lane runs `clio.tests` only; `clio.mcp.e2e` is driven from TeamCity and needs a stood-up stand, so it does not gate every pull request. A regression in either invariant could merge unnoticed. This is the fact already recorded in `docs/knowledge/Tests/no-github-lane-runs-the-mcp-e2e-project.md`.

**Item 2.** `McpFixturePolicyTests.DataBindingDbArrange_ShouldCheckDestructiveOptIn_BeforeItRunsAnyCommand` read `DataBindingDbFixtureBase.cs` with `File.ReadAllText` + `IndexOf`, so comments and string literals counted. An implementation that moved the real check after the first stand touch while leaving a matching comment in front of it still passed.

## Changes

- **Moved, no new CI lane.** `FixtureCleanupOwnershipTests` → `clio.tests/McpFixtureCleanupOwnershipTests.cs` (`Category("Unit")`). `clio.tests` already had a project reference to `clio.mcp.e2e` (for `McpFixturePolicyTests`), so only friend access was missing: `clio.mcp.e2e.csproj` now carries `InternalsVisibleTo(clio.tests)` in the same `AssemblyAttribute` form `clio.csproj` uses, and `BoundedCleanup` / `ArrangeOwnership` stay `internal`. A new lane would have been a job to maintain for tests that already fit the existing one.
- **`DestructiveArrangeGate`** (new, `clio.mcp.e2e/Support/`): takes a `DestructiveArrangeSteps` record — the authorization decision (a named `DestructiveAuthorizationDecision` delegate, not `Func<bool,bool,bool>`, because two positional booleans swap silently on a safety gate), the deny hook, the clio-executable resolver, the environment resolver — plus the remaining arrange steps as a callback. It fails closed even when the deny hook returns instead of throwing.
- **`ArrangeAsync`** now consists of loading settings and handing everything to the gate; the workspace/package steps moved into `CreateWorkspaceAndPackageAsync`. Behaviour under the opt-in is unchanged: same steps, same order.
- **Guards replacing the text search.** `McpDestructiveArrangeGateTests` executes the gate with recording delegates and asserts the recorded call order (opt-in off → only `is-authorized` and `deny`; opt-in on → decision, executable, environment, remaining steps; stand-free arrange → no environment probe). `McpFixturePolicyTests` keeps the fixture attached to the gate with two assertions: one invokes the production seam and pins that it carries `DestructiveStandAuthorization.IsAuthorized` and an ignoring deny hook, the other reads the `ArrangeAsync` body **with its comment lines stripped** and requires it to contain no stand-touching call of its own.

## Validation

- `dotnet build clio.tests/clio.tests.csproj -c Debug` — succeeded, 0 errors.
- `dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug -f net8.0` — succeeded, 0 errors (TeamCity runs this project on net8.0).
- `dotnet test clio.tests/clio.tests.csproj --no-build -f net10.0 --filter "TestCategory!=Integration&(FullyQualifiedName~McpFixture|FullyQualifiedName~McpDestructiveArrangeGate)"` — Passed 22, Failed 0, Skipped 0.
- Lane proof: `dotnet test … --list-tests --filter "TestCategory!=Integration"` (the predicate `.github/scripts/Invoke-TestShard.ps1` builds for the unit suite) lists all five moved tests and the four new gate tests. Both fixtures are unassigned in `clio.tests/TestSharding/test-shards.json`, so they run in the final catch-all shard (`unit-4`), which selects everything not assigned to an earlier shard.
- Mutation check — each break was applied, rebuilt, run, then reverted:
  - resolve the clio executable before the authorization check → 4 gate-ordering tests fail;
  - remove the fail-closed `throw` after the deny hook → `RunAsync_ShouldStillFailClosed_WhenTheDenyHookReturns` fails;
  - wire the production seam to `(_, _) => true` → `DataBindingDbArrange_ShouldWireTheRealAuthorizationDecision` fails;
  - make `ArrangeAsync` resolve the executable itself, outside the gate → `DataBindingDbArrange_ShouldDelegateEveryStandTouchToTheGate` fails.

## Review tier

Full 3-lens fan-out (pre-PR gate 1): code-quality, bug-detector, security. No Blockers. All three raised the same High — the first draft replaced the text guard with a reflection existence check that could not fail for the reason it named; that is fixed above by the two guards. Mediums addressed in this PR: named authorization delegate, extracted arrange body, corrected csproj and `DestructiveStandAuthorization` remarks. Deliberately not done (noted as follow-ups, out of scope here): an IL-level scan of the `ArrangeAsync` state machine (the narrowed, comment-stripped text guard covers the same regression at a fraction of the complexity); moving the other three environment-free suites still in `clio.mcp.e2e` (`ClioCliCommandRunnerEnvelopeTests`, `ClioCliCommandRunnerRedactionTests`, `WorkerSpawnObserverReleaseWaitTests`); a placement rule in `clio.mcp.e2e/AGENTS.md`.

Residual worth stating: the gate's ordering is proven by execution, and the fixture's use of the gate is proven by the two guards above — one behavioural, one textual over a comment-stripped method body.

MCP reviewed, no update required — no command, MCP tool, prompt or resource changed; the diff is test-harness code only.
docs reviewed, no update required — no command behaviour, option or help text changed.
ClioRing compatibility reviewed, no Ring-consumed contract changed — the diff touches `clio.mcp.e2e/**` and `clio.tests/**` only; no MCP tool name, argument, result, progress event or CLI verb was modified.
Knowledge base: no new record — `docs/knowledge/Tests/no-github-lane-runs-the-mcp-e2e-project.md` already states the fact this PR acts on, and no record's `applies-to` covers a moved path. `scripts/check-knowledge-applies-to.py`: all 250 records resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
