### PR TITLE
Make the odata-update pre-write check retry, pair and bound for real (#1315)

### DIFF
--- a/clio.mcp.e2e/ODataUpdatePreWriteValidationE2ETests.cs
+++ b/clio.mcp.e2e/ODataUpdatePreWriteValidationE2ETests.cs
@@ -84,6 +84,7 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 		});
 
 		// Assert
+		AssertMachineReadableChannel(callResult);
 		ODataWriteResponse structured = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
 		callResult.IsError.Should().NotBeTrue(
 			because: "a payload the CSDL confirms is a normal tool result, not a protocol-level error");
@@ -204,6 +205,7 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 	/// </summary>
 	/// <param name="callResult">Tool result returned by the MCP server.</param>
 	private static void AssertStructuredFailure(CallToolResult callResult) {
+		AssertMachineReadableChannel(callResult);
 		ODataWriteResponse structured = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
 		callResult.IsError.Should().NotBeTrue(
 			because: "a refused write is a structured tool result the agent can read, not a protocol-level failure");
@@ -211,5 +213,21 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 			because: "the structured success flag is what an agent branches on; a false success here IS issue #1212");
 		structured.Error.Should().NotBeNullOrWhiteSpace(
 			because: "a structured failure must carry the reason on the same channel as the flag");
+	}
+
+	/// <summary>
+	/// Asserts the result actually carries the machine-readable envelope BEFORE it is parsed. The guard is
+	/// on <see cref="CallToolResult.Content"/>, not on <see cref="CallToolResult.StructuredContent"/>:
+	/// <c>odata-update</c> declares no structured output schema, so this server answers with
+	/// <c>StructuredContent == null</c> and the serialized <c>ODataWriteResponse</c> travels as JSON TEXT in
+	/// <c>Content</c> - which is the channel an MCP client parses for this tool. Without the guard, a result
+	/// carrying no payload at all would reach <c>Extract</c> and surface as "could not parse", which reads
+	/// like a shape mismatch rather than like the missing answer it would be.
+	/// </summary>
+	/// <param name="callResult">Tool result returned by the MCP server.</param>
+	private static void AssertMachineReadableChannel(CallToolResult callResult) {
+		callResult.Content.Should().NotBeNullOrEmpty(
+			because: "an agent branches on the serialized envelope, so a result that carried no payload channel "
+				+ "at all would leave it nothing to read - and this tool ships that envelope in Content");
 	}
 }

--- a/clio.mcp.e2e/ODataUpdatePreWriteValidationE2ETests.cs
+++ b/clio.mcp.e2e/ODataUpdatePreWriteValidationE2ETests.cs
@@ -3,6 +3,7 @@ using Allure.NUnit;
 using Allure.NUnit.Attributes;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Creatio;
+using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
 using ModelContextProtocol.Protocol;
 
@@ -52,6 +53,7 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 		});
 
 		// Assert
+		AssertStructuredFailure(callResult);
 		string surfacedText = SerializeSurfacedText(callResult);
 		surfacedText.Should().Contain(UnknownField,
 			because: "the caller can only fix the payload if the refusal names the offending field");
@@ -82,6 +84,11 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 		});
 
 		// Assert
+		ODataWriteResponse structured = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
+		callResult.IsError.Should().NotBeTrue(
+			because: "a payload the CSDL confirms is a normal tool result, not a protocol-level error");
+		structured.Success.Should().BeTrue(
+			because: "the structured success flag is the field an agent branches on - the prose below is not");
 		IReadOnlyList<RecordedStubRequest> requests = await stand.GetRecordedRequestsAsync();
 		requests.Should().Contain(
 			request => request.Method == "GET" && request.Url.EndsWith("/odata/$metadata", StringComparison.Ordinal),
@@ -116,6 +123,7 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 		});
 
 		// Assert
+		AssertStructuredFailure(callResult);
 		string surfacedText = SerializeSurfacedText(callResult);
 		surfacedText.Should().Contain("could not be verified",
 			because: "an outcome the tool could neither confirm nor refute must read as unverified, never as success");
@@ -161,6 +169,7 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 		});
 
 		// Assert
+		AssertStructuredFailure(callResult);
 		string surfacedText = SerializeSurfacedText(callResult);
 		surfacedText.Should().Contain("could not be verified",
 			because: "the absence of a recognized error shape is not field verification - it must read as unverified");
@@ -184,4 +193,23 @@ public sealed class ODataUpdatePreWriteValidationE2ETests {
 	/// <returns>Serialized text of the whole result payload.</returns>
 	private static string SerializeSurfacedText(CallToolResult callResult) =>
 		JsonSerializer.Serialize(callResult.Content) + JsonSerializer.Serialize(callResult.StructuredContent);
+
+	/// <summary>
+	/// Asserts the STRUCTURED half of a refusal, which the prose assertions cannot reach: issue #1212 is a
+	/// false-SUCCESS defect, so a transport that serialized the right no-write explanation next to
+	/// <c>success:true</c> would satisfy every wording assertion in this fixture and still be the bug.
+	/// <c>IsError</c> stays false because a refused write is a normal tool RESULT (the pattern
+	/// <c>ODataReadToolE2ETests</c> asserts); the protocol-level error flag is reserved for a binding or
+	/// transport failure.
+	/// </summary>
+	/// <param name="callResult">Tool result returned by the MCP server.</param>
+	private static void AssertStructuredFailure(CallToolResult callResult) {
+		ODataWriteResponse structured = EntitySchemaStructuredResultParser.Extract<ODataWriteResponse>(callResult);
+		callResult.IsError.Should().NotBeTrue(
+			because: "a refused write is a structured tool result the agent can read, not a protocol-level failure");
+		structured.Success.Should().BeFalse(
+			because: "the structured success flag is what an agent branches on; a false success here IS issue #1212");
+		structured.Error.Should().NotBeNullOrWhiteSpace(
+			because: "a structured failure must carry the reason on the same channel as the flag");
+	}
 }

--- a/clio.tests/Command/McpServer/ODataCreateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataCreateToolTests.cs
@@ -41,8 +41,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(
@@ -76,8 +76,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://env/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":\"11111111-1111-1111-1111-111111111111\"}");
@@ -87,8 +87,12 @@ public sealed class ODataCreateToolTests {
 		tool.Create(new ODataCreateArgs { EnvironmentName = "dev", Entity = "Account", Rows = Arr("[{\"Name\":\"A\"}]") });
 
 		// Assert
-		resolver.Received(1).Resolve<IApplicationClient>(Arg.Is<EnvironmentOptions>(o => o.Environment == "dev"));
-		resolver.Received(1).Resolve<IServiceUrlBuilder>(Arg.Is<EnvironmentOptions>(o => o.Environment == "dev"));
+		// because: one paired resolution is the point - two separate ones re-read the settings and could
+		// pair one environment's authenticated session with another environment's url
+		resolver.Received(1).ResolvePair<IApplicationClient, IServiceUrlBuilder>(
+			Arg.Is<EnvironmentOptions>(o => o.Environment == "dev"));
+		resolver.DidNotReceive().Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>());
+		resolver.DidNotReceive().Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>());
 	}
 
 	[Test]
@@ -135,8 +139,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"Column Name is required\"}}");
@@ -161,8 +165,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/AddressType");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"An error has occurred.\",\"ExceptionMessage\":\"Object reference not set to an instance of an object.\",\"ExceptionType\":\"System.NullReferenceException\"}");
@@ -187,8 +191,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/0/odata/UsrCustomerStatus");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"No HTTP resource was found that matches the request URI '.../0/odata/UsrCustomerStatus'.\",\"MessageDetail\":\"No type was found that matches the controller named 'UsrCustomerStatus'.\"}");
@@ -216,8 +220,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"Authorization has been denied for this request.\"}");
@@ -243,8 +247,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/EmailMessageData");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#EmailMessageData/$entity\",\"Id\":\"22222222-2222-2222-2222-222222222222\",\"Message\":\"Hello there\"}");
@@ -269,8 +273,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/UsrIntegrationLog");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#UsrIntegrationLog/$entity\","
@@ -298,8 +302,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Code\":-1,\"Exception\":\"Access to the entity is denied.\","
@@ -326,8 +330,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/UsrThing");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"@odata.context\":\"http://creatio/odata/$metadata#UsrThing/$entity\",\"Id\":\"33333333-3333-3333-3333-333333333333\",\"Code\":200,\"Message\":\"Created\"}");
@@ -352,8 +356,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://secret-host:88/prod-app/0/odata/UsrCustomerStatus");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"No HTTP resource was found that matches the request URI 'http://secret-host:88/prod-app/0/odata/UsrCustomerStatus'.\"}");
@@ -377,8 +381,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Message\":\"\",\"MessageDetail\":\"\"}");
@@ -403,8 +407,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		// A ModelState validation body carries a member beyond Message/MessageDetail, so TryDetect does
 		// not recognize it; with no Id it falls through to the id-missing fallback branch.
@@ -430,8 +434,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/NumberKeyed");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Id\":42,\"Name\":\"Office\"}");
@@ -456,8 +460,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/AddressType");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"Name\":\"Office\"}");
@@ -481,8 +485,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(
@@ -510,8 +514,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Account");
 		client.ExecutePostRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"bad row\"}}");
@@ -534,8 +538,8 @@ public sealed class ODataCreateToolTests {
 	private static ODataCreateTool BuildTool(IApplicationClient client) {
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		return new ODataCreateTool(resolver);
 	}
@@ -709,8 +713,8 @@ public sealed class ODataCreateToolTests {
 		IApplicationClient client = Substitute.For<IApplicationClient>();
 		IServiceUrlBuilder urlBuilder = Substitute.For<IServiceUrlBuilder>();
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
-		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
-		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(metadataBody);
@@ -868,10 +872,12 @@ public sealed class ODataCreateToolTests {
 		});
 
 		// Assert
+		// because: Received(1) is what pins the single-attempt budget - OptionalMetadataAttempts lives in
+		// the retry ABOVE the transport, while the argument the transport itself gets is TransportAttempts
 		client.Received(1).ExecuteGetRequest(
 			"http://creatio/odata/$metadata",
 			ODataFieldValidation.OptionalMetadataTimeoutMs,
-			ODataFieldValidation.OptionalMetadataAttempts,
+			ODataFieldValidation.TransportAttempts,
 			Arg.Any<int>());
 	}
 }

--- a/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataDeleteToolTests.cs
@@ -37,6 +37,8 @@ public sealed class ODataDeleteToolTests {
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
 		ODataDeleteTool tool = new(resolver);
 
@@ -59,6 +61,8 @@ public sealed class ODataDeleteToolTests {
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		ODataDeleteTool tool = new(resolver);
 
 		ODataWriteResponse response = tool.Delete(new ODataDeleteArgs {
@@ -114,6 +118,8 @@ public sealed class ODataDeleteToolTests {
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
 		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("<html><head><title>401 - Unauthorized: Access is denied due to invalid credentials.</title></head></html>");
@@ -142,6 +148,8 @@ public sealed class ODataDeleteToolTests {
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
 		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns(string.Empty);
@@ -166,6 +174,8 @@ public sealed class ODataDeleteToolTests {
 		IToolCommandResolver resolver = Substitute.For<IToolCommandResolver>();
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(urlBuilder);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, urlBuilder));
 		urlBuilder.Build(Arg.Any<string>()).Returns("http://creatio/odata/Contact(8ecab4a1-0ca3-4515-9399-efe0a19390bd)");
 		client.ExecuteDeleteRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
 			.Returns("{\"error\":{\"code\":\"\",\"message\":\"The DELETE request violates a foreign key constraint\"}}");

--- a/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
@@ -293,7 +293,7 @@ public sealed class ODataUpdateToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Exhausts the bounded retry when every pre-write attempt answers with an empty body, then fails unverified without writing (issue #1315 item 1).")]
+	[Description("Exhausts the bounded retry when every pre-write attempt answers with an empty body, then fails unverified without writing, spending only ONE probe attempt because the metadata leg already proved the target silent (issue #1315 item 1).")]
 	public void Update_Should_Exhaust_The_Bounded_Retry_And_Refuse_To_Write() {
 		// Arrange
 		IApplicationClient client = Substitute.For<IApplicationClient>();
@@ -311,6 +311,38 @@ public sealed class ODataUpdateToolTests {
 			because: "the caller has to be able to tell an unverifiable pre-write from a rejected field");
 		client.Received(ODataFieldValidation.TransientAttempts)
 			.ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		// because: the metadata leg already spent the full budget on a target that answered nothing, so a
+		// second full budget on the same dead target would push the refusal past the MCP client's ceiling
+		client.Received(ODataFieldValidation.ExhaustedTransportProbeAttempts).ExecuteGetRequest(
+			Arg.Is<string>(url => url.Contains("?$select=", StringComparison.Ordinal)),
+			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.DidNotReceiveWithAnyArgs().ExecutePatchRequest(null, null, 0);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Keeps the probe's full retry budget when the metadata leg ended with an ANSWER rather than silence: the transport is proven alive, so an empty probe body is still worth retrying (issue #1315 item 1).")]
+	public void Update_Should_Keep_The_Full_Probe_Budget_After_An_Answered_Metadata_Read() {
+		// Arrange - the metadata endpoint answers with JSON that is neither CSDL nor a recognized Creatio
+		// fault, so the type stays unresolved and the call degrades to the $select probe; that answer is
+		// proof the target is reachable, which an empty body is not.
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(call => call.ArgAt<string>(0).EndsWith("/$metadata", StringComparison.Ordinal)
+				? "{\"unrelated\":1}"
+				: string.Empty);
+		Fixture f = FixtureFor(client);
+
+		// Act
+		ODataWriteResponse response = Update(f, ODataUpdateToolTests.NameUpdate);
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "an empty probe body proves nothing about the field names, and unverified is never a write");
+		// because: a JSON answer is definitive - a second identical request cannot turn it into CSDL
+		client.Received(1).ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		// because: the transport answered the metadata read, so the probe keeps the full budget the
+		// flaky-stand class needs - the dead-target shortcut must not fire on a live target
 		client.Received(ODataFieldValidation.TransientAttempts).ExecuteGetRequest(
 			Arg.Is<string>(url => url.Contains("?$select=", StringComparison.Ordinal)),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
@@ -413,6 +445,9 @@ public sealed class ODataUpdateToolTests {
 
 	/// <summary>Fixture built around an already-configured client (the retry cases stub it per attempt).</summary>
 	private static Fixture FixtureFor(IApplicationClient client) => new(client);
+
+	/// <summary>The one-field payload the retry-budget tests write; its name exists on the CSDL fixture.</summary>
+	private const string NameUpdate = "{\"Name\":\"New\"}";
 
 	[Test]
 	[Category("Unit")]

--- a/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
+++ b/clio.tests/Command/McpServer/ODataUpdateToolTests.cs
@@ -125,6 +125,22 @@ public sealed class ODataUpdateToolTests {
 			Resolver = Substitute.For<IToolCommandResolver>();
 			Resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(Client);
 			Resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>()).Returns(UrlBuilder);
+			Resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+				.Returns((Client, UrlBuilder));
+			Tool = new ODataUpdateTool(Resolver);
+		}
+
+		/// <summary>
+		/// Fixture around an ALREADY configured client, for the cases whose stub answers differ per
+		/// attempt rather than per URL (the bounded-retry tests).
+		/// </summary>
+		public Fixture(IApplicationClient client) {
+			Client = client;
+			UrlBuilder = Substitute.For<IServiceUrlBuilder>();
+			UrlBuilder.Build(Arg.Any<string>()).Returns(call => $"http://creatio/{call.Arg<string>()}");
+			Resolver = Substitute.For<IToolCommandResolver>();
+			Resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+				.Returns((Client, UrlBuilder));
 			Tool = new ODataUpdateTool(Resolver);
 		}
 
@@ -243,7 +259,7 @@ public sealed class ODataUpdateToolTests {
 		// Assert
 		response.Success.Should().BeTrue(because: response.Error);
 		f.Client.Received(1).ExecuteGetRequest(MetadataUrl, ODataFieldValidation.RequestTimeoutMs,
-			ODataFieldValidation.TransientAttempts, ODataFieldValidation.TransientDelaySec);
+			ODataFieldValidation.TransportAttempts, ODataFieldValidation.TransientDelaySec);
 		f.Client.DidNotReceive().ExecuteGetRequest(
 			Arg.Is<string>(url => url.Contains("?$select=", StringComparison.Ordinal)),
 			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>()
@@ -251,6 +267,152 @@ public sealed class ODataUpdateToolTests {
 		);
 		f.Client.Received(1).ExecutePatchRequest(KeyUrl, """{"Name":"New"}""", 30000);
 	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Retries the pre-write metadata read when the transport answers with an empty body, and writes once the retry returns the CSDL (issue #1315 item 1).")]
+	public void Update_Should_Retry_The_Metadata_Read_After_An_Empty_Body() {
+		// Arrange - an empty body is how the pinned creatio.client reports a transient transport failure:
+		// its synchronous ExecuteGetRequest swallows HttpRequestException / TaskCanceledException into
+		// string.Empty and passes the literal 1 into its own send loop, so the transport can never retry.
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(string.Empty, CsdL());
+		client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Returns(string.Empty);
+		Fixture f = FixtureFor(client);
+
+		// Act
+		ODataWriteResponse response = Update(f, """{"Name":"New"}""");
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "the second attempt returned the CSDL, so the payload is verified and the write proceeds");
+		client.Received(2).ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.Received(1).ExecutePatchRequest(KeyUrl, """{"Name":"New"}""", 30000);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Exhausts the bounded retry when every pre-write attempt answers with an empty body, then fails unverified without writing (issue #1315 item 1).")]
+	public void Update_Should_Exhaust_The_Bounded_Retry_And_Refuse_To_Write() {
+		// Arrange
+		IApplicationClient client = Substitute.For<IApplicationClient>();
+		client.ExecuteGetRequest(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>())
+			.Returns(string.Empty);
+		Fixture f = FixtureFor(client);
+
+		// Act
+		ODataWriteResponse response = Update(f, """{"Name":"New"}""");
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "an outcome the tool could neither confirm nor refute must never be reported as a write");
+		response.Error!.Should().Contain("could not be verified",
+			because: "the caller has to be able to tell an unverifiable pre-write from a rejected field");
+		client.Received(ODataFieldValidation.TransientAttempts)
+			.ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.Received(ODataFieldValidation.TransientAttempts).ExecuteGetRequest(
+			Arg.Is<string>(url => url.Contains("?$select=", StringComparison.Ordinal)),
+			Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+		client.DidNotReceiveWithAnyArgs().ExecutePatchRequest(null, null, 0);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Does not retry a definitive pre-write answer: a CSDL that resolves the type is read once (issue #1315 item 1).")]
+	public void Update_Should_Not_Retry_A_Definitive_Metadata_Answer() {
+		// Arrange
+		Fixture f = CsdLFixture();
+		f.Client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Returns(string.Empty);
+
+		// Act
+		ODataWriteResponse response = Update(f, """{"Name":"New"}""");
+
+		// Assert
+		response.Success.Should().BeTrue(because: response.Error);
+		f.Client.Received(1).ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("Abandons a CSDL whose BaseType chain is longer than the supported inheritance depth, fails the payload as unverified and writes nothing instead of walking the chain (issue #1315 item 4).")]
+	public void Update_Should_Refuse_A_Metadata_Inheritance_Chain_Deeper_Than_The_Cap() {
+		// Arrange - the chain is server-authored and acyclic, so the cycle guard admits it; only a depth
+		// bound stops the walk. A recursive walk over a chain long enough to exhaust the stack would take
+		// the whole shared MCP process down with an uncatchable StackOverflowException, which no test can
+		// observe from inside the process - so this asserts the cap fires, not the crash it prevents.
+		Fixture f = new(DeeplyInheritedCsdl(200),
+			_ => throw new InvalidOperationException("the probe must not run: the metadata answer is terminal"));
+
+		// Act
+		ODataWriteResponse response = Update(f, """{"Name":"New"}""");
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "a type the walk refused to resolve leaves the field names unverified, and unverified is not a write");
+		response.Error!.Should().Contain("could not be verified",
+			because: "the caller must read this as an unverifiable pre-write, the same as any other one");
+		response.Error!.Should().Contain("No write was performed",
+			because: "the caller has to learn the record is untouched so it can safely retry");
+		f.Client.DidNotReceiveWithAnyArgs().ExecutePatchRequest(null, null, 0);
+	}
+
+	[Test]
+	[Category("Unit")]
+	[Description("A BaseType chain within the supported depth is still walked end to end: a property declared only on the deepest base type is accepted (issue #1315 item 4).")]
+	public void Update_Should_Still_Walk_A_Chain_Within_The_Depth_Cap() {
+		// Arrange
+		Fixture f = new(DeeplyInheritedCsdl(5), _ => throw new InvalidOperationException("probe must not run"));
+		f.Client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Returns(string.Empty);
+
+		// Act
+		ODataWriteResponse response = Update(f, """{"RootOnly":"x"}""");
+
+		// Assert
+		response.Success.Should().BeTrue(
+			because: "RootOnly is declared on the last type of the chain, so bounding the walk must not shorten it");
+		f.Client.Received(1).ExecutePatchRequest(KeyUrl, """{"RootOnly":"x"}""", 30000);
+	}
+
+	/// <summary>
+	/// CSDL whose Contact derives through a chain of <paramref name="depth"/> generated base types. The
+	/// LAST type of the chain declares RootOnly, so a walk that stops early is visible as a rejected field
+	/// rather than as a silently shorter property set.
+	/// </summary>
+	private static string DeeplyInheritedCsdl(int depth) {
+		System.Text.StringBuilder types = new();
+		for (int i = 0; i < depth; i++) {
+			string baseType = i + 1 < depth
+				? $" BaseType=\"Terrasoft.Configuration.OData.Base{i + 1}\""
+				: string.Empty;
+			string rootOnly = i + 1 < depth ? string.Empty : "<Property Name=\"RootOnly\" Type=\"Edm.String\" />";
+			types.Append($"""
+				      <EntityType Name="Base{i}"{baseType}>
+				        <Key><PropertyRef Name="Id" /></Key>
+				        <Property Name="Id" Type="Edm.Guid" Nullable="false" />
+				        {rootOnly}
+				      </EntityType>
+
+				""");
+		}
+		return $"""
+			<?xml version="1.0" encoding="utf-8" standalone="no"?>
+			<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+			  <edmx:DataServices>
+			    <Schema Namespace="Terrasoft.Configuration.OData" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			      <EntityType Name="Contact" BaseType="Terrasoft.Configuration.OData.Base0">
+			        <Key><PropertyRef Name="Id" /></Key>
+			        <Property Name="Id" Type="Edm.Guid" Nullable="false" />
+			        <Property Name="Name" Type="Edm.String" />
+			      </EntityType>
+			{types}    </Schema>
+			  </edmx:DataServices>
+			</edmx:Edmx>
+			""";
+	}
+
+	/// <summary>Fixture built around an already-configured client (the retry cases stub it per attempt).</summary>
+	private static Fixture FixtureFor(IApplicationClient client) => new(client);
 
 	[Test]
 	[Category("Unit")]
@@ -607,10 +769,10 @@ public sealed class ODataUpdateToolTests {
 		// Color is reported.
 		f.Client.Received(1).ExecuteGetRequest(
 			$"{KeyUrl}?$select=Id,Name,JobTitle,Color",
-			ODataFieldValidation.RequestTimeoutMs, ODataFieldValidation.TransientAttempts, ODataFieldValidation.TransientDelaySec);
+			ODataFieldValidation.RequestTimeoutMs, ODataFieldValidation.TransportAttempts, ODataFieldValidation.TransientDelaySec);
 		f.Client.Received(2).ExecuteGetRequest(
 			Arg.Is<string>(url => url.Contains("?$select=", StringComparison.Ordinal)),
-			ODataFieldValidation.FollowUpProbeTimeoutMs, ODataFieldValidation.TransientAttempts, ODataFieldValidation.TransientDelaySec);
+			ODataFieldValidation.FollowUpProbeTimeoutMs, ODataFieldValidation.TransportAttempts, ODataFieldValidation.TransientDelaySec);
 		f.Client.DidNotReceiveWithAnyArgs().ExecutePatchRequest(null, null, 0);
 	}
 
@@ -633,8 +795,8 @@ public sealed class ODataUpdateToolTests {
 
 	[Test]
 	[Category("Unit")]
-	[Description("Sends the bounded retry parameters (30s timeout, 3 attempts, 1s delay) for the pre-write requests.")]
-	public void Update_Should_Use_Bounded_Retry_For_PreWrite_Requests() {
+	[Description("Calls the transport with ONE attempt and the 30s pre-write timeout: the retry lives above the body classification (see the retry tests), because the pinned transport discards its own maxAttempts argument.")]
+	public void Update_Should_Call_The_Transport_With_A_Single_Attempt() {
 		// Arrange
 		Fixture f = CsdLFixture();
 		f.Client.ExecutePatchRequest(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>())
@@ -646,8 +808,10 @@ public sealed class ODataUpdateToolTests {
 		// Assert
 		response.Success.Should().BeTrue(because: response.Error);
 		f.Client.Received(1).ExecuteGetRequest(MetadataUrl, ODataFieldValidation.RequestTimeoutMs,
-			ODataFieldValidation.TransientAttempts, ODataFieldValidation.TransientDelaySec)
-			// because: the retry budget must stay bounded so a dead metadata endpoint cannot hang the tool
+			ODataFieldValidation.TransportAttempts, ODataFieldValidation.TransientDelaySec)
+			// because: the per-request budget must stay bounded so a dead metadata endpoint cannot hang the
+			// tool, and asking the transport for more than one attempt would only inflate that budget - it
+			// cannot produce a second request
 		;
 	}
 
@@ -904,6 +1068,8 @@ public sealed class ODataUpdateToolTests {
 		resolver.Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>()).Returns(client);
 		resolver.Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
 			.Returns(firstRoot, repointedRoot);
+		resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>())
+			.Returns((client, firstRoot));
 		ODataUpdateTool tool = new(resolver);
 
 		// Act
@@ -917,7 +1083,9 @@ public sealed class ODataUpdateToolTests {
 
 		// Assert
 		response.Success.Should().BeTrue();
-		resolver.Received(1).Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>());
+		resolver.Received(1).ResolvePair<IApplicationClient, IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>());
+		resolver.DidNotReceive().Resolve<IServiceUrlBuilder>(Arg.Any<EnvironmentOptions>());
+		resolver.DidNotReceive().Resolve<IApplicationClient>(Arg.Any<EnvironmentOptions>());
 		repointedRoot.DidNotReceiveWithAnyArgs().Build(null);
 		client.Received(1).ExecuteGetRequest(MetadataUrl, Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>());
 		client.Received(1).ExecutePatchRequest(KeyUrl, """{"Name":"New"}""", 30000);

--- a/clio.tests/Command/McpServer/ODataWriteToolsLiveIntegrationTests.cs
+++ b/clio.tests/Command/McpServer/ODataWriteToolsLiveIntegrationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json;
 using Clio.Command.McpServer.Tools;
 using Clio.Common;
@@ -104,6 +104,10 @@ public sealed class ODataWriteToolsLiveIntegrationTests {
 		public TCommand Resolve<TCommand>(EnvironmentOptions options) {
 			LastResolvedTenantKey = GetTenantKey(options);
 			return serviceProvider.GetRequiredService<TCommand>();
+		}
+		public (TFirst First, TSecond Second) ResolvePair<TFirst, TSecond>(EnvironmentOptions options) {
+			LastResolvedTenantKey = GetTenantKey(options);
+			return (serviceProvider.GetRequiredService<TFirst>(), serviceProvider.GetRequiredService<TSecond>());
 		}
 		public TCommand ResolveWithoutEnvironment<TCommand>(EnvironmentOptions options) =>
 			serviceProvider.GetRequiredService<TCommand>();

--- a/clio.tests/Command/McpServer/ToolCommandResolverTests.cs
+++ b/clio.tests/Command/McpServer/ToolCommandResolverTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO.Abstractions.TestingHelpers;
 using Clio.Command;
 using Clio.Command.McpServer;
@@ -588,5 +588,48 @@ public class ToolCommandResolverTests {
 			because: "the access token must never leak into error text (FR-11)");
 		exception.Message.Should().Contain("Bearer",
 			because: "the error must name the real constraint (only Bearer is supported)");
+	}
+	[Test]
+	[Description("ResolvePair takes both services out of ONE environment snapshot: an environment repointed between the two would-be resolutions cannot pair one environment's client with another environment's URL builder.")]
+	[Category("Unit")]
+	public void ResolvePair_Should_Resolve_Both_Services_From_One_Environment_Snapshot() {
+		// Arrange - FindEnvironment answers a DIFFERENT uri on each call, which is what a repointed
+		// environment looks like to the resolver: ResolveSettingsAndKey re-reads the settings on every
+		// resolution, by design (ENG-94529).
+		System.IO.Abstractions.IFileSystem originalFileSystem = SettingsRepository.FileSystem;
+		MockFileSystem fileSystem = TestFileSystem.MockFileSystem();
+		SettingsRepository.FileSystem = fileSystem;
+		ISettingsRepository settingsRepository = Substitute.For<ISettingsRepository>();
+		ISettingsBootstrapService settingsBootstrapService = Substitute.For<ISettingsBootstrapService>();
+		settingsBootstrapService.GetReport().Returns(new SettingsBootstrapReport(
+			"healthy", SettingsRepository.AppSettingsFile, "dev", "dev", 1, [], [], true, true));
+		settingsRepository.IsEnvironmentExists("dev").Returns(true);
+		settingsRepository.FindEnvironment("dev").Returns(
+			new EnvironmentSettings { Uri = "http://first.creatio", Login = "Supervisor", Password = "Supervisor" },
+			new EnvironmentSettings { Uri = "http://repointed.creatio", Login = "Supervisor", Password = "Supervisor" });
+		ToolCommandResolver resolver = CreateResolver(settingsRepository, settingsBootstrapService);
+		EnvironmentOptions options = new() { Environment = "dev" };
+
+		try {
+			// Act
+			(IApplicationClient _, IServiceUrlBuilder pairedUrlBuilder) =
+				resolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(options);
+			// The control: two separate resolutions on the SAME repointed repository, which is what the
+			// keyed writes used to do. Without it, a single Received(1) would also hold for a resolver that
+			// simply never re-reads the settings, and the assertion would prove nothing about pairing.
+			IServiceUrlBuilder separatelyResolved = resolver.Resolve<IServiceUrlBuilder>(options);
+
+			// Assert
+			// ONE read belongs to the pair and ONE to the separate control resolution. Three reads would
+			// mean the pair itself straddled two snapshots, which is the defect under test.
+			settingsRepository.Received(2).FindEnvironment("dev");
+			pairedUrlBuilder.Build("odata/Contact").Should().StartWith("http://first.creatio",
+				because: "both services of the pair must come from the snapshot the single settings read selected");
+			separatelyResolved.Build("odata/Contact").Should().StartWith("http://repointed.creatio",
+				because: "a second, independent resolution re-reads the settings and lands on the repointed environment - the divergence ResolvePair exists to remove");
+		}
+		finally {
+			SettingsRepository.FileSystem = originalFileSystem;
+		}
 	}
 }

--- a/clio/Command/McpServer/Tools/ODataCreateTool.cs
+++ b/clio/Command/McpServer/Tools/ODataCreateTool.cs
@@ -71,8 +71,11 @@ public sealed class ODataCreateTool(IToolCommandResolver commandResolver) {
 		IServiceUrlBuilder urlBuilder;
 		try {
 			EnvironmentOptions options = new() { Environment = args.EnvironmentName };
-			client = commandResolver.Resolve<IApplicationClient>(options);
-			urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
+			// ONE resolution for both, for the reason ODataKeyedWrite.ResolveTarget states: every
+			// resolution re-reads the settings, so an environment repointed between two of them would pair
+			// this client's authenticated session with the other environment's url - and odata-create uses
+			// the pair for a metadata read AND the POSTs that follow it.
+			(client, urlBuilder) = commandResolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(options);
 		} catch (Exception ex) {
 			return ODataCreateBatchResponse.RequestError(SensitiveErrorTextRedactor.Redact(ex.Message));
 		}

--- a/clio/Command/McpServer/Tools/ODataFieldValidation.cs
+++ b/clio/Command/McpServer/Tools/ODataFieldValidation.cs
@@ -427,8 +427,9 @@ internal static class ODataFieldValidation {
 	/// <summary>
 	/// Walks the <c>BaseType</c> chain (cycle- and depth-guarded) accumulating every property name in
 	/// <paramref name="type"/>'s resolved set. Returns <see langword="false"/> when the chain is longer
-	/// than <see cref="MaxInheritanceDepth"/>, in which case <paramref name="type"/> is left partially
-	/// collected and must not be used as the oracle.
+	/// than <see cref="MaxInheritanceDepth"/>, in which case <paramref name="type"/> keeps only its OWN
+	/// declared properties (nothing is merged before the chain is known to be complete) and must not be
+	/// used as the oracle.
 	/// </summary>
 	/// <remarks>
 	/// Iterative, and that is the point: the walk follows SERVER-AUTHORED <c>BaseType</c> links, so the

--- a/clio/Command/McpServer/Tools/ODataFieldValidation.cs
+++ b/clio/Command/McpServer/Tools/ODataFieldValidation.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Xml;
 using Clio.Common;
 
@@ -33,10 +34,35 @@ internal static class ODataFieldValidation {
 
 	/// <summary>
 	/// Attempts for the pre-write requests: the metadata/probe GET is read-only and idempotent,
-	/// so a bounded retry at the transport absorbs the flaky-stand class (an isolated 5xx or an
-	/// empty body) without ever re-sending a write.
+	/// so a bounded retry absorbs the flaky-stand class (an isolated 5xx or an empty body) without
+	/// ever re-sending a write.
 	/// </summary>
+	/// <remarks>
+	/// The retry runs HERE, around the fetch AND its classification, and the transport is called with
+	/// ONE attempt - not because a second layer would be redundant, but because the transport has no
+	/// retry to delegate to. Decompiling the pinned <c>creatio.client</c> 2.0.2 shows the synchronous
+	/// <c>ExecuteGetRequest</c> passing the literal <c>1</c> into its own send loop in place of the
+	/// <c>maxAttempts</c> argument, and swallowing <c>HttpRequestException</c> /
+	/// <c>TaskCanceledException</c> into <see cref="string.Empty"/>. So the argument never produced a
+	/// second request, and a transient transport failure reaches this class as an EMPTY BODY - a
+	/// classification outcome, which only a retry above the classification can see.
+	/// </remarks>
 	internal const int TransientAttempts = 3;
+
+	/// <summary>
+	/// Attempts passed to the transport itself: one. See <see cref="TransientAttempts"/> for why the
+	/// retry cannot live there.
+	/// </summary>
+	internal const int TransportAttempts = 1;
+
+	/// <summary>
+	/// Upper bound on the CSDL <c>BaseType</c> chain the inheritance walk follows. The document is
+	/// server-authored, so its depth is caller-influenced input: a registered HTTPS target can answer
+	/// with a very long ACYCLIC chain, which the cycle guard admits by definition. Creatio's own OData
+	/// hierarchy is two or three types deep, so a cap this high cannot be reached by a real service,
+	/// and exceeding it is treated as "the type could not be resolved" rather than followed.
+	/// </summary>
+	private const int MaxInheritanceDepth = 64;
 
 	/// <summary>Delay between <see cref="TransientAttempts"/> pre-write attempts, in seconds.</summary>
 	internal const int TransientDelaySec = 1;
@@ -131,6 +157,16 @@ internal static class ODataFieldValidation {
 			return null;
 		}
 
+		if (metadata.DepthExceeded) {
+			// NOT a degrade: the document DOES describe the entity, in a shape the walk refused to follow.
+			// Falling back to the $select probe here would answer a hostile or corrupt metadata document
+			// with a weaker oracle and could still end in a PATCH, so the call fails unverified instead -
+			// the same envelope an unverifiable probe produces, and no write.
+			return ODataWriteResponse.Failure(
+				$"The pre-write field check for {entity}({id}) returned a response that could not be verified: "
+				+ $"{metadata.UnverifiedDetail} No write was performed.");
+		}
+
 		// The metadata endpoint did not yield a usable type definition (unsupported, empty,
 		// non-XML, or a recognized error). Degrade to the $select probe for name validation.
 		return ValidateBySelectProbe(client, urlBuilder, entity, id, keys);
@@ -172,7 +208,8 @@ internal static class ODataFieldValidation {
 		HashSet<string> Properties,
 		Dictionary<string, string> PropertyTypes,
 		string? ServerError,
-		string? UnverifiedDetail);
+		string? UnverifiedDetail,
+		bool DepthExceeded = false);
 
 	/// <summary>
 	/// GETs the SERVICE-ROOT <c>odata/$metadata</c> document and parses the CSDL for the entity's
@@ -189,20 +226,66 @@ internal static class ODataFieldValidation {
 		IServiceUrlBuilder urlBuilder,
 		string entity,
 		int timeoutMs,
-		int attempts) {
+		int attempts) =>
+		RetryWhileTransient(
+			attempts,
+			() => FetchMetadataOnce(client, urlBuilder, entity, timeoutMs),
+			metadata => metadata.UnverifiedDetail == EmptyMetadataDetail);
+
+	/// <summary>The classification of an empty metadata body - the one outcome a retry can improve.</summary>
+	private const string EmptyMetadataDetail = "the OData metadata response was empty.";
+
+	/// <summary>
+	/// Runs <paramref name="fetchAndClassify"/> up to <paramref name="attempts"/> times, stopping at
+	/// the first outcome <paramref name="isTransient"/> rejects, and returns the last outcome when the
+	/// attempts are exhausted. The predicate reads the CLASSIFIED outcome, not the transport, because
+	/// the transport reports a failed pre-write GET as an empty body rather than as an exception (see
+	/// <see cref="TransientAttempts"/>); a parsed CSDL, a recognized Creatio error envelope, a JSON
+	/// body that is not the addressed record and an HTML error page are all definitive answers that a
+	/// second identical request cannot improve, so none of them is retried.
+	/// </summary>
+	private static TOutcome RetryWhileTransient<TOutcome>(
+		int attempts, Func<TOutcome> fetchAndClassify, Func<TOutcome, bool> isTransient) {
+		TOutcome outcome = fetchAndClassify();
+		for (int attempt = 1; attempt < attempts && isTransient(outcome); attempt++) {
+			// The pre-write path is synchronous end to end (IApplicationClient.ExecuteGetRequest is a
+			// blocking call), so the pause between attempts is a blocking sleep too. It only ever runs on
+			// the already-failed branch.
+			Thread.Sleep(TimeSpan.FromSeconds(TransientDelaySec));
+			outcome = fetchAndClassify();
+		}
+		return outcome;
+	}
+
+	/// <summary>
+	/// One metadata fetch and its classification. See <see cref="FetchMetadata"/> for the route and
+	/// the outcome encoding.
+	/// </summary>
+	private static EntityMetadata FetchMetadataOnce(
+		IApplicationClient client,
+		IServiceUrlBuilder urlBuilder,
+		string entity,
+		int timeoutMs) {
 		string url = urlBuilder.Build("odata/$metadata");
-		string body = client.ExecuteGetRequest(url, timeoutMs, attempts, TransientDelaySec);
+		string body = client.ExecuteGetRequest(url, timeoutMs, TransportAttempts, TransientDelaySec);
 		if (string.IsNullOrWhiteSpace(body)) {
-			return new EntityMetadata(false, [], [], null, "the OData metadata response was empty.");
+			return new EntityMetadata(false, [], [], null, EmptyMetadataDetail);
 		}
 		if (body.TrimStart().StartsWith("<", StringComparison.Ordinal)) {
 			// The metadata endpoint answers with CSDL XML. A parse that yields the entity's type
 			// definition resolves the validation; any other parse outcome leaves the fields
 			// unverified (the fallback probe then decides what it can).
 			try {
-				CsdlType? type = ParseCSDLEntity(body, entity);
+				CsdlType? type = ParseCSDLEntity(body, entity, out bool depthExceeded);
 				if (type is not null) {
 					return new EntityMetadata(true, type.Properties, type.PropertyTypes, null, null);
+				}
+				if (depthExceeded) {
+					return new EntityMetadata(false, [], [], null,
+						"the OData metadata declares an inheritance chain for the entity deeper than "
+						+ $"{MaxInheritanceDepth} types, which no Creatio type hierarchy has, so the declared "
+						+ "properties could not be established.",
+						DepthExceeded: true);
 				}
 				return new EntityMetadata(false, [], [], null,
 					"the OData metadata response did not contain a type definition for the entity.");
@@ -236,15 +319,25 @@ internal static class ODataFieldValidation {
 
 	/// <summary>
 	/// Parses the CSDL document and resolves the <paramref name="entity"/> type following
-	/// <c>BaseType</c> inheritance (cycle-guarded). Returns the resolved type, or <c>null</c> when
-	/// the document carries no <c>EntityType</c> matching the entity name.
+	/// <c>BaseType</c> inheritance (cycle- and depth-guarded). Returns the resolved type, or
+	/// <c>null</c> when the document carries no <c>EntityType</c> matching the entity name or when the
+	/// inheritance chain exceeds <see cref="MaxInheritanceDepth"/>.
 	/// </summary>
-	private static CsdlType? ParseCSDLEntity(string body, string entity) {
+	/// <param name="depthExceeded">
+	/// Set when the walk was abandoned on the depth cap. It distinguishes "this document does not
+	/// describe the entity" from "this document describes it in a shape that cannot be trusted", which
+	/// the caller answers differently: the first degrades to the probe, the second fails the call.
+	/// </param>
+	private static CsdlType? ParseCSDLEntity(string body, string entity, out bool depthExceeded) {
+		depthExceeded = false;
 		Dictionary<string, CsdlType> types = ParseCSDLTypes(body);
 		if (!TryResolveEntity(types, entity, out CsdlType? target)) {
 			return null;
 		}
-		CollectInherited(target, types, visited: []);
+		if (!CollectInherited(target, types)) {
+			depthExceeded = true;
+			return null;
+		}
 		return target;
 	}
 
@@ -332,31 +425,46 @@ internal static class ODataFieldValidation {
 	}
 
 	/// <summary>
-	/// Walks the <c>BaseType</c> chain (cycle-guarded) accumulating every property name in
-	/// <paramref name="type"/>'s resolved set.
+	/// Walks the <c>BaseType</c> chain (cycle- and depth-guarded) accumulating every property name in
+	/// <paramref name="type"/>'s resolved set. Returns <see langword="false"/> when the chain is longer
+	/// than <see cref="MaxInheritanceDepth"/>, in which case <paramref name="type"/> is left partially
+	/// collected and must not be used as the oracle.
 	/// </summary>
-	private static void CollectInherited(
-		CsdlType type,
-		Dictionary<string, CsdlType> types,
-		HashSet<string> visited) {
-		if (!visited.Add(type.Name)) {
-			return;
-		}
-		if (type.BaseType is null) {
-			return;
-		}
+	/// <remarks>
+	/// Iterative, and that is the point: the walk follows SERVER-AUTHORED <c>BaseType</c> links, so the
+	/// chain length is caller-influenced input. The cycle guard alone admits an arbitrarily long acyclic
+	/// chain, and a recursive walk over one would exhaust the stack - an uncatchable
+	/// <c>StackOverflowException</c> that takes the whole shared MCP process down, not just this call.
+	/// The chain is collected first and applied in reverse so a base type's properties still reach every
+	/// type below it, exactly as the recursive post-order did.
+	/// </remarks>
+	private static bool CollectInherited(CsdlType type, Dictionary<string, CsdlType> types) {
+		List<CsdlType> chain = [type];
+		HashSet<string> visited = new(StringComparer.Ordinal) { type.Name };
+		CsdlType current = type;
 		// The map is keyed by the EntityType's short Name, but per CSDL 4.0 a BaseType attribute is a
 		// FULLY-QUALIFIED type name ("Terrasoft.Configuration.OData.BaseEntity"). Looking the raw value up
 		// never matched, so the whole walk was a silent no-op and every field inherited from BaseEntity
 		// (Id, CreatedOn, ModifiedOn, CreatedById, ModifiedById, ...) was reported as non-existent.
-		if (types.TryGetValue(ShortTypeName(type.BaseType), out CsdlType? baseType)) {
-			CollectInherited(baseType, types, visited);
-			type.Properties.UnionWith(baseType.Properties);
+		while (current.BaseType is not null
+			&& types.TryGetValue(ShortTypeName(current.BaseType), out CsdlType? baseType)
+			&& visited.Add(baseType.Name)) {
+			if (chain.Count > MaxInheritanceDepth) {
+				return false;
+			}
+			chain.Add(baseType);
+			current = baseType;
+		}
+		for (int i = chain.Count - 1; i > 0; i--) {
+			CsdlType derived = chain[i - 1];
+			CsdlType baseType = chain[i];
+			derived.Properties.UnionWith(baseType.Properties);
 			foreach (KeyValuePair<string, string> inherited in baseType.PropertyTypes) {
 				// A redeclared property on the derived type wins; TryAdd keeps the derived declaration.
-				type.PropertyTypes.TryAdd(inherited.Key, inherited.Value);
+				derived.PropertyTypes.TryAdd(inherited.Key, inherited.Value);
 			}
 		}
+		return true;
 	}
 
 	/// <summary>Strips the CSDL namespace qualifier from a type reference.</summary>
@@ -459,7 +567,26 @@ internal static class ODataFieldValidation {
 		string entity,
 		string id,
 		IReadOnlyList<string> keys,
-		int timeoutMs = RequestTimeoutMs) {
+		int timeoutMs = RequestTimeoutMs) =>
+		RetryWhileTransient(
+			TransientAttempts,
+			() => ProbeOnce(client, urlBuilder, entity, id, keys, timeoutMs),
+			probe => probe.UnverifiedDetail == EmptyProbeDetail);
+
+	/// <summary>The classification of an empty probe body - the one outcome a retry can improve.</summary>
+	private const string EmptyProbeDetail = "the probe response was empty.";
+
+	/// <summary>
+	/// One <c>$select</c> probe and its classification. See <see cref="Probe"/> for the outcome
+	/// encoding.
+	/// </summary>
+	private static ProbeResult ProbeOnce(
+		IApplicationClient client,
+		IServiceUrlBuilder urlBuilder,
+		string entity,
+		string id,
+		IReadOnlyList<string> keys,
+		int timeoutMs) {
 		// NOT percent-encoded: the comma is $select's own list separator, and encoding it turns a
 		// three-field select into a request for one selector literally named "Id%2CCreatedOn%2CName",
 		// which a conforming server rejects as an unknown property - failing every probe on this path.
@@ -468,7 +595,7 @@ internal static class ODataFieldValidation {
 		string selectList = "Id," + string.Join(",", keys);
 		string path = $"{ODataKeyFormatter.KeyPath(entity, id)}?$select={selectList}";
 		string url = urlBuilder.Build(path);
-		string body = client.ExecuteGetRequest(url, timeoutMs, TransientAttempts, TransientDelaySec);
+		string body = client.ExecuteGetRequest(url, timeoutMs, TransportAttempts, TransientDelaySec);
 		if (string.IsNullOrWhiteSpace(body)) {
 			// An empty body is read as UNVERIFIED here - the opposite of the write path, where
 			// ODataKeyedWrite.ValidateWriteResponse treats an empty/whitespace body as success. The
@@ -478,8 +605,8 @@ internal static class ODataFieldValidation {
 			// a session redirect, a gateway that stripped the body) - whereas a PATCH can legitimately
 			// answer a body-less 204 ack. Treating an empty probe body as "fields confirmed" would
 			// recreate the false success this validation exists to remove; both stay fail-closed after
-			// the bounded retry above is exhausted.
-			return new ProbeResult(false, null, "the probe response was empty.");
+			// the bounded retry in Probe is exhausted.
+			return new ProbeResult(false, null, EmptyProbeDetail);
 		}
 		try {
 			using JsonDocument doc = JsonDocument.Parse(body);

--- a/clio/Command/McpServer/Tools/ODataFieldValidation.cs
+++ b/clio/Command/McpServer/Tools/ODataFieldValidation.cs
@@ -33,9 +33,11 @@ internal static class ODataFieldValidation {
 	internal const int RequestTimeoutMs = 30_000;
 
 	/// <summary>
-	/// Attempts for the pre-write requests: the metadata/probe GET is read-only and idempotent,
-	/// so a bounded retry absorbs the flaky-stand class (an isolated 5xx or an empty body) without
-	/// ever re-sending a write.
+	/// Attempts for the pre-write requests: the metadata/probe GET is read-only and idempotent, so a
+	/// bounded retry absorbs the one flaky-stand outcome a second identical request can improve - an
+	/// EMPTY body - without ever re-sending a write. A 5xx is NOT in that class: the transport does not
+	/// call <c>EnsureSuccessStatusCode</c>, so an error status arrives here as its error PAGE or
+	/// envelope and is classified as a definitive answer, not retried.
 	/// </summary>
 	/// <remarks>
 	/// The retry runs HERE, around the fetch AND its classification, and the transport is called with
@@ -54,6 +56,24 @@ internal static class ODataFieldValidation {
 	/// retry cannot live there.
 	/// </summary>
 	internal const int TransportAttempts = 1;
+
+	/// <summary>
+	/// Attempts left to the $select probe when the metadata leg ALREADY exhausted
+	/// <see cref="TransientAttempts"/> on the empty-body outcome: one, then give up.
+	/// </summary>
+	/// <remarks>
+	/// An empty body is how this transport reports "the request did not come back" (see
+	/// <see cref="TransientAttempts"/>). Exhausting the metadata retry on that outcome is therefore
+	/// evidence the target is not answering at all, and running the probe's own full retry after it
+	/// would spend a second 3 x <see cref="RequestTimeoutMs"/> budget on the same dead target: the
+	/// pre-write path would take about 184 s before refusing, past the ~180 s ceiling MCP clients
+	/// impose, so the caller would see a client-side timeout instead of the tool's own refusal - the
+	/// refusal being the whole point of the check. One probe attempt holds the worst case at about
+	/// 122 s. When the metadata leg ended with an answer instead (CSDL, a Creatio fault, an HTML error
+	/// page, unrelated JSON) the transport is proven alive and the probe keeps the full
+	/// <see cref="TransientAttempts"/>.
+	/// </remarks>
+	internal const int ExhaustedTransportProbeAttempts = 1;
 
 	/// <summary>
 	/// Upper bound on the CSDL <c>BaseType</c> chain the inheritance walk follows. The document is
@@ -168,8 +188,12 @@ internal static class ODataFieldValidation {
 		}
 
 		// The metadata endpoint did not yield a usable type definition (unsupported, empty,
-		// non-XML, or a recognized error). Degrade to the $select probe for name validation.
-		return ValidateBySelectProbe(client, urlBuilder, entity, id, keys);
+		// non-XML, or a recognized error). Degrade to the $select probe for name validation. The probe
+		// inherits the retry budget the metadata leg EARNED: an exhausted empty-body retry means the
+		// target answered nothing at all, so the probe gets one attempt rather than a second full
+		// budget on the same dead target (see ExhaustedTransportProbeAttempts).
+		int probeAttempts = metadata.EmptyBody ? ExhaustedTransportProbeAttempts : TransientAttempts;
+		return ValidateBySelectProbe(client, urlBuilder, entity, id, keys, probeAttempts);
 	}
 
 	/// <summary>
@@ -209,7 +233,8 @@ internal static class ODataFieldValidation {
 		Dictionary<string, string> PropertyTypes,
 		string? ServerError,
 		string? UnverifiedDetail,
-		bool DepthExceeded = false);
+		bool DepthExceeded = false,
+		bool EmptyBody = false);
 
 	/// <summary>
 	/// GETs the SERVICE-ROOT <c>odata/$metadata</c> document and parses the CSDL for the entity's
@@ -230,9 +255,13 @@ internal static class ODataFieldValidation {
 		RetryWhileTransient(
 			attempts,
 			() => FetchMetadataOnce(client, urlBuilder, entity, timeoutMs),
-			metadata => metadata.UnverifiedDetail == EmptyMetadataDetail);
+			metadata => metadata.EmptyBody);
 
-	/// <summary>The classification of an empty metadata body - the one outcome a retry can improve.</summary>
+	/// <summary>
+	/// The caller-facing text of an empty metadata body - the one outcome a retry can improve. The retry
+	/// keys off <see cref="EntityMetadata.EmptyBody"/>, not off this string: a predicate that compared
+	/// the surfaced wording would stop retrying the moment the text was reworded, silently.
+	/// </summary>
 	private const string EmptyMetadataDetail = "the OData metadata response was empty.";
 
 	/// <summary>
@@ -269,7 +298,7 @@ internal static class ODataFieldValidation {
 		string url = urlBuilder.Build("odata/$metadata");
 		string body = client.ExecuteGetRequest(url, timeoutMs, TransportAttempts, TransientDelaySec);
 		if (string.IsNullOrWhiteSpace(body)) {
-			return new EntityMetadata(false, [], [], null, EmptyMetadataDetail);
+			return new EntityMetadata(false, [], [], null, EmptyMetadataDetail, EmptyBody: true);
 		}
 		if (body.TrimStart().StartsWith("<", StringComparison.Ordinal)) {
 			// The metadata endpoint answers with CSDL XML. A parse that yields the entity's type
@@ -450,7 +479,7 @@ internal static class ODataFieldValidation {
 		while (current.BaseType is not null
 			&& types.TryGetValue(ShortTypeName(current.BaseType), out CsdlType? baseType)
 			&& visited.Add(baseType.Name)) {
-			if (chain.Count > MaxInheritanceDepth) {
+			if (chain.Count >= MaxInheritanceDepth) {
 				return false;
 			}
 			chain.Add(baseType);
@@ -489,8 +518,9 @@ internal static class ODataFieldValidation {
 		IServiceUrlBuilder urlBuilder,
 		string entity,
 		string id,
-		IReadOnlyList<string> keys) {
-		ProbeResult batch = Probe(client, urlBuilder, entity, id, keys);
+		IReadOnlyList<string> keys,
+		int attempts) {
+		ProbeResult batch = Probe(client, urlBuilder, entity, id, keys, attempts);
 		if (batch.Succeeded) {
 			return null;
 		}
@@ -527,7 +557,7 @@ internal static class ODataFieldValidation {
 				partial = true;
 				break;
 			}
-			ProbeResult single = Probe(client, urlBuilder, entity, id, [key], FollowUpProbeTimeoutMs);
+			ProbeResult single = Probe(client, urlBuilder, entity, id, [key], attempts, FollowUpProbeTimeoutMs);
 			if (single.Succeeded) {
 				continue;
 			}
@@ -553,11 +583,12 @@ internal static class ODataFieldValidation {
 	/// a failure - empty, non-JSON, or JSON that is not the addressed record). The text signals are
 	/// redacted at construction.
 	/// </summary>
-	private sealed record ProbeResult(bool Succeeded, string? ServerError, string? UnverifiedDetail);
+	private sealed record ProbeResult(
+		bool Succeeded, string? ServerError, string? UnverifiedDetail, bool EmptyBody = false);
 
 	/// <summary>
-	/// GETs the addressed record with <c>$select=Id,<keys></c> (bounded retry: the probe is
-	/// read-only). Only the addressed record carrying every probed key confirms them; a recognized
+	/// GETs the addressed record with <c>$select=Id,<keys></c> (bounded retry over
+	/// <paramref name="attempts"/>: the probe is read-only). Only the addressed record carrying every probed key confirms them; a recognized
 	/// error shape is captured (redacted) as <see cref="ProbeResult.ServerError"/>; every other body -
 	/// empty, non-JSON, or JSON that is not that record - is captured (redacted) as
 	/// <see cref="ProbeResult.UnverifiedDetail"/>.
@@ -568,13 +599,18 @@ internal static class ODataFieldValidation {
 		string entity,
 		string id,
 		IReadOnlyList<string> keys,
+		int attempts,
 		int timeoutMs = RequestTimeoutMs) =>
 		RetryWhileTransient(
-			TransientAttempts,
+			attempts,
 			() => ProbeOnce(client, urlBuilder, entity, id, keys, timeoutMs),
-			probe => probe.UnverifiedDetail == EmptyProbeDetail);
+			probe => probe.EmptyBody);
 
-	/// <summary>The classification of an empty probe body - the one outcome a retry can improve.</summary>
+	/// <summary>
+	/// The caller-facing text of an empty probe body - the one outcome a retry can improve. The retry keys
+	/// off <see cref="ProbeResult.EmptyBody"/>, not off this string, for the reason
+	/// <see cref="EmptyMetadataDetail"/> states.
+	/// </summary>
 	private const string EmptyProbeDetail = "the probe response was empty.";
 
 	/// <summary>
@@ -607,7 +643,7 @@ internal static class ODataFieldValidation {
 			// answer a body-less 204 ack. Treating an empty probe body as "fields confirmed" would
 			// recreate the false success this validation exists to remove; both stay fail-closed after
 			// the bounded retry in Probe is exhausted.
-			return new ProbeResult(false, null, EmptyProbeDetail);
+			return new ProbeResult(false, null, EmptyProbeDetail, EmptyBody: true);
 		}
 		try {
 			using JsonDocument doc = JsonDocument.Parse(body);
@@ -779,7 +815,7 @@ internal static class ODataFieldValidation {
 			+ "credentials. No write was performed.";
 	}
 
-	/// <summary>Extracts the property name from the service's unknown-property fault, if any.</summary>	/// <summary>Extracts the property name from the service's unknown-property fault, if any.</summary>
+	/// <summary>Extracts the property name from the service's unknown-property fault, if any.</summary>
 	private static string? ExtractUnknownProperty(string serverError) {
 		Match match = UnknownPropertyPattern.Match(serverError);
 		return match.Success && !string.IsNullOrWhiteSpace(match.Groups[1].Value)

--- a/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
+++ b/clio/Command/McpServer/Tools/ODataKeyedWrite.cs
@@ -58,13 +58,18 @@ internal static class ODataKeyedWrite {
 	/// environment snapshot as the write itself. Resolving a second builder reloads the settings, so a
 	/// repointed environment could have validation read the type from environment B while the PATCH
 	/// still went to A: a field that exists only on B would pass and then be silently discarded by A,
-	/// with the tool reporting success.
+	/// with the tool reporting success. For the same reason the client and the builder come out of ONE
+	/// <see cref="IToolCommandResolver.ResolvePair{TFirst,TSecond}"/> call rather than two resolutions.
 	/// </remarks>
 	internal static (IApplicationClient client, IServiceUrlBuilder urlBuilder, string url) ResolveTarget(
 		IToolCommandResolver commandResolver, string environmentName, string entity, string id) {
 		EnvironmentOptions options = new() { Environment = environmentName };
-		IApplicationClient client = commandResolver.Resolve<IApplicationClient>(options);
-		IServiceUrlBuilder urlBuilder = commandResolver.Resolve<IServiceUrlBuilder>(options);
+		// ONE resolution, not two: IToolCommandResolver.ResolvePair reads the environment settings once
+		// and takes both services out of the container that snapshot selected. Two separate Resolve calls
+		// read the settings twice, so an environment repointed between them pairs A's authenticated
+		// client with B's url builder - the write then goes to B carrying A's session.
+		(IApplicationClient client, IServiceUrlBuilder urlBuilder) =
+			commandResolver.ResolvePair<IApplicationClient, IServiceUrlBuilder>(options);
 		string url = urlBuilder.Build(ODataKeyFormatter.KeyPath(entity, id));
 		return (client, urlBuilder, url);
 	}

--- a/clio/Command/McpServer/Tools/ToolCommandResolver.cs
+++ b/clio/Command/McpServer/Tools/ToolCommandResolver.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Text;
 using Clio;
@@ -20,6 +20,23 @@ public interface IToolCommandResolver {
 	/// <param name="options">Environment options that identify the execution target.</param>
 	/// <returns>A command instance configured for the requested target.</returns>
 	TCommand Resolve<TCommand>(EnvironmentOptions options);
+
+	/// <summary>
+	/// Resolves TWO services for the same target from ONE environment snapshot.
+	/// </summary>
+	/// <remarks>
+	/// Two <see cref="Resolve{TCommand}"/> calls are NOT equivalent: each one re-reads the settings
+	/// repository, so an environment repointed between them yields two containers for two different
+	/// targets. A caller that pairs an authenticated client with a URL builder (the keyed OData writes)
+	/// would then send environment A's session to environment B's url. This method reads the settings
+	/// once and takes both services out of the container that snapshot selected.
+	/// </remarks>
+	/// <typeparam name="TFirst">The first service type.</typeparam>
+	/// <typeparam name="TSecond">The second service type.</typeparam>
+	/// <param name="options">Environment options that identify the execution target.</param>
+	/// <returns>Both services, resolved from one container.</returns>
+	(TFirst First, TSecond Second) ResolvePair<TFirst, TSecond>(EnvironmentOptions options);
+
 	TCommand ResolveWithoutEnvironment<TCommand>(EnvironmentOptions options);
 
 	/// <summary>
@@ -114,7 +131,21 @@ public class ToolCommandResolver(
 	/// <inheritdoc />
 	public TCommand Resolve<TCommand>(EnvironmentOptions options) {
 		ArgumentNullException.ThrowIfNull(options);
+		return AcquireContainer(options).GetRequiredService<TCommand>();
+	}
 
+	/// <inheritdoc />
+	public (TFirst First, TSecond Second) ResolvePair<TFirst, TSecond>(EnvironmentOptions options) {
+		ArgumentNullException.ThrowIfNull(options);
+		// ONE acquisition, both services: the branch selection, the settings read and the cache-key
+		// computation all happen exactly once, so the pair cannot straddle two environments.
+		IServiceProvider container = AcquireContainer(options);
+		return (container.GetRequiredService<TFirst>(), container.GetRequiredService<TSecond>());
+	}
+
+	// The single entry point both Resolve and ResolvePair use, so they can never disagree about which
+	// branch, which settings snapshot or which cache key a call belongs to.
+	private IServiceProvider AcquireContainer(EnvironmentOptions options) {
 		// Credential-passthrough branch (FR-03/FR-04/FR-12). A per-request CredentialContext, when
 		// present, is authoritative: build an EPHEMERAL EnvironmentSettings straight from the header
 		// credentials — no settings repo, no env-name match, no interactive Fill, nothing persisted.
@@ -140,14 +171,20 @@ public class ToolCommandResolver(
 					+ "are not accepted when credential passthrough is enabled over HTTP. Supply the target environment "
 					+ "and credentials via the X-Integration-Credentials header, not tool arguments.");
 			}
-			return ResolvePassthrough<TCommand>(credentialContext);
+			return AcquirePassthroughContainer(credentialContext);
 		}
 
+		return AcquireRegisteredContainer(options);
+	}
+
+	// The one place the registry / explicit-URI branch reads the settings and acquires its container,
+	// so every caller that needs more than one service off the same snapshot gets the SAME container
+	// rather than a second settings read.
+	private IServiceProvider AcquireRegisteredContainer(EnvironmentOptions options) {
 		(EnvironmentSettings settings, string cacheKey) = ResolveSettingsAndKey(options);
 		_lastResolvedTenantKey.Value = cacheKey;
-		IServiceProvider container = sessionContainerCache.Acquire(cacheKey,
+		return sessionContainerCache.Acquire(cacheKey,
 			() => new BindingsModule().Register(settings, NonInteractiveConsole.ForceInContainer));
-		return container.GetRequiredService<TCommand>();
 	}
 
 	/// <inheritdoc />
@@ -262,7 +299,7 @@ public class ToolCommandResolver(
 	// (AC-04) so a hostile url cannot be used as a credential-redirection lever, then the ephemeral
 	// settings are built and cached under a credential-discriminating key. This method is linear:
 	// EnsureAllowed precedes every settings/container/client construction by construction.
-	private TCommand ResolvePassthrough<TCommand>(CredentialContext context) {
+	private IServiceProvider AcquirePassthroughContainer(CredentialContext context) {
 		// AC-04 / FR-17: validate the caller-influenced target url BEFORE building any settings,
 		// container, or client. A rejection is caller-actionable (fix your input), so surface it as an
 		// EnvironmentResolutionException — consistent with the cookie / missing-auth / non-Bearer
@@ -309,9 +346,8 @@ public class ToolCommandResolver(
 		// EnvironmentScoped graph SHAPE is invariant across tenants and is validated once at mcp-http host
 		// startup (BindingsModule.ValidateEnvironmentScopedGraph), so re-validating the full ~455-registration
 		// graph on every near-continuous rotating-token cache miss is pure startup-grade cost.
-		IServiceProvider container = sessionContainerCache.Acquire(cacheKey,
+		return sessionContainerCache.Acquire(cacheKey,
 			() => new BindingsModule().Register(settings, NonInteractiveConsole.ForceInContainer, validateGraph: false));
-		return container.GetRequiredService<TCommand>();
 	}
 
 	/// <summary>

--- a/clio/Command/McpServer/Tools/ToolCommandResolver.cs
+++ b/clio/Command/McpServer/Tools/ToolCommandResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 using System.Text;
 using Clio;
@@ -40,12 +40,13 @@ public interface IToolCommandResolver {
 	TCommand ResolveWithoutEnvironment<TCommand>(EnvironmentOptions options);
 
 	/// <summary>
-	/// The cache key the MOST RECENT <see cref="Resolve{TCommand}"/> call on the CURRENT async-flow
-	/// cached its container under. The BaseTool execution path reads this immediately after resolving a
+	/// The cache key the MOST RECENT <see cref="Resolve{TCommand}"/> or
+	/// <see cref="ResolvePair{TFirst,TSecond}"/> call on the CURRENT async-flow cached its container
+	/// under (both go through the same container acquisition, so both publish this key). The BaseTool execution path reads this immediately after resolving a
 	/// command so it can lock / mark-in-use on the SAME key without recomputing it via
 	/// <see cref="GetTenantKey"/> (M2, ENG-93208 — eliminates the divergence window and the second
 	/// <c>settings.Fill</c> per invocation). Flow-local so concurrent tenants never read each other's
-	/// value; <see langword="null"/> before any <see cref="Resolve{TCommand}"/> call on the flow.
+	/// value; <see langword="null"/> before any resolution on the flow.
 	/// </summary>
 	string LastResolvedTenantKey { get; }
 

--- a/docs/knowledge/Common/creatio-client-get-discards-max-attempts.md
+++ b/docs/knowledge/Common/creatio-client-get-discards-max-attempts.md
@@ -1,6 +1,7 @@
 ---
 description: creatio.client 2.0.2's synchronous ExecuteGetRequest discards its maxAttempts argument and swallows transport exceptions into an empty string, so a caller asking for 3 attempts gets exactly one request and reads a transient failure as an empty body
 applies-to:
+  - Directory.Packages.props
   - clio/Common/CreatioClientAdapter.cs
   - clio/Common/IApplicationClient.cs
   - clio/Command/McpServer/Tools/ODataFieldValidation.cs
@@ -18,6 +19,9 @@ than as an exception. Established by
 `~/.dotnet/tools/ilspycmd -t Creatio.Client.CreatioClient ~/.nuget/packages/creatio.client/2.0.2/lib/netstandard2.0/Creatio.Client.dll`.
 The ASYNC `ExecuteGetRequestAsync` DOES forward `maxAttempts`; only the string-returning synchronous
 overload — the one `IApplicationClient` exposes and nearly every clio caller uses — does not.
+Neither overload calls `EnsureSuccessStatusCode` on this path (`ReadResponseBody` only reads the
+content), so a 4xx/5xx is NOT a transport failure here: its error page or envelope is returned as the
+body. Only a connection failure or a timeout produces the empty string.
 
 **Why it is this way** — the synchronous overload is a compatibility wrapper over the async pipeline
 and it flattens both the retry and the failure channel to keep the `string` return type total. The

--- a/docs/knowledge/Common/creatio-client-get-discards-max-attempts.md
+++ b/docs/knowledge/Common/creatio-client-get-discards-max-attempts.md
@@ -1,0 +1,33 @@
+---
+description: creatio.client 2.0.2's synchronous ExecuteGetRequest discards its maxAttempts argument and swallows transport exceptions into an empty string, so a caller asking for 3 attempts gets exactly one request and reads a transient failure as an empty body
+applies-to:
+  - clio/Common/CreatioClientAdapter.cs
+  - clio/Common/IApplicationClient.cs
+  - clio/Command/McpServer/Tools/ODataFieldValidation.cs
+ticket: GH-1315
+date: 2026-09-12
+---
+
+**What is true** — in the pinned `creatio.client` 2.0.2 (`Directory.Packages.props`), the SYNCHRONOUS
+`CreatioClient.ExecuteGetRequest(url, requestTimeout, maxAttempts, delaySec)` passes the literal `1`
+into its own `SendAsync` retry loop in place of the caller's `maxAttempts`, and wraps the call in
+`catch (HttpRequestException) { return string.Empty; }` /
+`catch (TaskCanceledException) { return string.Empty; }`. So the argument produces no second request
+at any value, and a connection failure or a timeout arrives at the caller as an EMPTY BODY rather
+than as an exception. Established by
+`~/.dotnet/tools/ilspycmd -t Creatio.Client.CreatioClient ~/.nuget/packages/creatio.client/2.0.2/lib/netstandard2.0/Creatio.Client.dll`.
+The ASYNC `ExecuteGetRequestAsync` DOES forward `maxAttempts`; only the string-returning synchronous
+overload — the one `IApplicationClient` exposes and nearly every clio caller uses — does not.
+
+**Why it is this way** — the synchronous overload is a compatibility wrapper over the async pipeline
+and it flattens both the retry and the failure channel to keep the `string` return type total. The
+interface signature still advertises `maxAttempts`, so nothing at the call site says the value is
+inert, and the argument reads as an implemented feature.
+
+**What breaks if you ignore it** — a bounded retry expressed as `ExecuteGetRequest(url, timeout, 3, 1)`
+does not exist: the call is made once, and its unit test proves only that the argument was passed.
+`ODataFieldValidation`'s pre-write check shipped exactly that shape (GH-1227) and was rewritten to
+loop around the fetch AND its classification, retrying the empty-body outcome, because that outcome
+is the only visible trace a transient failure leaves. Any retry you need from a synchronous
+`IApplicationClient` GET must be written above the call and must key off the returned BODY, not off an
+exception that will never be thrown.

--- a/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
+++ b/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Creatio's OData v4 endpoint accepts a PATCH naming properties the entity type does not have and answers an empty 204-like body without writing anything - odata-update pre-validates every data field NAME against the service-root $metadata CSDL, with a $select probe fallback
 applies-to:
   - clio/Command/McpServer/Tools/ODataUpdateTool.cs
@@ -33,9 +33,15 @@ separately rather than shipped non-deterministically here.
 
 `ODataUpdateTool` therefore runs `ODataFieldValidation.ValidateDataFields` before every
 PATCH. The PRIMARY validator is the service's own metadata: `GET odata/$metadata` is fetched
-(bounded: 30 s timeout, 3 attempts, 1 s delay) and parsed as CSDL, and the entity's property
-set comes from ONE deterministic GET, which replaces the earlier per-field binary `$select`
-probing. Only STRUCTURAL `Property` elements enter that set, following `BaseType` inheritance;
+(bounded: 30 s timeout per request, up to 3 attempts, 1 s apart) and parsed as CSDL, and the entity's
+property set comes from ONE deterministic GET, which replaces the earlier per-field binary `$select`
+probing. The attempts are counted in `ODataFieldValidation`, around the fetch AND its classification,
+and the transport is asked for a single attempt: the pinned transport discards its own `maxAttempts`
+and reports a transient failure as an empty body, so only a retry above the classification can see one
+(`../Common/creatio-client-get-discards-max-attempts.md`). Only STRUCTURAL `Property` elements enter
+that set, following a `BaseType` chain that is walked iteratively and capped at 64 types - the
+document is server-authored, so an acyclic chain long enough to exhaust the stack is caller-influenced
+input, and exceeding the cap fails the call as unverified instead of degrading to the probe;
 a `NavigationProperty` is deliberately excluded, because an OData relationship is written
 through bind semantics rather than by assigning the navigation name, and the contract points
 callers at the structural foreign key (`AccountId`, not `Account`). The fallback probe leaves a

--- a/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
+++ b/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: Creatio's OData v4 endpoint accepts a PATCH naming properties the entity type does not have and answers an empty 204-like body without writing anything - odata-update pre-validates every data field NAME against the service-root $metadata CSDL, with a $select probe fallback
 applies-to:
   - clio/Command/McpServer/Tools/ODataUpdateTool.cs

--- a/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
+++ b/docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md
@@ -38,7 +38,15 @@ property set comes from ONE deterministic GET, which replaces the earlier per-fi
 probing. The attempts are counted in `ODataFieldValidation`, around the fetch AND its classification,
 and the transport is asked for a single attempt: the pinned transport discards its own `maxAttempts`
 and reports a transient failure as an empty body, so only a retry above the classification can see one
-(`../Common/creatio-client-get-discards-max-attempts.md`). Only STRUCTURAL `Property` elements enter
+(`../Common/creatio-client-get-discards-max-attempts.md`). Only the EMPTY-body outcome is retried; a
+non-2xx status is not, because the transport never calls `EnsureSuccessStatusCode` and an error status
+therefore arrives as its error page or envelope - a definitive answer a second identical request cannot
+improve. The two legs share one wall-time budget: when the metadata leg EXHAUSTS its retry on the
+empty-body outcome the target is proven silent, so the `$select` fallback then runs with a SINGLE
+attempt instead of a second full budget (worst case about 122 s rather than about 184 s, which is past
+the roughly 180 s ceiling MCP clients impose - a tool that refuses a write after the client has already
+timed out has refused nothing the caller can see). When the metadata leg ended with an answer instead,
+the transport is alive and the probe keeps the full three attempts. Only STRUCTURAL `Property` elements enter
 that set, following a `BaseType` chain that is walked iteratively and capped at 64 types - the
 document is server-authored, so an acyclic chain long enough to exhaust the stack is caller-influenced
 input, and exceeding the cap fails the call as unverified instead of degrading to the probe;
@@ -100,7 +108,8 @@ the record's JSON or an error and never legitimately returns empty, so an empty 
 request did not reach the OData pipeline intact (proxy page, session redirect, gateway that stripped
 the body); a PATCH, by contrast, can legitimately answer a body-less 204. Treating an empty probe
 body as "fields confirmed" would recreate the false success this validation removes; both stay
-fail-closed after the bounded retry.
+fail-closed after the bounded retry - whose size on the probe leg depends on what the metadata leg
+already learned about the target, as described above.
 
 **How the route and the no-write are proved** — the service-root `$metadata` route and the
 absence of the PATCH are pinned end-to-end, not just in-process:


### PR DESCRIPTION
🔗 **Issue:** [#1315](https://github.com/Advance-Technologies-Foundation/clio/issues/1315)

Closes #1315

## Summary

The five P2 follow-ups the review of #1227 left open. Four are implemented; item 2 is a scope question and is **decided, not implemented** — recorded below and on the issue.

## Root cause (item 1 — the retry that could not fire)

Decompiling the pinned transport (`creatio.client` 2.0.2, `ilspycmd -t Creatio.Client.CreatioClient`) shows the argument is not merely ineffective, it is discarded:

```csharp
public string ExecuteGetRequest(string url, int requestTimeout = 100000, int maxAttempts = 1, int delaySec = 1) {
    EnsureLegacyAuthentication();
    try { return ReadResponseBody(SendAsync(..., requestTimeout, 1, delaySec, CancellationToken.None), true); }
    catch (HttpRequestException) { return string.Empty; }
    catch (TaskCanceledException) { return string.Empty; }
}
```

`maxAttempts` is replaced by the literal `1` on the way into `SendAsync`, and a transport failure or timeout is swallowed into `string.Empty`. So a transient pre-write failure reaches clio as an **empty body** — a classification outcome — and `TransientAttempts: 3` never produced a second request. The async overload does forward the argument; only the string-returning synchronous one, which is what `IApplicationClient` exposes, does not.

(The issue text describes 1.0.40's `"Error: ..."` body shape. 2.0.2 carries no such literal, so only the empty-body shape is implemented — coding for a shape the pinned transport cannot emit would be a synthetic case.)

## Changes

**1. Real retry, on a bounded total budget.** `ODataFieldValidation.RetryWhileTransient` runs the fetch **and its classification** up to `TransientAttempts` times, and the transport is called with one attempt. Only the empty-body outcome is retried: a parsed CSDL, a recognized Creatio error envelope, an HTML error page and a JSON body that is not the addressed record are definitive answers a second identical request cannot improve. A non-2xx is in the definitive class, not the transient one — the transport never calls `EnsureSuccessStatusCode`, so an error status arrives as its error page or envelope. `TryGetPropertyTypes` stays single-shot (`OptionalMetadataAttempts = 1`), so `odata-create`'s optional type read is unchanged.

The two legs share ONE wall-time budget. Retrying both in full would cost about 184 s on a dead target, past the roughly 180 s ceiling MCP clients impose — the caller would see a client-side timeout instead of the refusal the whole check exists to produce. So the `$select` fallback inherits what the metadata leg learned: **one** attempt (`ExhaustedTransportProbeAttempts`) when that leg exhausted itself on the empty-body outcome (the target is proven silent), the full `TransientAttempts` when it ended with an answer (the transport is proven alive). Worst case about **122 s** on the two paths the review raised. The third path — a batch probe answered with a named fault, then the capped per-field follow-up fan-out — is unchanged in shape and gains at most one 32 s retry window, because the first follow-up that comes back unverified returns immediately. The retry keys off an `EmptyBody` flag on `EntityMetadata` / `ProbeResult`, not off the surfaced wording — a reworded caller-facing string must not silently stop the retry.

**3. Atomic environment resolve.** `IToolCommandResolver` gains `ResolvePair<TFirst, TSecond>`; `Resolve` and `ResolvePair` now share one `AcquireContainer`, so the branch selection, the settings read and the cache key happen exactly once and both services come out of the same container. `ODataKeyedWrite.ResolveTarget` uses it — `odata-delete` gets the same fix through that shared helper — and so does `ODataCreateTool`, the one remaining caller that still resolved the pair separately.

**4. Bounded CSDL walk.** `CollectInherited` is iterative, cycle- **and** depth-guarded (`MaxInheritanceDepth = 64`, admitting a chain of exactly 64 types including the addressed one). The chain is collected first and applied in reverse, so a base type's properties still reach every type below it. Exceeding the cap is not a degrade: the document *does* describe the entity, in a shape the walk refused to follow, so the call fails as unverified with no PATCH rather than falling back to the weaker `$select` probe.

**5. Structured E2E assertions.** All four cases in `ODataUpdatePreWriteValidationE2ETests` now assert the deserialized `success` flag and `IsError` the way `ODataReadToolE2ETests` does, on top of the prose, and guard that the machine-readable channel is present before parsing it. `IsError` stays false because a refused write is a normal tool *result*; the protocol error flag is reserved for binding/transport failures. The happy-path case asserts `success == true`.

One measured detail worth stating rather than hiding: `odata-update` declares no structured output schema, so this server answers with `StructuredContent == null` and the serialized `ODataWriteResponse` travels as JSON **text** in `Content` — which is what an MCP client parses for this tool. The pre-parse guard is therefore on `Content`. Giving the tool a structured output schema is a contract change and is out of scope here.

## Item 2 — decided, not implemented: the `$metadata` model stays

The CSDL model is kept, and nothing is deleted. It is the only source of the entity's declared **Edm types**, and that map is consumed beyond name validation: `propertyTypes` flows out of `ValidateDataFields` into `ODataDateTimeGuard`, and `TryGetPropertyTypes` serves `odata-create`, which does not validate field names at all. Collapsing to the single keyed `$select` probe would delete the only supplier of that map and weaken the date-time guard on write paths that are not the one under discussion. The probe stays as the fallback it already is.

## Validation

```
dotnet build clio/clio.csproj -c Debug -f net10.0                       -> Build succeeded (no new warnings)
dotnet test clio.tests/clio.tests.csproj -f net10.0 \
  --filter "Category=Unit&Module=McpServer"                             -> 5206 passed, 0 failed, 2 skipped
dotnet test clio.mcp.e2e/clio.mcp.e2e.csproj \
  --filter "FullyQualifiedName~ODataUpdatePreWriteValidationE2ETests"   -> 4 passed / 0 failed on net10.0 (15 s)
                                                                           4 passed / 0 failed on net8.0  (18 s)
```

The E2E fixture is `[Category("McpE2E.NoEnvironment")]` — a loopback stub answers every request, no Creatio stand is involved — so it was **actually run locally**, not merely compiled.

New coverage:

- `Update_Should_Retry_The_Metadata_Read_After_An_Empty_Body` — two observed requests, then the write.
- `Update_Should_Exhaust_The_Bounded_Retry_And_Refuse_To_Write` — three metadata requests, then exactly ONE probe request, unverified, no PATCH.
- `Update_Should_Keep_The_Full_Probe_Budget_After_An_Answered_Metadata_Read` — one metadata request (a JSON answer is definitive), then three probe requests. Asserted per URL: both cases total four GETs, so a total count would not tell them apart.
- `Update_Should_Not_Retry_A_Definitive_Metadata_Answer` — one request.
- `Update_Should_Refuse_A_Metadata_Inheritance_Chain_Deeper_Than_The_Cap` / `Update_Should_Still_Walk_A_Chain_Within_The_Depth_Cap`.
- `ResolvePair_Should_Resolve_Both_Services_From_One_Environment_Snapshot` — mutates the settings repository between the two former resolutions, and asserts the *control* divergence too (a lone call count would also hold for a resolver that never re-reads the settings).

Two honesty notes, deliberately not papered over:

- **Item 4's test proves the cap fires, not the crash it prevents.** A 200-type chain would not have overflowed the old recursion (that needs tens of thousands of frames), and a test that actually overflowed the stack could not report its own result. The value of the change is the bound; the value of the test is that the bound is reached and answered correctly.
- **Item 1's two-request proof sits at the `IApplicationClient` substitute seam**, which is where the repeated calls are observable (the adapter is a pass-through). The E2E stub has no "empty once, then CSDL" mode and adding one is outside the smallest complete repair.

`Thread.Sleep` between attempts: the whole pre-write path is synchronous (`IApplicationClient.ExecuteGetRequest` blocks) and the pause runs only on the already-failed branch. Worst-case wall time is 3 × 30 s + 2 × 1 s on the metadata leg plus one 30 s probe ≈ **122 s** (dead target), or one 30 s metadata read plus 3 × 30 s + 2 × 1 s of probing ≈ 122 s (target alive but unhelpful) — under the ~180 s client ceiling in both directions.

## Review tier

Full 3-lens fan-out (pre-PR gate): code-quality, bug-detector, security reviewers over `git diff origin/master...HEAD`.

**0 Blockers.** Everything the three lenses raised is fixed in `90810ab`:

| Sev | Finding | Disposition |
|---|---|---|
| High (all 3 lenses) | The new retry pushed dead-target pre-write wall time from ~60 s to ~184 s, above the ~180 s MCP client ceiling | Fixed — the probe inherits the metadata leg's outcome (`ExhaustedTransportProbeAttempts`); worst case ≈122 s, pinned by two per-URL attempt-count tests |
| Medium | `AssertStructuredFailure` parsed without first checking a payload channel exists | Fixed — `AssertMachineReadableChannel` runs before `Extract`. The reviewer asked for a `StructuredContent` null-check specifically; that assertion is false here (this tool has no structured output schema), so the guard is on `Content`, where the envelope actually travels |
| Medium | `ODataCreateToolTests` asserted `OptionalMetadataAttempts` where the code passes `TransportAttempts` | Fixed — both are `1`, so it passed by coincidence; `Received(1)` is what pins the single-attempt budget |
| Low | Retry predicate compared a caller-facing message string | Fixed — `EmptyBody` flag on `EntityMetadata` / `ProbeResult` |
| Low | `TransientAttempts` doc claimed a 5xx is retried | Fixed — the decompile shows no `EnsureSuccessStatusCode`, so an error status returns its error page and is classified definitive. Both the remark and the knowledge record now say so |
| Low | Depth cap admitted 65 types while documenting 64 | Fixed — `>=` |
| Low | Duplicated `<summary>` on one line; `LastResolvedTenantKey` doc omitted `ResolvePair`; stray UTF-8 BOM | Fixed |
| Low | Knowledge record's `applies-to` missed `Directory.Packages.props` (the pin that makes the transport fact version-specific) | Fixed |

Also removed while in the file: 19 now-dead `resolver.Resolve<…>` stub pairs in `ODataCreateToolTests` — the tool only calls `ResolvePair`.

## Deliberately out of scope

- **Unbounded `$metadata` body size.** The pre-write GET reads the whole CSDL into a string with no ceiling. A byte bound is impossible from clio against the pinned transport (no per-chunk callback, no `Stream` overload, no `HttpMessageHandler` seam); it needs `Creatio.Client` 2.1.0.
- **The same double-resolve in the read-only tools.** `ResolvePair` is now available to them; converting them is a separate, wider change with no reported symptom.
- **FR-19 mode-scoping nuance** in the credential-passthrough branch of `ToolCommandResolver` — untouched by this change and unrelated to the pre-write path.
- **`ServiceUrlBuilder`'s mutating `Build` overload.** Noted by a reviewer as a design smell; changing it touches every OData tool and belongs in its own change.
- **Giving `odata-update` a structured output schema** so `StructuredContent` is populated — a published contract change, not a follow-up to this fix.

## MCP / docs / Ring

**MCP reviewed, no update required** for the tool contract: `odata-update` / `odata-delete` keep their name, arguments, descriptions and destructive classification; the behaviour change is internal to the pre-write check and is covered by the updated `clio.mcp.e2e` fixture. `odata-update` appears in no `Prompts/`, `Resources/` or `clio/tpl/**` artifact.

**Docs reviewed, no update required**: these are MCP-only tools with no CLI verb — `odata-update` appears in none of `clio/help/en`, `clio/docs/commands`, `clio/Commands.md`.

**ClioRing compatibility reviewed, no Ring-consumed contract changed.** Inspected `clio-ring/ClioRing`, `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing.Desktop` (incl. `actions.json`) and `clio-ring/ClioRing.Tests`: `grep -rn "odata"` and `grep -rn "IToolCommandResolver\|ResolvePair"` over `clio-ring/` return nothing, so no Ring-invoked tool, nested `clio-run` command, progress or stage contract is touched.

## Knowledge base

- Added `docs/knowledge/Common/creatio-client-get-discards-max-attempts.md` — the decompiled transport fact, which the code cannot say.
- Updated `docs/knowledge/McpServer/odata-update-probes-data-fields-before-write.md` (its `applies-to` covers the changed files): the retry now lives above the classification, and the inheritance walk is bounded.
- `make check-knowledge` / `scripts/check-knowledge-applies-to.py`: all 251 records resolve and match the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
