### PR TITLE
Never replay a write when re-authentication recovers an expired session (#1313)

### DIFF
--- a/clio.tests/Command/McpServer/CredentialPassthroughClientIdentityTests.cs
+++ b/clio.tests/Command/McpServer/CredentialPassthroughClientIdentityTests.cs
@@ -214,7 +214,7 @@ public class CredentialPassthroughClientIdentityTests {
 		CreatioClient compatibilityClient = container.GetRequiredService<CreatioClient>();
 		IApplicationClient applicationClient = container.GetRequiredService<IApplicationClient>();
 		((ICreatioApplicationClient)applicationClient).ExportSessionCookies();
-		Lazy<CreatioClient> adapterClient = GetPrivateField<Lazy<CreatioClient>>(applicationClient, "_lazyClient");
+		Lazy<CreatioClient> adapterClient = GetAdapterLazyClient(applicationClient);
 		SetPrivateField(applicationClient, "_listenerStarted", true);
 
 		try {
@@ -240,7 +240,7 @@ public class CredentialPassthroughClientIdentityTests {
 		IServiceProvider container = BuildFormsContainer();
 		IApplicationClient applicationClient = container.GetRequiredService<IApplicationClient>();
 		((ICreatioApplicationClient)applicationClient).ExportSessionCookies();
-		CreatioClient adapterClient = GetPrivateField<Lazy<CreatioClient>>(applicationClient, "_lazyClient").Value;
+		CreatioClient adapterClient = GetAdapterLazyClient(applicationClient).Value;
 
 		// Act
 		((IDisposable)container).Dispose();
@@ -251,5 +251,12 @@ public class CredentialPassthroughClientIdentityTests {
 		// Assert
 		await act.Should().ThrowAsync<ObjectDisposedException>(
 			because: "the adapter must remain the sole owner and release a request-only forms transport at provider teardown");
+	}
+
+	// The adapter holds its Creatio client behind the ICreatioClientTransport seam (GitHub #1313), so
+	// the lazy client is one hop further in than it used to be.
+	private static Lazy<CreatioClient> GetAdapterLazyClient(IApplicationClient applicationClient) {
+		object transport = GetPrivateField<object>(applicationClient, "_transport");
+		return GetPrivateField<Lazy<CreatioClient>>(transport, "_lazyClient");
 	}
 }

--- a/clio.tests/Command/McpServer/EmailTemplateToolTests.cs
+++ b/clio.tests/Command/McpServer/EmailTemplateToolTests.cs
@@ -149,7 +149,7 @@ public sealed class EmailTemplateToolTests {
 				: Rows(),
 			_ => throw new InvalidOperationException($"Unexpected URL: {url}")
 		});
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
 			.Returns(_ => { rowExists = true; return string.Empty; });
 		EmailTemplateContentVariant absent = tool.Get(new EmailTemplateGetArgs {
 			EmailId = EmailId.ToString("D"), EnvironmentName = "dev"
@@ -170,7 +170,7 @@ public sealed class EmailTemplateToolTests {
 			tool.Get(new EmailTemplateGetArgs { EmailId = EmailId.ToString("D"), EnvironmentName = "dev" })
 				.Variants.Single(variant => variant.Format == "beefree").Checksum,
 			because: "the create receipt must describe the row Creatio stored, not the request values");
-		client.Received(1).ExecutePostRequest(
+		client.Received(1).ExecuteNonReplayablePostRequest(
 			Arg.Is<string>(url => url.EndsWith("odata/BfEmailTemplate", StringComparison.Ordinal)),
 			Arg.Is<string>(payload => payload.Contains("\"PageJson\":\"{new:true}\"")), 30_000);
 		client.DidNotReceive().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
@@ -201,7 +201,7 @@ public sealed class EmailTemplateToolTests {
 		response.Success.Should().BeFalse(because: "the supplied checksum does not describe current content");
 		response.Error.Should().Contain("changed after it was read",
 			because: "the caller needs an actionable optimistic-concurrency diagnostic");
-		client.DidNotReceive().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
+		client.DidNotReceive().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
 		client.DidNotReceive().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
 	}
 
@@ -237,7 +237,7 @@ public sealed class EmailTemplateToolTests {
 		client.Received(1).ExecutePatchRequest(
 			Arg.Is<string>(url => url.EndsWith($"odata/EmailTemplate({EmailId:D})", StringComparison.Ordinal)),
 			Arg.Is<string>(payload => payload == "{\"Subject\":\"After\"}"), 30_000);
-		client.DidNotReceive().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
+		client.DidNotReceive().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
 	}
 
 	[Test]
@@ -263,7 +263,7 @@ public sealed class EmailTemplateToolTests {
 				: Rows(),
 			_ => throw new InvalidOperationException($"Unexpected URL: {url}")
 		});
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
 			.Returns(_ => { rowExists = true; return string.Empty; });
 		EmailTemplateContentVariant absent = tool.Get(new EmailTemplateGetArgs {
 			EmailId = EmailId.ToString("D"), EnvironmentName = "dev", LanguageId = LanguageId.ToString("D")
@@ -280,7 +280,7 @@ public sealed class EmailTemplateToolTests {
 		// Assert
 		response.Success.Should().BeTrue(because: "the requested translation remained absent after the guarded read");
 		response.Created.Should().BeTrue(because: "EmailTemplateLang did not contain the requested language");
-		client.Received(1).ExecutePostRequest(
+		client.Received(1).ExecuteNonReplayablePostRequest(
 			Arg.Is<string>(url => url.EndsWith("odata/EmailTemplateLang", StringComparison.Ordinal)),
 			Arg.Is<string>(payload => payload.Contains($"\"LanguageId\":\"{LanguageId:D}\"")), 30_000);
 		client.DidNotReceive().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
@@ -364,7 +364,7 @@ public sealed class EmailTemplateToolTests {
 				: Rows(),
 			_ => throw new InvalidOperationException($"Unexpected URL: {url}")
 		});
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000)
 			.Returns(_ => { rowExists = true; return string.Empty; });
 		EmailTemplateContentVariant absent = tool.Get(new EmailTemplateGetArgs {
 			EmailId = EmailId.ToString("D"), EnvironmentName = "dev", LanguageId = LanguageId.ToString("D")
@@ -464,7 +464,7 @@ public sealed class EmailTemplateToolTests {
 		response.Success.Should().BeTrue(
 			because: "the resolved default row still matches the checksum the read returned");
 		response.Created.Should().BeFalse(because: "the default row already exists and must be edited in place");
-		client.DidNotReceiveWithAnyArgs().ExecutePostRequest(default, default, default);
+		client.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(default, default, default);
 		// because: posting here would leave the email with two default beefree rows
 		client.Received(1).ExecutePatchRequest(
 			Arg.Any<string>(),
@@ -509,7 +509,7 @@ public sealed class EmailTemplateToolTests {
 			because: "both tools document an empty language as the default variant, so the read must resolve it to the IsDefault row rather than to the literal empty language");
 		response.Success.Should().BeTrue(because: "the resolved default row still matches the checksum the read returned");
 		response.Created.Should().BeFalse(because: "the default row already exists and must be edited in place");
-		client.DidNotReceiveWithAnyArgs().ExecutePostRequest(default, default, default);
+		client.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(default, default, default);
 		// because: posting here would leave the email with two rows flagged IsDefault, and IsDefault decides which content the email sends
 	}
 
@@ -555,7 +555,7 @@ public sealed class EmailTemplateToolTests {
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		client.ExecuteGetRequest(Arg.Any<string>(), 30_000).Returns(call => response(call.Arg<string>()));
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000).Returns(string.Empty);
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000).Returns(string.Empty);
 		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000).Returns(string.Empty);
 		return (client, new EmailTemplateTool(new EmailTemplateContentService(resolver)));
 	}

--- a/clio.tests/Command/McpServer/ODataCreateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataCreateToolTests.cs
@@ -44,7 +44,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(
 				"{\"Id\":\"11111111-1111-1111-1111-111111111111\",\"Name\":\"Acme\"}",
 				"{\"Id\":\"22222222-2222-2222-2222-222222222222\",\"Name\":\"Globex\"}");
@@ -65,7 +65,7 @@ public sealed class ODataCreateToolTests {
 		response.Results[1].Index.Should().Be(1, because: "per-row results preserve input order");
 		response.Results[1].Id.Should().Be("22222222-2222-2222-2222-222222222222", because: "the second created record Id is reported");
 		urlBuilder.Received(1).Build("odata/Account");
-		client.Received(2).ExecutePostRequest("http://creatio/odata/Account", Arg.Any<string>(), 30_000, 1, 1);
+		client.Received(2).ExecuteNonReplayablePostRequest("http://creatio/odata/Account", Arg.Any<string>(), 30_000, 1, 1);
 	}
 
 	[Test]
@@ -79,7 +79,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://env/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":\"11111111-1111-1111-1111-111111111111\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -138,7 +138,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"Column Name is required\"}}");
 		ODataCreateTool tool = new(resolver);
 
@@ -164,7 +164,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/AddressType");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"An error has occurred.\",\"ExceptionMessage\":\"Object reference not set to an instance of an object.\",\"ExceptionType\":\"System.NullReferenceException\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -190,7 +190,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/0/odata/UsrCustomerStatus");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"No HTTP resource was found that matches the request URI '.../0/odata/UsrCustomerStatus'.\",\"MessageDetail\":\"No type was found that matches the controller named 'UsrCustomerStatus'.\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -219,7 +219,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"Authorization has been denied for this request.\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -246,7 +246,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/EmailMessageData");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#EmailMessageData/$entity\",\"Id\":\"22222222-2222-2222-2222-222222222222\",\"Message\":\"Hello there\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -272,7 +272,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/UsrIntegrationLog");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#UsrIntegrationLog/$entity\","
 				+ "\"Id\":\"33333333-3333-3333-3333-333333333333\",\"Success\":false,"
 				+ "\"errorInfo\":null}");
@@ -301,7 +301,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Code\":-1,\"Exception\":\"Access to the entity is denied.\","
 				+ "\"Id\":\"44444444-4444-4444-4444-444444444444\"}");
 		ODataCreateTool tool = new(resolver);
@@ -329,7 +329,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/UsrThing");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#UsrThing/$entity\",\"Id\":\"33333333-3333-3333-3333-333333333333\",\"Code\":200,\"Message\":\"Created\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -355,7 +355,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://secret-host:88/prod-app/0/odata/UsrCustomerStatus");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"No HTTP resource was found that matches the request URI 'http://secret-host:88/prod-app/0/odata/UsrCustomerStatus'.\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -380,7 +380,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"\",\"MessageDetail\":\"\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -408,7 +408,7 @@ public sealed class ODataCreateToolTests {
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		// A ModelState validation body carries a member beyond Message/MessageDetail, so TryDetect does
 		// not recognize it; with no Id it falls through to the id-missing fallback branch.
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"The request is invalid.\",\"ModelState\":{\"row\":[\"failed calling http://secret-host:88/prod-app/0/odata/Account\"]}}");
 		ODataCreateTool tool = new(resolver);
 
@@ -433,7 +433,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/NumberKeyed");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":42,\"Name\":\"Office\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -459,7 +459,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/AddressType");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Name\":\"Office\"}");
 		ODataCreateTool tool = new(resolver);
 
@@ -484,7 +484,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(
 				"{\"error\":{\"code\":\"\",\"message\":\"bad row\"}}",
 				"{\"Id\":\"22222222-2222-2222-2222-222222222222\"}");
@@ -499,7 +499,7 @@ public sealed class ODataCreateToolTests {
 		response.Created.Should().Be(1, because: "the second row inserts even though the first failed");
 		response.Failed.Should().Be(1, because: "the first row failed");
 		response.Results.Should().HaveCount(2, because: "continue-on-error attempts every row");
-		client.Received(2).ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000, 1, 1);
+		client.Received(2).ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000, 1, 1);
 	}
 
 	[Test]
@@ -513,7 +513,7 @@ public sealed class ODataCreateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"bad row\"}}");
 		ODataCreateTool tool = new(resolver);
 
@@ -526,7 +526,7 @@ public sealed class ODataCreateToolTests {
 		// Assert
 		response.Failed.Should().Be(1, because: "the first row failed and aborted the batch");
 		response.Results.Should().HaveCount(1, because: "stop-on-error aborts before the second row");
-		client.Received(1).ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000, 1, 1);
+		client.Received(1).ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), 30_000, 1, 1);
 	}
 
 	#region record-created side-effect state
@@ -568,7 +568,7 @@ public sealed class ODataCreateToolTests {
 	public void Create_Should_Report_RecordCreated_True_On_Success() {
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":\"11111111-1111-1111-1111-111111111111\"}");
 		ODataCreateTool tool = BuildTool(client);
 
@@ -589,7 +589,7 @@ public sealed class ODataCreateToolTests {
 	public void Create_Should_Report_RecordCreated_Unknown_On_Server_Error() {
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"An error has occurred.\"}}");
 		ODataCreateTool tool = BuildTool(client);
 
@@ -624,7 +624,7 @@ public sealed class ODataCreateToolTests {
 		response.Results[0].RecordCreated.Should().BeFalse(
 			because: "the row never reached the server, so not-inserted is verified");
 		response.Unverified.Should().Be(0, because: "a locally rejected row is not an unknown outcome");
-		client.DidNotReceive().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+		client.DidNotReceive().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
 			Arg.Any<int>(), Arg.Any<int>());
 	}
 
@@ -634,7 +634,7 @@ public sealed class ODataCreateToolTests {
 	public void Create_Should_Report_RecordCreated_Unknown_On_Non_Json_Response() {
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("<html><head><title>404 - File or directory not found.</title></head></html>");
 		ODataCreateTool tool = BuildTool(client);
 
@@ -663,7 +663,7 @@ public sealed class ODataCreateToolTests {
 	public void Create_Should_Report_RecordCreated_Unknown_On_Transport_Failure() {
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(_ => throw new HttpRequestException("connection reset"));
 		ODataCreateTool tool = BuildTool(client);
 
@@ -714,7 +714,7 @@ public sealed class ODataCreateToolTests {
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(metadataBody);
-		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		client.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":\"11111111-1111-1111-1111-111111111111\"}");
 		return (new ODataCreateTool(resolver), client);
 	}
@@ -740,7 +740,7 @@ public sealed class ODataCreateToolTests {
 		response.Results[0].Error.Should().Contain("DueDate",
 			because: "the caller can only fix the row when the refusal names the offending field");
 		client.DidNotReceiveWithAnyArgs()
-			.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+			.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
 	[Test]
@@ -760,7 +760,7 @@ public sealed class ODataCreateToolTests {
 		// Assert
 		response.Created.Should().Be(1,
 			because: "Name is Edm.String, so a date-shaped text value is a legitimate insert");
-		client.Received(1).ExecutePostRequest(
+		client.Received(1).ExecuteNonReplayablePostRequest(
 			"http://creatio/odata/Account", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
@@ -784,7 +784,7 @@ public sealed class ODataCreateToolTests {
 				+ "turn a valid row into a failure");
 		response.Results[1].Success.Should().BeFalse(
 			because: "without a declared type the shape alone decides, and fail-closed is the honest answer");
-		client.Received(1).ExecutePostRequest(
+		client.Received(1).ExecuteNonReplayablePostRequest(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
@@ -804,7 +804,7 @@ public sealed class ODataCreateToolTests {
 
 		// Assert
 		client.DidNotReceiveWithAnyArgs().ExecuteGetRequest(null, 0, 0, 0);
-		client.Received(3).ExecutePostRequest(
+		client.Received(3).ExecuteNonReplayablePostRequest(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
@@ -849,7 +849,7 @@ public sealed class ODataCreateToolTests {
 				+ "so a throwing metadata endpoint must not turn a valid row into a failure");
 		response.Results[1].Success.Should().BeFalse(
 			because: "with no declared type the literal's shape alone decides, and fail-closed is the honest answer");
-		client.Received(1).ExecutePostRequest(
+		client.Received(1).ExecuteNonReplayablePostRequest(
 			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 

--- a/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterLoginDiagnosticsTests.cs
@@ -42,7 +42,7 @@ internal class CreatioClientAdapterLoginDiagnosticsTests {
 
 	private static IReauthExecutor CreatePassthroughExecutor() {
 		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
-		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
 			.Returns(ci => ci.Arg<Func<string>>()());
 		return executor;
 	}

--- a/clio.tests/Common/CreatioClientAdapterReauthTests.cs
+++ b/clio.tests/Common/CreatioClientAdapterReauthTests.cs
@@ -53,7 +53,7 @@ internal class CreatioClientAdapterReauthTests {
 		string canned) {
 		CapturedExecute captured = new();
 		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
-		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
 			.Returns(ci => {
 				captured.Call = ci.Arg<Func<string>>();
 				captured.Predicate = ci.Arg<Func<string, bool>>();
@@ -161,7 +161,7 @@ internal class CreatioClientAdapterReauthTests {
 	public void ExecutePostRequestGeneric_ShouldDeserializeExecutorResult_WhenExecutorReturnsValidJson() {
 		// Arrange — simulate a successful retry: executor handled the reauth and returned JSON.
 		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
-		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
 			.Returns("{\"success\":true}");
 		CreatioClientAdapter adapter = CreateAdapter(executor);
 
@@ -183,7 +183,7 @@ internal class CreatioClientAdapterReauthTests {
 		// opaque JsonException ("Invalid response format") that triggered ENG-90393 in the
 		// first place.
 		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
-		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
 			.Returns(LoginPageBody);
 		CreatioClientAdapter adapter = CreateAdapter(executor);
 
@@ -348,8 +348,8 @@ internal class CreatioClientAdapterReauthTests {
 		// hard-codes the wrapped callback so we exercise the full Execute -> isUnauthorized
 		// -> Login -> retry path without touching the NuGet CreatioClient.
 		IReauthExecutor passthrough = Substitute.For<IReauthExecutor>();
-		passthrough.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>())
-			.Returns(ci => real.Execute(ServerCall, ci.Arg<Func<string, bool>>()));
+		passthrough.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
+			.Returns(ci => real.Execute(ServerCall, ci.Arg<Func<string, bool>>(), ci.ArgAt<bool>(2)));
 		CreatioClientAdapter adapter = CreateAdapter(passthrough);
 
 		// Act
@@ -360,6 +360,113 @@ internal class CreatioClientAdapterReauthTests {
 			because: "after a single reauth + retry the adapter must surface the final JSON payload");
 		loginCalls.Should().Be(1,
 			because: "ReauthExecutor must perform exactly one Login when the first response is the login page");
+	}
+
+	#endregion
+
+	#region Tests: Transport delegation and the no-replay rule for writes
+
+	// The transport seam (ICreatioClientTransport) is what makes these assertions possible at all:
+	// before it, the fixture had to resolve its Lazy<CreatioClient> to null, so the callback handed to
+	// the reauth executor could never be invoked and the delegation itself went unverified.
+	private static ICreatioClientTransport CreateTransport(string response) {
+		ICreatioClientTransport transport = Substitute.For<ICreatioClientTransport>();
+		transport.ExecutePutRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
+			Arg.Any<int>()).Returns(response);
+		transport.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
+			Arg.Any<int>()).Returns(response);
+		transport.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(response);
+		return transport;
+	}
+
+	[Test]
+	[Description("The callback ExecutePutRequest hands to the reauth executor issues exactly the PUT it was asked for, with every argument preserved")]
+	public void ExecutePutRequest_ShouldDelegateToTransportPutWithAllArguments_WhenCapturedCallbackIsInvoked() {
+		// Arrange
+		ICreatioClientTransport transport = CreateTransport("{\"put\":true}");
+		CapturedExecute captured = new();
+		IReauthExecutor executor = Substitute.For<IReauthExecutor>();
+		executor.Execute(Arg.Any<Func<string>>(), Arg.Any<Func<string, bool>>(), Arg.Any<bool>())
+			.Returns(ci => {
+				captured.Call = ci.Arg<Func<string>>();
+				return "{}";
+			});
+		CreatioClientAdapter adapter = new(transport, executor);
+
+		// Act
+		adapter.ExecutePutRequest("/x", "body", 7_000, 3, 5);
+		string captureResult = captured.Call();
+
+		// Assert
+		captureResult.Should().Be("{\"put\":true}",
+			because: "the captured callback must return what the transport produced, proving it is the PUT and not another verb");
+		transport.Received(1).ExecutePutRequest("/x", "body", 7_000, 3, 5);
+		// because: url, body, timeout, attempts and delay must all survive the hop into the callback -
+		// a dropped or reordered argument used to be invisible, since the callback was never invoked
+		transport.DidNotReceive().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+			Arg.Any<int>(), Arg.Any<int>());
+		transport.DidNotReceive().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+			Arg.Any<int>(), Arg.Any<int>());
+		transport.DidNotReceive().ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(),
+			Arg.Any<int>(), Arg.Any<int>());
+		transport.DidNotReceive().ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
+			Arg.Any<int>());
+		// because: every other verb is excluded explicitly - "it returned the PUT sentinel" alone would
+		// still pass if the adapter had also issued a second request through another verb
+	}
+
+	[Test]
+	[Description("An expired-session response to a PUT re-authenticates but issues the PUT exactly once")]
+	public void ExecutePutRequest_ShouldIssueExactlyOneUnderlyingCall_WhenSessionExpiredResponseIsReturned() {
+		// Arrange - the transport always answers with the login page, so a replay would be visible.
+		ICreatioClientTransport transport = CreateTransport(LoginPageBody);
+		CreatioClientAdapter adapter = new(transport, reauthExecutor: null);
+
+		// Act
+		string result = adapter.ExecutePutRequest("/x", "body");
+
+		// Assert
+		transport.Received(1).ExecutePutRequest("/x", "body", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		transport.Received(1).Login();
+		// because: exactly one underlying PUT is the whole point - a replay here commits the write a
+		// second time; the single Login proves the session was still refreshed for the next call
+		result.Should().Be(LoginPageBody,
+			because: "the unreplayed original response must reach the caller so it can report the expired session");
+	}
+
+	[Test]
+	[Description("An expired-session response to a declared-write POST re-authenticates but issues the POST exactly once")]
+	public void ExecuteNonReplayablePostRequest_ShouldIssueExactlyOneUnderlyingCall_WhenSessionExpiredResponseIsReturned() {
+		// Arrange
+		ICreatioClientTransport transport = CreateTransport(LoginPageBody);
+		CreatioClientAdapter adapter = new(transport, reauthExecutor: null);
+
+		// Act
+		adapter.ExecuteNonReplayablePostRequest("/x", "body");
+
+		// Assert
+		transport.Received(1).ExecutePostRequest("/x", "body", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		transport.Received(1).Login();
+		// because: a POST the caller declared a write must behave exactly like PUT, even though the
+		// plain POST below still replays
+	}
+
+	[Test]
+	[Description("A GET still replays after re-authentication - the no-replay rule must not disable session recovery for reads")]
+	public void ExecuteGetRequest_ShouldReplayAfterReauth_WhenSessionExpiredResponseIsReturned() {
+		// Arrange
+		ICreatioClientTransport transport = CreateTransport(LoginPageBody);
+		CreatioClientAdapter adapter = new(transport, reauthExecutor: null);
+
+		// Act
+		adapter.ExecuteGetRequest("/x");
+
+		// Assert
+		transport.Received(2).ExecuteGetRequest("/x", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		transport.Received(1).Login();
+		// because: the read path must still recover from an expired session - two GETs around one Login
+		// is the ENG-90393 behaviour this change must not remove
 	}
 
 	#endregion

--- a/clio.tests/Common/LegacyApplicationClientCompatibilityTests.cs
+++ b/clio.tests/Common/LegacyApplicationClientCompatibilityTests.cs
@@ -49,8 +49,31 @@ public class LegacyApplicationClientCompatibilityTests {
 			.WithMessage($"*{nameof(LegacyApplicationClient)}*");
 	}
 
+	[Test]
+	[Description("A client written before the non-replayable POST existed still answers it, by forwarding to its own POST with every argument preserved")]
+	public void LegacyImplementer_ShouldForwardNonReplayablePostToItsOwnPost_WhenCalled() {
+		// Arrange
+		LegacyApplicationClient legacy = new();
+		IApplicationClient client = legacy;
+
+		// Act
+		string result = client.ExecuteNonReplayablePostRequest("/x", "body", 7_000, 3, 5);
+
+		// Assert
+		result.Should().Be(LegacyApplicationClient.PostResult,
+			because: "the defaulted member must reach the implementer's own POST, not return a silent null");
+		legacy.LastPost.Should().Be(("/x", "body", 7_000, 3, 5),
+			because: "an implementer with no replay behaviour of its own is already correct with the default body, "
+				+ "but only if every argument survives the forward");
+	}
+
 	/// <summary>An IApplicationClient frozen at the shape it had before PUT was added.</summary>
 	private sealed class LegacyApplicationClient : IApplicationClient {
+
+		internal const string PostResult = "legacy-post";
+
+		/// <summary>Arguments the last POST arrived with, so the forwarding test can compare them.</summary>
+		internal (string Url, string Body, int Timeout, int MaxAttempts, int DelaySec) LastPost { get; private set; }
 
 		public event EventHandler<WebSocketState> ConnectionStateChanged;
 
@@ -68,7 +91,10 @@ public class LegacyApplicationClientCompatibilityTests {
 			int maxAttempts = 1, int delaySec = 1) => string.Empty;
 
 		public string ExecutePostRequest(string url, string requestData,
-			int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1) => string.Empty;
+			int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1) {
+			LastPost = (url, requestData, requestTimeout, maxAttempts, delaySec);
+			return PostResult;
+		}
 
 		public T ExecutePostRequest<T>(string url, string requestData,
 			int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1)

--- a/clio.tests/Common/NoReauthExecutorTests.cs
+++ b/clio.tests/Common/NoReauthExecutorTests.cs
@@ -16,7 +16,7 @@ internal sealed class NoReauthExecutorTests {
 		NoReauthExecutor sut = new();
 
 		// Act
-		string result = sut.Execute(() => "payload", _ => true);
+		string result = sut.Execute(() => "payload", _ => true, replayAllowed: true);
 
 		// Assert
 		result.Should().Be("payload",
@@ -34,7 +34,7 @@ internal sealed class NoReauthExecutorTests {
 		sut.Execute(() => {
 			callCount++;
 			return "payload";
-		}, _ => true);
+		}, _ => true, replayAllowed: true);
 
 		// Assert
 		callCount.Should().Be(1,
@@ -52,7 +52,7 @@ internal sealed class NoReauthExecutorTests {
 		string result = sut.Execute(() => "login-page", _ => {
 			predicateInvocations++;
 			return true;
-		});
+		}, replayAllowed: true);
 
 		// Assert
 		predicateInvocations.Should().Be(0,

--- a/clio.tests/Common/ReauthExecutorTests.cs
+++ b/clio.tests/Common/ReauthExecutorTests.cs
@@ -54,7 +54,7 @@ internal class ReauthExecutorTests {
 		string result = sut.Execute(() => {
 			callCount++;
 			return "{\"success\":true}";
-		}, ReauthExecutor.IsSessionExpiredResponse);
+		}, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		result.Should().Be("{\"success\":true}",
@@ -75,7 +75,7 @@ internal class ReauthExecutorTests {
 		string[] responses = { LoginPageBody, "{\"ok\":true}" };
 
 		// Act
-		string result = sut.Execute(() => responses[callCount++], ReauthExecutor.IsSessionExpiredResponse);
+		string result = sut.Execute(() => responses[callCount++], ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		result.Should().Be("{\"ok\":true}",
@@ -93,7 +93,7 @@ internal class ReauthExecutorTests {
 		ReauthExecutor sut = CreateExecutor(() => throw new InvalidOperationException("login failed"));
 
 		// Act
-		Action act = () => sut.Execute(() => LoginPageBody, ReauthExecutor.IsSessionExpiredResponse);
+		Action act = () => sut.Execute(() => LoginPageBody, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
@@ -110,7 +110,7 @@ internal class ReauthExecutorTests {
 
 		// Act — Execute observes the HTML kick-out, enters the reauth path, and the
 		// throwing Login propagates out without the bump statement executing.
-		Action act = () => sut.Execute(() => LoginPageBody, ReauthExecutor.IsSessionExpiredResponse);
+		Action act = () => sut.Execute(() => LoginPageBody, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>(
@@ -131,7 +131,7 @@ internal class ReauthExecutorTests {
 		string[] responses = { LoginPageBody, "{}" };
 
 		// Act
-		sut.Execute(() => responses[callCount++], ReauthExecutor.IsSessionExpiredResponse);
+		sut.Execute(() => responses[callCount++], ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		sut.LoginVersion.Should().Be(versionBefore + 1,
@@ -161,11 +161,11 @@ internal class ReauthExecutorTests {
 		string Call() => Volatile.Read(ref serverAuthenticated) ? "{}" : LoginPageBody;
 
 		// Act
-		Task<string> a = Task.Run(() => sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse));
+		Task<string> a = Task.Run(() => sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true));
 		aEnteredLogin.Wait(TimeSpan.FromSeconds(2));
 		// A is now parked inside Login() while holding the reauth lock with versionAtStart
 		// still equal to the executor's current version.
-		Task<string> b = Task.Run(() => sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse));
+		Task<string> b = Task.Run(() => sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true));
 		// Flip the simulated server state to authenticated BEFORE releasing A, so that the
 		// retry call() returns JSON regardless of which thread reaches it first.
 		Volatile.Write(ref serverAuthenticated, true);
@@ -205,9 +205,9 @@ internal class ReauthExecutorTests {
 		}
 
 		// Act — three successive Execute calls, each starting with an invalidated session.
-		string r1 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse);
-		string r2 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse);
-		string r3 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse);
+		string r1 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
+		string r2 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
+		string r3 = sut.Execute(Call, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		r1.Should().Be("{\"ok\":true}",
@@ -232,7 +232,7 @@ internal class ReauthExecutorTests {
 		string result = sut.Execute(() => {
 			callCount++;
 			return LoginPageBody;
-		}, ReauthExecutor.IsSessionExpiredResponse);
+		}, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: true);
 
 		// Assert
 		result.Should().Be(LoginPageBody,
@@ -244,13 +244,59 @@ internal class ReauthExecutorTests {
 	}
 
 	[Test]
+	[Description("Execute re-authenticates but does NOT re-issue the call when replay is not allowed, and returns the original unauthorized response")]
+	public void Execute_ShouldReauthWithoutReplaying_WhenReplayIsNotAllowed() {
+		// Arrange
+		int loginCallCount = 0;
+		int callCount = 0;
+		ReauthExecutor sut = CreateExecutor(() => loginCallCount++);
+
+		// Act
+		string result = sut.Execute(() => {
+			callCount++;
+			return LoginPageBody;
+		}, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: false);
+
+		// Assert
+		callCount.Should().Be(1,
+			because: "a write must be issued exactly once - the body-based predicate cannot prove the write did not commit, so a replay could commit it twice");
+		loginCallCount.Should().Be(1,
+			because: "the session is still refreshed so the caller's next request succeeds; only the replay is withheld");
+		result.Should().Be(LoginPageBody,
+			because: "without a replay there is no second response, so the original one must reach the caller for classification");
+	}
+
+	[Test]
+	[Description("Execute rethrows the JsonException without re-issuing the call when replay is not allowed")]
+	public void Execute_ShouldRethrowWithoutReplaying_WhenCallThrowsJsonExceptionAndReplayIsNotAllowed() {
+		// Arrange
+		int loginCallCount = 0;
+		int callCount = 0;
+		ReauthExecutor sut = CreateExecutor(() => loginCallCount++);
+
+		// Act
+		Action act = () => sut.Execute<string>(() => {
+			callCount++;
+			throw new JsonReaderException("'<' is an invalid start of a value.");
+		}, ReauthExecutor.IsSessionExpiredResponse, replayAllowed: false);
+
+		// Assert
+		act.Should().Throw<JsonReaderException>(
+			because: "the caller must see the failure rather than have a possibly-committed write repeated");
+		callCount.Should().Be(1,
+			because: "the non-replayable call must run exactly once even on the exception path");
+		loginCallCount.Should().Be(1,
+			because: "re-authentication still runs so the next request works; only the replay is withheld");
+	}
+
+	[Test]
 	[Description("Execute throws ArgumentNullException when the call delegate is null")]
 	public void Execute_ShouldThrowArgumentNullException_WhenCallIsNull() {
 		// Arrange
 		ReauthExecutor sut = CreateExecutor(() => { });
 
 		// Act
-		Action act = () => sut.Execute<string>(null, _ => false);
+		Action act = () => sut.Execute<string>(null, _ => false, replayAllowed: true);
 
 		// Assert
 		act.Should().Throw<ArgumentNullException>(
@@ -264,7 +310,7 @@ internal class ReauthExecutorTests {
 		ReauthExecutor sut = CreateExecutor(() => { });
 
 		// Act
-		Action act = () => sut.Execute(() => "x", null);
+		Action act = () => sut.Execute(() => "x", null, replayAllowed: true);
 
 		// Assert
 		act.Should().Throw<ArgumentNullException>(
@@ -286,7 +332,7 @@ internal class ReauthExecutorTests {
 				throw new JsonReaderException("'<' is an invalid start of a value.");
 			}
 			return "ok";
-		}, _ => false);
+		}, _ => false, replayAllowed: true);
 
 		// Assert
 		result.Should().Be("ok", because: "after reauth the retry must return the successful response");
@@ -302,7 +348,7 @@ internal class ReauthExecutorTests {
 		// Act — both calls throw JsonException
 		Action act = () => sut.Execute<string>(
 			() => throw new JsonReaderException("'<' is an invalid start of a value."),
-			_ => false);
+			_ => false, replayAllowed: true);
 
 		// Assert
 		act.Should().Throw<JsonReaderException>(

--- a/clio.tests/Query/CallServiceCommandDeleteTests.cs
+++ b/clio.tests/Query/CallServiceCommandDeleteTests.cs
@@ -41,7 +41,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		// Assert
 		switch (method) {
 			case "post":
-				applicationClient.Received(1).ExecutePostRequest("http://host/svc", "{\"id\":1}", 12_345, 1,
+				applicationClient.Received(1).ExecuteNonReplayablePostRequest("http://host/svc", "{\"id\":1}", 12_345, 1,
 					Arg.Any<int>());
 				break;
 			case "delete":
@@ -109,7 +109,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		command.Execute(options);
 
 		// Assert
-		applicationClient.Received(1).ExecutePostRequest("http://host/svc", "{}", 12_345, 1, Arg.Any<int>());
+		applicationClient.Received(1).ExecuteNonReplayablePostRequest("http://host/svc", "{}", 12_345, 1, Arg.Any<int>());
 		// because: MaxAttempts carries no [Option] and its setter is internal, so a raised count can only
 		// come from plumbing - never from a caller who vouched for the endpoint being replayable
 	}
@@ -140,7 +140,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 			.ExecuteDeleteRequest("http://host/svc", "{\"id\":1}", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		applicationClient
 			.DidNotReceive()
-			.ExecutePostRequest("http://host/svc", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+			.ExecuteNonReplayablePostRequest("http://host/svc", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 	}
 
 	[Test]
@@ -165,7 +165,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		// Assert
 		applicationClient
 			.Received(1)
-			.ExecutePostRequest("http://host/svc", "{}", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+			.ExecuteNonReplayablePostRequest("http://host/svc", "{}", Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		applicationClient
 			.DidNotReceive()
 			.ExecuteDeleteRequest("http://host/svc", Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
@@ -198,7 +198,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		applicationClient
 			.Received(1)
 			.ExecutePatchRequest("http://host/svc", "{\"id\":1}", 12_345, 1, 3);
-		applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(),
+		applicationClient.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		applicationClient.DidNotReceiveWithAnyArgs().ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
@@ -231,7 +231,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		applicationClient
 			.Received(1)
 			.ExecutePutRequest("http://host/svc", "{\"id\":1}", 54_321, 1, 2);
-		applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(),
+		applicationClient.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		applicationClient.DidNotReceiveWithAnyArgs().ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
@@ -262,7 +262,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 			  .Throw<ArgumentException>("because only GET/POST/DELETE/PATCH/PUT are supported")
 			  .WithParameterName("httpMethod")
 			  .WithMessage("Unsupported HTTP method 'options'*");
-		applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(),
+		applicationClient.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		applicationClient.DidNotReceiveWithAnyArgs().ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
@@ -366,7 +366,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IFileSystem fileSystem = Substitute.For<IFileSystem>();
 		serviceUrlBuilder.Build("odata/BulkEmailCategory").Returns("http://host/0/odata/BulkEmailCategory");
-		applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(),
+		applicationClient.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(),
 				Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Code\":-1,\"Exception\":\"request failed\"}");
 
@@ -387,6 +387,45 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		result.Should().Be(1,
 			"the error classification must fire on the POST dispatch branch, not only on GET");
 		fileSystem.DidNotReceive().WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>());
+	}
+
+	[Test]
+	[Description("Reports an expired session as its own failure instead of a generic HTML page when a write was not replayed")]
+	public void Execute_ShouldReportExpiredSession_WhenWriteResponseIsTheLoginPage() {
+		// Arrange - the client re-authenticated but deliberately did not replay the write, so the
+		// original login-page body reaches the command (GitHub #1313).
+		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
+		EnvironmentSettings settings = new();
+		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IFileSystem fileSystem = Substitute.For<IFileSystem>();
+		ILogger logger = Substitute.For<ILogger>();
+		serviceUrlBuilder.Build("svc").Returns("http://host/svc");
+		applicationClient.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(),
+				Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns("<!DOCTYPE html><html><body><form action=\"/0/Login/NuiLogin.aspx\"></form></body></html>");
+
+		CallServiceCommand command = new(applicationClient, settings, serviceUrlBuilder, fileSystem) {
+			Logger = logger
+		};
+		CallServiceCommandOptions options = new() {
+			ServicePath = "svc",
+			HttpMethodName = "POST",
+			RequestBody = "{}",
+			ResultFileName = "result.json"
+		};
+
+		// Act
+		int result = command.Execute(options);
+
+		// Assert
+		result.Should().Be(1,
+			because: "an unreplayed write never reached the service, so the command must not report success");
+		fileSystem.DidNotReceive().WriteAllTextToFile(Arg.Any<string>(), Arg.Any<string>());
+		logger.Received(1).WriteError(Arg.Is<string>(m => m.Contains("session had expired")
+			&& m.Contains("may or may not have been applied")));
+		// because: without its own classification the operator only sees "the response is an HTML page",
+		// with nothing pointing at the session - and the message must not claim the write was rejected,
+		// because the same ambiguity that forbids the automatic replay forbids claiming that
 	}
 
 	[Test]
@@ -634,7 +673,7 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 		serviceUrlBuilder.Build("odata/UsrThing").Returns("http://host/0/odata/UsrThing");
 		applicationClient.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(responseBody);
-		applicationClient.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
+		applicationClient.ExecuteNonReplayablePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
 			Arg.Any<int>()).Returns(responseBody);
 		applicationClient.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(),
 			Arg.Any<int>()).Returns(responseBody);
@@ -721,5 +760,65 @@ public class CallServiceCommandDeleteTests : BaseCommandTests<CallServiceCommand
 			.ExecutePatchRequest("http://host/svc", "{\"id\":1}", 60_000, 1, 1);
 		// because: the command default this test pins is the TIMEOUT; a write the caller did not authorize
 		// replaying is still issued once, whatever the inherited attempt count says
+	}
+
+	[TestCase("select", TestName = "PostReplay_select")]
+	[TestCase("SELECT", TestName = "PostReplay_select_uppercase")]
+	[Description("dataservice -t select keeps the replayable POST, because SelectQuery is a read and must still recover from an expired session")]
+	public void Execute_Should_Allow_Post_Replay_For_DataService_Select(string operationType) {
+		// Arrange
+		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
+		EnvironmentSettings settings = new();
+		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IFileSystem fileSystem = Substitute.For<IFileSystem>();
+		serviceUrlBuilder.Build(ServiceUrlBuilder.KnownRoute.Select).Returns("http://host/DataService/json/SyncReply/SelectQuery");
+
+		DataServiceQuery command = new(applicationClient, settings, serviceUrlBuilder, fileSystem);
+		DataServiceQueryOptions options = new() {
+			OperationType = operationType,
+			RequestBody = "{}",
+			TimeOut = 12_345
+		};
+
+		// Act
+		command.Execute(options);
+
+		// Assert
+		applicationClient.Received(1).ExecutePostRequest(
+			"http://host/DataService/json/SyncReply/SelectQuery", "{}", 12_345, 1, Arg.Any<int>());
+		applicationClient.DidNotReceiveWithAnyArgs().ExecuteNonReplayablePostRequest(default, default, default,
+			default, default);
+		// because: a select changes nothing, so refusing the automatic re-authentication replay would turn a
+		// recoverable stale session into a failed read and prevent no duplicate write
+	}
+
+	[TestCase("insert", TestName = "PostNoReplay_insert")]
+	[TestCase("update", TestName = "PostNoReplay_update")]
+	[TestCase("delete", TestName = "PostNoReplay_delete")]
+	[Description("dataservice -t insert|update|delete posts as a write, so automatic re-authentication must never re-issue it")]
+	public void Execute_Should_Refuse_Post_Replay_For_DataService_Writes(string operationType) {
+		// Arrange
+		IApplicationClient applicationClient = Substitute.For<IApplicationClient>();
+		EnvironmentSettings settings = new();
+		IServiceUrlBuilder serviceUrlBuilder = Substitute.For<IServiceUrlBuilder>();
+		IFileSystem fileSystem = Substitute.For<IFileSystem>();
+		serviceUrlBuilder.Build(Arg.Any<ServiceUrlBuilder.KnownRoute>()).Returns("http://host/DataService/write");
+
+		DataServiceQuery command = new(applicationClient, settings, serviceUrlBuilder, fileSystem);
+		DataServiceQueryOptions options = new() {
+			OperationType = operationType,
+			RequestBody = "{}",
+			TimeOut = 12_345
+		};
+
+		// Act
+		command.Execute(options);
+
+		// Assert
+		applicationClient.Received(1).ExecuteNonReplayablePostRequest("http://host/DataService/write", "{}", 12_345,
+			1, Arg.Any<int>());
+		applicationClient.DidNotReceiveWithAnyArgs().ExecutePostRequest(default, default, default, default, default);
+		// because: the expired-session detector is body-based, so a committed InsertQuery whose response looks
+		// like the sign-in page would otherwise be posted a second time (GitHub #1313)
 	}
 }

--- a/clio.tests/Query/CallServiceCommandResponseContextTests.cs
+++ b/clio.tests/Query/CallServiceCommandResponseContextTests.cs
@@ -27,7 +27,7 @@ public class CallServiceCommandResponseContextTests : BaseCommandTests<CallServi
 		//The URL is built from the NORMALIZED path, which is also the path the response context is
 		//derived from - stubbing the raw option value would miss a case carrying a 0/ prefix.
 		serviceUrlBuilder.Build(Arg.Any<string>()).Returns(url);
-		applicationClient.ExecutePostRequest(url, Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+		applicationClient.ExecuteNonReplayablePostRequest(url, Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(response);
 		CallServiceCommand command = new(applicationClient, new EnvironmentSettings(), serviceUrlBuilder,
 			Substitute.For<IFileSystem>());

--- a/clio/BindingsModule.cs
+++ b/clio/BindingsModule.cs
@@ -1605,6 +1605,10 @@ public class BindingsModule {
 					// LoginDiagnostics holds per-adapter state (client correlation token, attempt
 					// counter); it is created by CreatioClientAdapter, not resolved from DI.
 					|| implementedInterface == typeof(ILoginDiagnostics)
+					// CreatioClientTransport wraps the adapter's own Lazy<CreatioClient>; like the two
+					// above it is per-adapter state created by CreatioClientAdapter, and its only
+					// constructor argument is that lazy client, which DI cannot supply.
+					|| implementedInterface == typeof(ICreatioClientTransport)
 					// Application-client implementations have ownership-sensitive constructors and
 					// are registered explicitly for the active environment. Auto-registration would
 					// either create an unbound adapter or introduce a circular ownership lease.

--- a/clio/Command/McpServer/Tools/EmailTemplateTool.cs
+++ b/clio/Command/McpServer/Tools/EmailTemplateTool.cs
@@ -568,7 +568,10 @@ public sealed class EmailTemplateContentService(IToolCommandResolver commandReso
 		IReadOnlyDictionary<string, object> data) {
 		string payload = JsonSerializer.Serialize(data);
 		string response = string.IsNullOrWhiteSpace(recordId)
-			? client.ExecutePostRequest(urls.Build(ODataKeyFormatter.CollectionPath(entity)), payload, RequestTimeout)
+			// Both branches are record writes, so neither may be replayed by automatic
+			// re-authentication (GitHub #1313); PATCH refuses replay for the whole verb.
+			? client.ExecuteNonReplayablePostRequest(urls.Build(ODataKeyFormatter.CollectionPath(entity)),
+				payload, RequestTimeout)
 			: client.ExecutePatchRequest(urls.Build(ODataKeyFormatter.KeyPath(entity, recordId)), payload, RequestTimeout);
 		if (!string.IsNullOrWhiteSpace(response)) {
 			using JsonDocument document = JsonDocument.Parse(response);

--- a/clio/Command/McpServer/Tools/ODataCreateTool.cs
+++ b/clio/Command/McpServer/Tools/ODataCreateTool.cs
@@ -122,7 +122,10 @@ public sealed class ODataCreateTool(IToolCommandResolver commandResolver) {
 					Error = zoneLessDateTime
 				};
 			}
-			string responseJson = client.ExecutePostRequest(url, row.GetRawText(), 30_000);
+			// Declared a write: automatic re-authentication must never re-issue this POST, or a
+			// false-positive expired-session classification of the OData echo creates the record
+			// twice (GitHub #1313).
+			string responseJson = client.ExecuteNonReplayablePostRequest(url, row.GetRawText(), 30_000);
 			return ParseCreated(responseJson, index);
 		} catch (Exception ex) {
 			// The request may have reached Creatio and been applied before the failure surfaced here, so the

--- a/clio/Common/ApplicationClientLease.cs
+++ b/clio/Common/ApplicationClientLease.cs
@@ -59,6 +59,10 @@ internal sealed class ApplicationClientLease(IApplicationClient client) : IOwned
 		CancellationToken cancellationToken = default) =>
 		Extended.ExecutePostRequestAsync(url, requestData, requestTimeout, maxAttempts, delaySec, cancellationToken);
 
+	public string ExecuteNonReplayablePostRequest(string url, string requestData,
+		int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1) =>
+		_client.ExecuteNonReplayablePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) =>
 		_client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec);

--- a/clio/Common/CreatioClientAdapter.cs
+++ b/clio/Common/CreatioClientAdapter.cs
@@ -13,7 +13,7 @@ namespace Clio.Common;
 public class CreatioClientAdapter : IOwnedApplicationClient {
 	#region Fields: Private
 
-	private readonly Lazy<CreatioClient> _lazyClient;
+	private readonly ICreatioClientTransport _transport;
 	private readonly IServiceUrlBuilder _serviceUrlBuilder;
 	private readonly JsonConverter _jsonConverter;
 	private readonly IReauthExecutor _reauthExecutor;
@@ -23,11 +23,20 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 	private bool _disposed;
 	private bool _listenerStarted;
 
-	private CreatioClient Client {
+	// Named Client rather than Transport so the ~20 call sites below keep reading as "the Creatio
+	// client": the seam replaced the concrete NuGet type, not the adapter's own structure.
+	// EnsureCreated is called INSIDE the lock on purpose. When this property still returned
+	// _lazyClient.Value, creation happened under the lock and was therefore mutually exclusive with
+	// Dispose. Returning the transport and letting it create the client on first use would move
+	// creation outside, so a caller that had already passed the disposed check could create a client
+	// after Dispose saw IsCreated == false - leaking its pooled HTTP transport for the process
+	// lifetime.
+	private ICreatioClientTransport Client {
 		get {
 			lock (_lifetimeSync) {
 				ObjectDisposedException.ThrowIf(_disposed, this);
-				return _lazyClient.Value;
+				_transport.EnsureCreated();
+				return _transport;
 			}
 		}
 	}
@@ -37,13 +46,23 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 	#region Constructors: Private
 
 	// The reauthExecutor parameter is null in production: the executor captures a closure
-	// over this adapter's own _lazyClient.Value.Login() and is therefore created here
+	// over this adapter's own transport Login() and is therefore created here
 	// rather than resolved from DI. Tests pass a non-null executor through the internal
 	// constructor below to exercise the adapter in isolation from CreatioClient.
 	private CreatioClientAdapter(Lazy<CreatioClient> lazyClient, IServiceUrlBuilder serviceUrlBuilder,
 		JsonConverter jsonConverter, IReauthExecutor reauthExecutor,
-		ILoginDiagnostics loginDiagnostics = null, bool ownsClient = false) {
-		_lazyClient = lazyClient;
+		ILoginDiagnostics loginDiagnostics = null, bool ownsClient = false)
+		// The transport is per-adapter state built over this adapter's own lazy client, exactly like
+		// the reauth executor and the diagnostics recorder below, so it is created here rather than
+		// resolved from DI - which also means every construction site (including the MCP per-tenant
+		// child container that builds its connections inline) gets it without a separate wiring step.
+		: this(new CreatioClientTransport(lazyClient), serviceUrlBuilder, jsonConverter, reauthExecutor,
+			loginDiagnostics, ownsClient) { }
+
+	private CreatioClientAdapter(ICreatioClientTransport transport, IServiceUrlBuilder serviceUrlBuilder,
+		JsonConverter jsonConverter, IReauthExecutor reauthExecutor,
+		ILoginDiagnostics loginDiagnostics, bool ownsClient) {
+		_transport = transport;
 		_ownsClient = ownsClient;
 		_serviceUrlBuilder = serviceUrlBuilder;
 		_jsonConverter = jsonConverter ?? new JsonConverter();
@@ -57,7 +76,7 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 		// method and both login paths really route through it.
 		_loginDiagnostics = loginDiagnostics ?? new LoginDiagnostics();
 		_reauthExecutor = reauthExecutor ?? new ReauthExecutor(
-			() => _loginDiagnostics.Track(() => _lazyClient.Value.Login(), LoginAttemptKind.Reauthentication));
+			() => _loginDiagnostics.Track(() => Client.Login(), LoginAttemptKind.Reauthentication));
 	}
 
 	#endregion
@@ -105,6 +124,15 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 		: this(lazyClient, null, null,
 			reauthExecutor ?? throw new ArgumentNullException(nameof(reauthExecutor)), ownsClient: true) { }
 
+	// Test-only constructor for the transport seam. Lets a test substitute the Creatio transport and
+	// assert the exact underlying call (verb, url, body, timeout, attempts) the adapter delegates to,
+	// and the number of times it is issued. The reauth executor MAY be null: leaving it to the default
+	// is the only way to exercise the real replay policy end to end (GitHub #1313).
+	internal CreatioClientAdapter(ICreatioClientTransport transport, IReauthExecutor reauthExecutor,
+		ILoginDiagnostics loginDiagnostics = null)
+		: this(transport ?? throw new ArgumentNullException(nameof(transport)), null, null, reauthExecutor,
+			loginDiagnostics, ownsClient: true) { }
+
 	// DI composition constructor: unlike the public Lazy overload (which preserves borrowed-client
 	// compatibility), this adapter is the sole owner of the lazily-created environment client.
 	internal CreatioClientAdapter(Lazy<CreatioClient> lazyClient, bool ownsClient)
@@ -149,9 +177,19 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 	// cannot silently lose either wrapper.
 	// Not generic: the session-expired predicate inspects the raw response body, so it only applies to
 	// the string-returning request methods — which is all of them that go through the reauth executor.
-	private string ExecuteRequest(Func<string> call) =>
+	// replayAllowed says whether an expired-session classification may re-issue this call. It is
+	// stated at every call site rather than defaulted: the classification is body-based, so it cannot
+	// tell a write the server rejected unauthenticated from a write that committed and whose
+	// legitimate response merely contains a login-page marker. Replaying the second kind commits it
+	// twice (GitHub #1313).
+	// The rule is NOT "every write passes false". It is: the verbs clio only ever uses for record
+	// writes (PUT, PATCH, DELETE) refuse replay, and so does a POST the caller declared a write. The
+	// remaining methods - POST, CallConfigurationService, the Upload* family - keep replaying because
+	// the adapter cannot classify them, and turning replay off there would remove the session recovery
+	// this executor exists for. A caller that knows better opts out at its own call site.
+	private string ExecuteRequest(Func<string> call, bool replayAllowed) =>
 		_reauthExecutor.Execute(() => _loginDiagnostics.TrackRequest(call),
-			ReauthExecutor.IsSessionExpiredResponse);
+			ReauthExecutor.IsSessionExpiredResponse, replayAllowed);
 
 	#endregion
 
@@ -171,7 +209,8 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 		// reauth executor — otherwise a stale-cookie response surfaces directly as raw HTML
 		// to the caller.
 		return ExecuteRequest(
-			() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout));
+			() => Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout),
+			replayAllowed: true);
 	}
 
 	public void DownloadFile(string url, string filePath, string requestData) {
@@ -194,13 +233,17 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 
 	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
+		// DELETE has no read-shaped caller in clio: every site is an OData record deletion or a
+		// user-supplied call-service write, so replay is refused for the whole verb.
 		return ExecuteRequest(
-			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
+			() => Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: false);
 	}
 
 	public string ExecuteGetRequest(string url, int requestTimeout = Timeout.Infinite, int maxAttempts = 1,
 		int delaySec = 1) {
-		return ExecuteRequest(() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec));
+		return ExecuteRequest(() => Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: true);
 	}
 
 	/// <inheritdoc />
@@ -211,8 +254,21 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 
 	public string ExecutePostRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
+		// POST is the one verb the adapter cannot classify: clio issues DataService SelectQuery reads,
+		// long-running configuration-service calls AND record-creating writes through it. Replay stays
+		// on here - removing it would undo the session recovery this executor exists for - and a caller
+		// that knows its POST is a write asks for ExecuteNonReplayablePostRequest instead.
 		return ExecuteRequest(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: true);
+	}
+
+	/// <inheritdoc />
+	public string ExecuteNonReplayablePostRequest(string url, string requestData,
+		int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1) {
+		return ExecuteRequest(
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: false);
 	}
 
 	public T ExecutePostRequest<T>(string url, string requestData, int requestTimeout = Timeout.Infinite,
@@ -221,7 +277,8 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 		// Re-auth detection runs against the raw body so an expired session cannot reach
 		// the JSON deserializer (which would throw on the HTML login page).
 		string response = ExecuteRequest(
-			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
+			() => Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: true);
 		// If the retry also returned the session-expired HTML page, the JSON deserializer
 		// below would surface the same opaque "Invalid response format" symptom that
 		// triggered ENG-90393. Throw a clearer message so the caller (and the user) can
@@ -244,21 +301,25 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 
 	public string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
+		// PATCH, like PUT below, only ever carries a record update in clio.
 		return ExecuteRequest(
-			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
+			() => Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: false);
 	}
 
 	public string ExecutePutRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1) {
 		return ExecuteRequest(
-			() => Client.ExecutePutRequest(url, requestData, requestTimeout, maxAttempts, delaySec));
+			() => Client.ExecutePutRequest(url, requestData, requestTimeout, maxAttempts, delaySec),
+			replayAllowed: false);
 	}
 
 	public void Listen(CancellationToken cancellationToken) {
-		CreatioClient client;
+		ICreatioClientTransport client;
 		lock (_lifetimeSync) {
 			ObjectDisposedException.ThrowIf(_disposed, this);
-			client = _lazyClient.Value;
+			_transport.EnsureCreated();
+			client = _transport;
 			_listenerStarted = true;
 		}
 		client.ConnectionStateChanged += (sender, state) => { ConnectionStateChanged?.Invoke(sender, state); };
@@ -306,22 +367,22 @@ public class CreatioClientAdapter : IOwnedApplicationClient {
 			// CreatioClient's SignalR listener can still re-enter Login while its cancellation is
 			// draining. Disposing the pooled HTTP transport here races that reconnect and crashes the
 			// process; listener clients therefore live until process/GC teardown after cancellation.
-			if (_ownsClient && !_listenerStarted && _lazyClient.IsValueCreated) {
-				_lazyClient.Value?.Dispose();
+			if (_ownsClient && !_listenerStarted && _transport.IsCreated) {
+				_transport.Dispose();
 			}
 		}
 	}
 
 	public string UploadAlmFile(string url, string filePath) {
-		return ExecuteRequest(() => Client.UploadAlmFile(url, filePath));
+		return ExecuteRequest(() => Client.UploadAlmFile(url, filePath), replayAllowed: true);
 	}
 
 	public string UploadAlmFileByChunk(string url, string filePath) {
-		return ExecuteRequest(() => Client.UploadAlmFileByChunk(url, filePath));
+		return ExecuteRequest(() => Client.UploadAlmFileByChunk(url, filePath), replayAllowed: true);
 	}
 
 	public string UploadFile(string url, string filePath) {
-		return ExecuteRequest(() => Client.UploadFile(url, filePath));
+		return ExecuteRequest(() => Client.UploadFile(url, filePath), replayAllowed: true);
 	}
 
 	/// <inheritdoc />

--- a/clio/Common/CreatioClientTransport.cs
+++ b/clio/Common/CreatioClientTransport.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Creatio.Client;
+using Creatio.Client.Dto;
+
+namespace Clio.Common;
+
+/// <summary>
+/// Production <see cref="ICreatioClientTransport"/>: forwards every member to the lazily created
+/// <see cref="CreatioClient"/> and adds nothing else.
+/// </summary>
+/// <remarks>
+/// The authoritative documentation lives on <see cref="ICreatioClientTransport"/>. The client is kept
+/// lazy because several construction sites build an adapter for an environment that is never actually
+/// contacted; resolving the client eagerly would open a connection (and fail on a bad URL) at
+/// construction time. Nothing here forwards through the reauth executor or the login diagnostics -
+/// that wrapping belongs to <see cref="CreatioClientAdapter"/>, and this type adds nothing to the
+/// call it forwards.
+/// </remarks>
+internal sealed class CreatioClientTransport : ICreatioClientTransport {
+
+	#region Fields: Private
+
+	private readonly Lazy<CreatioClient> _lazyClient;
+
+	#endregion
+
+	#region Constructors: Public
+
+	/// <summary>Creates a transport over the supplied lazy client.</summary>
+	/// <param name="lazyClient">The lazily created Creatio client. Required.</param>
+	public CreatioClientTransport(Lazy<CreatioClient> lazyClient) {
+		_lazyClient = lazyClient ?? throw new ArgumentNullException(nameof(lazyClient));
+	}
+
+	#endregion
+
+	#region Properties: Private
+
+	private CreatioClient Client => _lazyClient.Value;
+
+	#endregion
+
+	#region Properties: Public
+
+	/// <inheritdoc />
+	public bool IsCreated => _lazyClient.IsValueCreated;
+
+	#endregion
+
+	#region Events: Public
+
+	/// <inheritdoc />
+	public event EventHandler<WebSocketState> ConnectionStateChanged {
+		add => Client.ConnectionStateChanged += value;
+		remove => Client.ConnectionStateChanged -= value;
+	}
+
+	/// <inheritdoc />
+	public event EventHandler<WsMessage> MessageReceived {
+		add => Client.MessageReceived += value;
+		remove => Client.MessageReceived -= value;
+	}
+
+	#endregion
+
+	#region Methods: Public
+
+	/// <inheritdoc />
+	public string CallConfigurationService(string serviceName, string serviceMethod, string requestData,
+		int requestTimeout) =>
+		Client.CallConfigurationService(serviceName, serviceMethod, requestData, requestTimeout);
+
+	/// <inheritdoc />
+	public void Dispose() {
+		// Only a created client owns unmanaged transport state; resolving the Lazy here just to
+		// dispose it would open the very connection the caller decided never to use.
+		if (_lazyClient.IsValueCreated) {
+			_lazyClient.Value?.Dispose();
+		}
+	}
+
+	/// <inheritdoc />
+	public void EnsureCreated() {
+		_ = _lazyClient.Value;
+	}
+
+	/// <inheritdoc />
+	public void DownloadFile(string url, string filePath, string requestData) =>
+		Client.DownloadFile(url, filePath, requestData);
+
+	/// <inheritdoc />
+	public string ExecuteDeleteRequest(string url, string requestData, int requestTimeout, int maxAttempts,
+		int delaySec) =>
+		Client.ExecuteDeleteRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
+	/// <inheritdoc />
+	public string ExecuteGetRequest(string url, int requestTimeout, int maxAttempts, int delaySec) =>
+		Client.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec);
+
+	/// <inheritdoc />
+	public Task<HttpResponseMessage> ExecuteGetRequestAsync(string url, int requestTimeout, int maxAttempts,
+		int delaySec, CancellationToken cancellationToken) =>
+		Client.ExecuteGetRequestAsync(url, requestTimeout, maxAttempts, delaySec, cancellationToken);
+
+	/// <inheritdoc />
+	public string ExecutePatchRequest(string url, string requestData, int requestTimeout, int maxAttempts,
+		int delaySec) =>
+		Client.ExecutePatchRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
+	/// <inheritdoc />
+	public string ExecutePostRequest(string url, string requestData, int requestTimeout, int maxAttempts,
+		int delaySec) =>
+		Client.ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
+	/// <inheritdoc />
+	public Task<HttpResponseMessage> ExecutePostRequestAsync(string url, string requestData, int requestTimeout,
+		int maxAttempts, int delaySec, CancellationToken cancellationToken) =>
+		Client.ExecutePostRequestAsync(url, requestData, requestTimeout, maxAttempts, delaySec, cancellationToken);
+
+	/// <inheritdoc />
+	public string ExecutePutRequest(string url, string requestData, int requestTimeout, int maxAttempts,
+		int delaySec) =>
+		Client.ExecutePutRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
+	/// <inheritdoc />
+	public IReadOnlyList<CreatioSessionCookie> ExportSessionCookies() => Client.ExportSessionCookies();
+
+	/// <inheritdoc />
+	public void ImportSessionCookies(IEnumerable<CreatioSessionCookie> cookies) =>
+		Client.ImportSessionCookies(cookies);
+
+	/// <inheritdoc />
+	public void Login() => Client.Login();
+
+	/// <inheritdoc />
+	public Task<HttpResponseMessage> LoginAsync(int requestTimeout, CancellationToken cancellationToken) =>
+		Client.LoginAsync(requestTimeout, cancellationToken);
+
+	/// <inheritdoc />
+	public void StartListening(CancellationToken cancellationToken) => Client.StartListening(cancellationToken);
+
+	/// <inheritdoc />
+	public string UploadAlmFile(string url, string filePath) => Client.UploadAlmFile(url, filePath);
+
+	/// <inheritdoc />
+	public string UploadAlmFileByChunk(string url, string filePath) => Client.UploadAlmFileByChunk(url, filePath);
+
+	/// <inheritdoc />
+	public string UploadFile(string url, string filePath) => Client.UploadFile(url, filePath);
+
+	/// <inheritdoc />
+	public Task<HttpResponseMessage> UploadImageAsync(string url, byte[] data, string fileName, string mimeType,
+		int requestTimeout, CancellationToken cancellationToken) =>
+		Client.UploadImageAsync(url, data, fileName, mimeType, requestTimeout, cancellationToken);
+
+	#endregion
+}

--- a/clio/Common/IApplicationClient.cs
+++ b/clio/Common/IApplicationClient.cs
@@ -30,6 +30,32 @@ public interface IApplicationClient {
 		int maxAttempts = 1, int delaySec = 1)
 		where T : BaseResponse, new();
 
+	/// <summary>
+	/// Executes an authenticated HTTP POST that the caller has declared to be a write, and that
+	/// automatic re-authentication must therefore never re-issue.
+	/// </summary>
+	/// <param name="url">The absolute request URL.</param>
+	/// <param name="requestData">The request body.</param>
+	/// <param name="requestTimeout">The request timeout in milliseconds.</param>
+	/// <param name="maxAttempts">The maximum number of attempts.</param>
+	/// <param name="delaySec">The delay between retry attempts in seconds.</param>
+	/// <returns>The raw response body.</returns>
+	/// <remarks>
+	/// POST is the only verb clio uses for both reads (DataService <c>SelectQuery</c>, long-running
+	/// configuration-service calls) and writes (record creation, arbitrary <c>call-service</c>
+	/// payloads), so the read/write decision cannot be made from the verb and has to be made by the
+	/// caller. A client whose expired-session recovery replayed the call would otherwise commit a
+	/// write twice whenever its legitimate response happened to contain a login-page marker
+	/// (GitHub #1313).
+	/// Defaulted rather than abstract for the same reason as <see cref="ExecutePutRequest"/>: this is
+	/// a stable public contract with implementations outside this repository, and an abstract member
+	/// here fails every one of them with CS0535. A transport with no replay behaviour of its own is
+	/// already correct with the default body.
+	/// </remarks>
+	string ExecuteNonReplayablePostRequest(string url, string requestData,
+		int requestTimeout = Timeout.Infinite, int maxAttempts = 1, int delaySec = 1) =>
+		ExecutePostRequest(url, requestData, requestTimeout, maxAttempts, delaySec);
+
 	string ExecutePatchRequest(string url, string requestData, int requestTimeout = Timeout.Infinite,
 		int maxAttempts = 1, int delaySec = 1);
 

--- a/clio/Common/ICreatioClientTransport.cs
+++ b/clio/Common/ICreatioClientTransport.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Creatio.Client;
+using Creatio.Client.Dto;
+
+namespace Clio.Common;
+
+/// <summary>
+/// The transport surface <see cref="CreatioClientAdapter"/> consumes from the
+/// <see cref="Creatio.Client.CreatioClient"/> NuGet type, expressed as an interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Exists purely as a test seam. <c>CreatioClient</c> is a concrete NuGet class with no interface and
+/// no virtual members, so the adapter's own unit tests could not substitute it: they resolved the
+/// adapter's <see cref="Lazy{T}"/> to <see langword="null"/> and therefore could never invoke the
+/// callback handed to <see cref="IReauthExecutor"/>. That left the delegation itself unverified — a
+/// PUT routed to the underlying DELETE, or a dropped url/body/timeout argument, passed every test
+/// (GitHub #1313).
+/// </para>
+/// <para>
+/// The members mirror the underlying client one-for-one; this interface deliberately adds no
+/// behaviour of its own. <see cref="IsCreated"/> and <see cref="IDisposable"/> expose the lazy
+/// client's lifetime so the adapter can keep its ownership rules unchanged.
+/// </para>
+/// </remarks>
+internal interface ICreatioClientTransport : IDisposable {
+
+	/// <summary>Raised when the SignalR listener connection state changes.</summary>
+	event EventHandler<WebSocketState> ConnectionStateChanged;
+
+	/// <summary>Raised when the SignalR listener receives a message.</summary>
+	event EventHandler<WsMessage> MessageReceived;
+
+	/// <summary>Whether the underlying client has been created already.</summary>
+	bool IsCreated { get; }
+
+	/// <summary>Creates the underlying client now, if it does not exist yet.</summary>
+	/// <remarks>
+	/// Lets <see cref="CreatioClientAdapter"/> keep creation and disposal mutually exclusive under its
+	/// own lifetime lock, as they were when it held the <see cref="Lazy{T}"/> itself. Without it a
+	/// caller that had already passed the disposed check could create a client after <c>Dispose</c>
+	/// observed <see cref="IsCreated"/> as <see langword="false"/>, and that client - with its pooled
+	/// HTTP transport - would never be released.
+	/// </remarks>
+	void EnsureCreated();
+
+	/// <inheritdoc cref="IApplicationClient.CallConfigurationService"/>
+	string CallConfigurationService(string serviceName, string serviceMethod, string requestData,
+		int requestTimeout);
+
+	/// <inheritdoc cref="IApplicationClient.DownloadFile"/>
+	void DownloadFile(string url, string filePath, string requestData);
+
+	/// <inheritdoc cref="IApplicationClient.ExecuteDeleteRequest"/>
+	string ExecuteDeleteRequest(string url, string requestData, int requestTimeout, int maxAttempts, int delaySec);
+
+	/// <inheritdoc cref="IApplicationClient.ExecuteGetRequest"/>
+	string ExecuteGetRequest(string url, int requestTimeout, int maxAttempts, int delaySec);
+
+	/// <inheritdoc cref="ICreatioApplicationClient.ExecuteGetRequestAsync"/>
+	Task<HttpResponseMessage> ExecuteGetRequestAsync(string url, int requestTimeout, int maxAttempts,
+		int delaySec, CancellationToken cancellationToken);
+
+	/// <inheritdoc cref="IApplicationClient.ExecutePatchRequest"/>
+	string ExecutePatchRequest(string url, string requestData, int requestTimeout, int maxAttempts, int delaySec);
+
+	/// <inheritdoc cref="IApplicationClient.ExecutePostRequest(string,string,int,int,int)"/>
+	string ExecutePostRequest(string url, string requestData, int requestTimeout, int maxAttempts, int delaySec);
+
+	/// <inheritdoc cref="ICreatioApplicationClient.ExecutePostRequestAsync"/>
+	Task<HttpResponseMessage> ExecutePostRequestAsync(string url, string requestData, int requestTimeout,
+		int maxAttempts, int delaySec, CancellationToken cancellationToken);
+
+	/// <inheritdoc cref="IApplicationClient.ExecutePutRequest"/>
+	string ExecutePutRequest(string url, string requestData, int requestTimeout, int maxAttempts, int delaySec);
+
+	/// <inheritdoc cref="ICreatioApplicationClient.ExportSessionCookies"/>
+	IReadOnlyList<CreatioSessionCookie> ExportSessionCookies();
+
+	/// <inheritdoc cref="ICreatioApplicationClient.ImportSessionCookies"/>
+	void ImportSessionCookies(IEnumerable<CreatioSessionCookie> cookies);
+
+	/// <inheritdoc cref="IApplicationClient.Login"/>
+	void Login();
+
+	/// <inheritdoc cref="ICreatioApplicationClient.LoginAsync"/>
+	Task<HttpResponseMessage> LoginAsync(int requestTimeout, CancellationToken cancellationToken);
+
+	/// <summary>Starts the SignalR listener for the configured application.</summary>
+	/// <param name="cancellationToken">Token that stops the listener.</param>
+	void StartListening(CancellationToken cancellationToken);
+
+	/// <inheritdoc cref="IApplicationClient.UploadAlmFile"/>
+	string UploadAlmFile(string url, string filePath);
+
+	/// <inheritdoc cref="IApplicationClient.UploadAlmFileByChunk"/>
+	string UploadAlmFileByChunk(string url, string filePath);
+
+	/// <inheritdoc cref="IApplicationClient.UploadFile"/>
+	string UploadFile(string url, string filePath);
+
+	/// <inheritdoc cref="ICreatioApplicationClient.UploadImageAsync"/>
+	Task<HttpResponseMessage> UploadImageAsync(string url, byte[] data, string fileName, string mimeType,
+		int requestTimeout, CancellationToken cancellationToken);
+}

--- a/clio/Common/IReauthExecutor.cs
+++ b/clio/Common/IReauthExecutor.cs
@@ -14,7 +14,8 @@ internal interface IReauthExecutor {
 
 	/// <summary>
 	/// Executes <paramref name="call"/>. If <paramref name="isUnauthorized"/> returns
-	/// <see langword="true"/> for the first result, performs a single login + retry.
+	/// <see langword="true"/> for the first result, re-authenticates and — only when
+	/// <paramref name="replayAllowed"/> is <see langword="true"/> — retries the call once.
 	/// </summary>
 	/// <remarks>
 	/// Detection is purely body-based: the predicate inspects the returned value. Transport
@@ -27,6 +28,18 @@ internal interface IReauthExecutor {
 	/// <typeparam name="T">Result type returned by the underlying call.</typeparam>
 	/// <param name="call">The call to execute, typically a wrapper over an HTTP request.</param>
 	/// <param name="isUnauthorized">Predicate that classifies a result as a session-expired response.</param>
-	/// <returns>The original result if it is not unauthorized; otherwise the result of the retry.</returns>
-	T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized);
+	/// <param name="replayAllowed">
+	/// Whether the call may be issued a second time after a successful re-login. A call the caller
+	/// knows to be a record write - PUT, PATCH, DELETE, and a POST declared as a write - passes
+	/// <see langword="false"/>, so a false-positive classification of an already-committed response
+	/// cannot commit it twice. Everything the caller cannot classify passes <see langword="true"/>
+	/// and keeps the session recovery. There is deliberately no default: every call site has to state
+	/// which one it is.
+	/// </param>
+	/// <returns>
+	/// The original result when it is not unauthorized. When it is unauthorized, the result of the
+	/// single retry if <paramref name="replayAllowed"/> is <see langword="true"/>, otherwise the
+	/// original (unauthorized) result, with the re-login still performed so the next call succeeds.
+	/// </returns>
+	T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized, bool replayAllowed);
 }

--- a/clio/Common/NoReauthExecutor.cs
+++ b/clio/Common/NoReauthExecutor.cs
@@ -11,10 +11,11 @@ namespace Clio.Common;
 /// Passthrough clients are built from opaque bearer material (FR-18): there are no
 /// login/password credentials to re-login with, so an unauthorized response cannot be
 /// recovered here. The <c>isUnauthorized</c> predicate is intentionally ignored — the
-/// call is executed once and its result returned verbatim.
+/// call is executed once and its result returned verbatim, and <c>replayAllowed</c> is moot
+/// because nothing is ever replayed here.
 /// </remarks>
 internal sealed class NoReauthExecutor : IReauthExecutor {
 
 	/// <inheritdoc />
-	public T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized) => call();
+	public T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized, bool replayAllowed) => call();
 }

--- a/clio/Common/ReauthExecutor.cs
+++ b/clio/Common/ReauthExecutor.cs
@@ -70,7 +70,7 @@ internal sealed class ReauthExecutor : IReauthExecutor {
 	#region Methods: Public
 
 	/// <inheritdoc />
-	public T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized) {
+	public T Execute<T>(Func<T> call, Func<T, bool> isUnauthorized, bool replayAllowed) {
 		if (call is null) {
 			throw new ArgumentNullException(nameof(call));
 		}
@@ -89,6 +89,11 @@ internal sealed class ReauthExecutor : IReauthExecutor {
 			// the retry also throws, the exception propagates to the caller unchanged.
 			int observedVersion = Volatile.Read(ref _loginVersion);
 			TryReauthenticate(observedVersion);
+			if (!replayAllowed) {
+				// A write must not be issued twice. The session is refreshed for whatever the caller
+				// does next, but this request is not repeated; the original failure surfaces instead.
+				throw;
+			}
 			return call();
 		}
 		if (!isUnauthorized(result)) {
@@ -103,6 +108,16 @@ internal sealed class ReauthExecutor : IReauthExecutor {
 		// the reauth lock — exactly the parallel-burst case the dedupe is designed for.
 		int sessionObservedVersion = Volatile.Read(ref _loginVersion);
 		TryReauthenticate(sessionObservedVersion);
+		if (!replayAllowed) {
+			// GitHub #1313. The predicate is body-based, so it cannot distinguish "the server
+			// rejected the write unauthenticated" from "the write committed and its legitimate
+			// response happens to contain a login-page marker". For a non-idempotent call the
+			// second reading is unrecoverable — a replay would commit the write a second time —
+			// so the write is never repeated. Re-login still happened above, so the caller's next
+			// request works; this response is returned verbatim and the caller classifies it
+			// (call-service reports it as an expired session and exits non-zero).
+			return result;
+		}
 		// At most one retry, regardless of the retry's outcome. The caller observes the
 		// second response as-is; if it is still the login page (Login failed, or the
 		// session was invalidated again between Login and retry) the caller decides.

--- a/clio/Query/DataServiceQuery.cs
+++ b/clio/Query/DataServiceQuery.cs
@@ -127,6 +127,16 @@ public class DataServiceQuery : BaseServiceCommand<DataServiceQueryOptions> {
 				};
 	}
 
+	/// <inheritdoc />
+	/// <remarks>
+	/// Only <c>-t select</c> is a read. It is a POST on the fixed <c>SelectQuery</c> route, it changes
+	/// nothing, and it must keep the expired-session recovery: refusing the replay there turns a
+	/// recoverable stale session into a failed read and buys nothing. <c>insert</c> / <c>update</c> /
+	/// <c>delete</c> are record writes and keep the base refusal (GitHub #1313).
+	/// </remarks>
+	private protected override bool AllowsPostReplay(DataServiceQueryOptions options) =>
+		string.Equals(options.OperationType, "SELECT", StringComparison.OrdinalIgnoreCase);
+
 	#endregion
 
 }
@@ -179,6 +189,15 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 			return true;
 		}
 
+		// Checked BEFORE the markup branch: the expired-session detector has two arms, and the second
+		// one is a JSON 401 envelope from the .svc endpoints, which is not markup at all. Leaving the
+		// check inside the markup branch classified that arm as "the service reported the request as
+		// failed", which says nothing about the session or about the request not having been replayed.
+		if (ReauthExecutor.IsSessionExpiredResponse(response)) {
+			classification = new ServiceResponseClassification(ServiceResponseFailure.ExpiredSession);
+			return false;
+		}
+
 		if (CreatioResponseError.IsMarkup(response)) {
 			//An HTML/XML body is never a successful service payload: the request did not reach the
 			//service intact. Recognizing the markup is what decides failure - the status line, the known
@@ -229,7 +248,19 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 		HttpErrorStatus,
 		KnownErrorPage,
 		NotAServicePayload,
-		ReportedFailure
+		ReportedFailure,
+
+		/// <summary>
+		/// The body is Creatio's sign-in page. Reported separately from
+		/// <see cref="NotAServicePayload"/> because it is the one markup failure whose cause the user
+		/// can name, and because a write is never replayed automatically (GitHub #1313) - without a
+		/// distinct message an expired session during a POST/PUT/PATCH/DELETE read as "the response is
+		/// an HTML page", with nothing pointing at the session. The message deliberately does NOT
+		/// promise the request was rejected: the same body-based ambiguity that forbids the automatic
+		/// replay forbids claiming it here, and telling the operator to just re-run would recreate the
+		/// duplicate write by hand.
+		/// </summary>
+		ExpiredSession
 	}
 
 	private readonly record struct ServiceResponseClassification(
@@ -321,6 +352,9 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 			ServiceResponseFailure.HttpErrorStatus => $"HTTP status {classification.StatusCode}",
 			ServiceResponseFailure.KnownErrorPage => "the response is an error page and carries no HTTP status",
 			ServiceResponseFailure.NotAServicePayload => "the response is an HTML page, not a service payload",
+			ServiceResponseFailure.ExpiredSession =>
+				"the Creatio session had expired; this response is the sign-in page, so the request may or "
+				+ "may not have been applied - verify the target before re-running the command",
 			ServiceResponseFailure.ReportedFailure => "the service reported the request as failed",
 			var _ => "the response could not be classified as a service payload"
 		};
@@ -369,9 +403,24 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 	/// </summary>
 	protected readonly record struct ServiceRequestOutcome(bool Succeeded, string ResponseBody);
 
+	/// <summary>
+	/// Whether a POST this command issues may be re-sent after a successful re-login.
+	/// </summary>
+	/// <remarks>
+	/// The answer is the call site's intent, not the verb: POST carries both reads and writes here.
+	/// The base answer is <see langword="false"/> because <c>call-service</c> posts to a user-supplied
+	/// service path whose response body is arbitrary, and the expired-session detector is body-based -
+	/// a service that answers a committed POST with markup mentioning <c>/Login/</c> would otherwise be
+	/// re-authenticated AND re-posted, writing the record twice (GitHub #1313). A subclass that knows a
+	/// particular POST is a read says so by overriding this.
+	/// </remarks>
+	/// <param name="options">The parsed options of the command being executed.</param>
+	private protected virtual bool AllowsPostReplay(T options) => false;
+
 	private protected ServiceRequestOutcome ExecuteServiceRequest(string url, string requestData,
 		string resultFileName = null, string httpMethod = "",
-		CreatioResponseContext responseContext = CreatioResponseContext.Service){
+		CreatioResponseContext responseContext = CreatioResponseContext.Service,
+		bool postReplayAllowed = false){
 		string normalizedMethod = string.IsNullOrWhiteSpace(httpMethod)
 			? "POST"
 			: httpMethod.ToUpperInvariant();
@@ -389,8 +438,16 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 		//replay risk with no corresponding capability.
 		int attempts = normalizedMethod == "GET" ? MaxAttempts : 1;
 		string jsonResult = normalizedMethod switch {
-					"POST" => ApplicationClient.ExecutePostRequest(url, requestData, RequestTimeout,
-						attempts, DelaySec),
+					//Non-replayable unless the command declared this POST a read (see AllowsPostReplay):
+					//the response body is arbitrary and the client's expired-session detector is body-based,
+					//so a service that legitimately answers a committed POST with HTML mentioning /Login/
+					//would otherwise be re-authenticated AND re-posted, writing the record twice
+					//(GitHub #1313). GET below always keeps replaying - it changes nothing.
+					"POST" => postReplayAllowed
+						? ApplicationClient.ExecutePostRequest(url, requestData, RequestTimeout, attempts,
+							DelaySec)
+						: ApplicationClient.ExecuteNonReplayablePostRequest(url, requestData, RequestTimeout,
+							attempts, DelaySec),
 					"GET" => ApplicationClient.ExecuteGetRequest(url, RequestTimeout, attempts, DelaySec),
 					"DELETE" => ApplicationClient.ExecuteDeleteRequest(url, requestData, RequestTimeout,
 						attempts, DelaySec),
@@ -462,7 +519,7 @@ public abstract class BaseServiceCommand<T> : RemoteCommand<T> where T : CallSer
 		}
 		ServiceRequestOutcome outcome = ExecuteServiceRequest(
 			BuildUrl(options), requestData, options.ResultFileName, options.HttpMethodName,
-			ResolveResponseContext(options));
+			ResolveResponseContext(options), AllowsPostReplay(options));
 		return outcome.Succeeded ? 0 : 1;
 	}
 

--- a/docs/knowledge/Common/creatio-client-transport-is-the-adapter-test-seam.md
+++ b/docs/knowledge/Common/creatio-client-transport-is-the-adapter-test-seam.md
@@ -1,0 +1,40 @@
+---
+description: CreatioClientAdapter talks to the NuGet CreatioClient only through ICreatioClientTransport, created inside the adapter (not DI) and skipped in the BindingsModule auto-registration scan
+applies-to:
+  - clio/Common/ICreatioClientTransport.cs
+  - clio/Common/CreatioClientTransport.cs
+  - clio/Common/CreatioClientAdapter.cs
+  - clio/BindingsModule.cs
+ticket: "#1313"
+date: 2026-09-12
+---
+
+**What is true** — `CreatioClientAdapter` no longer holds a `Lazy<CreatioClient>` field. It holds an
+`ICreatioClientTransport`, which mirrors the NuGet client one-for-one (requests, login, cookies,
+listener events, `IsCreated`, `Dispose`) and adds no behaviour. The production implementation
+`CreatioClientTransport` is constructed **inside** the adapter's private constructor over the lazy
+client, the same way `ReauthExecutor` and `LoginDiagnostics` are - so every construction site gets it,
+including the MCP per-tenant child container that builds its Creatio connections inline and never goes
+through `ApplicationClientFactory`. `ICreatioClientTransport` is therefore in the `ValidateOnBuild`
+skip list in `BindingsModule`, next to `IReauthExecutor` and `ILoginDiagnostics`.
+
+The transport also exposes `EnsureCreated()`, and the adapter calls it **inside** `_lifetimeSync`,
+where it holds the disposed check. Creation used to happen under that lock because the adapter
+resolved the `Lazy` itself; letting the transport create the client lazily on first use would move
+creation outside the lock, so a caller that had already passed the disposed check could create a
+client after `Dispose` read `IsCreated` as `false` - and that client, with its pooled HTTP transport,
+would never be released.
+
+**Why it is this way** — `CreatioClient` is a concrete NuGet class with no interface and no virtual
+members, so the adapter's unit tests could not substitute it. They resolved the adapter's `Lazy` to
+`null` and never invoked the callback handed to the reauth executor, which left the delegation itself
+untested: a PUT routed to the underlying DELETE, or a dropped url / body / timeout argument, passed
+every test. Proving "the write is issued exactly once" for the no-replay rule needs to count the
+underlying calls, which is impossible without the seam.
+
+**What breaks if you ignore it** — registering the transport in DI instead cannot work: its only
+constructor argument is the adapter's own lazy client, so the container has nothing to supply, and
+leaving it out of the skip list makes the auto-registration scan pick it up and fail `ValidateOnBuild`,
+which refuses to start the whole host, `mcp-server` included. Two tests reach the lazy client by
+reflection through `_transport` (`CredentialPassthroughClientIdentityTests`); renaming that field
+breaks them with no compile error.

--- a/docs/knowledge/Common/reauth-never-replays-a-write.md
+++ b/docs/knowledge/Common/reauth-never-replays-a-write.md
@@ -1,0 +1,83 @@
+---
+description: automatic re-authentication replays a call only when the caller said it may - PUT/PATCH/DELETE never replay, POST replays unless the caller used ExecuteNonReplayablePostRequest, and the read/write split for POST is a call-site decision because SelectQuery is a POST too
+applies-to:
+  - clio/Common/IReauthExecutor.cs
+  - clio/Common/ReauthExecutor.cs
+  - clio/Common/NoReauthExecutor.cs
+  - clio/Common/CreatioClientAdapter.cs
+  - clio/Common/IApplicationClient.cs
+  - clio/Query/DataServiceQuery.cs
+  - clio/Command/McpServer/Tools/ODataCreateTool.cs
+  - clio/Command/McpServer/Tools/EmailTemplateTool.cs
+ticket: "#1313"
+date: 2026-09-12
+---
+
+**What is true** — `IReauthExecutor.Execute` takes a required `replayAllowed` flag, and the rule behind
+it is not the HTTP verb alone:
+
+- `ExecutePutRequest`, `ExecutePatchRequest`, `ExecuteDeleteRequest` pass `false`. Every clio call site
+  of those three verbs is a record write, so the whole verb can be decided in `CreatioClientAdapter`.
+- `ExecutePostRequest` passes `true`. POST is the one verb clio uses for **both** directions:
+  DataService `SelectQuery` reads, `CallConfigurationService` and record-creating writes all go
+  through it. Turning replay off for POST would switch off the expired-session recovery that
+  `ReauthExecutor` exists for.
+- `CallConfigurationService` and the `UploadAlmFile` / `UploadAlmFileByChunk` / `UploadFile` family
+  also pass `true`, even though they are not reads. The rule is not "every write passes `false`" -
+  it is "the verbs clio only ever uses for record writes refuse replay, and so does a POST the
+  caller declared a write". Those four are the calls most likely to outlive a session (package
+  install, long compile triggers, multi-megabyte uploads), so they keep the recovery.
+- A caller that knows its POST is a write asks for it by name: `ExecuteNonReplayablePostRequest`, a
+  defaulted member on `IApplicationClient` whose default body simply forwards to `ExecutePostRequest`.
+- `GET` keeps replaying.
+
+`call-service` / `dataservice` therefore decides POST **per call site, by intent**, through
+`BaseServiceCommand<T>.AllowsPostReplay(options)`:
+
+- `dataservice -t select` is a read - a POST on the fixed `SelectQuery` route that changes nothing -
+  so `DataServiceQuery` overrides the hook to allow the replay. Refusing it there would turn a
+  recoverable stale session into a failed read and prevent no duplicate.
+- `dataservice -t insert|update|delete` and every `call-service` POST keep the base `false`: the
+  `call-service` endpoint is user-supplied, so its response shape is unknown and the body-based
+  detector can misfire on a committed write.
+- `--method PUT|PATCH|DELETE` needs no hook - `CreatioClientAdapter` refuses replay for those verbs
+  outright. The trade-off is deliberate: `odata-update` / `odata-delete` and any `call-service`
+  PUT/PATCH/DELETE lose the automatic session recovery, so an expired session surfaces to the caller
+  as `ExpiredSession` and the operator retries by hand after checking the target.
+
+Adoption of `ExecuteNonReplayablePostRequest` is deliberately staged. Its callers are the POSTs that
+create or change a record against an endpoint whose response shape clio does not control:
+`DataServiceQuery` (`call-service` / `dataservice`, where the endpoint is user-supplied, minus the
+`select` read above),
+`ODataCreateTool` and `EmailTemplateTool`'s create branch. Fixed-route POST writes elsewhere
+(`DataBindingCommand`,
+`CreateBusinessProcessCommand`, `ApplicationSectionDeleteCommand`, `PageUpdateOptions`, and
+`RemoteCommand` through the generic `ExecutePostRequest<T>`, which has no non-replayable counterpart)
+still replay. Move one over when its endpoint is shown to answer a committed write with markup -
+not speculatively.
+
+When replay is refused, the executor still performs the login, and the caller gets the original
+unauthorized response back (or, on the `JsonException` path, the original exception). `call-service`
+classifies that body as `ServiceResponseFailure.ExpiredSession`. That message deliberately does not
+promise the request was rejected - it says the write may or may not have been applied and to verify
+the target before re-running, because the ambiguity that forbids the automatic replay forbids the
+promise too.
+
+**Why it is this way** — the expired-session detector is body-based (`IsSessionExpiredResponse`): it
+reads the response, not the HTTP status, because on-prem .NET Framework Creatio answers an expired
+cookie with HTTP 200 and an HTML login page. A body-based test cannot distinguish "the server
+rejected this write unauthenticated" from "the write committed and its legitimate response happens to
+contain `/Login/`". `call-service` points at an arbitrary user-supplied endpoint, so the second case
+is reachable, and replaying it commits the write twice.
+
+`maxAttempts: 1` does not prevent this: that argument bounds `Creatio.Client`'s own transport retry,
+which is a different layer from the reauth retry above it.
+
+**What breaks if you ignore it** — passing `replayAllowed: true` from a write call site brings back a
+silently duplicated PUT/PATCH/POST: two records created, or an update applied twice, with `success`
+reported and nothing in the log. Passing `false` from a read call site (or from `ExecutePostRequest`
+wholesale) breaks the other direction just as quietly: a long-running operation that outlives its
+session stops recovering and starts returning raw login HTML to its caller, which is exactly the
+ENG-90393 symptom the executor was written for. Do **not** re-add a caller-facing `MaxAttempts`-style
+escape hatch to re-enable replay - that was added in `56addae21` and removed the same day in
+`a0f2ac01f`; see the remarks in `DataServiceQuery.ExecuteServiceRequest`.

--- a/docs/knowledge/Common/session-reauth-is-deliberately-silent.md
+++ b/docs/knowledge/Common/session-reauth-is-deliberately-silent.md
@@ -7,8 +7,9 @@ ticket: ENG-90393
 date: 2026-08-19
 ---
 
-**What is true** — when `ReauthExecutor.Execute` detects an expired session it re-authenticates and
-retries the call without emitting a single log line. This is a deliberate design point, not an
+**What is true** — when `ReauthExecutor.Execute` detects an expired session it re-authenticates
+(and retries the call, when the caller allowed a replay — see
+`reauth-never-replays-a-write.md`) without emitting a single log line. This is a deliberate design point, not an
 oversight: an earlier version wrote `Detected expired Creatio session; re-authenticated and retrying
 the request.` as a warning, and that line was removed together with the whole logger plumbing.
 `ReauthExecutor` has no `ILogger` field and no logger constructor parameter, and


### PR DESCRIPTION
🔗 **Issue:** [#1313](https://github.com/Advance-Technologies-Foundation/clio/issues/1313)

Closes #1313

## Summary

Automatic re-authentication no longer replays a write, and `CreatioClientAdapter` finally has a substitutable transport so the reauth tests can assert what it actually delegated.

**Deviation from the issue's literal wording, stated up front:** the issue says PUT, PATCH, POST and DELETE all opt out of replay unconditionally. POST cannot be decided by verb. clio issues DataService `SelectQuery` reads, `CallConfigurationService` (the minutes-long calls that session expiry actually hits), package/ALM uploads **and** record-creating writes through `ExecutePostRequest`. Making POST non-replayable at the adapter would switch off exactly the expired-session recovery ENG-90393 added. The read/write split for POST is therefore a call-site decision, as the issue's own caution paragraph anticipated.

The rule implemented:

| Verb | Replay after re-login | Decided where |
|---|---|---|
| PUT, PATCH, DELETE | never | the adapter — every clio call site of these three verbs is a record write |
| POST | yes, **unless the caller declared it a write** | the call site |
| GET | yes | the adapter |

Concretely for POST call sites: `dataservice -t select` is a read (a POST on the fixed `SelectQuery` route) and keeps the replay, via the new hook `BaseServiceCommand<T>.AllowsPostReplay(options)`. `dataservice -t insert|update|delete`, every `call-service` POST (user-supplied endpoint, unknown response shape), `odata-create` and the email-template create branch declare themselves writes and never replay. `CallConfigurationService` and the `Upload*` family keep replaying — they are the calls most likely to outlive a session, and the adapter cannot classify them.

Trade-off, stated deliberately: `odata-create`, `odata-update`, `odata-delete`, the email-template create/update and any `call-service` PUT/PATCH/DELETE lose the automatic session recovery. On an expired session the caller now sees the unreplayed response — `ExpiredSession` for `call-service`, a failed non-JSON response for the OData tools — and retries by hand after checking the target. Duplicating a committed write is not recoverable; retrying a refused one is.

No `MaxAttempts`-based escape hatch was reintroduced (`56addae21` / `a0f2ac01f`).

## Root cause

Detection is body-based (`ReauthExecutor.IsSessionExpiredResponse`): on-prem .NET Framework Creatio answers an expired cookie with HTTP 200 and an HTML login page, so the classifier reads the response rather than the status. That test cannot separate "the server rejected this write unauthenticated" from "the write committed and its legitimate response contains `/Login/`". `call-service` points at an arbitrary user-supplied endpoint, so the false positive is reachable, and `ReauthExecutor` then re-invoked `call()` — a second committed PUT/PATCH/POST/DELETE, reported as success.

`maxAttempts: 1` does not prevent this: that argument bounds `Creatio.Client`'s own transport retry, a layer below the reauth retry.

## Changes

- `IReauthExecutor.Execute` takes a required `replayAllowed` flag (no default — every call site has to state which kind of call it is). `ReauthExecutor` re-authenticates either way; when replay is refused it returns the original unauthorized response instead of re-issuing the call, and rethrows on the `JsonException` path. `NoReauthExecutor` is unaffected (it never replayed).
- `CreatioClientAdapter` passes `false` for PUT / PATCH / DELETE, `true` for GET / POST / `CallConfigurationService` / `Upload*`.
- New `IApplicationClient.ExecuteNonReplayablePostRequest` — a **defaulted** interface member whose default body forwards to `ExecutePostRequest`, for the same reason `ExecutePutRequest` is defaulted (an abstract member is source-breaking for out-of-repo implementers with CS0535). `DataServiceQuery.ExecuteServiceRequest` uses it for POST unless `AllowsPostReplay(options)` says the command declared this POST a read (`DataServiceQuery` overrides it for `-t select`); `ODataCreateTool` and `EmailTemplateTool`'s create branch use it too; `ApplicationClientLease` forwards it.
- New `ServiceResponseFailure.ExpiredSession` in `DataServiceQuery`: the true-positive path now surfaces the login page to `call-service`, which previously read as "the response is an HTML page, not a service payload". It now names the session as the cause. The message deliberately does not promise the request was rejected: it says the write may or may not have been applied and to verify the target before re-running, because the same body-based ambiguity that forbids the automatic replay forbids that promise. The classification is also checked before the markup branch, since the detector's second arm is a JSON 401 envelope from the `.svc` endpoints and is not markup at all. Only locally authored text is printed — the remote body is still never logged and never written to `--destination`.
- New `ICreatioClientTransport` / `CreatioClientTransport`: the adapter no longer holds a `Lazy<CreatioClient>`. `CreatioClient` is a concrete NuGet class with no virtual members, so the adapter's tests had to resolve their `Lazy` to `null` and could never invoke the callback handed to the executor — the delegation itself was unverified, and counting underlying calls (what the no-replay rule needs to assert) was impossible. The transport is built inside the adapter's private constructor over its own lazy client, exactly like `ReauthExecutor` and `LoginDiagnostics`, so every construction site gets it — including the MCP per-tenant child container that builds its Creatio connections inline and never goes through `ApplicationClientFactory` (ENG-93208 B1). It is in the `BindingsModule` `ValidateOnBuild` skip list next to `IReauthExecutor` / `ILoginDiagnostics`, because its only constructor argument is that lazy client.
- Tests: executor-level replay-policy pair; adapter-level "the captured callback issues exactly the PUT it was asked for, with every argument preserved"; "exactly one underlying call + exactly one Login" for PUT and for the declared-write POST; the contrasting "a GET still replays"; the `call-service` expired-session classification; and a forwarding test on the frozen `LegacyApplicationClient` fixture so the defaulted-member promise is actually exercised (NSubstitute proxies return `null` for a default interface member, so the `call-service`, `odata-create` and email-template POST stubs were all re-pointed to the new member). Plus a `dataservice` pair pinning the per-call-site rule itself: `-t select` reaches `ExecutePostRequest` and nothing else, `-t insert|update|delete` reach `ExecuteNonReplayablePostRequest` and nothing else.
- Knowledge records: `docs/knowledge/Common/reauth-never-replays-a-write.md` and `docs/knowledge/Common/creatio-client-transport-is-the-adapter-test-seam.md`. `session-reauth-is-deliberately-silent.md` amended (the retry is now conditional; the no-logging fact it records is unchanged). `child-container-connection-sites-bypass-the-client-factory.md` and `McpServer/odata-write-transport-never-throws-on-non-2xx.md` reviewed, still true, unchanged.

## Known limits, not code

Per the measured-behaviour rule, this PR does not widen beyond the reported defect:

- `RemoteCommand`'s own POST and the generic `ExecutePostRequest<T>` stay replayable. They are internal, fixed service routes, not user-supplied endpoints; the documented rule tells a future caller how to opt out.
- The `JsonException` replay path is only reachable from the `Upload*` methods, which stay replayable — that is the measured ENG-90393 behaviour and no upload defect was reported.
- `DownloadFile` remains outside the executor for the reason already documented at its call site.

## Validation

```
dotnet build clio/clio.csproj -c Debug -f net10.0                 # 0 errors, no new CLIO* warnings
dotnet test clio.tests/clio.tests.csproj -f net10.0 --no-build \
  --filter "Category=Unit&(Module=Query|Module=McpServer|Module=Common)"   # 6802 passed, 20 known macOS failures, 5 skipped
dotnet test clio.tests/clio.tests.csproj -f net10.0 --no-build --filter "Category=Unit"   # full suite, clio/Common changed
```

Full suite on macOS: **12672 passed, 28 failed, 40 skipped**. All 28 failures are the known macOS-only families that also fail on a clean checkout — `DbHubTomlStore` (`Upsert_*`, `Remove_*`, `EnsureRunnable_*`, `ValidateForInstallation_*`), `NetFrameworkHttps` `Configure_*`, `IsRegisteredProfilePath`, the IIS target helpers, `ExtractIdentityService_*`, `ProcessExecutor.ExecuteAndCaptureAsync_ShouldClearInheritedEnvironment`, and `Create_ShouldAddInjectableLocalizationAbstraction` (asserts a `T:\` Windows path). None are in the reauth / client / call-service area, and none of them are new here.

## Review tier

Full 3-lens fan-out (code quality, bug detection, security) over `git diff origin/master...HEAD` — the change touches shared infrastructure (`clio/Common`) and the authentication path — plus one combined reviewer pass over the final diff after the follow-up fixes (the per-call-site POST rule, the `ExpiredSession` wording and the `EnsureCreated` lifetime fix). **No Blocker and no High findings.** The reviewer confirmed the lock ordering (`_reauthLock` → `_lifetimeSync`, never the reverse, so `EnsureCreated()` under the lifetime lock cannot deadlock with `Dispose`) and that no stale `ExecutePostRequest` stub remains on a path that now calls the non-replayable member.

Medium / Low, recorded rather than coded (the measured-behaviour rule):

- The three MCP write paths that now receive the login page raw (`ODataKeyedWrite.ValidateWriteResponse`, `EmailTemplateTool.Write`, `ODataCreateTool.ParseCreated`) report a parser-level failure rather than naming the session. All three fail closed and none claims a create, so no silent success — but an `IsSessionExpiredResponse` check in those three spots would give the agent the same wording `call-service` now has. Worth a follow-up, out of scope here.
- `ExecutePostRequest<T>` still has no non-replayable counterpart, so `RemoteCommand`'s fixed-route POST writes keep replaying. Documented in the knowledge record as deliberately staged.
- `ExecuteServiceRequest` takes the answer as a parameter while `AllowsPostReplay` computes it; there is exactly one call site today, so the two cannot disagree.
- The `!replayAllowed` arm of `ReauthExecutor`'s `catch (JsonException)` is unreachable in production (only `Upload*` deserializes inline, and it replays); it is covered by a test.
- The two new `dataservice` tests sit in `CallServiceCommandDeleteTests` next to the rest of this base class's replay-policy coverage and construct the command directly, matching that file's existing style rather than the DI pattern.

One rule worth carrying forward, from the NSubstitute pitfall: a default interface member is intercepted on a substitute and returns `""` instead of running its body, and `TryClassifyResponse` treats an empty response as success — so a new defaulted operation must never be verified through a substitute alone. `LegacyApplicationClientCompatibilityTests` exercises the real default body.

## MCP / docs / Ring

- **MCP reviewed.** No tool contract changed — no arguments, descriptions, destructive flags or result shapes were touched, so no `clio.mcp.e2e` update is required. The *behaviour* of `odata-create`, `odata-update`, `odata-delete` and the email-template write does change on an expired session: they now receive the raw login page instead of a transparently replayed result. All of them fail closed already — `ODataKeyedWrite.ValidateWriteResponse` cannot parse the HTML and returns `CreatioResponseError.DescribeNonJsonResponse(...)` as a failure; `ODataCreateTool.ParseCreated` takes its `catch (JsonException)` path, which reports `Success = false` with `RecordCreated = null` and the unknown-side-effect retry guidance (never a confirmed create); and `EmailTemplateTool.Write` throws on the same parse. No tool reports a silent success, and no tool `[Description]` mentions retry/replay/session behaviour, so none needed rewording.
- **Docs reviewed, no update required.** `clio/docs/commands/call-service.md`, `clio/docs/commands/dataservice.md` and `clio/help/en/call-service.txt` carry no retry/replay/session wording to correct (there is no `clio/help/en/dataservice.txt`; that gap predates this change).
- `ClioRing compatibility reviewed, no Ring-consumed contract changed` — inspected `clio-ring/` for `call-service`, `dataservice` and `IApplicationClient`: no match in any `*.cs` or `*.json`, including `ClioRing.Desktop/actions.json`. Nothing in Ring consumes the changed surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
