### PR TITLE
Restore references, confine link paths and reconcile Libs in nuget2dll (#1311)

### DIFF
--- a/clio.tests/Common/NugetMaterializer.Tests.cs
+++ b/clio.tests/Common/NugetMaterializer.Tests.cs
@@ -675,6 +675,77 @@ public class NugetMaterializerTests
 		// string is exactly what let a crafted Include become an option
 	}
 
+	[Test]
+	[Description("Restores the package references an earlier conversion commented out when the legacy "
+		+ "repair removes the props imports that replaced them (issue 1311)")]
+	public void Materializer_RestoresCommentedReferences_When_LegacyRepairRemovesEveryPropsImport(){
+		// Arrange
+		string savedCsproj = null;
+		_fileSystem.ReadAllText(CsprojFileName).Returns(MockCsProjWithoutNugetButWithImports());
+		//Neither props file survived, so both imports go and nothing references the dependency any more.
+		_fileSystem.ExistsFile(Arg.Any<string>()).Returns(false);
+		_fileSystem.When(fs => fs.WriteAllTextToFile(CsprojFileName, Arg.Any<string>()))
+			.Do(ci => savedCsproj = ci.ArgAt<string>(1));
+
+		//Act
+		int actual = _sut.Materialize(PackageName);
+
+		//Assert
+		actual.Should().Be(1, because: "there is nothing left to materialize");
+		savedCsproj.Should().NotBeNull(because: "the repaired csproj has to be written");
+		savedCsproj.Should().Contain("<PackageReference Include=\"Nuget1\" Version=\"1.1.1\" />",
+			because: "without it the project builds while silently losing the dependency and its build assets");
+		savedCsproj.Should().NotContain("<!--<PackageReference",
+			because: "the comment is what replaced the reference and it is no longer the current state");
+		_logger.Received(1).WriteInfo(Arg.Is<string>(m => m.StartsWith("Restored the Nuget1")));
+		// because: the restore has to be reported, and the exact wording is not what this test is about
+	}
+
+	[Test]
+	[Description("Leaves an already converted, healthy package untouched: every props import is usable, so "
+		+ "nothing is repaired and no commented reference is restored (issue 1311)")]
+	public void Materializer_RestoresNothing_When_EveryPropsFileIsStillUsable(){
+		// Arrange
+		_fileSystem.ReadAllText(CsprojFileName).Returns(MockCsProjWithoutNugetButWithImports());
+		foreach (string moniker in new[] {"net472", "netstandard"}) {
+			string propsPath = $"{PackageName}-{moniker}.nuget.props";
+			_fileSystem.ExistsFile(propsPath).Returns(true);
+			_fileSystem.ReadAllText(propsPath).Returns("<Project></Project>");
+		}
+
+		//Act
+		int actual = _sut.Materialize(PackageName);
+
+		//Assert
+		actual.Should().Be(1, because: "the package is already converted, so there is nothing to convert");
+		_fileSystem.DidNotReceive().WriteAllTextToFile(CsprojFileName, Arg.Any<string>());
+		_logger.DidNotReceive().WriteInfo(Arg.Is<string>(m => m.StartsWith("Restored the")));
+	}
+
+	[Test]
+	[Description("Keeps the references commented while one props import still stands, because a reference "
+		+ "and the dll that replaced it in the same project fail the build on a duplicate assembly (issue 1311)")]
+	public void Materializer_RestoresNothing_When_OnePropsImportSurvivesTheRepair(){
+		// Arrange
+		string savedCsproj = null;
+		string net472Props = $"{PackageName}-net472.nuget.props";
+		_fileSystem.ReadAllText(CsprojFileName).Returns(MockCsProjWithoutNugetButWithImports());
+		_fileSystem.ExistsFile(net472Props).Returns(true);
+		_fileSystem.ReadAllText(net472Props).Returns("<Project></Project>");
+		_fileSystem.ExistsFile($"{PackageName}-netstandard.nuget.props").Returns(false);
+		_fileSystem.When(fs => fs.WriteAllTextToFile(CsprojFileName, Arg.Any<string>()))
+			.Do(ci => savedCsproj = ci.ArgAt<string>(1));
+
+		//Act
+		_sut.Materialize(PackageName);
+
+		//Assert
+		savedCsproj.Should().NotBeNull(because: "the stale netstandard import had to be removed");
+		savedCsproj.Should().Contain("<!--<PackageReference",
+			because: "the net472 props file still materializes that dependency");
+		_logger.DidNotReceive().WriteInfo(Arg.Is<string>(m => m.StartsWith("Restored the")));
+	}
+
 	#region Methods: Private
 
 	// The command line is passed as tokens, not as one interpolated string, so the assertions describe the

--- a/clio.tests/Common/NugetMaterializerConfinementTests.cs
+++ b/clio.tests/Common/NugetMaterializerConfinementTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Clio.Common;
+using Clio.Workspaces;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Clio.Tests.Common;
+
+/// <summary>
+/// Confinement of the nuget2dll paths against real symbolic links. The lexical prefix check cannot see
+/// them, so these run against the real file system rather than a substitute.
+/// </summary>
+[TestFixture]
+[Property("Module", "Common")]
+[Category("Unit")]
+public class NugetMaterializerConfinementTests
+{
+
+	#region Constants: Private
+
+	private const string PackageName = "Good";
+
+	#endregion
+
+	#region Fields: Private
+
+	private string _workspaceRoot;
+	private string _outsideRoot;
+	private IFileSystem _fileSystem;
+	private ILogger _logger;
+	private IProcessExecutor _processExecutor;
+	private IPropsBuilder _propsBuilder;
+	private IWorkspacePathBuilder _workspacePathBuilder;
+	private NugetMaterializer _sut;
+	private PropsBuilder _realPropsBuilder;
+
+	#endregion
+
+	#region Setup/Teardown
+
+	[SetUp]
+	public void Setup(){
+		string testRoot = Path.Combine(Path.GetTempPath(), "clio-1311-" + Guid.NewGuid().ToString("N"));
+		_workspaceRoot = Path.Combine(testRoot, "workspace");
+		_outsideRoot = Path.Combine(testRoot, "outside");
+		Directory.CreateDirectory(Path.Combine(_workspaceRoot, "packages"));
+		Directory.CreateDirectory(Path.Combine(_workspaceRoot, ".nuget"));
+		Directory.CreateDirectory(_outsideRoot);
+
+		_fileSystem = new FileSystem(new System.IO.Abstractions.FileSystem());
+		_logger = Substitute.For<ILogger>();
+		_propsBuilder = Substitute.For<IPropsBuilder>();
+		_processExecutor = Substitute.For<IProcessExecutor>();
+		_processExecutor.ExecuteAndCaptureAsync(Arg.Any<ProcessExecutionOptions>())
+			.Returns(_ => Task.FromResult(new ProcessExecutionResult {Started = true, ExitCode = 0}));
+		_workspacePathBuilder = Substitute.For<IWorkspacePathBuilder>();
+		_workspacePathBuilder.RootPath.Returns(_workspaceRoot);
+		_workspacePathBuilder.PackagesFolderPath.Returns(Path.Combine(_workspaceRoot, "packages"));
+		_workspacePathBuilder.BuildPackagePath(Arg.Any<string>())
+			.Returns(ci => Path.Combine(_workspaceRoot, "packages", ci.ArgAt<string>(0)));
+		_workspacePathBuilder.BuildPackageProjectPath(Arg.Any<string>())
+			.Returns(ci => Path.Combine(_workspaceRoot, "packages", ci.ArgAt<string>(0),
+				ci.ArgAt<string>(0) + ".csproj"));
+		_workspacePathBuilder.BuildPackagePropsPath(Arg.Any<string>(), Arg.Any<string>())
+			.Returns(ci => Path.Combine(_workspaceRoot, "packages", ci.ArgAt<string>(0), "Files",
+				$"{ci.ArgAt<string>(0)}-{ci.ArgAt<string>(1)}.nuget.props"));
+		_workspacePathBuilder.NugetFolderPath.Returns(Path.Combine(_workspaceRoot, ".nuget"));
+		_sut = new NugetMaterializer(_workspacePathBuilder, _fileSystem, _logger, _processExecutor, _propsBuilder);
+		_realPropsBuilder = new PropsBuilder(_fileSystem, _logger, _workspacePathBuilder);
+	}
+
+	[TearDown]
+	public void TearDown(){
+		string testRoot = Directory.GetParent(_workspaceRoot)?.FullName;
+		if (testRoot is not null && Directory.Exists(testRoot)) {
+			//Deleting a link removes the link, not what it points at.
+			Directory.Delete(testRoot, true);
+		}
+	}
+
+	#endregion
+
+	#region Methods: Private
+
+	private static void CreateDirectoryLinkOrIgnore(string path, string target){
+		try {
+			Directory.CreateSymbolicLink(path, target);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+			Assert.Ignore("This platform does not let the test process create a symbolic link: "
+				+ exception.Message);
+		}
+	}
+
+	private static string CreateSentinel(string directoryPath){
+		Directory.CreateDirectory(directoryPath);
+		string sentinelPath = Path.Combine(directoryPath, "sentinel.txt");
+		File.WriteAllText(sentinelPath, "must survive");
+		return sentinelPath;
+	}
+
+	#endregion
+
+	[Test]
+	[Description("Refuses a package folder that is a symbolic link, so the csproj, its backup and the props "
+		+ "files are never written through it into another directory (issue 1311)")]
+	public void Materializer_Refuses_PackageFolderThatIsASymbolicLink(){
+		// Arrange
+		string victimFolder = Path.Combine(_outsideRoot, "victim");
+		string sentinelPath = CreateSentinel(victimFolder);
+		File.WriteAllText(Path.Combine(victimFolder, PackageName + ".csproj"), @"
+			<Project Sdk=""Microsoft.NET.Sdk"">
+				<ItemGroup>
+					<PackageReference Include=""Nuget1"" Version=""1.1.1"" />
+				</ItemGroup>
+			</Project>");
+		CreateDirectoryLinkOrIgnore(Path.Combine(_workspaceRoot, "packages", PackageName), victimFolder);
+
+		//Act
+		int actual = _sut.Materialize(PackageName);
+
+		//Assert
+		actual.Should().Be(1,
+			because: "the lexical prefix check passes, yet the folder resolves outside the workspace");
+		File.Exists(sentinelPath).Should().BeTrue(because: "nothing outside the workspace may be touched");
+		File.Exists(Path.Combine(victimFolder, PackageName + ".csproj.bak")).Should().BeFalse(
+			because: "no file may be written through the link");
+		_propsBuilder.DidNotReceive().Build(Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Refuses a helper project folder that is a symbolic link, so the recursive bin/obj delete "
+		+ "never runs outside the workspace (issue 1311)")]
+	public void Materializer_Refuses_HelperFolderThatIsASymbolicLink(){
+		// Arrange
+		string packageFolder = Path.Combine(_workspaceRoot, "packages", PackageName);
+		Directory.CreateDirectory(packageFolder);
+		File.WriteAllText(Path.Combine(packageFolder, PackageName + ".csproj"), @"
+			<Project Sdk=""Microsoft.NET.Sdk"">
+				<ItemGroup>
+					<PackageReference Include=""Nuget1"" Version=""1.1.1"" />
+				</ItemGroup>
+			</Project>");
+		string victimFolder = Path.Combine(_outsideRoot, "victim");
+		string sentinelPath = CreateSentinel(Path.Combine(victimFolder, "bin"));
+		CreateDirectoryLinkOrIgnore(Path.Combine(_workspaceRoot, ".nuget", PackageName), victimFolder);
+
+		//Act
+		int actual = _sut.Materialize(PackageName);
+
+		//Assert
+		actual.Should().Be(1, because: "the helper project resolves outside the workspace");
+		File.Exists(sentinelPath).Should().BeTrue(
+			because: "the recursive bin delete must not run through the link");
+		_processExecutor.DidNotReceiveWithAnyArgs().ExecuteAndCaptureAsync(default);
+		_propsBuilder.DidNotReceive().Build(Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Refuses to write props or reconcile Libs when the package Files folder is a symbolic "
+		+ "link, so the folder clearing does not empty a directory outside the workspace (issue 1311)")]
+	public void PropsBuilder_Refuses_WhenPackageFilesFolderIsASymbolicLink(){
+		// Arrange
+		string packageFolder = Path.Combine(_workspaceRoot, "packages", PackageName);
+		Directory.CreateDirectory(packageFolder);
+		string victimFolder = Path.Combine(_outsideRoot, "victim");
+		string sentinelPath = CreateSentinel(Path.Combine(victimFolder, "Libs", "net472"));
+		CreateDirectoryLinkOrIgnore(Path.Combine(packageFolder, "Files"), victimFolder);
+
+		//Act
+		PropsBuildResult actual = _realPropsBuilder.Build(PackageName);
+
+		//Assert
+		actual.HasAnyProps.Should().BeFalse(
+			because: "no props file may be written through a link out of the workspace");
+		File.Exists(sentinelPath).Should().BeTrue(
+			because: "the Libs reconciliation must not reach a directory outside the workspace");
+	}
+
+}

--- a/clio.tests/Common/PropsBuilder.Tests.cs
+++ b/clio.tests/Common/PropsBuilder.Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using Clio.Common;
 using FluentAssertions;
 using Clio.Workspaces;
@@ -193,6 +194,68 @@ public class PropsBuilder_Tests
 		_fileSystem.Received(0).WriteAllTextToFile(
 			Arg.Any<string>(),
 			Arg.Is<string>(c => c.Contains($"Include=\"{PackageName}\"")));
+	}
+
+	[Test]
+	[Description("Removes from Files/Libs/<moniker> exactly the assemblies the previous props file "
+		+ "declared when a later run leaves that moniker without dependencies, so a stale dll stops "
+		+ "shipping in the Creatio package while a hand-placed dll is left alone (issue 1311)")]
+	public void Build_RemovesPreviouslyMaterializedAssemblies_When_MonikerLosesItsLastDependency(){
+		//Arrange
+		string workspaceRoot = Path.Combine(Path.GetTempPath(), "clio-1311-props");
+		MockFileSystem mockFileSystem = new();
+		IFileSystem realFileSystem = new FileSystem(mockFileSystem);
+		IWorkspacePathBuilder pathBuilder = BuildPathBuilderFor(workspaceRoot);
+		PropsBuilder sut = new(realFileSystem, _logger, pathBuilder);
+		string net472BinDir = Path.Combine(workspaceRoot, NugetFolderPath, PackageName, "bin", "net472");
+		string netStandardBinDir = Path.Combine(workspaceRoot, NugetFolderPath, PackageName, "bin", "netstandard");
+		string net472LibsDir = Path.Combine(workspaceRoot, PackageFolderPath, PackageName, "Files", "Libs", "net472");
+		string materializedDll = Path.Combine(net472LibsDir, "Castle.Core.dll");
+		string handPlacedDll = Path.Combine(net472LibsDir, "Contoso.HandPlaced.dll");
+		foreach (string moniker in new[] {"net472", "netstandard"}) {
+			mockFileSystem.AddFile(
+				Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "tpl", $"propItem-{moniker}.xml.tpl"),
+				new MockFileData(MockPropItemTemplate));
+		}
+		mockFileSystem.AddFile(
+			Path.Combine(workspaceRoot, PackageFolderPath, PackageName, PackageName + ".csproj"),
+			new MockFileData(MockCsProjWithNugetContent()));
+		mockFileSystem.AddFile(Path.Combine(net472BinDir, "Castle.Core.dll"), new MockFileData("dll"));
+		mockFileSystem.AddDirectory(netStandardBinDir);
+
+		//Act
+		sut.Build(PackageName);
+		bool materializedByFirstRun = mockFileSystem.File.Exists(materializedDll);
+		//A dll the developer put into Libs by hand and references through its own HintPath.
+		mockFileSystem.AddFile(handPlacedDll, new MockFileData("dll"));
+		//The dependency is dropped from the package, so the helper project builds nothing for net472.
+		mockFileSystem.File.Delete(Path.Combine(net472BinDir, "Castle.Core.dll"));
+		PropsBuildResult secondRun = sut.Build(PackageName);
+
+		//Assert
+		materializedByFirstRun.Should().BeTrue(
+			because: "the first run must copy the dependency into the package Libs folder");
+		secondRun.HasAnyProps.Should().BeFalse(
+			because: "neither moniker has a dependency left to reference");
+		mockFileSystem.File.Exists(materializedDll).Should().BeFalse(
+			because: "its import is gone, so the assembly must not stay in the deployed Creatio package");
+		mockFileSystem.File.Exists(handPlacedDll).Should().BeTrue(
+			because: "the folder also holds dlls this command never materialized");
+	}
+
+	//This one test needs real copy, clear and delete semantics, which a substituted IFileSystem
+	//cannot express, so it drives the production FileSystem over an in-memory one.
+	private static IWorkspacePathBuilder BuildPathBuilderFor(string workspaceRoot){
+		IWorkspacePathBuilder pathBuilder = Substitute.For<IWorkspacePathBuilder>();
+		pathBuilder.RootPath.Returns(workspaceRoot);
+		pathBuilder.NugetFolderPath.Returns(Path.Combine(workspaceRoot, NugetFolderPath));
+		pathBuilder.PackagesFolderPath.Returns(Path.Combine(workspaceRoot, PackageFolderPath));
+		pathBuilder.BuildPackageProjectPath(Arg.Is(PackageName))
+			.Returns(Path.Combine(workspaceRoot, PackageFolderPath, PackageName, PackageName + ".csproj"));
+		pathBuilder.BuildPackagePropsPath(Arg.Is(PackageName), Arg.Any<string>())
+			.Returns(ci => Path.Combine(workspaceRoot, PackageFolderPath, PackageName, "Files",
+				$"{PackageName}-{ci.ArgAt<string>(1)}.nuget.props"));
+		return pathBuilder;
 	}
 
 	private void MockCsProjAndTemplateReads(){

--- a/clio/Common/FileSystem.cs
+++ b/clio/Common/FileSystem.cs
@@ -244,6 +244,64 @@ public class FileSystem(Ms.IFileSystem msFileSystem) : IFileSystem {
 		throw new ArgumentOutOfRangeException(nameof(path), $"Path {path} does not exist");
 	}
 
+	public bool HasLinkWithin(string confinementRoot, string path) {
+		if (string.IsNullOrWhiteSpace(confinementRoot) || string.IsNullOrWhiteSpace(path)) {
+			return false;
+		}
+		string fullRoot = msFileSystem.Path.GetFullPath(confinementRoot);
+		string current = msFileSystem.Path.GetFullPath(path);
+		string rootPrefix = fullRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+			+ Path.DirectorySeparatorChar;
+		if (!PathsEqual(current, fullRoot)
+			&& !current.StartsWith(rootPrefix, StringComparison.OrdinalIgnoreCase)) {
+			//Not under this root, so this root does not confine it - the caller's lexical check owns
+			//that case. Walking up anyway would probe every ancestor up to the filesystem root.
+			return false;
+		}
+		while (true) {
+			if (IsLink(current)) {
+				return true;
+			}
+			if (PathsEqual(current, fullRoot)) {
+				return false;
+			}
+			string parent = msFileSystem.Path.GetDirectoryName(current);
+			if (string.IsNullOrEmpty(parent) || PathsEqual(parent, current)) {
+				//The walk left the root without meeting it, so nothing here proves the path is confined.
+				return true;
+			}
+			current = parent;
+		}
+	}
+
+	private static bool PathsEqual(string left, string right) =>
+		string.Equals(left.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+			right.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+			StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Tells whether the path itself is a link. A link whose target is gone still answers true:
+	/// a write through it creates the target outside the confined folder.
+	/// </summary>
+	private bool IsLink(string path) {
+		try {
+			Ms.IFileSystemInfo info = msFileSystem.Directory.Exists(path)
+				? msFileSystem.DirectoryInfo.New(path)
+				: msFileSystem.FileInfo.New(path);
+			if (info.LinkTarget is not null) {
+				return true;
+			}
+			//Attributes of a path that does not exist come back as (FileAttributes)(-1), which carries
+			//every bit including ReparsePoint, so existence has to be settled before they are read.
+			return info.Exists && (info.Attributes & FileAttributes.ReparsePoint) != 0;
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
+			or ArgumentException or NotSupportedException or NotImplementedException) {
+			//Nothing could be read about this segment, so nothing proves it is a real directory.
+			return true;
+		}
+	}
+
 	public void DeleteDirectory(string directoryPath) {
 		DeleteDirectory(directoryPath, false);
 	}

--- a/clio/Common/IFileSystem.cs
+++ b/clio/Common/IFileSystem.cs
@@ -64,6 +64,26 @@ namespace Clio.Common
 		IFileSystemInfo CreateFileSymLink(string path, string pathToTarget);
 
 		/// <summary>
+		/// Tells whether any segment from <paramref name="confinementRoot"/> down to
+		/// <paramref name="path"/> is a symbolic link, a junction, or any other reparse point.
+		/// </summary>
+		/// <param name="confinementRoot">Folder the path must stay inside. It is probed as well.</param>
+		/// <param name="path">Path about to be written, cleared or deleted. It need not exist yet.</param>
+		/// <returns>
+		/// True when a link stands anywhere on that ancestry, or when the walk cannot reach the root.
+		/// False when every segment is a real file or directory, and when the path is not under the root
+		/// at all - that case is not this root's to confine.
+		/// </returns>
+		/// <remarks>
+		/// A canonical string-prefix confinement check is lexical: it still follows a link that already
+		/// exists on disk, so a caller that has to keep writes and deletes inside a folder has to reject
+		/// the links themselves. Only the segments below the root are walked: a workspace legitimately
+		/// sits under a linked path - on macOS the temp directory is reached through /var -> /private/var -
+		/// and walking on to the filesystem root would refuse every such workspace.
+		/// </remarks>
+		bool HasLinkWithin(string confinementRoot, string path);
+
+		/// <summary>
 		/// Checks if a file exists at the given file path. If the file exists and the delete flag is set to true, the file is deleted.
 		/// If the file exists and the delete flag is set to false, an exception is thrown.
 		/// </summary>

--- a/clio/Common/NugetMaterializer.cs
+++ b/clio/Common/NugetMaterializer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using Clio.Project.NuGet;
 using Clio.Workspaces;
@@ -38,7 +39,8 @@ public class NugetMaterializer : INugetMaterializer
 	private const string NetStandardTargetFramework = "netstandard2.0";
 	private const string NugetHelperFolderName = ".nuget";
 
-	//The Import attribute that names the props file this csproj pulls in.
+	//The Import element and the attribute that names the props file this csproj pulls in.
+	private const string ImportTag = "Import";
 	private const string ProjectAttribute = "Project";
 
 	#endregion
@@ -176,6 +178,35 @@ public class NugetMaterializer : INugetMaterializer
 	private string BuildNugetProjectFolderPath(string packageName) =>
 		Path.Combine(_workspacePathBuilder.RootPath, NugetHelperFolderName, packageName);
 
+	private string BuildNugetHelperRootPath() =>
+		Path.Combine(_workspacePathBuilder.RootPath, NugetHelperFolderName);
+
+	/// <summary>
+	/// Reports whether the path stays inside the confinement root without passing through a link,
+	/// and names the offending segment when it does not.
+	/// </summary>
+	/// <remarks>
+	/// The canonical string-prefix check next to it is lexical, so it still follows a link that already
+	/// exists: a <c>packages/Good</c> or <c>.nuget/Good</c> symlink pointing somewhere else makes the
+	/// later template, csproj, backup and props writes - and the recursive bin/obj delete - land outside
+	/// the workspace.
+	/// </remarks>
+	private bool IsConfined(string confinementRoot, string path){
+		if (!_fileSystem.HasLinkWithin(confinementRoot, path)) {
+			return true;
+		}
+		_logger.WriteError($"The {path} path resolves through a symbolic link or a junction. "
+			+ "No package reference was converted");
+		return false;
+	}
+
+	//The csproj, its backup and the props files all live inside the package folder.
+	private bool IsPackagePathConfined(string path) =>
+		IsConfined(_workspacePathBuilder.PackagesFolderPath, path);
+
+	private bool IsHelperPathConfined(string path) =>
+		IsConfined(BuildNugetHelperRootPath(), path);
+
 	/// <summary>
 	/// Writes the helper project from the template and drops the output of the previous run.
 	/// </summary>
@@ -186,19 +217,33 @@ public class NugetMaterializer : INugetMaterializer
 	/// dependency removed from the real csproj kept its DLL and its import. Recreating the project
 	/// and clearing the output makes every run describe the references the csproj declares now.
 	/// </remarks>
-	private void CreateNugetProject(string packageName){
+	/// <returns>True when the helper project was written; false when its path is not confined.</returns>
+	private bool CreateNugetProject(string packageName){
 		string nugetProjectFolderPath = BuildNugetProjectFolderPath(packageName);
+		string nugetCsprojPath = Path.Combine(nugetProjectFolderPath, $"{packageName}.csproj");
+		if (!IsHelperPathConfined(nugetProjectFolderPath)) {
+			return false;
+		}
 		_fileSystem.CreateDirectoryIfNotExists(nugetProjectFolderPath);
 
 		string baseDir = AppDomain.CurrentDomain.BaseDirectory;
 		string templatePath = Path.Combine(baseDir, "tpl", "NugetProject.csproj.tpl");
 		string templateContent = _fileSystem.ReadAllText(templatePath);
-		string nugetCsprojPath = Path.Combine(nugetProjectFolderPath, $"{packageName}.csproj");
+		//The file, not only its folder: a link left in its place would carry the write to its target.
+		if (!IsHelperPathConfined(nugetCsprojPath)) {
+			return false;
+		}
 		_fileSystem.WriteAllTextToFile(nugetCsprojPath, templateContent);
 
 		foreach (string staleOutputFolder in StaleHelperOutputFolders) {
-			_fileSystem.DeleteDirectoryIfExists(Path.Combine(nugetProjectFolderPath, staleOutputFolder));
+			string staleOutputPath = Path.Combine(nugetProjectFolderPath, staleOutputFolder);
+			//Re-checked immediately before the recursive delete, the destructive step of this method.
+			if (!IsHelperPathConfined(staleOutputPath)) {
+				return false;
+			}
+			_fileSystem.DeleteDirectoryIfExists(staleOutputPath);
 		}
+		return true;
 	}
 
 	/// <summary>
@@ -251,7 +296,9 @@ public class NugetMaterializer : INugetMaterializer
 		return csProjContent;
 	}
 
-	private void UpdateCsProjFile(string packageName, IEnumerable<XElement> xElements, PropsBuildResult propsBuildResult){
+	/// <returns>True when the csproj is in its intended state; false when it could not be written.</returns>
+	private bool UpdateCsProjFile(string packageName, IEnumerable<XElement> xElements,
+		PropsBuildResult propsBuildResult){
 		bool needsBackUp = false;
 		
 		//Comment out only the PackageReference elements that were actually materialized.
@@ -275,11 +322,11 @@ public class NugetMaterializer : INugetMaterializer
 		needsBackUp |= AddPropsImport(packageName, NetStandardMoniker, propsBuildResult.NetStandardPropsCreated);
 
 		if (!needsBackUp) {
-			return;
+			return true;
 		}
 		
 		//A conversion snapshots the project as it is right now, replacing any earlier snapshot.
-		SaveCsProjFile(true);
+		return SaveCsProjFile(true);
 	}
 
 	/// <summary>
@@ -294,8 +341,15 @@ public class NugetMaterializer : INugetMaterializer
 	/// False for the stale-import repair: it must keep the pre-conversion copy it repairs after,
 	/// since copying the already-converted csproj over it destroys the only recovery copy.
 	/// </param>
-	private void SaveCsProjFile(bool refreshBackup){
+	/// <returns>True when the csproj was written; false when its path is not confined.</returns>
+	private bool SaveCsProjFile(bool refreshBackup){
 		string backupPath = $"{_csprojPath}.bak";
+		//Re-checked immediately before the write: this is the only step that overwrites the developer's
+		//own project file and its recovery copy. The backup is a leaf of its own - CopyFile follows a
+		//link left in its place and overwrites whatever it points at.
+		if (!IsPackagePathConfined(_csprojPath) || !IsPackagePathConfined(backupPath)) {
+			return false;
+		}
 		if (!refreshBackup && _fileSystem.ExistsFile(backupPath)) {
 			_logger.WriteInfo($"Keeping the existing csproj backup file {backupPath}");
 		} else {
@@ -303,6 +357,7 @@ public class NugetMaterializer : INugetMaterializer
 			_fileSystem.CopyFile(_csprojPath, backupPath, true);
 		}
 		_fileSystem.WriteAllTextToFile(_csprojPath, BuildCsProjText());
+		return true;
 	}
 
 	/// <summary>
@@ -329,31 +384,98 @@ public class NugetMaterializer : INugetMaterializer
 	/// A clio version before the empty-props fix could leave such an import behind, and MSBuild
 	/// then fails the whole project with "Root element is missing" on every build.
 	/// </summary>
+	/// <param name="packageName">Package whose csproj is repaired.</param>
 	private void RepairUnusablePropsImports(string packageName){
 		if (_csproj is null) {
 			//The csproj is empty or could not be parsed; there is nothing to repair here
 			return;
 		}
 		
-		bool repaired = false;
+		List<string> propsFileNames = [];
+		List<string> propsFilePaths = [];
 		foreach (string moniker in new[] {Net472Moniker, NetStandardMoniker}) {
-			string propsFileName = WorkspacePathBuilder.BuildPackagePropsFileName(packageName, moniker);
-			string propsFilePath = _workspacePathBuilder.BuildPackagePropsPath(packageName, moniker);
+			propsFileNames.Add(WorkspacePathBuilder.BuildPackagePropsFileName(packageName, moniker));
+			propsFilePaths.Add(_workspacePathBuilder.BuildPackagePropsPath(packageName, moniker));
+		}
+		//Everything this method can write or delete is confined up front: refusing halfway through
+		//would leave the csproj importing a props file this run has already deleted, which is the
+		//MSB4019 failure the method exists to prevent.
+		if (!IsPackagePathConfined(_csprojPath) || propsFilePaths.Any(p => !IsPackagePathConfined(p))) {
+			return;
+		}
+		
+		bool repaired = false;
+		for (int i = 0; i < propsFileNames.Count; i++) {
+			string propsFilePath = propsFilePaths[i];
 			bool propsFileUsable = _fileSystem.ExistsFile(propsFilePath)
 				&& !string.IsNullOrWhiteSpace(_fileSystem.ReadAllText(propsFilePath));
 			if (propsFileUsable) {
 				continue;
 			}
 			_fileSystem.DeleteFileIfExists(propsFilePath);
-			repaired |= RemovePropsImport(propsFileName);
+			repaired |= RemovePropsImport(propsFileNames[i]);
 		}
 		
 		if (!repaired) {
 			return;
 		}
+
+		//Only when no props import is left. With one moniker still importing usable props, restoring the
+		//references would put a PackageReference and the dll reference that replaced it in one project,
+		//and the build fails on the duplicate assembly. That this run removed a props import is also what
+		//identifies the comments as an earlier conversion's work rather than a developer's own edit.
+		bool anyPropsImportLeft = _csproj.Descendants(ImportTag)
+			.Any(e => propsFileNames.Contains(e.Attribute(ProjectAttribute)?.Value));
+		if (!anyPropsImportLeft) {
+			RestoreCommentedPackageReferences();
+		}
 		
 		//The repair runs after a conversion, so the pre-conversion snapshot must survive it.
-		SaveCsProjFile(false);
+		if (!SaveCsProjFile(false)) {
+			_logger.WriteError($"The {_csprojPath} file still imports props files that were removed, "
+				+ "so the project will not load. Restore it from its .bak copy");
+		}
+	}
+
+	/// <summary>
+	/// Turns the PackageReference comments a previous conversion wrote back into elements.
+	/// </summary>
+	/// <remarks>
+	/// A conversion replaces a materialized PackageReference with a comment holding the element text,
+	/// so a comment that parses as a PackageReference with an Include attribute is that work. A
+	/// reference a developer commented out by hand is indistinguishable from it, and restoring it is
+	/// accepted here: this runs only after a props import this tool wrote has just been removed and
+	/// none is left, so the alternative is a project that keeps building without its dependencies.
+	/// </remarks>
+	private void RestoreCommentedPackageReferences(){
+		List<XComment> comments = _csproj.DescendantNodes().OfType<XComment>().ToList();
+		foreach (XComment comment in comments) {
+			XElement packageReference = ParsePackageReferenceComment(comment.Value);
+			if (packageReference is null) {
+				continue;
+			}
+			comment.ReplaceWith(packageReference);
+			_logger.WriteInfo($"Restored the {packageReference.Attribute("Include")?.Value} package reference "
+				+ $"in the {_csprojPath} file, because the props file that replaced it is gone");
+		}
+	}
+
+	/// <summary>
+	/// Reads a comment back as a PackageReference element, or reports that it is an ordinary comment.
+	/// </summary>
+	private static XElement ParsePackageReferenceComment(string commentText){
+		if (string.IsNullOrWhiteSpace(commentText)) {
+			return null;
+		}
+		try {
+			XElement element = XElement.Parse(commentText.Trim());
+			return element.Name.LocalName == Tag && element.Attribute("Include") is not null
+				? element
+				: null;
+		} catch (XmlException) {
+			//Prose, not an element this tool wrote.
+			return null;
+		}
 	}
 
 	/// <summary>
@@ -361,7 +483,7 @@ public class NugetMaterializer : INugetMaterializer
 	/// </summary>
 	/// <returns>True when the csproj was modified.</returns>
 	private bool RemovePropsImport(string propsFileName){
-		List<XElement> staleImports = _csproj.Descendants("Import")
+		List<XElement> staleImports = _csproj.Descendants(ImportTag)
 			.Where(e => e.Attribute(ProjectAttribute)?.Value == propsFileName)
 			.ToList();
 		
@@ -394,7 +516,7 @@ public class NugetMaterializer : INugetMaterializer
 			return RemovePropsImport(propsFileName);
 		}
 		
-		bool importExists = _csproj.Descendants("Import")
+		bool importExists = _csproj.Descendants(ImportTag)
 			.Any(e => e.Attribute(ProjectAttribute)?.Value == propsFileName
 				&& e.Attribute("Condition")?.Value == condition);
 		
@@ -403,7 +525,7 @@ public class NugetMaterializer : INugetMaterializer
 			return false;
 		}
 		
-		XElement importElement = new("Import");
+		XElement importElement = new(ImportTag);
 		importElement.SetAttributeValue("Condition", condition);
 		importElement.SetAttributeValue(ProjectAttribute, propsFileName);
 		
@@ -430,8 +552,9 @@ public class NugetMaterializer : INugetMaterializer
 	/// The name arrives from the command line and reaches file reads, writes, builds and deletes -
 	/// the props files, the csproj and its .bak, and the helper project. A rooted name, or one
 	/// carrying a separator or a dot segment, resolves outside
-	/// <see cref="IWorkspacePathBuilder.PackagesFolderPath"/>, so the check runs before the first
-	/// filesystem call rather than inside each caller.
+	/// <see cref="IWorkspacePathBuilder.PackagesFolderPath"/>, so the check runs here rather than
+	/// inside each caller. The lexical checks run first and touch nothing; only a name that passes
+	/// them reaches the link probe, which is what the string comparison cannot see.
 	/// </remarks>
 	public bool IsPackageNameWithinPackagesFolder(string packageName){
 		if (string.IsNullOrWhiteSpace(packageName)) {
@@ -458,7 +581,7 @@ public class NugetMaterializer : INugetMaterializer
 				+ $"{packagesFolderPath} packages folder");
 			return false;
 		}
-		return true;
+		return IsConfined(packagesFolderPath, packagePath);
 	}
 
 	public int Materialize(string packageName){
@@ -475,7 +598,9 @@ public class NugetMaterializer : INugetMaterializer
 			return 1;
 		}
 
-		CreateNugetProject(packageName);
+		if (!CreateNugetProject(packageName)) {
+			return 1;
+		}
 		if (!AddNugetReferences(packageName, xElements) || !BuildNugetProject(packageName)) {
 			return 1;
 		}
@@ -488,8 +613,7 @@ public class NugetMaterializer : INugetMaterializer
 			RepairUnusablePropsImports(packageName);
 			return 1;
 		}
-		UpdateCsProjFile(packageName, xElements, propsBuildResult);
-		return 0;
+		return UpdateCsProjFile(packageName, xElements, propsBuildResult) ? 0 : 1;
 	}
 
 	#endregion

--- a/clio/Common/PropsBuilder.cs
+++ b/clio/Common/PropsBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Clio.Workspaces;
 
@@ -81,6 +82,10 @@ public interface IPropsBuilder
 	/// ┃ ┗ 📂netstandard                      <br/>
 	/// ┣ 📜PKG_NAME-net472.nuget.props        <br/>
 	/// ┣ 📜PKG_NAME-netstandard.nuget.props   <br/>
+	/// A moniker that has no dependency to reference gets no props file, and the assemblies the
+	/// previous props file declared are removed from its Files/Libs/&lt;moniker&gt; folder, so an
+	/// assembly materialized by an earlier run stops shipping in the package. Dlls placed there by
+	/// hand are left alone.
 	/// </remarks>
 	PropsBuildResult Build(string packageName);
 
@@ -151,12 +156,74 @@ public class PropsBuilder : IPropsBuilder
 		ItemType propsFileItem = moniker == Moniker.net472
 			? ItemType.Net472PropsFilePath
 			: ItemType.NetStdPropsFilePath;
+		ItemType libsFolderItem = moniker == Moniker.net472
+			? ItemType.Net472PackageLibsPath
+			: ItemType.NetStdPackageLibsPath;
+		string propsFilePath = GetPathTo(propsFileItem, packageName);
+		string libsFolderPath = GetPathTo(libsFolderItem, packageName);
+		//Both are written, cleared or deleted below. A canonical prefix check cannot see a link that
+		//already exists on the way to them, so the segments are probed before anything is touched.
+		if (!IsConfinedToPackagesFolder(propsFilePath) || !IsConfinedToPackagesFolder(libsFolderPath)) {
+			return false;
+		}
 		string binDir = GetPathTo(binDirItem, packageName);
 		IEnumerable<string> dlls = GetDependencyDlls(binDir, packageName);
 
 		string propsContent = Process(dlls, packageName, moniker, materializedAssemblies);
-		string propsFilePath = GetPathTo(propsFileItem, packageName);
+		if (string.IsNullOrWhiteSpace(propsContent)) {
+			RemovePreviouslyMaterializedAssemblies(propsFilePath, libsFolderPath);
+		}
 		return SavePropsFile(propsFilePath, propsContent, moniker);
+	}
+
+	/// <summary>
+	/// Reports whether the path stays inside the packages folder without passing through a link.
+	/// </summary>
+	private bool IsConfinedToPackagesFolder(string path){
+		if (!_fileSystem.HasLinkWithin(_workspacePathBuilder.PackagesFolderPath, path)) {
+			return true;
+		}
+		_logger.WriteError($"The {path} path resolves through a symbolic link or a junction, "
+			+ "so no props file was written for it");
+		return false;
+	}
+
+	/// <summary>
+	/// Deletes from the package Libs folder exactly the assemblies the previous run's props file
+	/// declared, and nothing else.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="Process"/> only clears Files/Libs/&lt;moniker&gt; when it materializes something
+	/// there, so a moniker that ends up with no dependency at all kept the previous run's dlls while
+	/// its import was removed, and the stale assembly still shipped in the deployed Creatio package.
+	/// The folder is not this tool's to empty - a developer also puts dlls there by hand and references
+	/// them by HintPath - so only the names the generated props file declares are removed. No props
+	/// file means nothing was ever materialized for this moniker, and nothing is touched.
+	/// </remarks>
+	private void RemovePreviouslyMaterializedAssemblies(string propsFilePath, string libsFolderPath){
+		if (!_fileSystem.ExistsFile(propsFilePath) || !_fileSystem.ExistsDirectory(libsFolderPath)) {
+			return;
+		}
+		XDocument previousProps;
+		try {
+			previousProps = XDocument.Parse(_fileSystem.ReadAllText(propsFilePath));
+		} catch (XmlException) {
+			_logger.WriteWarning($"Could not read {propsFilePath}, so no assembly was removed "
+				+ $"from {libsFolderPath}");
+			return;
+		}
+		IEnumerable<string> ownedAssemblies = previousProps
+			.Descendants(ReferenceTag)
+			.Select(reference => reference.Attribute(IncludeTag)?.Value)
+			.Where(assemblyName => !string.IsNullOrWhiteSpace(assemblyName))
+			.Distinct(StringComparer.OrdinalIgnoreCase);
+		foreach (string assemblyName in ownedAssemblies) {
+			string assemblyPath = Path.Combine(libsFolderPath, assemblyName + ".dll");
+			if (_fileSystem.DeleteFileIfExists(assemblyPath)) {
+				_logger.WriteLine($"Removed {assemblyPath}, because {assemblyName} is no longer "
+					+ "a dependency of this package");
+			}
+		}
 	}
 
 	/// <summary>

--- a/clio/docs/commands/switch-nuget-to-dll-reference.md
+++ b/clio/docs/commands/switch-nuget-to-dll-reference.md
@@ -49,7 +49,29 @@ and the command exits with code `1`.
 
 A package broken by a clio version older than this fix — an empty props file plus its `<Import>` —
 is repaired the next time the command runs against it: the unusable props file is deleted and its
-import removed, so the package builds again.
+import removed, so the package builds again. When the csproj declares no `PackageReference` at all,
+because an earlier conversion commented every one of them out, and the repair leaves no props import
+behind, those commented references are turned back into elements. Otherwise the project would build
+while silently losing the analyzers and build assets those packages carried. References are not
+restored while one props import survives, because a `PackageReference` and the dll reference that
+replaced it in the same project fail the build on a duplicate assembly.
+
+When a target framework ends up with no dependency to reference, the assemblies its previous props
+file declared are removed from `Files/Libs/<moniker>` as well. Its `<Import>` is removed, so a dll
+materialized by an earlier run would otherwise stay in the Creatio package and be deployed with it.
+Only the names the generated props file lists are removed: that folder also holds dlls put there by
+hand and referenced through their own `HintPath`, and those are left alone. A moniker for which no
+props file was ever generated has nothing removed.
+
+Every path the command writes to or deletes must be a real file or directory. A package folder, the
+`.nuget` helper folder, the helper csproj, the package csproj and its `.bak`, the props files and the
+package `Files/Libs` folder are each checked, and a symbolic link or junction anywhere between the
+workspace `packages` (or `.nuget`) folder and the target makes the command exit with code `1` without
+writing or deleting through it. The confinement check that keeps the command inside the workspace
+compares canonical path strings, which does not resolve links, so a link that already exists on disk
+would otherwise carry those writes — and the recursive `bin`/`obj` delete — outside the workspace.
+The `packages` and `.nuget` folders themselves are not checked: they are the workspace's own layout,
+and a `packages` folder that is a junction onto another drive is an ordinary setup.
 
 ## Examples
 

--- a/clio/help/en/switch-nuget-to-dll-reference.txt
+++ b/clio/help/en/switch-nuget-to-dll-reference.txt
@@ -23,7 +23,17 @@ NOTES
     When no props file could be created at all, the csproj is left unchanged and
     the command exits with code 1. A nuget package that contributes no assembly,
     such as an analyzer, keeps its PackageReference. An unusable props file left
-    by an older clio version, and its import, are removed on the next run.
+    by an older clio version, and its import, are removed on the next run; when
+    that repair leaves the csproj with no props import at all, the package
+    references an earlier conversion had commented out are restored, so the
+    project keeps its dependencies and build assets.
+    A target framework that ends up with no dependency also has the assemblies
+    its previous props file declared removed from Files/Libs/<moniker>, so a dll
+    materialized by an earlier run stops shipping in the Creatio package. A dll
+    placed in that folder by hand is left alone.
+    A package folder, or the .nuget helper folder of the package, that is a
+    symbolic link or a junction is refused: the command exits with code 1 without
+    writing or deleting anything through it.
 
 EXAMPLES
     clio switch-nuget-to-dll-reference MyPackage

--- a/docs/knowledge/Common/empty-props-file-breaks-msbuild-import.md
+++ b/docs/knowledge/Common/empty-props-file-breaks-msbuild-import.md
@@ -16,7 +16,9 @@ Root element is missing.
 ```
 
 So `PropsBuilder` must never write a props file with no content, and `NugetMaterializer` must never
-add the matching `<Import>` for a props file that was not written. `PropsBuilder.Build` returns
+add the matching `<Import>` for a props file that was not written. When a moniker produces no content,
+`PropsBuilder` also removes from `Files/Libs/<moniker>` exactly the assemblies the previous props file
+declared — that folder holds hand-placed dlls too, so it is never emptied wholesale on that path. `PropsBuilder.Build` returns
 `PropsBuildResult` for exactly this reason — the per-moniker flags are the only thing that tells the
 caller which imports are safe to add.
 
@@ -27,7 +29,9 @@ handled, `Process` returned an empty string and the file was written anyway.
 
 A package already broken this way is repaired on the next run: `RepairUnusablePropsImports` deletes
 the unusable props file and removes its import even when every `PackageReference` is already
-commented out and there is nothing left to materialize.
+commented out and there is nothing left to materialize. When that run leaves no props import at all,
+it also turns the `PackageReference` comments back into elements, because otherwise the project
+builds again while silently losing the analyzers and build assets those packages carried.
 
 **What breaks if you ignore it** — `switch-nuget-to-dll-reference` reports success, and the package
 it just converted no longer builds at all: every build of that csproj dies at project-load time,

--- a/docs/knowledge/Common/nuget2dll-confinement-walk-stops-at-workspace-root.md
+++ b/docs/knowledge/Common/nuget2dll-confinement-walk-stops-at-workspace-root.md
@@ -1,0 +1,27 @@
+---
+description: the nuget2dll path confinement walks reparse points only down to the workspace root, because DbHubPathSafety's walk to the filesystem root refuses every workspace under a linked path
+applies-to:
+  - clio/Common/NugetMaterializer.cs
+  - clio/Common/PropsBuilder.cs
+  - clio/Common/FileSystem.cs
+ticket: GH-1311
+date: 2026-09-12
+---
+
+**What is true** — `FileSystem.HasLinkWithin` walks from a leaf path up to the confinement root
+(`<workspace>/packages` or `<workspace>/.nuget`) and stops there. It deliberately does NOT walk on to
+the filesystem root, which is what the existing `DbHubPathSafety.RefuseUnsafeTarget`
+(`clio/Common/DbHub/DbHubTomlStore.cs`) does. The root itself is exempt: it is the developer's own
+workspace layout, and a `packages/` folder that is a junction onto another drive is an ordinary
+Windows setup that worked before.
+
+**Why it is this way** — a workspace legitimately sits under a linked path. On macOS the temp
+directory itself is reached through `/var` -> `/private/var`, and `Path.GetFullPath` does not
+resolve that, so an ancestry walk to `/` reports a reparse point for every workspace created under
+`Path.GetTempPath()`. Only the segments the workspace owns can be required to be real directories.
+
+**What breaks if you ignore it** — replacing this walk with `DbHubPathSafety.RefuseUnsafeTarget`
+makes `switch-nuget-to-dll-reference` refuse to run at all on macOS temp workspaces, and on any
+developer machine whose checkout lives under a symlinked home or volume path. The command exits 1
+with "path is a symbolic link or a junction" and converts nothing, with no way for the user to tell
+that the link it objects to is not theirs.


### PR DESCRIPTION
🔗 **Issue:** [#1311](https://github.com/Advance-Technologies-Foundation/clio/issues/1311)

Refs #1311 — items 2, 3 and 4. **Item 1 (per-target-framework package-asset ownership read from `project.assets.json`) is deliberately left out**: it reshapes `PropsBuildResult` and the `PropsBuilder.Process` reference loop that open PR #1496 (issue #1283) is already editing, so the two changes would conflict. It follows after #1496 merges, on top of the reshaped loop. This PR keeps its `PropsBuilder` edit out of that loop. Full reasoning in the [diagnosis comment](https://github.com/Advance-Technologies-Foundation/clio/issues/1311#issuecomment-5646729985).

## Summary

Three of the four design-level follow-ups raised in the review of #1281, for `switch-nuget-to-dll-reference` (`nuget2dll`).

## Root cause

**Item 2 — legacy repair loses the dependencies.** `Materialize` reaches `RepairUnusablePropsImports` when the csproj declares no `PackageReference` at all, because an earlier conversion commented every one of them out. The repair deletes the unusable props files and removes their `Import` elements, but nothing turns those comments back into elements. The project loads again and builds with its analyzers and build assets gone, and nothing says so.

**Item 3 — confinement is lexical.** `IsPackageNameWithinPackagesFolder` was `Path.GetFullPath` plus `StartsWith`, which does not resolve links, so an existing `packages/<name>` link passed it. `BuildNugetProjectFolderPath` had no confinement at all, and its output feeds a recursive `bin`/`obj` delete.

**Item 4 — stale `Files/Libs/<tfm>`.** `PropsBuilder.Process` returns at its zero-DLL check before it reaches the folder clearing, so a moniker that loses its last dependency keeps the previous run's DLL in the package while its `Import` is removed.

## Changes

- **`NugetMaterializer.RepairUnusablePropsImports`** restores the commented `PackageReference` elements, gated on: this run actually removed a props import, and no props import is left afterwards. That gate is also what identifies the comments as clio's own work rather than a developer's hand-commented reference — a package this tool never converted has no props import to remove. Restoring while one props import still stands would put a `PackageReference` and the dll reference that replaced it in one project and fail the build on a duplicate assembly; nothing is restored there, and that partial case is a stated limit, not code.
- **`IFileSystem.HasLinkWithin(confinementRoot, path)`** walks the segments between a confinement root and a path about to be written, cleared or deleted, and reports a reparse point anywhere on it. A link whose target no longer exists still answers true — a write through it creates the target outside the folder. Every mutated leaf now goes through it: the package folder, the `.nuget` helper folder and its csproj, `bin` and `obj` before the recursive delete, the package csproj **and its `.bak`**, the props files, and the package `Files/Libs/<moniker>` folder. `PropsBuilder` checks its own two leaves before it writes anything.
  - The walk stops at the confinement root and the root itself is exempt. Walking on to the filesystem root — what the existing `DbHubPathSafety.RefuseUnsafeTarget` does — would refuse every workspace that merely sits under a linked path (on macOS the temp directory is reached through `/var` → `/private/var`), and a `packages/` folder that is a junction onto another drive is an ordinary Windows layout that worked before. Recorded in `docs/knowledge/Common/nuget2dll-confinement-walk-stops-at-workspace-root.md`.
- **`PropsBuilder.BuildProps`** removes from `Files/Libs/<moniker>` exactly the assemblies the previous props file declared when the moniker produces no props content. The issue asked for ownership-based reconciliation and it is needed: the zero-DLL case is reached by an analyzer-only package, whose `Files/Libs/<moniker>` holds dlls the developer put there by hand and references through their own `HintPath`. A moniker that never had a props file has nothing removed.
- Docs and CLI help updated for all three behaviours.

## Validation

```
dotnet build clio/clio.csproj -c Debug -f net10.0            # succeeded, no new CLIO*/CS warnings in touched files
dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit&Module=Common"
dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit"
```

`Module=Common`: 20 failures, all pre-existing macOS-only (`DbHubTomlStore` `Upsert`/`Remove`/`ValidateForInstallation`, `NetFrameworkHttps` `Configure`, `IsRegisteredProfilePath`, `ExecuteAndCaptureAsync_ShouldClearInheritedEnvironment_WhenRequested`). The last one is not in the usual three-family set; `git diff origin/master --stat -- clio/Common/ProcessExecutor.cs clio.tests/Common/ProcessExecutorTests.cs` is empty and its output shows unexpanded `${VAR:-unset}`, i.e. a local shell-expansion difference.

Full `Category=Unit`: **28 failures on this branch, every one of them also failing on a clean `aef02b584` worktree** (29 there; the extra `Execute_ShouldClearCacheAndLogResult` is a flaky cache test). **No new failure.**

Seven new tests, all passing: two symlink-sentinel tests for the package and `.nuget` helper folders, one for a symlinked package `Files` folder driving the real `PropsBuilder`, a two-run `MockFileSystem` regression proving the stale assembly goes and a hand-placed dll stays, and three for the restore gate (restores, does not restore on a healthy re-run, does not restore while one props import survives). Symlink creation is wrapped so a platform that denies it reports `Assert.Ignore` rather than a false pass.

## Review tier

Full 3-lens fan-out (pre-PR comprehensive gate): code-quality, bug-detector, security reviewers over `git diff origin/master...HEAD`.

Fixed from that review: a Blocker (the first version deleted the whole `Files/Libs/<moniker>` folder, which destroys hand-placed dlls for an analyzer-only package — replaced by the ownership-based removal above); three Highs (`IsLink` answered false for a dangling link, the `.bak` leaf was never confined, `PropsBuilder` had no confinement at all); and Mediums — the confinement root is no longer refused, the repair confines everything up front instead of aborting mid-loop, a failed save is now reported, `IsLink` fails closed on an unreadable segment, the `restoreCommentedReferences` flag was dropped because `!anyPropsImportLeft` already covers it, and interface XML docs were corrected.

Left as advisory (Medium/Low): the moniker → `ItemType` mapping is repeated in `PropsBuilder` — deliberately not refactored, that is #1496 territory; the legacy-repair path does not reconcile `Files/Libs` because it never invokes `PropsBuilder`; a `TOCTOU` window remains between each re-check and its operation, which cannot be closed without handle-based operations and is outside the threat model (a link planted in the developer's own workspace, not an active race).

MCP reviewed, no update required — `grep -rn "nuget2dll\|switch-nuget\|NugetMaterializer" clio/Command/McpServer/ clio.mcp.e2e/` returns nothing; this command has no MCP tool, prompt or resource.

docs reviewed and updated: `clio/help/en/switch-nuget-to-dll-reference.txt`, `clio/docs/commands/switch-nuget-to-dll-reference.md`. `clio/Commands.md` and `clio/Wiki/WikiAnchors.txt` need no change — no verb, alias or option changed.

ClioRing compatibility reviewed, no Ring-consumed contract changed — `grep -rn "nuget2dll\|switch-nuget\|NugetMaterializer" clio-ring/` returns nothing, and no MCP tool surface, progress event or CLI verb reachable through `clio-run` was touched.

Knowledge base: `docs/knowledge/Common/nuget2dll-confinement-walk-stops-at-workspace-root.md` added; `docs/knowledge/Common/empty-props-file-breaks-msbuild-import.md` updated for the restore and the Libs reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
