### PR TITLE
Bind a dispatched argument once and classify a Creatio error without prose (#1314)

### DIFF
--- a/clio.mcp.e2e/ODataReadExpandContextE2ETests.cs
+++ b/clio.mcp.e2e/ODataReadExpandContextE2ETests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Allure.NUnit;
+using Allure.NUnit.Attributes;
+using Clio.Command.McpServer.Tools;
+using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Results;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+
+namespace Clio.Mcp.E2E;
+
+/// <summary>
+/// Pins the <c>@odata.context</c> shape a real Creatio service returned for an expanded read -
+/// <c>Contact?$select=Id,Name,AccountId&amp;$expand=Account&amp;$top=1</c> answering with the fragment
+/// <c>#Contact(Id,Name,AccountId,Account())</c> - through the REAL stdio MCP server, not only through
+/// the in-process parser unit tests. <c>odata-read</c> is a long-tail tool, so a call to it travels
+/// <c>McpDurableCallToolHandler</c> -> <c>IClioRunExecutor.InvokeResolvedAsync</c> -> the same
+/// <c>DispatchAsync</c> that serves a nested <c>clio-run</c> call.
+/// <para>
+/// The unit tests over <c>ODataReadTool</c>'s context parser cannot see the argument binding,
+/// serialization and dispatch the live call actually travels through, so a change on that path could
+/// turn an accepted body into a failure with every unit test still green.
+/// </para>
+/// </summary>
+[TestFixture]
+//A loopback stub answers every request in this fixture - no Creatio sandbox is involved.
+[Category("McpE2E.NoEnvironment")]
+[AllureNUnit]
+[AllureFeature(ODataReadTool.ToolName)]
+[NonParallelizable]
+public sealed class ODataReadExpandContextE2ETests {
+	private const string Entity = "Contact";
+	private const string NavigationProperty = "Account";
+
+	[Test]
+	[AllureTag(ODataReadTool.ToolName)]
+	[AllureName("odata-read accepts the live expanded context fragment over stdio")]
+	[AllureDescription("Sends select plus expand through the real stdio MCP server against a stub answering with the live-proven #Contact(Id,Name,AccountId,Account()) context, and verifies the read is accepted as a top-level read of the requested set with the expanded record in the payload.")]
+	[Description("odata-read with expand is answered with the live-proven parenthesized context fragment and reports success with the expanded record, proving the fragment parser is reached and satisfied over the real MCP dispatch path.")]
+	public async Task ODataRead_Should_Accept_The_Expanded_Context_Shape_Through_TheLongTailDispatch() {
+		// Arrange
+		await using ODataPreWriteStand stand = await ODataPreWriteStand.StartAsync(
+			RuntimeDetectionStubServer.ODataExpandRead, Entity);
+
+		// Act
+		CallToolResult callResult = await stand.Session.CallToolAsync(
+			ODataReadTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["environment-name"] = stand.EnvironmentName,
+					["entity"] = Entity,
+					["select"] = new[] { "Id", "Name", "AccountId" },
+					["expand"] = new[] { NavigationProperty },
+					["top"] = 1
+				}
+			},
+			stand.CancellationToken);
+		ODataReadResponse response = EntitySchemaStructuredResultParser.Extract<ODataReadResponse>(callResult);
+
+		// Assert
+		callResult.IsError.Should().NotBeTrue(
+			because: "a bindable odata-read payload must return a structured tool response, not a protocol error");
+		response.Success.Should().BeTrue(
+			because: "the parenthesized projection fragment is what a real Creatio service answers to an expanded "
+				+ "read, so it must be accepted as a top-level read of the requested set");
+		response.Count.Should().Be(1,
+			because: "the stub answered the one requested record and the read must report it as returned data");
+		response.Value.Should().NotBeNull(
+			because: "an accepted expanded read must carry the records, not only a success flag");
+		response.Value!.Value.EnumerateArray().Should().NotBeEmpty(
+			because: "reading the first record below would otherwise throw an unhelpful sequence error "
+				+ "instead of reporting that the read returned nothing");
+		response.Value.Value.EnumerateArray().First().TryGetProperty(NavigationProperty, out JsonElement expanded)
+			.Should().BeTrue(
+				because: "the expanded navigation property is the payload the caller asked for by sending expand");
+		expanded.ValueKind.Should().Be(JsonValueKind.Object,
+			because: "an expanded single-valued navigation property arrives as the nested entity object");
+
+		IReadOnlyList<RecordedStubRequest> requests = await stand.GetRecordedRequestsAsync();
+		requests.Should().Contain(request => request.Url.Contains("$expand=Account", StringComparison.Ordinal),
+			because: "asserting the answer alone would still pass if expand were dropped before the request left "
+				+ "the process, so the recorded query is what proves it was sent");
+	}
+}

--- a/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
+++ b/clio.mcp.e2e/Support/Creatio/RuntimeDetectionStubServer.cs
@@ -136,6 +136,17 @@ internal sealed class RuntimeDetectionStubServer : IAsyncDisposable {
 	public const string ODataPreWriteEmptyRecord = "emptyrecord";
 
 	/// <summary>
+	/// <see cref="RuntimeDetectionStubServerConfiguration.ODataPreWriteMode"/> value that answers a
+	/// COLLECTION read carrying <c>$expand</c> with the shape a real Creatio service returned for
+	/// <c>Contact?$select=Id,Name,AccountId&amp;$expand=Account&amp;$top=1</c>: an
+	/// <c>@odata.context</c> whose fragment carries the projection and the expanded navigation property
+	/// as <c>Account()</c>, plus one record with the expanded object nested in it. The fragment is built
+	/// from the request's own <c>$select</c>/<c>$expand</c>, so the stub answers what was asked rather
+	/// than a literal it could drift from.
+	/// </summary>
+	public const string ODataExpandRead = "expandread";
+
+	/// <summary>
 	/// Path of the stub's own introspection endpoint. A GET returns a JSON array of
 	/// <c>{ "method": ..., "url": ... }</c> for every request the stub has served, letting a test prove
 	/// which URL the pre-write validation actually requested and that no PATCH was issued.
@@ -414,15 +425,47 @@ http.createServer((request, response) => {
             + " See http://admin:{{ODataPreWriteUnverifiedSecret}}@{{ODataPreWriteUnverifiedHost}}:80/trace for details.");
         return;
       }
+      const isCollectionExpandRead = request.method === "GET"
+        && url.includes("/odata/" + config.ODataEntity + "?")
+        && url.includes("$expand=");
+      if (isCollectionExpandRead && config.ODataPreWriteMode === "{{ODataExpandRead}}") {
+        // The live-proven expand shape: the context fragment names the selected columns AND the
+        // expanded navigation property with empty parentheses, and the record nests the expanded entity.
+        // The query is read through the URL parser rather than by splitting on the parameter name: a
+        // name that is a substring of another ($select inside a hypothetical $selectAny) would make a
+        // hand-rolled split answer the wrong value, and the parser also does the percent-decoding.
+        const query = new URL(url, "http://127.0.0.1").searchParams;
+        const splitList = (value) => (value ? value.split(",") : []);
+        const projection = splitList(query.get("$select"));
+        const expanded = splitList(query.get("$expand"));
+        const fragment = config.ODataEntity + "("
+          + projection.concat(expanded.map((nav) => nav + "()")).join(",") + ")";
+        // Object.create(null) so a column literally named __proto__ or constructor becomes an own
+        // property of the answer instead of mutating/ignoring an inherited one.
+        const record = Object.assign(Object.create(null), { Id: "00000000-0000-0000-0000-000000000001" });
+        for (const column of projection) {
+          if (column && column !== "Id") {
+            record[column] = "probe";
+          }
+        }
+        for (const nav of expanded) {
+          record[nav] = { Id: "00000000-0000-0000-0000-000000000002", Name: "probe" };
+        }
+        sendJson(response, 200, {
+          "@odata.context": "http://127.0.0.1/odata/$metadata#" + fragment,
+          value: [record]
+        });
+        return;
+      }
       if (isKeyedProbe) {
         // The record the $select probe addressed, echoed back with the OData context annotation and
         // EVERY column the probe selected - what a conforming service answers, and what the probe now
         // requires as proof that those fields exist.
-        const selected = decodeURIComponent(url.split("$select=")[1].split("&")[0]).split(",");
-        const record = {
+        const selected = (new URL(url, "http://127.0.0.1").searchParams.get("$select") || "").split(",");
+        const record = Object.assign(Object.create(null), {
           "@odata.context": "http://127.0.0.1/odata/$metadata#" + config.ODataEntity,
           Id: "00000000-0000-0000-0000-000000000001"
-        };
+        });
         for (const column of selected) {
           if (column && column !== "Id") {
             record[column] = "probe";

--- a/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
+++ b/clio.tests/Command/McpServer/ClioRunDispatchTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Clio.Command.McpServer;
@@ -115,11 +116,71 @@ public sealed class ClioRunDispatchTests {
 
 		// Assert
 		string text = ErrorText(result);
-		result.IsError.Should().BeTrue(because: "clio-run must reject an incompatible target argument before invoking the tool");
+		result.IsError.Should().BeTrue(because: "clio-run must answer an incompatible target argument with an error result, and the tool body must never run");
 		text.Should().Contain("invalid-parameter-type", because: "the nested dispatch must use the MCP argument error contract");
 		text.Should().Contain("value", because: "the target argument name must be actionable");
 		text.Should().Contain("string", because: "the diagnostic must state the expected JSON type");
 		text.Should().NotContain("Cannot get the value of a token type", because: "the SDK implementation exception must not leak to the agent");
+	}
+
+	// A composite args record that counts its own deserializations, so a test can observe HOW MANY times
+	// a dispatched call binds the caller's JSON. System.Text.Json creates one instance per bind, so the
+	// counter is exactly the number of binds. Public because the SDK builds the tool over a public
+	// method whose parameter type it must be able to reach; the counter itself stays internal and is
+	// incremented atomically, since the SDK may bind on a thread pool thread.
+	public sealed class CountingArgs {
+		internal static int BindCount;
+
+		public CountingArgs() => Interlocked.Increment(ref BindCount);
+
+		[JsonPropertyName("value")]
+		public string? Value { get; set; }
+	}
+
+	[McpServerToolType]
+	private static class CountingToolType {
+		internal const string ToolName = "counting-tool";
+
+		internal static bool BodyRan;
+
+		[McpServerTool(Name = ToolName, Destructive = false)]
+		[System.ComponentModel.Description("Counts how often its arguments are bound.")]
+		public static string Run([System.ComponentModel.Description("payload")] CountingArgs args) {
+			BodyRan = true;
+			return $"ran:{args.Value}";
+		}
+	}
+
+	// The counting tool - unlike the older fixtures in this file, which keep JsonSerializerOptions.Default
+	// because their assertions are written against its property naming - is built with the PRODUCTION MCP
+	// serializer options, so the bind count it observes is the one the shipped server produces.
+	private static McpServerTool BuildCountingTool() =>
+		McpServerTool.Create(
+			typeof(CountingToolType).GetMethod(nameof(CountingToolType.Run))!,
+			target: null,
+			new McpServerToolCreateOptions { SerializerOptions = BindingsModule.CreateMcpSerializerOptions() });
+
+	[Test]
+	[Category("Unit")]
+	[Description("Binds a successfully dispatched clio-run argument exactly once, so the nested dispatch no longer deserializes the same JSON for a diagnostic it then discards.")]
+	public async Task RunAsync_ShouldBindDispatchedArgumentsOnce_WhenTheCallSucceeds() {
+		// Arrange
+		RegisterTool(CountingToolType.ToolName, BuildCountingTool(), destructive: false);
+		Interlocked.Exchange(ref CountingArgs.BindCount, 0);
+		CountingToolType.BodyRan = false;
+		JsonElement arguments = JsonDocument.Parse("{\"args\":{\"value\":\"payload\"}}").RootElement;
+
+		// Act
+		CallToolResult result = await _sut.RunAsync(
+			CountingToolType.ToolName, arguments, destructiveSurface: false, CallContext(), CancellationToken.None);
+
+		// Assert
+		result.IsError.Should().NotBe(true,
+			because: "a well-formed dispatched call must succeed and reach the target tool body");
+		CountingToolType.BodyRan.Should().BeTrue(
+			because: "the dispatch must actually run the target tool, not short-circuit before it");
+		Volatile.Read(ref CountingArgs.BindCount).Should().Be(1,
+			because: "the SDK's own binding is the only deserialization a successful dispatch owes");
 	}
 
 	// A real SDK-built tool whose method throws, so InvokeAsync surfaces an exception (which the SDK

--- a/clio.tests/Common/CreatioResponseErrorDetectionTests.cs
+++ b/clio.tests/Common/CreatioResponseErrorDetectionTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using System.Text.Json;
 using Clio.Common;
 using FluentAssertions;
@@ -85,5 +87,90 @@ public sealed class CreatioResponseErrorDetectionTests {
 		isError.Should().BeTrue(because: "the body carries only the routing-error keys, which is the recognized routing shape");
 		message.Should().Contain("controller named 'Foo'",
 			because: "the most specific routing detail is surfaced");
+	}
+
+	// One large OData v4 error body, shared by the two tests below: no string `message` member, so the
+	// message-producing path falls back to copying the whole `error` subtree out with GetRawText().
+	private static string BuildLargeODataErrorBody() {
+		StringBuilder builder = new();
+		builder.Append("{\"error\":{\"code\":\"500\",\"details\":[");
+		for (int index = 0; index < 4000; index++) {
+			if (index > 0) {
+				builder.Append(',');
+			}
+			builder.Append("{\"target\":\"field").Append(index).Append("\",\"detail\":\"")
+				.Append('x', 250).Append("\"}");
+		}
+		builder.Append("]}}");
+		return builder.ToString();
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Classifies a large OData v4 error body without materializing the error subtree, so a read that only needs the routing kind does not allocate the prose it discards.")]
+	public void TryClassify_Should_Not_Materialize_The_Error_Subtree_For_A_Large_Body() {
+		// Arrange
+		//Deliberately synchronous: GC.GetAllocatedBytesForCurrentThread() counts the CURRENT thread, so an
+		//await between the two reads could resume on a different pool thread and measure nothing.
+		string body = BuildLargeODataErrorBody();
+		JsonElement root = JsonDocument.Parse(body).RootElement;
+		//One throwaway call so JIT and first-use allocations are not charged to the measured one.
+		CreatioResponseError.TryClassify(root, CreatioResponseContext.ODataPayload, out bool _);
+		long before = GC.GetAllocatedBytesForCurrentThread();
+
+		// Act
+		bool isError = CreatioResponseError.TryClassify(root, CreatioResponseContext.ODataPayload,
+			out bool isUnregisteredEntity);
+		long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+		// Assert
+		isError.Should().BeTrue(because: "an OData v4 error envelope is a recognized error whatever its size");
+		isUnregisteredEntity.Should().BeFalse(because: "an OData v4 error is not the routing miss the hint applies to");
+		allocated.Should().BeLessThan(body.Length,
+			because: "classification must not copy the error subtree out of the document to decide a kind");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Still returns the raw error subtree as the message for the same body, because the write callers report that text to the user.")]
+	public void TryDetect_Should_Still_Return_The_Raw_Error_Subtree_When_There_Is_No_Message_Member() {
+		// Arrange
+		string body = BuildLargeODataErrorBody();
+		JsonElement root = JsonDocument.Parse(body).RootElement;
+
+		// Act
+		bool isError = CreatioResponseError.TryDetect(root, CreatioResponseContext.ODataPayload, out string message);
+
+		// Assert
+		isError.Should().BeTrue(because: "the detection decision is the same on both contracts");
+		message.Should().Contain("field3999",
+			because: "a write caller reports the server's own error detail and must keep getting the whole subtree");
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Reports the unregistered-entity routing miss as a kind produced during detection, not by searching the formatted message for the hint wording.")]
+	public void TryClassify_Should_Report_The_Routing_Miss_Without_Reading_The_Hint_Text() {
+		// Arrange
+		const string routingMissBody =
+			"{\"Message\":\"No HTTP resource was found that matches the request URI.\"," +
+			"\"MessageDetail\":\"No type was found that matches the controller named 'Foo'\"}";
+		const string otherErrorBody = "{\"Message\":\"Something else went wrong.\"}";
+
+		// Act
+		bool routingMissDetected = CreatioResponseError.TryClassify(
+			JsonDocument.Parse(routingMissBody).RootElement, CreatioResponseContext.ODataPayload,
+			out bool routingMissIsUnregistered);
+		bool otherDetected = CreatioResponseError.TryClassify(
+			JsonDocument.Parse(otherErrorBody).RootElement, CreatioResponseContext.ODataPayload,
+			out bool otherIsUnregistered);
+
+		// Assert
+		routingMissDetected.Should().BeTrue(because: "the bare routing shape is a recognized OData error");
+		routingMissIsUnregistered.Should().BeTrue(
+			because: "the routing-miss wording is what the locally authored retry hint applies to");
+		otherDetected.Should().BeTrue(because: "a bare Message body is still an error on an OData endpoint");
+		otherIsUnregistered.Should().BeFalse(
+			because: "an unrelated failure must not be reported as the asynchronous-rebuild wait");
 	}
 }

--- a/clio/Command/McpServer/McpToolErrorFilter.cs
+++ b/clio/Command/McpServer/McpToolErrorFilter.cs
@@ -812,8 +812,38 @@ public static class McpToolErrorFilter
 			+ "so there is no doubt which value wins.";
 	}
 
+	/// <summary>
+	/// The full argument preflight: the structural checks below PLUS a trial deserialization of every
+	/// supplied argument, which is what produces the precise per-argument <c>invalid-parameter-type</c>
+	/// text. The trial binds the argument a second time, so on a path where the SDK is about to bind the
+	/// same JSON anyway this belongs on the FAILURE path only — see
+	/// <see cref="TryCreateArgumentShapeError"/> and <c>ClioRunTool</c>'s dispatch.
+	/// </summary>
 	internal static bool TryCreateArgumentDeserializationError(
 		RequestContext<CallToolRequestParams> context,
+		out CallToolResult? result) =>
+		TryCreateArgumentError(context, includeBindingTrial: true, out result);
+
+	/// <summary>
+	/// The allocation-free half of the preflight: the checks that read only an argument's
+	/// <see cref="JsonElement.ValueKind"/> and the parameter's declared type, and never deserialize.
+	/// </summary>
+	/// <remarks>
+	/// These two cannot move to the failure path, for opposite reasons. An explicit JSON null for a
+	/// required non-nullable parameter does NOT fail SDK binding — it binds to null and the tool body
+	/// runs — so only a check ahead of invocation keeps the direct and <c>clio-run</c> paths agreeing.
+	/// A JSON-encoded object DOES fail binding, but the point of that diagnostic is to name the shape
+	/// BEFORE the generic deserialization text can be produced, and running it here keeps its precedence
+	/// over the trial-deserialization message unchanged.
+	/// </remarks>
+	internal static bool TryCreateArgumentShapeError(
+		RequestContext<CallToolRequestParams> context,
+		out CallToolResult? result) =>
+		TryCreateArgumentError(context, includeBindingTrial: false, out result);
+
+	private static bool TryCreateArgumentError(
+		RequestContext<CallToolRequestParams> context,
+		bool includeBindingTrial,
 		out CallToolResult? result) {
 		result = null;
 		if (context.Params?.Arguments is not { } arguments) {
@@ -825,6 +855,15 @@ public static class McpToolErrorFilter
 		}
 
 		foreach (ParameterInfo parameter in method.GetParameters()) {
+			// Shared definition - see McpToolArgumentSupport.IsBindableToolParameter (ENG-95885). The SDK
+			// injects CancellationToken, IServiceProvider, RequestContext<> and its own server types from the
+			// request context, never from the arguments object, so a caller key that merely collides with such
+			// a parameter's name is not an argument for it. Without this guard the checks below would judge
+			// that key against the framework type and answer a well-formed call with a false
+			// invalid-parameter-type, hiding whatever the real failure was.
+			if (!McpToolArgumentSupport.IsBindableToolParameter(parameter)) {
+				continue;
+			}
 			string argumentName = GetArgumentName(parameter);
 			if (!arguments.TryGetValue(argumentName, out JsonElement argumentValue)) {
 				continue;
@@ -849,6 +888,9 @@ public static class McpToolErrorFilter
 			if (TryCreateJsonEncodedObjectError(
 				context.Params.Name, argumentName, parameter.ParameterType, argumentValue, out result)) {
 				return true;
+			}
+			if (!includeBindingTrial) {
+				continue;
 			}
 			try {
 				argumentValue.Deserialize(parameter.ParameterType, SerializerOptions);

--- a/clio/Command/McpServer/Tools/ClioRunTool.cs
+++ b/clio/Command/McpServer/Tools/ClioRunTool.cs
@@ -273,7 +273,14 @@ public sealed class ClioRunExecutor(
 		callContext.Params = childParams;
 		callContext.MatchedPrimitive = tool;
 		try {
-			if (McpToolErrorFilter.TryCreateArgumentDeserializationError(
+			// Only the checks that read an argument's JSON value kind run here. The trial
+			// deserialization that produces the precise per-argument diagnostic moved into the catch
+			// below, because it binds the same JSON the SDK is about to bind: on the success path this
+			// dispatch deserialized every nested argument twice, roughly doubling binding CPU and
+			// large-object allocation for a big composite payload. A failed bind throws out of
+			// InvokeAsync before the tool body runs, so the caller still gets the same message and the
+			// tool still does not execute.
+			if (McpToolErrorFilter.TryCreateArgumentShapeError(
 				callContext,
 				out CallToolResult? argumentErrorResult)) {
 				return argumentErrorResult;
@@ -286,6 +293,20 @@ public sealed class ClioRunExecutor(
 			throw;
 		}
 		catch (Exception ex) when (!McpExceptionPolicy.IsUnrecoverable(ex)) {
+			// An argument the SDK could not bind throws from InvokeAsync (before the tool body runs), and
+			// only here is the trial deserialization worth paying for: it reproduces the failure and turns
+			// it into the same precise invalid-parameter-type diagnostic this dispatch returned when the
+			// trial ran up front. The cost moved rather than vanished - a call that FAILS to bind now binds
+			// twice (the SDK's failed attempt plus this trial) instead of once - which is the deliberate
+			// trade: the extra pass is spent only on a call that is already failing. The call self-gates -
+			// well-formed arguments deserialize, it returns false, and a JsonException raised by the tool
+			// BODY falls through to the generic redacted message below exactly as before.
+			// Deliberately NOT gated on the exception type: an SDK that
+			// starts wrapping its binding failure would silently revert the diagnostic to that generic text.
+			// The trial is a DIAGNOSTIC, never a second failure mode - see TryDiagnoseBindingFailure.
+			if (TryDiagnoseBindingFailure(callContext) is { } bindingErrorResult) {
+				return bindingErrorResult;
+			}
 			// Without this catch the exception escapes to the outer McpToolErrorFilter, which the agent
 			// sees as a generic "An error occurred invoking '<tool>'" with no detail — so it cannot
 			// self-correct. Surface the real (inner-most) message as a structured Error result instead
@@ -298,6 +319,31 @@ public sealed class ClioRunExecutor(
 		finally {
 			callContext.Params = originalParams;
 			callContext.MatchedPrimitive = originalPrimitive;
+		}
+	}
+
+	/// <summary>
+	/// Reproduces a binding failure the SDK threw out of <c>InvokeAsync</c> as the precise
+	/// <c>invalid-parameter-type</c> diagnostic, or <see langword="null"/> when the arguments bind
+	/// cleanly (the failure came from the tool body) or the trial itself could not run.
+	/// </summary>
+	/// <remarks>
+	/// The trial is a diagnostic, never a second failure mode. Its own exception is turned into "no
+	/// diagnostic available" rather than propagated, so the caller still receives the tool's real
+	/// failure redacted by the dispatch: a raw reflection or converter error escaping from here would
+	/// both bypass <c>SensitiveErrorTextRedactor</c> and replace the failure the agent needs to see.
+	/// </remarks>
+	private static CallToolResult? TryDiagnoseBindingFailure(
+		RequestContext<CallToolRequestParams> callContext) {
+		try {
+			return McpToolErrorFilter.TryCreateArgumentDeserializationError(
+				callContext, out CallToolResult? bindingErrorResult)
+				? bindingErrorResult
+				: null;
+		}
+		catch (Exception diagnosticFailure) when (!McpExceptionPolicy.IsUnrecoverable(diagnosticFailure)) {
+			//Handled by producing no diagnostic: the caller falls through to the original exception.
+			return null;
 		}
 	}
 

--- a/clio/Common/CreatioResponseError.cs
+++ b/clio/Common/CreatioResponseError.cs
@@ -202,16 +202,15 @@ internal static partial class CreatioResponseError {
 	/// The extracted text is deliberately not an output. Callers that put their result into an MCP
 	/// transcript must use <see cref="DescribeServerReportedReadError"/> instead of
 	/// <see cref="TryDetect"/>, whose message carries server-controlled prose.
+	/// The routing miss is reported by the detector itself, not found by searching the formatted message
+	/// for the hint: the hint's wording would otherwise be part of this contract, and building
+	/// the message at all made a read materialize prose it discards - an OData v4 error body with no
+	/// string <c>message</c> member copied the entire <c>error</c> subtree out with
+	/// <c>GetRawText()</c> first.
 	/// </remarks>
 	internal static bool TryClassify(JsonElement root, CreatioResponseContext context,
-			out bool isUnregisteredEntity) {
-		isUnregisteredEntity = false;
-		if (!TryDetect(root, context, out string detected)) {
-			return false;
-		}
-		isUnregisteredEntity = detected.Contains(UnregisteredEntityHint, StringComparison.Ordinal);
-		return true;
-	}
+			out bool isUnregisteredEntity) =>
+		TryDetectCore(root, context, buildMessage: false, out string _, out isUnregisteredEntity);
 
 	internal static string DescribeNonJsonReadResponse() =>
 		"Creatio did not return a JSON OData response. This points to an IIS, proxy, routing, or session "
@@ -238,8 +237,22 @@ internal static partial class CreatioResponseError {
 	/// routing error the unregistered-entity hint is appended); otherwise an empty string.
 	/// </param>
 	/// <returns><see langword="true"/> when <paramref name="root"/> is a recognized error body.</returns>
-	public static bool TryDetect(JsonElement root, CreatioResponseContext context, out string message) {
+	public static bool TryDetect(JsonElement root, CreatioResponseContext context, out string message) =>
+		TryDetectCore(root, context, buildMessage: true, out message, out bool _);
+
+	/// <summary>
+	/// The single detection pass behind <see cref="TryDetect"/> and <see cref="TryClassify"/>. It always
+	/// reports whether the matched shape is the unregistered-entity routing miss;
+	/// <paramref name="buildMessage"/> decides whether the caller-facing text is composed as well.
+	/// </summary>
+	/// <remarks>
+	/// The detection decisions themselves are identical either way - only the message formatting is
+	/// skipped - so a classification never depends on the prose it does not build.
+	/// </remarks>
+	private static bool TryDetectCore(JsonElement root, CreatioResponseContext context, bool buildMessage,
+			out string message, out bool isUnregisteredEntity) {
 		message = string.Empty;
+		isUnregisteredEntity = false;
 		if (root.ValueKind != JsonValueKind.Object) {
 			return false;
 		}
@@ -254,12 +267,18 @@ internal static partial class CreatioResponseError {
 		//invites a duplicate retry. Explicit error envelopes are unaffected: the DataService and OData
 		//v4 error shapes are checked before this and still win.
 		bool hasProvenODataIdentity = !isService && HasODataContextAnnotation(root);
-		return TryDetectDataServiceEnvelope(root, out message)
-			|| (isService && TryDetectBaseResponse(root, out message))
-			|| TryDetectODataV4Error(root, out message)
-			|| (!hasProvenODataIdentity
-				&& (TryDetectAspNetException(root, out message)
-					|| TryDetectRoutingError(root, context, out message)));
+		if (TryDetectDataServiceEnvelope(root, buildMessage, out message)
+			|| (isService && TryDetectBaseResponse(root, buildMessage, out message))
+			|| TryDetectODataV4Error(root, buildMessage, out message)) {
+			return true;
+		}
+		if (hasProvenODataIdentity) {
+			return false;
+		}
+		//Only the routing branch can be the unregistered-entity miss, so it is the only one that reports
+		//it. Every other recognized shape leaves the flag false.
+		return TryDetectAspNetException(root, buildMessage, out message)
+			|| TryDetectRoutingError(root, context, buildMessage, out message, out isUnregisteredEntity);
 	}
 
 	/// <summary>
@@ -348,7 +367,7 @@ internal static partial class CreatioResponseError {
 	// rejects a login as {"Code":1,...} the same way - which is why it needs detecting at all.
 	// Requiring BOTH a non-zero Code and a non-empty Exception/Message keeps a payload that merely
 	// happens to carry a `Code` column from being read as a failure.
-	private static bool TryDetectDataServiceEnvelope(JsonElement root, out string message) {
+	private static bool TryDetectDataServiceEnvelope(JsonElement root, bool buildMessage, out string message) {
 		message = string.Empty;
 		if (HasODataControlAnnotation(root)) {
 			return false;
@@ -363,7 +382,7 @@ internal static partial class CreatioResponseError {
 		if (string.IsNullOrWhiteSpace(detail)) {
 			return false;
 		}
-		message = $"Creatio returned error code {codeValue}: {detail}";
+		message = buildMessage ? $"Creatio returned error code {codeValue}: {detail}" : string.Empty;
 		return true;
 	}
 
@@ -373,7 +392,7 @@ internal static partial class CreatioResponseError {
 	// failure, wrote it to --destination and exited 0 - the same false success this contract removes
 	// for the other envelopes. Only an explicit boolean false counts, so a payload carrying
 	// success=true, or a `success` string column, is left alone.
-	private static bool TryDetectBaseResponse(JsonElement root, out string message) {
+	private static bool TryDetectBaseResponse(JsonElement root, bool buildMessage, out string message) {
 		message = string.Empty;
 		//No OData-payload guard here, unlike the loose Code/Message detector: ValueResponse<T> and the
 		//insert-derived BaseResponse DTOs keep `value` or `id` on a failure, so guarding on those
@@ -401,6 +420,9 @@ internal static partial class CreatioResponseError {
 		//success:true, are both left alone.
 		if (!explicitFailure && !(hasPopulatedErrorInfo && !explicitSuccess)) {
 			return false;
+		}
+		if (!buildMessage) {
+			return true;
 		}
 		detail ??= First(root, "errorMessage", "ErrorMessage", "message", MessagePropertyName);
 		message = string.IsNullOrWhiteSpace(detail)
@@ -442,10 +464,16 @@ internal static partial class CreatioResponseError {
 	}
 
 	// OData v4 error envelope: { "error": { "message": ... } }.
-	private static bool TryDetectODataV4Error(JsonElement root, out string message) {
+	private static bool TryDetectODataV4Error(JsonElement root, bool buildMessage, out string message) {
 		message = string.Empty;
 		if (!(root.TryGetProperty("error", out JsonElement error) && error.ValueKind == JsonValueKind.Object)) {
 			return false;
+		}
+		//GetRawText() copies the WHOLE error subtree into a new string, and a read classifies the body
+		//without ever using the text - an 8,388,631-character subtree cost an extra 16,777,264 bytes for
+		//prose that was discarded. Detection needs the `error` object, not its content.
+		if (!buildMessage) {
+			return true;
 		}
 		message = error.TryGetProperty("message", out JsonElement m) && m.ValueKind == JsonValueKind.String
 			? m.GetString()
@@ -463,7 +491,7 @@ internal static partial class CreatioResponseError {
 		&& context.ValueKind == JsonValueKind.String
 		&& !string.IsNullOrWhiteSpace(context.GetString());
 
-	private static bool TryDetectAspNetException(JsonElement root, out string message) {
+	private static bool TryDetectAspNetException(JsonElement root, bool buildMessage, out string message) {
 		message = string.Empty;
 		bool isAspNetError = root.TryGetProperty("ExceptionType", out _)
 			|| root.TryGetProperty("ExceptionMessage", out _)
@@ -479,7 +507,9 @@ internal static partial class CreatioResponseError {
 		// would have prevented - a probed record whose own columns are named ExceptionMessage /
 		// ExceptionType / StackTrace - is already handled upstream by
 		// ODataFieldValidation.IsSelectedRecord, which returns before TryDetect is ever reached.
-		message = First(root, "ExceptionMessage", MessagePropertyName) ?? "Creatio returned a server error.";
+		message = buildMessage
+			? First(root, "ExceptionMessage", MessagePropertyName) ?? "Creatio returned a server error."
+			: string.Empty;
 		return true;
 	}
 
@@ -498,8 +528,9 @@ internal static partial class CreatioResponseError {
 	// metadata=none by-key read is ever added, revisit this branch. The ASP.NET-exception branch
 	// deliberately carries NO such guard - see the note in TryDetectAspNetException.
 	private static bool TryDetectRoutingError(JsonElement root, CreatioResponseContext context,
-		out string message) {
+		bool buildMessage, out string message, out bool isUnregisteredEntity) {
 		message = string.Empty;
+		isUnregisteredEntity = false;
 		if (!(root.TryGetProperty(MessagePropertyName, out JsonElement bareMessage)
 			&& bareMessage.ValueKind == JsonValueKind.String
 			&& !HasNonRoutingErrorMembers(root))) {
@@ -519,7 +550,7 @@ internal static partial class CreatioResponseError {
 		string? detail = First(root, "MessageDetail");
 		string primary = !string.IsNullOrEmpty(detail) ? detail : bareMessage.GetString() ?? string.Empty;
 		if (string.IsNullOrEmpty(primary)) {
-			message = "Creatio returned an empty error response.";
+			message = buildMessage ? "Creatio returned an empty error response." : string.Empty;
 			return true;
 		}
 		// The unregistered-entity hint (wait-and-retry, not compile/restart) is tied to a CONTENT
@@ -527,9 +558,10 @@ internal static partial class CreatioResponseError {
 		// bodies can share that shape, and telling the agent to wait for an async rebuild on an
 		// unrelated, non-transient failure would delay correct diagnosis. Append it only for the
 		// genuine routing miss; otherwise surface the message alone (still success=false).
-		message = IsRoutingMiss(detail) || IsRoutingMiss(bareMessage.GetString())
-			? $"{primary} {UnregisteredEntityHint}"
-			: primary;
+		isUnregisteredEntity = IsRoutingMiss(detail) || IsRoutingMiss(bareMessage.GetString());
+		if (buildMessage) {
+			message = isUnregisteredEntity ? $"{primary} {UnregisteredEntityHint}" : primary;
+		}
 		return true;
 	}
 

--- a/docs/knowledge/McpServer/argument-preflight-placement-differs-per-dispatch-path.md
+++ b/docs/knowledge/McpServer/argument-preflight-placement-differs-per-dispatch-path.md
@@ -1,0 +1,28 @@
+---
+description: the trial-deserialization argument preflight runs BEFORE the tool on a direct call but only AFTER a binding failure on the clio-run nested dispatch, and moving the direct one to the failure path would send a malformed call to a worker process first
+applies-to:
+  - clio/Command/McpServer/McpToolErrorFilter.cs
+  - clio/Command/McpServer/Tools/ClioRunTool.cs
+ticket: GH-1314
+date: 2026-09-12
+---
+
+**What is true** — `McpToolErrorFilter` exposes the argument preflight twice on purpose.
+`TryCreateArgumentShapeError` only reads an argument's JSON value kind (the explicit-null guard for a
+required non-nullable parameter, and the JSON-encoded-object shape error) and never deserializes.
+`TryCreateArgumentDeserializationError` additionally binds each argument once to produce the precise
+`invalid-parameter-type` text. `ClioRunTool.DispatchAsync` runs the shape half before
+`tool.InvokeAsync` and the full one only inside its catch, because the SDK throws an unwrapped
+`JsonException` out of `InvokeAsync` before the tool body runs. The call-tool filter
+(`HandleCallToolErrorsCore`) keeps running the FULL preflight up front for a direct call.
+
+**Why it is this way** — the explicit-null guard cannot move: `{"args":null}` binds to null and the
+tool body runs, so nothing is thrown to react to. The direct path cannot adopt the nested path's
+arrangement either: between that preflight and `next` sit the fail-closed execution-routing decision
+and the ENG-95262 worker relay, so a malformed direct call to a worker-routed tool would be relayed to
+a child process and answered by the child's own filter instead of being refused in the host.
+
+**What breaks if you ignore it** — gating the catch-side call on `ex is JsonException` reverts the
+diagnostic to the generic redacted "tool failed" text the moment an SDK version wraps its binding
+failure, with every unit test still green (the stub handlers throw whatever the test chose). Moving the
+direct-path preflight past `next` spends a worker process to discover an argument type error.


### PR DESCRIPTION
🔗 **Issue:** [#1314](https://github.com/Advance-Technologies-Foundation/clio/issues/1314)

Refs #1314

## Summary

Two hot paths did the same work twice and threw the second result away: the `clio-run` nested dispatch deserialized every argument a second time on the success path, and `CreatioResponseError.TryClassify` formatted a caller-facing message it never used just to look for a hint substring in it.

## Root cause

**Double bind.** `ClioRunExecutor.DispatchAsync` ran `McpToolErrorFilter.TryCreateArgumentDeserializationError` before `tool.InvokeAsync`. That preflight deserializes every supplied argument to produce the precise per-argument `invalid-parameter-type` text. The SDK then bound the same JSON again, so a successful dispatch of a large composite payload paid for two full binds — double the binding CPU and double the large-object allocation.

**Prose built to be discarded.** `TryClassify` only needs two booleans (is this an error; is it the unregistered-entity routing miss), but it reached them by calling `TryDetect` and searching the formatted message for `UnregisteredEntityHint`. For an OData v4 error body with no string `message` member, message-building copies the whole `error` subtree out with `GetRawText()` first — an 8,388,631-character subtree cost an extra 16,777,264 bytes of a string nothing read.

## Changes

- `McpToolErrorFilter`: the preflight is split into `TryCreateArgumentShapeError` (reads only `JsonElement.ValueKind` and the declared parameter type, never deserializes) and `TryCreateArgumentDeserializationError` (adds the trial bind). Both share one implementation behind an `includeBindingTrial` flag.
- `McpToolErrorFilter`: the preflight loop now skips framework-injected parameters through `McpToolArgumentSupport.IsBindableToolParameter` — the predicate `ClioRunTool` and the flat-argument normalizer already share. The SDK binds `CancellationToken`, `IServiceProvider`, `RequestContext<>` and its own server types from the request context, never from `arguments`, so a caller key colliding with such a name could previously be answered with a false `invalid-parameter-type`.
- `ClioRunTool.DispatchAsync`: shape checks stay ahead of `InvokeAsync`; the trial deserialization moved into the catch, where a binding failure has already been thrown out of `InvokeAsync` *before* the tool body ran. Same message on a malformed call; the cost moved to the path that was already failing. The trial is a diagnostic only — `TryDiagnoseBindingFailure` turns its own exception into "no diagnostic available" so the tool's real exception is still what the caller gets, redacted.
- `CreatioResponseError`: `TryDetect` and `TryClassify` are now one pass (`TryDetectCore`) with a `buildMessage` flag. Every `buildMessage` early return sits **after** the detection decision, so a classification can never differ from a detection. The routing miss is reported by the detector instead of being recovered from the text, so the hint's wording is no longer part of the contract.
- New loopback e2e fixture `ODataReadExpandContextE2ETests` + a `RuntimeDetectionStubServer` mode pinning the `@odata.context` shape a real Creatio service answers to an expanded read, through the real stdio server and the long-tail dispatch (`McpDurableCallToolHandler` → `InvokeResolvedAsync` → the shared `DispatchAsync`).
- Knowledge record `docs/knowledge/McpServer/argument-preflight-placement-differs-per-dispatch-path.md`.

### Deliberately not done

- The direct-call path keeps the full preflight up front. Between it and `next` sit the fail-closed execution-routing decision and the ENG-95262 worker relay, so a malformed direct call to a worker-routed tool would be relayed to a child process and answered by the child's filter instead of being refused in the host.
- The issue's "use the registered input schema for the preflight" sub-point: the preflight reads the tool METHOD's parameters, and switching it to the emitted schema would change *which* diagnostics are produced, not only when — a contract change, not a performance one. Hence `Refs`, not `Closes`.

## Validation

```
dotnet build clio/clio.csproj -c Debug -f net10.0                          # 0 errors, 11 pre-existing warnings
dotnet test clio.tests/clio.tests.csproj -f net10.0 \
  --filter "Category=Unit&(Module=McpServer|Module=Common)"                # 6725 passed, 20 failed
dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit"
                                                                          # 12663 passed, 28 failed
dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj -f net10.0 --filter \
  "FullyQualifiedName~ODataReadExpandContextE2ETests|FullyQualifiedName~ODataReadToolE2ETests"
                                                                          # 11 passed, 0 failed
dotnet test clio-ring/ClioRing.Tests/ClioRing.Tests.csproj -c Release      # 156 passed, 1 failed
```

All 28 unit failures are the known macOS-only families (`DbHubTomlStore`, `NetFrameworkHttps`, profile-path, `ProcessExecutor`, IIS/identity-service) and match the count measured on a clean tree; the single ClioRing failure is the pre-existing macOS path-separator test. Both e2e fixtures answer from a loopback stub — no Creatio sandbox is involved, so they run anywhere.

`dotnet publish -r win-x64 -p:PublishAot=true` was not run: NativeAOT cannot cross-compile to Windows from macOS. No Ring project or source file was touched.

## Review tier

Full 3-lens fan-out (code-quality, bug-detector, security) over `git diff origin/master...HEAD`. No Blocker/High.

Applied from the review: guarded the catch-side trial so it can never replace the tool's real failure or bypass redaction; skipped framework-injected parameters in the preflight loop; renamed the e2e test and corrected its summary to name the long-tail dispatch; removed a `CreatioErrorKind` enum whose members were mostly never read; atomic counter in the new test; URL-parser query reading in the stub (which also fixes a pre-existing `decodeURIComponent` hazard in the keyed probe).

Medium/Low left as documented limits, per the measured-behaviour rule:

- The `clio-run` diagnostic assumes the SDK **throws** a binding failure out of `InvokeAsync`. An SDK that returned `CallToolResult{IsError=true}` instead would silently fall back to the generic text. Pinned by `RunAsync_ShouldReportContractedTypeError_WhenDispatchedArgumentHasWrongType`, green on this branch.
- For a tool with more than one bindable parameter, the shape-error precedence between parameters can now differ. No clio tool has that shape today.
- The stub's `$expand` parser does not handle a nested `$select` inside an expand clause. `ODataReadTool` never emits one.
- Behaviour change beyond diagnostics, intended: a caller key colliding with a framework-injected parameter's name was previously rejected before execution and is now ignored (the SDK skips it and the tool runs), which is what a direct call already did.

One review suggestion was **not** applied: switching every `Build*Tool` fixture in `ClioRunDispatchTests` to the production MCP serializer options. It changes property naming and breaks `RunAsync_ShouldNotRedactSuccessEnvelope_WhenToolReturnsPocoWithUrl`, whose assertions are written against `JsonSerializerOptions.Default`. Only the new counting tool uses the production options, so its bind count is the one the shipped server produces.

## MCP / docs / ClioRing

**MCP reviewed, no update required** — no tool argument, description, destructive flag, result content or error envelope changed. The `invalid-parameter-type` result is produced by the same `CreateJsonErrorResult` / `BuildDeserializationErrorMessage` as before; only *when* it is produced moved.

**Docs reviewed, no update required** — no command verb, option or output changed.

**ClioRing compatibility reviewed** — Ring does consume `clio-run` (`clio-ring/ClioRing.Ipc/IpcProofRunner.cs`, `clio-ring/ClioRing.Ipc/DeployPlan.cs`, `clio-ring/ClioRing/ViewModels/{ClioWorkflowViewModel,ClioIpcViewModel,InstallFormViewModel,UninstallFormViewModel,WorkflowCommand}.cs`), so the gate applies. The success path, the progress/stage events and the error envelope are byte-identical; the only observable change is that a malformed argument is answered after the SDK's failed bind instead of before it, with the same payload. `ClioRing.Tests` run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
