### PR TITLE
Model the page-body factory scope chain and bound the lint report (#1312)

### DIFF
--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -473,16 +473,66 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 		baseline.Success.Should().BeTrue(
 			because: $"get-page must succeed for the seeded page '{SavePage}' before the gate can be proven. Error: {baseline.Error}");
 		string originalBody = await File.ReadAllTextAsync(baseline.Files.BodyFile);
+		bool restoreNeeded = false;
+		try {
+			// Act 2: the real save path — no dry-run — with a body only the AST lint pass rejects.
+			CallToolResult syncResult = await SyncBodyAsync(context, environmentName,
+				PageLintProbeBodies.ConditionallyDeclaredHelper(SavePage));
+			PageSyncResponse response = EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(syncResult);
 
-		// Act 2: the real save path — no dry-run — with a body only the AST lint pass rejects.
-		CallToolResult syncResult = await context.Session.CallToolAsync(
+			// Act 3: read the page back.
+			CallToolResult readbackResult = await context.Session.CallToolAsync(
+				PageGetTool.ToolName,
+				new Dictionary<string, object?> {
+					["args"] = new Dictionary<string, object?> {
+						["schema-name"] = SavePage,
+						["environment-name"] = environmentName
+					}
+				},
+				context.CancellationTokenSource.Token);
+			PageGetResponse readback = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(readbackResult);
+			string bodyAfter = readback.Success ? await File.ReadAllTextAsync(readback.Files.BodyFile) : null;
+			restoreNeeded = bodyAfter is not null && bodyAfter != originalBody;
+
+			// Assert
+			response.Success.Should().BeFalse(
+				because: "the handler calls a helper whose only declaration sits in a branch that never runs, so the page would throw a TypeError on open");
+			response.Pages.Should().ContainSingle(
+				because: "one page was submitted");
+			response.Pages[0].Error.Should().Contain("Page body lint failed",
+				because: "the canonical lint prefix is what tells the agent this was a lint rejection rather than a syntax or transport failure");
+			response.Pages[0].Error.Should().Contain("undefined-section-call",
+				because: "the rule id must reach the wire so the agent can map the refusal back to the authoring rule");
+			readback.Success.Should().BeTrue(
+				because: $"the page must still be readable after the refused write. Error: {readback.Error}");
+			bodyAfter.Should().Be(originalBody,
+				because: "a refused write must leave the stand untouched — this is the assertion the dry-run scenario cannot make");
+		} finally {
+			if (restoreNeeded) {
+				//Only reached when the gate let the probe body through, which is the failure this test
+				//exists to catch. The page is shared by the rest of the suite, so it is put back rather
+				//than left holding a body that throws on open.
+				try {
+					await SyncBodyAsync(context, environmentName, originalBody);
+				} catch (Exception restoreFailure) {
+					TestContext.Progress.WriteLine(
+						$"Failed to restore the body of '{SavePage}': {restoreFailure.Message}");
+				}
+			}
+		}
+	}
+
+	/// <summary>Saves one body to <c>SavePage</c> through the real (non-dry-run) sync-pages path.</summary>
+	private static Task<CallToolResult> SyncBodyAsync(ArrangeContext context, string environmentName,
+		string body) =>
+		context.Session.CallToolAsync(
 			ToolName,
 			new Dictionary<string, object?> {
 				["args"] = new Dictionary<string, object?> {
 					["pages"] = new[] {
 						new Dictionary<string, object?> {
 							["schema-name"] = SavePage,
-							["body"] = PageLintProbeBodies.ConditionallyDeclaredHelper(SavePage)
+							["body"] = body
 						}
 					},
 					["environment-name"] = environmentName,
@@ -490,35 +540,6 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 				}
 			},
 			context.CancellationTokenSource.Token);
-		PageSyncResponse response = EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(syncResult);
-
-		// Act 3: read the page back.
-		CallToolResult readbackResult = await context.Session.CallToolAsync(
-			PageGetTool.ToolName,
-			new Dictionary<string, object?> {
-				["args"] = new Dictionary<string, object?> {
-					["schema-name"] = SavePage,
-					["environment-name"] = environmentName
-				}
-			},
-			context.CancellationTokenSource.Token);
-		PageGetResponse readback = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(readbackResult);
-
-		// Assert
-		response.Success.Should().BeFalse(
-			because: "the handler calls a helper whose only declaration sits in a branch that never runs, so the page would throw a TypeError on open");
-		response.Pages.Should().ContainSingle(
-			because: "one page was submitted");
-		response.Pages[0].Error.Should().Contain("Page body lint failed",
-			because: "the canonical lint prefix is what tells the agent this was a lint rejection rather than a syntax or transport failure");
-		response.Pages[0].Error.Should().Contain("undefined-section-call",
-			because: "the rule id must reach the wire so the agent can map the refusal back to the authoring rule");
-		readback.Success.Should().BeTrue(
-			because: $"the page must still be readable after the refused write. Error: {readback.Error}");
-		string bodyAfter = await File.ReadAllTextAsync(readback.Files.BodyFile);
-		bodyAfter.Should().Be(originalBody,
-			because: "a refused write must leave the stand untouched — this is the assertion the dry-run scenario cannot make");
-	}
 
 	[Test]
 	[Description("Keeps JavaScript handlers out of JSON content validation failures.")]

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -492,7 +492,9 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 				context.CancellationTokenSource.Token);
 			PageGetResponse readback = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(readbackResult);
 			string bodyAfter = readback.Success ? await File.ReadAllTextAsync(readback.Files.BodyFile) : null;
-			restoreNeeded = bodyAfter is not null && bodyAfter != originalBody;
+			//A readback that did not come back cannot show the page is intact, and the write it was
+			//supposed to check may well have landed - so that case restores too.
+			restoreNeeded = bodyAfter is null || bodyAfter != originalBody;
 
 			// Assert
 			response.Success.Should().BeFalse(
@@ -513,7 +515,18 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 				//exists to catch. The page is shared by the rest of the suite, so it is put back rather
 				//than left holding a body that throws on open.
 				try {
-					await SyncBodyAsync(context, environmentName, originalBody);
+					CallToolResult restoreResult =
+						await SyncBodyAsync(context, environmentName, originalBody);
+					PageSyncResponse restored =
+						EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(restoreResult);
+					if (!restored.Success) {
+						//A refused save comes back in the envelope rather than as an exception, so
+						//without this the shared fixture page would be left holding a body that throws
+						//on open, silently.
+						TestContext.Progress.WriteLine(
+							$"Failed to restore the body of '{SavePage}': "
+							+ string.Join("; ", restored.Pages.Select(page => page.Error)));
+					}
 				} catch (Exception restoreFailure) {
 					TestContext.Progress.WriteLine(
 						$"Failed to restore the body of '{SavePage}': {restoreFailure.Message}");

--- a/clio.mcp.e2e/PageSyncToolE2ETests.cs
+++ b/clio.mcp.e2e/PageSyncToolE2ETests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +11,7 @@ using Allure.NUnit.Attributes;
 using Clio.Command;
 using Clio.Command.McpServer.Tools;
 using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
@@ -441,6 +442,82 @@ public sealed class PageSyncToolE2ETests : McpContractFixtureBase {
 			because: "the rule id must be visible in the wire response so the agent can map the failure back to the guidance doc that describes the anti-pattern");
 		response.Pages[0].Error.Should().Contain("NOT sent to Creatio",
 			because: "the operator must know the body did not reach the server without inspecting logs, mirroring the syntax-gate tail");
+	}
+
+	[Test]
+	[Description("A NON-dry-run sync-pages of a body whose handler calls a conditionally declared helper fails at the lint gate and leaves the page on the stand byte-identical — the existing lint scenario targets a page that does not exist, so it cannot show that a real save was prevented.")]
+	[AllureTag(ToolName)]
+	[AllureName("sync-pages blocks a real save on undefined-section-call and leaves the page unchanged")]
+	[AllureDescription("Against the seeded page ClioMcp_BlankPageToSave: captures the body with get-page, submits a marker-complete body whose returned handler calls a helper declared only inside an `if (false)` block, asserts the lint gate rejects the page, then re-reads the page and asserts the stored body is unchanged.")]
+	public async Task PageSyncTool_Should_Block_Real_Save_And_Leave_Page_Unchanged_When_HelperIsConditionallyDeclared() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping the real-save lint-gate test.");
+		}
+		string environmentName = await ResolveReachableEnvironmentAsync(settings);
+		await using ArrangeContext context = await ArrangeAsync();
+
+		// Act 1: capture the body the stand currently holds.
+		CallToolResult baselineResult = await context.Session.CallToolAsync(
+			PageGetTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = SavePage,
+					["environment-name"] = environmentName
+				}
+			},
+			context.CancellationTokenSource.Token);
+		PageGetResponse baseline = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(baselineResult);
+		baseline.Success.Should().BeTrue(
+			because: $"get-page must succeed for the seeded page '{SavePage}' before the gate can be proven. Error: {baseline.Error}");
+		string originalBody = await File.ReadAllTextAsync(baseline.Files.BodyFile);
+
+		// Act 2: the real save path — no dry-run — with a body only the AST lint pass rejects.
+		CallToolResult syncResult = await context.Session.CallToolAsync(
+			ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["pages"] = new[] {
+						new Dictionary<string, object?> {
+							["schema-name"] = SavePage,
+							["body"] = PageLintProbeBodies.ConditionallyDeclaredHelper(SavePage)
+						}
+					},
+					["environment-name"] = environmentName,
+					["skip-sampling"] = true
+				}
+			},
+			context.CancellationTokenSource.Token);
+		PageSyncResponse response = EntitySchemaStructuredResultParser.Extract<PageSyncResponse>(syncResult);
+
+		// Act 3: read the page back.
+		CallToolResult readbackResult = await context.Session.CallToolAsync(
+			PageGetTool.ToolName,
+			new Dictionary<string, object?> {
+				["args"] = new Dictionary<string, object?> {
+					["schema-name"] = SavePage,
+					["environment-name"] = environmentName
+				}
+			},
+			context.CancellationTokenSource.Token);
+		PageGetResponse readback = EntitySchemaStructuredResultParser.Extract<PageGetResponse>(readbackResult);
+
+		// Assert
+		response.Success.Should().BeFalse(
+			because: "the handler calls a helper whose only declaration sits in a branch that never runs, so the page would throw a TypeError on open");
+		response.Pages.Should().ContainSingle(
+			because: "one page was submitted");
+		response.Pages[0].Error.Should().Contain("Page body lint failed",
+			because: "the canonical lint prefix is what tells the agent this was a lint rejection rather than a syntax or transport failure");
+		response.Pages[0].Error.Should().Contain("undefined-section-call",
+			because: "the rule id must reach the wire so the agent can map the refusal back to the authoring rule");
+		readback.Success.Should().BeTrue(
+			because: $"the page must still be readable after the refused write. Error: {readback.Error}");
+		string bodyAfter = await File.ReadAllTextAsync(readback.Files.BodyFile);
+		bodyAfter.Should().Be(originalBody,
+			because: "a refused write must leave the stand untouched — this is the assertion the dry-run scenario cannot make");
 	}
 
 	[Test]

--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -9,6 +9,7 @@ using Clio.Command.McpServer.Tools;
 using Clio.Common;
 using Clio.Common.BrowserSession;
 using Clio.Mcp.E2E.Support.Configuration;
+using Clio.Mcp.E2E.Support.Creatio;
 using Clio.Mcp.E2E.Support.Mcp;
 using Clio.Mcp.E2E.Support.Results;
 using FluentAssertions;
@@ -347,6 +348,56 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 			because: "the rule id must be visible in the wire response so the agent can map the failure back to the guidance doc that describes the anti-pattern");
 		response.Error.Should().Contain("NOT sent to Creatio",
 			because: "the operator must know the body did not reach the server without inspecting logs, mirroring the syntax-gate tail");
+	}
+
+	[Test]
+	[Description("A NON-dry-run update-page of a body whose handler calls a conditionally declared helper fails at the lint gate and leaves the page on the stand byte-identical — dry-run scenarios make 'nothing was persisted' trivially true, so the real save path is what proves the gate actually blocks the write.")]
+	[AllureTag(ToolName)]
+	[AllureName("update-page blocks a non-dry-run save on undefined-section-call and leaves the page unchanged")]
+	[AllureDescription("Against the seeded page ClioMcp_BlankPageToSave: captures the body with get-page, submits a marker-complete body whose returned handler calls a helper declared only inside an `if (false)` block through the real save path (no dry-run), asserts the lint gate rejects it, then re-reads the page and asserts the stored body is unchanged.")]
+	public async Task PageUpdateTool_Should_Block_Real_Save_And_Leave_Page_Unchanged_When_HelperIsConditionallyDeclared() {
+		// Arrange
+		McpE2ESettings settings = TestConfiguration.Load();
+		settings.ClioProcessPath = TestConfiguration.ResolveFreshClioProcessPath();
+		if (!settings.AllowDestructiveMcpTests) {
+			Assert.Ignore("AllowDestructiveMcpTests is false — skipping the real-save lint-gate test.");
+		}
+		string environmentName = await ResolveReachableEnvironmentAsync(settings);
+		await using var arrangeContext = Arrange(TimeSpan.FromMinutes(5));
+		const string savePage = "ClioMcp_BlankPageToSave";
+		string baselineDir = Directory.CreateTempSubdirectory("clio-e2e-lint-gate-before-").FullName;
+		string readbackDir = Directory.CreateTempSubdirectory("clio-e2e-lint-gate-after-").FullName;
+		try {
+			PageGetResponse baseline = await GetPageAsync(arrangeContext, savePage, environmentName, baselineDir);
+			baseline.Success.Should().BeTrue(
+				because: $"get-page must succeed for the seeded page '{savePage}' before the gate can be proven. Error: {baseline.Error}");
+			string originalBody = await File.ReadAllTextAsync(baseline.Files.BodyFile);
+
+			// Act
+			PageUpdateResponse response = await UpdatePageAsync(
+				arrangeContext,
+				savePage,
+				PageLintProbeBodies.ConditionallyDeclaredHelper(savePage),
+				environmentName,
+				baselineDir);
+			PageGetResponse readback = await GetPageAsync(arrangeContext, savePage, environmentName, readbackDir);
+
+			// Assert
+			response.Success.Should().BeFalse(
+				because: "the handler calls a helper whose only declaration sits in a branch that never runs, so the page would throw a TypeError on open");
+			response.Error.Should().Contain("Page body lint failed",
+				because: "the canonical lint prefix is what tells the agent this was a lint rejection rather than a syntax or transport failure");
+			response.Error.Should().Contain("undefined-section-call",
+				because: "the rule id must reach the wire so the agent can map the refusal back to the authoring rule");
+			readback.Success.Should().BeTrue(
+				because: $"the page must still be readable after the refused write. Error: {readback.Error}");
+			string bodyAfter = await File.ReadAllTextAsync(readback.Files.BodyFile);
+			bodyAfter.Should().Be(originalBody,
+				because: "a refused write must leave the stand untouched — this is the assertion a dry-run scenario cannot make");
+		} finally {
+			TryDeleteDirectory(baselineDir);
+			TryDeleteDirectory(readbackDir);
+		}
 	}
 
 	[Test]

--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -384,7 +384,9 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 				baselineDir);
 			PageGetResponse readback = await GetPageAsync(arrangeContext, savePage, environmentName, readbackDir);
 			string bodyAfter = readback.Success ? await File.ReadAllTextAsync(readback.Files.BodyFile) : null;
-			restoreNeeded = bodyAfter is not null && bodyAfter != originalBody;
+			//A readback that did not come back cannot show the page is intact, and the write it was
+			//supposed to check may well have landed - so that case restores too.
+			restoreNeeded = bodyAfter is null || bodyAfter != originalBody;
 
 			// Assert
 			response.Success.Should().BeFalse(
@@ -417,7 +419,14 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 	private static async Task TryRestorePageBodyAsync(ArrangeContext context, string schemaName,
 		string body, string environmentName, string outputDirectory) {
 		try {
-			await UpdatePageAsync(context, schemaName, body, environmentName, outputDirectory);
+			PageUpdateResponse restored =
+				await UpdatePageAsync(context, schemaName, body, environmentName, outputDirectory);
+			if (!restored.Success) {
+				//A refused save comes back in the envelope rather than as an exception, so without this
+				//the shared fixture page would be left holding a body that throws on open, silently.
+				TestContext.Progress.WriteLine(
+					$"Failed to restore the body of '{schemaName}': {restored.Error}");
+			}
 		} catch (Exception restoreFailure) {
 			TestContext.Progress.WriteLine(
 				$"Failed to restore the body of '{schemaName}': {restoreFailure.Message}");

--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -404,8 +404,11 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 				//Only reached when the gate let the probe body through, which is the failure this test
 				//exists to catch. The page is shared by the rest of the suite, so it is put back rather
 				//than left holding a body that throws on open.
+				//Through readbackDir, not baselineDir: update-page compares the body on the stand against
+				//the baseline in its output directory, and only readbackDir holds one taken AFTER the
+				//probe write landed. Restoring against the stale baseline would be refused as a conflict.
 				await TryRestorePageBodyAsync(arrangeContext, savePage, originalBody, environmentName,
-					baselineDir);
+					readbackDir);
 			}
 			TryDeleteDirectory(baselineDir);
 			TryDeleteDirectory(readbackDir);

--- a/clio.mcp.e2e/PageUpdateToolE2ETests.cs
+++ b/clio.mcp.e2e/PageUpdateToolE2ETests.cs
@@ -367,11 +367,13 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 		const string savePage = "ClioMcp_BlankPageToSave";
 		string baselineDir = Directory.CreateTempSubdirectory("clio-e2e-lint-gate-before-").FullName;
 		string readbackDir = Directory.CreateTempSubdirectory("clio-e2e-lint-gate-after-").FullName;
+		string originalBody = null;
+		bool restoreNeeded = false;
 		try {
 			PageGetResponse baseline = await GetPageAsync(arrangeContext, savePage, environmentName, baselineDir);
 			baseline.Success.Should().BeTrue(
 				because: $"get-page must succeed for the seeded page '{savePage}' before the gate can be proven. Error: {baseline.Error}");
-			string originalBody = await File.ReadAllTextAsync(baseline.Files.BodyFile);
+			originalBody = await File.ReadAllTextAsync(baseline.Files.BodyFile);
 
 			// Act
 			PageUpdateResponse response = await UpdatePageAsync(
@@ -381,6 +383,8 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 				environmentName,
 				baselineDir);
 			PageGetResponse readback = await GetPageAsync(arrangeContext, savePage, environmentName, readbackDir);
+			string bodyAfter = readback.Success ? await File.ReadAllTextAsync(readback.Files.BodyFile) : null;
+			restoreNeeded = bodyAfter is not null && bodyAfter != originalBody;
 
 			// Assert
 			response.Success.Should().BeFalse(
@@ -391,12 +395,32 @@ public sealed class PageUpdateToolE2ETests : McpContractFixtureBase {
 				because: "the rule id must reach the wire so the agent can map the refusal back to the authoring rule");
 			readback.Success.Should().BeTrue(
 				because: $"the page must still be readable after the refused write. Error: {readback.Error}");
-			string bodyAfter = await File.ReadAllTextAsync(readback.Files.BodyFile);
 			bodyAfter.Should().Be(originalBody,
 				because: "a refused write must leave the stand untouched — this is the assertion a dry-run scenario cannot make");
 		} finally {
+			if (restoreNeeded) {
+				//Only reached when the gate let the probe body through, which is the failure this test
+				//exists to catch. The page is shared by the rest of the suite, so it is put back rather
+				//than left holding a body that throws on open.
+				await TryRestorePageBodyAsync(arrangeContext, savePage, originalBody, environmentName,
+					baselineDir);
+			}
 			TryDeleteDirectory(baselineDir);
 			TryDeleteDirectory(readbackDir);
+		}
+	}
+
+	/// <summary>
+	/// Best-effort restore of a shared fixture page's body. A failure here is reported to the console
+	/// and swallowed: it must not replace the assertion failure that made the restore necessary.
+	/// </summary>
+	private static async Task TryRestorePageBodyAsync(ArrangeContext context, string schemaName,
+		string body, string environmentName, string outputDirectory) {
+		try {
+			await UpdatePageAsync(context, schemaName, body, environmentName, outputDirectory);
+		} catch (Exception restoreFailure) {
+			TestContext.Progress.WriteLine(
+				$"Failed to restore the body of '{schemaName}': {restoreFailure.Message}");
 		}
 	}
 

--- a/clio.mcp.e2e/Support/Creatio/PageLintProbeBodies.cs
+++ b/clio.mcp.e2e/Support/Creatio/PageLintProbeBodies.cs
@@ -1,0 +1,29 @@
+namespace Clio.Mcp.E2E.Support.Creatio;
+
+/// <summary>
+/// Page bodies that are syntactically valid, carry every schema marker, and pass the regex
+/// validators - only the AST lint pass rejects them. Shared by the write-path suites so the
+/// update-page and sync-pages gate scenarios exercise byte-identical input.
+/// </summary>
+internal static class PageLintProbeBodies {
+
+	/// <summary>
+	/// A body whose returned handler calls a helper the factory declares only inside a branch that
+	/// never runs. The name hoists, so the binding exists; nothing ever stores the function in it, so
+	/// the handler throws a TypeError on the deployed page. Rejected with `undefined-section-call`.
+	/// </summary>
+	public static string ConditionallyDeclaredHelper(string schemaName) =>
+		$"define(\"{schemaName}\", /**SCHEMA_DEPS*/[]/**SCHEMA_DEPS*/, " +
+		"function/**SCHEMA_ARGS*/()/**SCHEMA_ARGS*/ { " +
+		"if (false) { function lintProbeHelper() { return 1; } } " +
+		"return { " +
+		"viewConfigDiff: /**SCHEMA_VIEW_CONFIG_DIFF*/[]/**SCHEMA_VIEW_CONFIG_DIFF*/, " +
+		"viewModelConfigDiff: /**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/[]/**SCHEMA_VIEW_MODEL_CONFIG_DIFF*/, " +
+		"modelConfigDiff: /**SCHEMA_MODEL_CONFIG_DIFF*/[]/**SCHEMA_MODEL_CONFIG_DIFF*/, " +
+		"handlers: /**SCHEMA_HANDLERS*/[{ request: \"crt.HandleViewModelInitRequest\", " +
+		"handler: async (request, next) => { lintProbeHelper(); return next?.handle(request); } }]" +
+		"/**SCHEMA_HANDLERS*/, " +
+		"converters: /**SCHEMA_CONVERTERS*/{}/**SCHEMA_CONVERTERS*/, " +
+		"validators: /**SCHEMA_VALIDATORS*/{}/**SCHEMA_VALIDATORS*/ }; });";
+
+}

--- a/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
@@ -1352,6 +1352,127 @@ internal class PageBodyAstLinterTests {
 			because: "a define-less body must not silently skip the rule that blocks a handler calling a helper that is not there");
 	}
 
+	[TestCase("if (someFlag) { helper = function() { return 1; }; }", TestName = "assignment in a runtime-conditional block")]
+	[TestCase("while (someFlag) { helper = function() { return 1; }; }", TestName = "assignment in a loop body")]
+	[TestCase("try { helper = riskyFactory(); } catch (error) { }", TestName = "assignment in a try block")]
+	[Description("An assignment that only runs when a branch is taken does not initialize the binding: the block runs conditionally, so the handler can still find `undefined` and throw a TypeError")]
+	public void Lint_ShouldEmitError_WhenTheOnlyAssignmentIsConditional(string assignment) {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { let helper; " + assignment + " " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().Contain(f =>
+				f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Severity == LintSeverity.Error,
+			because: "reaching the assignment at all depends on a runtime decision, so it proves nothing about the binding the handler reads");
+	}
+
+	[Test]
+	[Description("The verdict does not depend on where the assigning helper sits in the source: a hoisted `init()` declared after the factory's return still counts as initializing the binding it assigns")]
+	public void Lint_ShouldNotEmitError_WhenTheAssigningFunctionIsDeclaredAfterTheReturn() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { let helper; init(); " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; " +
+			"function init() { helper = function() { return 1; }; } });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().NotContain(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall,
+			because: "the same body with `function init()` written before the return was already accepted, and a blocking rule whose answer depends on statement order is not one an author can act on");
+	}
+
+	[Test]
+	[Description("An arrow factory with an expression body — `() => ({ handlers: [...] })` — is a discovered page schema, so a handler in it that calls an undeclared helper is still reported")]
+	public void Lint_ShouldEmitError_WhenAnArrowFactoryReturnsTheSchemaAsItsExpressionBody() {
+		// Arrange
+		string body =
+			"define(\"X\", [], () => ({ handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { missingModuleHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }));";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+				f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("missingModuleHelper"),
+			because: "an arrow with no `return` statement returns its object literal all the same, and skipping the shape would leave the rule silent on a page that fails at runtime");
+	}
+
+	[Test]
+	[Description("A factory that returns a variable holding the schema object literal is discovered too, so `const schema = { handlers: [...] }; return schema;` is covered like the inline form")]
+	public void Lint_ShouldEmitError_WhenTheFactoryReturnsANamedSchemaObject() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { " +
+			"const schema = { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { missingModuleHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; return schema; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+				f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("missingModuleHelper"),
+			because: "naming the returned object is an ordinary authoring style and must not turn the blocking rule off");
+	}
+
+	[Test]
+	[Description("The overall ceiling bounds warnings only: a body whose warnings fill the report still returns every blocking Error, because dropping one would let a page the platform rejects save clean")]
+	public void Lint_ShouldKeepErrors_WhenWarningsFillTheWholeReport() {
+		// Arrange
+		var handlers = new StringBuilder();
+		var converters = new StringBuilder();
+		var dataSources = new StringBuilder();
+		for (int index = 0; index < 60; index++) {
+			handlers.Append(
+				"{ request: \"crt.HandleViewModelAttributeChangeRequest\", " +
+				"handler: async (request, next) => { request.$context.set(\"Field\", 1); " +
+				"return next?.handle(request); } }, ");
+			handlers.Append(
+				"{ request: \"crt.HandleViewModelInitRequest\", " +
+				"handler: async (request, next) => { request.$context.executeRequest({}); " +
+				"return next?.handle(request); } }, ");
+			converters.Append($"\"plain{index}\": function(v) {{ return fetch(\"/api/{index}\"); }}, ");
+			dataSources.Append($"{{ entitySchemaName: \"Contact\", filters: [{index}] }}, ");
+		}
+		string body =
+			"define(\"X\", [], function() { return { " +
+			"handlers: [" + handlers +
+			"{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { missingModuleHelper(); return next?.handle(request); } }], " +
+			"converters: { " + converters + "\"crt.Reserved\": function(v) { return v; } }, " +
+			"validators: {}, viewModelConfig: [" + dataSources + "] }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Count(f => f.Severity == LintSeverity.Warning).Should().BeLessThanOrEqualTo(
+			PageBodyAstLinter.MaxFindingsTotal + WarningRuleCount,
+			because: "the overall ceiling still bounds the advisory part of the report, plus at most one counted summary per capped rule");
+		findings.Should().Contain(f => f.Rule == PageBodyAstLinter.RuleConverterCrtPrefixReserved,
+			because: "an Error that blocks the write must not be crowded out by warnings the caller does not have to act on");
+		findings.Should().Contain(f =>
+				f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("missingModuleHelper"),
+			because: "this rule runs after the main walk, so an exhausted report used to swallow it entirely and save a page whose handler throws");
+	}
+
+	// How many distinct Warning rules the linter ships; each capped rule may append one counted summary.
+	private const int WarningRuleCount = 4;
+
 	#endregion
 
 }

--- a/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
@@ -28,6 +28,10 @@ internal class PageBodyAstLinterTests {
 	private static IReadOnlyList<PageBodyLintFinding> LintBody(string body) =>
 		PageBodyAstLinter.Lint(ParseOrThrow(body));
 
+	// What the caller actually receives: every finding rendered through the canonical wire format.
+	private static int RenderedLength(IEnumerable<PageBodyLintFinding> findings) =>
+		string.Join("; ", findings.Select(PageBodyAstLinter.FormatFinding)).Length;
+
 	#endregion
 
 	#region Tests: clean bodies (no findings)
@@ -1046,8 +1050,68 @@ internal class PageBodyAstLinterTests {
 			.Where(f => f.Rule == PageBodyAstLinter.RuleConverterCrtPrefixReserved).ToList();
 		reported.Should().HaveCount(PageBodyAstLinter.MaxFindingsPerRule + 1,
 			because: "every offending key carries the same fix, so past the cap they collapse into one counted line");
-		reported[^1].Message.Should().Contain($"{keyCount - PageBodyAstLinter.MaxFindingsPerRule} further converter key(s)",
-			because: "the caller must still learn how many were suppressed");
+		reported[^1].Message.Should().Contain(
+			$"{keyCount - PageBodyAstLinter.MaxFindingsPerRule} further "
+				+ $"`{PageBodyAstLinter.RuleConverterCrtPrefixReserved}` finding(s)",
+			because: "the caller must still learn how many were suppressed; the wording is now the shared per-rule summary every bounded rule emits");
+	}
+
+	[Test]
+	[Description("A converter carrying thousands of `fetch(...)` calls stays bounded in BOTH finding count and rendered length — AST depth caps how deep the walk goes, not how wide one converter is, and the warning list is what the caller actually reads")]
+	public void Lint_ShouldBoundWarnings_WhenOneConverterFiresTheSameRuleThousandsOfTimes() {
+		// Arrange
+		int callCount = PageBodyAstLinter.MaxFindingsPerRule + 2000;
+		var calls = new StringBuilder();
+		for (int index = 0; index < callCount; index++) {
+			calls.Append($"fetch(\"/api/lookup?id={index}\"); ");
+		}
+		string body =
+			"define(\"X\", [], function() { return { handlers: [], converters: { " +
+			$"\"usr.Lookup\": function(v) {{ {calls}return v; }} " +
+			"}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		List<PageBodyLintFinding> reported = findings
+			.Where(f => f.Rule == PageBodyAstLinter.RuleConverterFetchCall).ToList();
+		reported.Should().HaveCount(PageBodyAstLinter.MaxFindingsPerRule + 1,
+			because: "the shared budget caps the rule and adds exactly one counted summary, instead of one warning per call site");
+		reported[^1].Message.Should().Contain(
+			$"{callCount - PageBodyAstLinter.MaxFindingsPerRule} further "
+				+ $"`{PageBodyAstLinter.RuleConverterFetchCall}` finding(s)",
+			because: "a partial report has to say how much it left out");
+		RenderedLength(findings).Should().BeLessThan(64 * 1024,
+			because: "the rendered warning list is what reaches the MCP client, and an unbounded one measured in megabytes is unusable");
+	}
+
+	[Test]
+	[Description("The whole report is bounded across rules, not only per rule: a body that trips several rules thousands of times each still returns a report the caller can read")]
+	public void Lint_ShouldBoundTheWholeReport_WhenSeveralRulesFireThousandsOfTimes() {
+		// Arrange
+		var converters = new StringBuilder();
+		var handlers = new StringBuilder();
+		for (int index = 0; index < 2000; index++) {
+			converters.Append($"\"crt.Converter{index}\": function(v) {{ return fetch(\"/api/{index}\"); }}, ");
+			handlers.Append(
+				"{ request: \"crt.HandleViewModelAttributeChangeRequest\", " +
+				"handler: async (request, next) => { request.$context.set(\"Field\", 1); " +
+				"return next?.handle(request); } }, ");
+		}
+		string body =
+			"define(\"X\", [], function() { return { " +
+			$"handlers: [{handlers}], converters: {{ {converters}}}, validators: {{}} }}; }});";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().HaveCountLessThanOrEqualTo(
+			PageBodyAstLinter.MaxFindingsTotal + PageBodyAstLinter.MaxFindingsPerRule,
+			because: "the global ceiling bounds the report itself, and each capped rule may still append its one summary line");
+		RenderedLength(findings).Should().BeLessThan(128 * 1024,
+			because: "the serialized report is the thing that has to stay usable, whichever mix of rules a generated body happens to trip");
 	}
 
 	[TestCase("innerWidth", TestName = "Window value property")]
@@ -1108,6 +1172,184 @@ internal class PageBodyAstLinterTests {
 			.Concat(PageBodyAstLinter.NonCallableRuntimeGlobals)
 			.Should().BeEquivalentTo(PageBodyAstLinter.KnownRuntimeGlobals,
 				because: "a catalog entry that lands in neither partition would be rejected as undeclared");
+	}
+
+	#endregion
+
+	#region Tests: definite initialization, factory isolation, return-anchored sections
+
+	[TestCase("if (false) { function helper() { return 1; } }", TestName = "non-executed block function")]
+	[TestCase("if (false) { var helper = function() { return 1; }; }", TestName = "non-executed conditional var")]
+	[TestCase("if (someFlag) { var helper = function() { return 1; }; }", TestName = "runtime-conditional var")]
+	[Description("A factory-scope binding whose only initializer sits in a branch that is not guaranteed to run is reported: the name hoists, the value never lands, and the handler throws a TypeError at runtime")]
+	public void Lint_ShouldEmitError_WhenFactoryHelperIsOnlyInitializedConditionally(string declaration) {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { " + declaration + " " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+			f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Severity == LintSeverity.Error,
+			because: "declaring the name is not proof the handler can call it — the binding is still `undefined` when the section runs");
+		findings.Single(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall).Message.Should()
+			.Contain("declared but not guaranteed to hold a value",
+				because: "\"not declared\" would be false here and would send the author looking for a helper that is already in the body");
+	}
+
+	[TestCase("if (true) { function helper() { return 1; } }", TestName = "executed block function")]
+	[TestCase("if (true) { var helper = function() { return 1; }; }", TestName = "executed conditional var")]
+	[TestCase("if (false) { } else { var helper = function() { return 1; }; }", TestName = "executed else branch")]
+	[Description("The paired executed branch stays accepted: `if (true)` really does run its block, so the same shapes that fail closed under `if (false)` must not block a page that works")]
+	public void Lint_ShouldNotEmitError_WhenFactoryHelperIsInitializedOnAnExecutedBranch(string declaration) {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { " + declaration + " " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().NotContain(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall,
+			because: "the branch the language folds to `true` always runs, so the binding really does hold the helper");
+	}
+
+	[Test]
+	[Description("A factory-scope `let helper;` whose only assignment sits after the factory's return is reported — the declaration is preloaded but the assignment is unreachable, so the handler throws a TypeError")]
+	public void Lint_ShouldEmitError_WhenTheOnlyAssignmentFollowsTheReturn() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { let helper; " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; helper = function() { return 1; }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+			f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("helper"),
+			because: "name existence is not definite initialization — the only assignment never runs");
+	}
+
+	[Test]
+	[Description("The same `let helper;` assigned BEFORE the factory's return is accepted — the assignment, not the declaration, is what makes the binding callable, and blocking it would reject a page that runs")]
+	public void Lint_ShouldNotEmitError_WhenTheBindingIsAssignedBeforeTheReturn() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { let helper; helper = function() { return 1; }; " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { helper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().NotContain(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall,
+			because: "an unconditional assignment before the return leaves a callable binding");
+	}
+
+	[Test]
+	[Description("A helper declared OUTSIDE the `define(...)` factory does not satisfy a handler call — the factory scope chains to the runtime globals only, because Page Designer can keep the handler entry while dropping the outer declaration")]
+	public void Lint_ShouldEmitError_WhenHelperIsDeclaredOutsideTheFactory() {
+		// Arrange
+		string body =
+			"function outerHelper() { return 1; } " +
+			"define(\"X\", [], function() { " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { outerHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+			f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("outerHelper"),
+			because: "a script-level declaration outside the AMD factory is exactly the module-scope helper Page Designer drops, which is the failure mode this rule exists for");
+	}
+
+	[Test]
+	[Description("The paired local declaration stays accepted: the same helper declared INSIDE the factory is visible to the handler, so factory isolation did not start rejecting working pages")]
+	public void Lint_ShouldNotEmitError_WhenTheSameHelperIsDeclaredInsideTheFactory() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { function outerHelper() { return 1; } " +
+			"return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { outerHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().NotContain(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall,
+			because: "the factory's own declarations are what its handlers close over");
+	}
+
+	[Test]
+	[Description("A nested property that merely happens to be named `handlers` is ordinary metadata, not a page-schema section: section discovery is anchored to the direct properties of the object the factory returns, so a call inside that metadata must not block the write")]
+	public void Lint_ShouldNotEmitError_WhenASameNamedPropertyIsNestedMetadata() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { " +
+			"var meta = { handlers: { run: () => applicationCallback() } }; " +
+			"return { viewConfigDiff: [meta], handlers: [], converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().NotContain(f => f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall,
+			because: "a property named `handlers` anywhere in the tree is not the returned page schema, and flagging it blocks a valid page");
+	}
+
+	[Test]
+	[Description("Return-anchored discovery still covers the real section: the returned `handlers` array of the same body is scanned, so narrowing the rule did not turn it off")]
+	public void Lint_ShouldStillEmitError_WhenTheReturnedSectionCallsAnUndeclaredHelper() {
+		// Arrange
+		string body =
+			"define(\"X\", [], function() { " +
+			"var meta = { handlers: { run: () => applicationCallback() } }; " +
+			"return { viewConfigDiff: [meta], handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { missingModuleHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; });";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+			f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("missingModuleHelper"),
+			because: "the returned object's own `handlers` property is the page schema the rule guards");
+	}
+
+	[Test]
+	[Description("A body with no `define(...)` wrapper is still covered: nothing upstream of the linter requires an AMD factory, so return-anchored discovery falls back to every function's returned object literal")]
+	public void Lint_ShouldEmitError_WhenABodyWithoutDefineReturnsABrokenSection() {
+		// Arrange
+		string body =
+			"var schema = (function() { return { handlers: [{ request: \"crt.HandleViewModelInitRequest\", " +
+			"handler: async (request, next) => { missingModuleHelper(); return next?.handle(request); } }], " +
+			"converters: {}, validators: {} }; })();";
+
+		// Act
+		IReadOnlyList<PageBodyLintFinding> findings = LintBody(body);
+
+		// Assert
+		findings.Should().ContainSingle(f =>
+			f.Rule == PageBodyAstLinter.RuleUndefinedSectionCall && f.Message.Contains("missingModuleHelper"),
+			because: "a define-less body must not silently skip the rule that blocks a handler calling a helper that is not there");
 	}
 
 	#endregion

--- a/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
@@ -1470,6 +1470,20 @@ internal class PageBodyAstLinterTests {
 			because: "this rule runs after the main walk, so an exhausted report used to swallow it entirely and save a page whose handler throws");
 	}
 
+	[Test]
+	[Description("The distinct-name cap for undefined-section-call stays below the per-rule finding cap: that relation is what keeps the rule's own summary from claiming names the report never listed")]
+	public void UndefinedSectionCallNameCap_ShouldStayBelowThePerRuleFindingCap() {
+		// Arrange
+		int nameCap = PageBodyAstLinter.MaxUndefinedSectionCallNames;
+
+		// Act
+		int perRuleCap = PageBodyAstLinter.MaxFindingsPerRule;
+
+		// Assert
+		nameCap.Should().BeLessThan(perRuleCap,
+			because: "a name cleared for reporting must always get a slot; raising this cap past the per-rule one would let blocking Errors be suppressed while the rule's own summary - which counts only the names it refused itself - stayed silent about them");
+	}
+
 	// How many distinct Warning rules the linter ships; each capped rule may append one counted summary.
 	private const int WarningRuleCount = 4;
 

--- a/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
+++ b/clio.tests/Command/McpServer/PageBodyAstLinterTests.cs
@@ -1109,7 +1109,7 @@ internal class PageBodyAstLinterTests {
 		// Assert
 		findings.Should().HaveCountLessThanOrEqualTo(
 			PageBodyAstLinter.MaxFindingsTotal + PageBodyAstLinter.MaxFindingsPerRule,
-			because: "the global ceiling bounds the report itself, and each capped rule may still append its one summary line");
+			because: "the ceiling bounds the warnings the report carries, and each capped rule may still append its one summary line");
 		RenderedLength(findings).Should().BeLessThan(128 * 1024,
 			because: "the serialized report is the thing that has to stay usable, whichever mix of rules a generated body happens to trip");
 	}

--- a/clio/Command/McpServer/Tools/PageBodyAstLinter.cs
+++ b/clio/Command/McpServer/Tools/PageBodyAstLinter.cs
@@ -77,10 +77,11 @@ internal static class PageBodyAstLinter {
 		if (ast is null) {
 			return Array.Empty<PageBodyLintFinding>();
 		}
-		var findings = new List<PageBodyLintFinding>();
-		Visit(ast, default, depth: 0, findings);
-		CheckUndefinedSectionCalls(ast, findings);
-		return findings;
+		LintFindingBudget budget = new();
+		Visit(ast, default, depth: 0, budget);
+		CheckUndefinedSectionCalls(ast, budget);
+		budget.AppendSummaries();
+		return budget.Findings;
 	}
 
 	/// <summary>
@@ -134,35 +135,34 @@ internal static class PageBodyAstLinter {
 		bool EnclosingFunctionIsValidatorInstance,
 		string EnclosingPropertyKey);
 
-	private static void Visit(Node node, VisitContext ctx, int depth, List<PageBodyLintFinding> findings) {
+	private static void Visit(Node node, VisitContext ctx, int depth, LintFindingBudget budget) {
 		if (depth > MaxAstDepth) {
-			findings.Add(new PageBodyLintFinding(
-				Rule: RuleBodyTooDeeplyNested,
-				Severity: LintSeverity.Error,
-				Line: node.Location.Start.Line,
-				Column: node.Location.Start.Column + 1,
-				Message: $"Page body AST exceeds the safe traversal depth ({MaxAstDepth}). The lint pass refuses to walk further to avoid a StackOverflowException that would kill the MCP server process."));
+			//Every sibling at the cap would otherwise repeat this same finding, so it goes through
+			//the budget like every other rule.
+			budget.TryAdd(RuleBodyTooDeeplyNested, LintSeverity.Error,
+				node.Location.Start.Line, node.Location.Start.Column + 1,
+				() => $"Page body AST exceeds the safe traversal depth ({MaxAstDepth}). The lint pass refuses to walk further to avoid a StackOverflowException that would kill the MCP server process.");
 			return;
 		}
 		switch (node) {
 			case ObjectExpression obj:
-				CheckSchemaSectionShapes(obj, findings);
-				CheckEntityDataSourceStaticFilters(obj, ctx, findings);
-				CheckUnscopedAttributeChangeHandler(obj, depth, findings);
+				CheckSchemaSectionShapes(obj, budget);
+				CheckEntityDataSourceStaticFilters(obj, ctx, budget);
+				CheckUnscopedAttributeChangeHandler(obj, depth, budget);
 				break;
 			case Property prop:
-				CheckProperty(prop, ctx, findings);
+				CheckProperty(prop, ctx, budget);
 				break;
 			case CallExpression call:
-				CheckCallExpression(call, ctx, findings);
+				CheckCallExpression(call, ctx, budget);
 				break;
 			case ReturnStatement ret:
-				CheckReturnStatement(ret, ctx, findings);
+				CheckReturnStatement(ret, ctx, budget);
 				break;
 		}
 		foreach (Node child in node.ChildNodes) {
 			VisitContext childCtx = ComputeChildContext(node, child, ctx);
-			Visit(child, childCtx, depth + 1, findings);
+			Visit(child, childCtx, depth + 1, budget);
 		}
 	}
 
@@ -342,34 +342,183 @@ internal static class PageBodyAstLinter {
 	// in hundreds of kilobytes - unreadable, and the caller only ever fixes the first few before re-running.
 	internal const int MaxFindingsPerRule = 50;
 
+	// Ceiling on the whole report, across rules. AST depth bounds how deep the walk goes, not how WIDE the
+	// body is: a generated page can trip several rules thousands of times each, and per-rule caps alone
+	// still let the response grow with the number of rules that happen to fire.
+	internal const int MaxFindingsTotal = 150;
+
+	/// <summary>
+	/// The single sink every rule writes through. A rule RESERVES a slot before its message is built, so a
+	/// wide body cannot allocate the long interpolated strings it will never show; what does not fit is
+	/// counted and collapses into one summary finding per rule.
+	/// </summary>
+	private sealed class LintFindingBudget {
+
+		private readonly List<PageBodyLintFinding> _findings = new();
+		private readonly Dictionary<string, int> _reported = new(StringComparer.Ordinal);
+		private readonly Dictionary<string, SuppressedRuleCount> _suppressed = new(StringComparer.Ordinal);
+		private readonly List<string> _suppressedOrder = new();
+
+		public IReadOnlyList<PageBodyLintFinding> Findings => _findings;
+
+		/// <summary>
+		/// Claims a slot for one finding of <paramref name="rule"/>, or counts it as suppressed.
+		/// </summary>
+		public bool TryReserve(string rule, LintSeverity severity, int line, int column){
+			_reported.TryGetValue(rule, out int reported);
+			bool hasRoom = _findings.Count < MaxFindingsTotal && reported < MaxFindingsPerRule;
+			if (!hasRoom) {
+				RecordSuppressed(rule, severity, line, column);
+				return false;
+			}
+			_reported[rule] = reported + 1;
+			return true;
+		}
+
+		/// <summary>Adds a finding whose slot was already claimed with <see cref="TryReserve"/>.</summary>
+		public void AddReserved(string rule, LintSeverity severity, int line, int column, string message) =>
+			_findings.Add(new PageBodyLintFinding(rule, severity, line, column, message));
+
+		/// <summary>
+		/// Reserves and adds in one step. <paramref name="message"/> is a factory on purpose: it runs only
+		/// when the finding is actually kept.
+		/// </summary>
+		public void TryAdd(string rule, LintSeverity severity, int line, int column,
+			Func<string> message){
+			if (TryReserve(rule, severity, line, column)) {
+				AddReserved(rule, severity, line, column, message());
+			}
+		}
+
+		/// <summary>Counts one finding that will not be shown, and remembers where it sat.</summary>
+		public void RecordSuppressed(string rule, LintSeverity severity, int line, int column){
+			if (_suppressed.TryGetValue(rule, out SuppressedRuleCount existing)) {
+				_suppressed[rule] = existing with {Count = existing.Count + 1, Line = line, Column = column};
+				return;
+			}
+			_suppressedOrder.Add(rule);
+			_suppressed[rule] = new SuppressedRuleCount(severity, 1, line, column);
+		}
+
+		/// <summary>
+		/// Appends one counted summary per rule that had findings suppressed. Rules that render their own
+		/// summary - `undefined-section-call` counts DISTINCT names, not occurrences - are skipped here so
+		/// the report never carries two summaries for the same rule.
+		/// </summary>
+		public void AppendSummaries(){
+			foreach (string rule in _suppressedOrder) {
+				if (SelfSummarisingRules.Contains(rule)) {
+					continue;
+				}
+				SuppressedRuleCount suppressed = _suppressed[rule];
+				_reported.TryGetValue(rule, out int reported);
+				_findings.Add(new PageBodyLintFinding(
+					Rule: rule,
+					Severity: suppressed.Severity,
+					Line: suppressed.Line,
+					Column: suppressed.Column,
+					Message: $"{suppressed.Count} further `{rule}` finding(s) past the first {reported} were "
+						+ "omitted from this report; fix the listed ones and re-run validate-page to see "
+						+ "the rest."));
+			}
+		}
+
+	}
+
+	/// <summary>How many findings of one rule were dropped, and where the last of them sat.</summary>
+	private readonly record struct SuppressedRuleCount(
+		LintSeverity Severity,
+		int Count,
+		int Line,
+		int Column);
+
+	// Rules that render their own summary line, so the shared budget must not add a second one.
+	private static readonly IReadOnlyCollection<string> SelfSummarisingRules =
+		new HashSet<string>([RuleUndefinedSectionCall], StringComparer.Ordinal);
+
+	/// <summary>
+	/// How a bare callee name resolved against the scope chain.
+	/// </summary>
+	private enum BindingResolution {
+
+		/// <summary>Bound to a value that is there by the time the call runs.</summary>
+		Usable,
+
+		/// <summary>
+		/// The binding exists, but nothing guarantees a value was stored in it before the section that
+		/// calls it runs - a conditional declaration, a declaration without an initializer, or a binding
+		/// assigned only after the factory returned. The call throws a TypeError at runtime.
+		/// </summary>
+		DeclaredButNotInitialized,
+
+		/// <summary>No binding of that name in any enclosing scope.</summary>
+		Undeclared
+
+	}
+
 	/// <summary>
 	/// A lexical scope and its chain of enclosing scopes. Resolution walks outwards, so a name
 	/// declared in a sibling or nested function is invisible here - which is the whole point: a
 	/// single flat name set made the rule accept `missingHelper()` as soon as ANY unrelated
 	/// function in the body happened to declare that name.
+	///
+	/// Each binding also carries whether it is DEFINITELY INITIALIZED: `if (false) { function h(){} }`
+	/// and `let h;` both put the name in scope while leaving it `undefined`, so a handler calling `h()`
+	/// throws a TypeError. Definite initialization is demanded only once resolution leaves the function
+	/// that contains the call: inside one function body the statements really do run in order before
+	/// the call (`if (true) { var later = fn; } later();`), whereas a handler returned by the factory
+	/// runs long after the factory body finished, so whatever the factory left uninitialized stays so.
 	/// </summary>
 	private sealed class LexicalScope {
 
-		private readonly HashSet<string> _names = new(StringComparer.Ordinal);
+		//Name -> definitely initialized before the enclosing function finished.
+		private readonly Dictionary<string, bool> _names = new(StringComparer.Ordinal);
 		private readonly LexicalScope _parent;
 
-		public LexicalScope(LexicalScope parent){
+		public LexicalScope(LexicalScope parent, bool isFunctionBoundary = false){
 			_parent = parent;
+			IsFunctionBoundary = isFunctionBoundary;
 		}
 
-		public void Declare(string name){
-			if (!string.IsNullOrEmpty(name)) {
-				_names.Add(name);
+		/// <summary>True when this scope belongs to a function, so leaving it crosses a call boundary.</summary>
+		public bool IsFunctionBoundary { get; }
+
+		public void Declare(string name, bool definitelyInitialized){
+			if (string.IsNullOrEmpty(name)) {
+				return;
 			}
+			//A name declared twice (`var h; var h = fn;`) is usable as soon as ANY of its declarations
+			//initializes it, so the flags merge with OR rather than the last one winning.
+			_names[name] = definitelyInitialized
+				|| (_names.TryGetValue(name, out bool existing) && existing);
 		}
 
-		public bool IsDeclared(string name){
+		/// <summary>
+		/// Records that an assignment stored a value into an already-declared binding, wherever in the
+		/// chain it was declared (`let h; h = () =&gt; 1;` in a factory body).
+		/// </summary>
+		public void MarkInitialized(string name){
 			for (LexicalScope scope = this; scope is not null; scope = scope._parent) {
-				if (scope._names.Contains(name)) {
-					return true;
+				if (scope._names.ContainsKey(name)) {
+					scope._names[name] = true;
+					return;
 				}
 			}
-			return false;
+		}
+
+		public BindingResolution Resolve(string name){
+			bool crossedFunctionBoundary = false;
+			for (LexicalScope scope = this; scope is not null; scope = scope._parent) {
+				if (scope._names.TryGetValue(name, out bool definitelyInitialized)) {
+					return !crossedFunctionBoundary || definitelyInitialized
+						? BindingResolution.Usable
+						: BindingResolution.DeclaredButNotInitialized;
+				}
+				if (scope.IsFunctionBoundary) {
+					crossedFunctionBoundary = true;
+				}
+			}
+			return BindingResolution.Undeclared;
 		}
 
 	}
@@ -434,19 +583,122 @@ internal static class PageBodyAstLinter {
 
 	}
 
-	private static void CheckUndefinedSectionCalls(Script ast, List<PageBodyLintFinding> findings) {
-		LexicalScope scriptScope = new(null);
+	/// <summary>
+	/// Reference identity for AST nodes, so an anchor set holds the exact nodes the walk produced.
+	/// </summary>
+	private sealed class NodeReferenceComparer : IEqualityComparer<Node> {
+
+		public static readonly NodeReferenceComparer Instance = new();
+
+		public bool Equals(Node x, Node y) => ReferenceEquals(x, y);
+
+		public int GetHashCode(Node obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+
+	}
+
+	/// <summary>
+	/// Everything one undefined-call scan needs besides the current scope: the runtime-global root the
+	/// AMD factory inherits INSTEAD of the script scope, the factory functions themselves, the section
+	/// properties of the object each factory returns, and the output sinks.
+	/// </summary>
+	private sealed record SectionScanState(
+		LexicalScope GlobalScope,
+		HashSet<Node> FactoryFunctions,
+		HashSet<Node> SectionProperties,
+		LintFindingBudget Sink,
+		UndefinedCallBudget NameBudget);
+
+	private const string DefineGlobalName = "define";
+
+	// The page-schema sections the rule guards. A property of one of these names is a section ONLY
+	// when it is a direct property of the object the factory returns - see CollectSectionProperties.
+	private static readonly string[] SectionPropertyNames = ["handlers", "converters", "validators"];
+
+	private static void CheckUndefinedSectionCalls(Script ast, LintFindingBudget budget) {
+		//Two roots, not one. Seeding script-level user declarations into the single root the AMD
+		//factory inherits let a helper declared OUTSIDE `define(...)` satisfy a handler call - the
+		//exact shape this rule exists to catch, because Page Designer can keep the handler entry and
+		//drop the outer declaration. The factory chains to the runtime globals only.
+		LexicalScope globalScope = new(null);
 		foreach (string global in CallableRuntimeGlobals) {
-			scriptScope.Declare(global);
+			globalScope.Declare(global, definitelyInitialized: true);
 		}
+		LexicalScope scriptScope = new(globalScope, isFunctionBoundary: true);
 		bool strict = HasUseStrictDirective(ast.Body);
-		DeclareHoistedNames(ast, scriptScope, depth: 0, strict, atStatementLevel: true);
-		DeclareBlockNames(ast.Body, scriptScope, depth: 0);
-		UndefinedCallBudget budget = new();
-		ScanForUndefinedSectionCalls(ast, scriptScope, insideSection: false, depth: 0, strict, findings,
-			budget);
-		if (budget.OmittedOccurrenceCount > 0 && budget.LastOmitted.HasValue) {
-			findings.Add(BuildOmittedSummary(budget.LastOmitted.Value, budget));
+		DeclareHoistedNames(ast, scriptScope, depth: 0, strict, atStatementLevel: true,
+			unconditional: true);
+		DeclareBlockNames(ast.Body, scriptScope, depth: 0, unconditional: true);
+		HashSet<Node> factories = new(NodeReferenceComparer.Instance);
+		CollectFactoryFunctions(ast, factories, depth: 0);
+		HashSet<Node> sections = new(NodeReferenceComparer.Instance);
+		CollectSectionProperties(ast, factories, sections, depth: 0);
+		SectionScanState state = new(globalScope, factories, sections, budget, new UndefinedCallBudget());
+		ScanForUndefinedSectionCalls(ast, scriptScope, insideSection: false, depth: 0, strict, state);
+		if (state.NameBudget.OmittedOccurrenceCount > 0 && state.NameBudget.LastOmitted.HasValue) {
+			PageBodyLintFinding summary = BuildOmittedSummary(state.NameBudget.LastOmitted.Value,
+				state.NameBudget);
+			budget.AddReserved(summary.Rule, summary.Severity, summary.Line, summary.Column,
+				summary.Message);
+		}
+	}
+
+	/// <summary>
+	/// Collects the function arguments of every `define(...)` call - the AMD factories whose scope must
+	/// NOT inherit script-level user declarations.
+	/// </summary>
+	private static void CollectFactoryFunctions(Node node, HashSet<Node> factories, int depth) {
+		if (node is null || depth > MaxAstDepth) {
+			return;
+		}
+		if (node is CallExpression {Callee: Identifier {Name: DefineGlobalName}} call) {
+			foreach (Node argument in call.Arguments) {
+				if (argument is IFunction) {
+					factories.Add(argument);
+				}
+			}
+		}
+		foreach (Node child in node.ChildNodes) {
+			CollectFactoryFunctions(child, factories, depth + 1);
+		}
+	}
+
+	/// <summary>
+	/// Collects the page-schema section properties: the `handlers` / `converters` / `validators`
+	/// properties of the object literal a factory RETURNS. Matching the names anywhere in the tree
+	/// instead turned ordinary nested metadata such as `{ handlers: { run: () =&gt; cb() } }` into a
+	/// section and blocked pages that run correctly.
+	///
+	/// When the body carries no `define(...)` factory at all - nothing upstream of the linter requires
+	/// one - the same return-anchored rule is applied to every function in the body, so the rule keeps
+	/// working on a bare module without falling back to the name-anywhere match.
+	/// </summary>
+	private static void CollectSectionProperties(Node node, HashSet<Node> factories,
+		HashSet<Node> sections, int depth) {
+		if (node is null || depth > MaxAstDepth) {
+			return;
+		}
+		if (node is IFunction function && (factories.Count == 0 || factories.Contains(node))) {
+			CollectReturnedSectionProperties(function, sections);
+		}
+		foreach (Node child in node.ChildNodes) {
+			CollectSectionProperties(child, factories, sections, depth + 1);
+		}
+	}
+
+	private static void CollectReturnedSectionProperties(IFunction function, HashSet<Node> sections) {
+		if (function.Body is not BlockStatement body) {
+			return;
+		}
+		foreach (Statement statement in body.Body) {
+			if (statement is not ReturnStatement {Argument: ObjectExpression returned}) {
+				continue;
+			}
+			foreach (Node element in returned.Properties) {
+				if (TryGetEntryProperty(element, out Property property, out string key)
+					&& Array.IndexOf(SectionPropertyNames, key) >= 0) {
+					sections.Add(property);
+				}
+			}
 		}
 	}
 
@@ -497,7 +749,7 @@ internal static class PageBodyAstLinter {
 	/// declarations belong to their own scope.
 	/// </summary>
 	private static void DeclareHoistedNames(Node node, LexicalScope scope, int depth, bool strict,
-		bool atStatementLevel) {
+		bool atStatementLevel, bool unconditional) {
 		if (node is null || depth > MaxAstDepth) {
 			return;
 		}
@@ -514,12 +766,43 @@ internal static class PageBodyAstLinter {
 				afterReturn = true;
 				continue;
 			}
-			if (DeclareHoistedChildName(child, scope, depth, strict, atStatementLevel)) {
+			bool childUnconditional = IsUnconditionalChild(node, child, unconditional);
+			if (DeclareHoistedChildName(child, scope, depth, strict, atStatementLevel,
+				childUnconditional)) {
 				continue;
 			}
-			DeclareHoistedNames(child, scope, depth + 1, strict, atStatementLevel: false);
+			DeclareHoistedNames(child, scope, depth + 1, strict, atStatementLevel: false,
+				childUnconditional);
 		}
 	}
+
+	/// <summary>
+	/// True when <paramref name="child"/> is reached every time its parent is, so a declaration it
+	/// carries really does run. Statements of a block run in order; an `if` whose test is the literal
+	/// `true` or `false` takes the one branch the language folds it to. Nothing else is folded - a
+	/// loop, a `try`, a `switch` case or an `if` on any other expression leaves its declarations
+	/// conditional, which is what makes `if (false) { function helper(){} }` fail closed.
+	/// </summary>
+	private static bool IsUnconditionalChild(Node parent, Node child, bool parentUnconditional) {
+		if (!parentUnconditional) {
+			return false;
+		}
+		if (parent is IfStatement ifStatement) {
+			bool? test = TryFoldBooleanLiteral(ifStatement.Test);
+			if (ReferenceEquals(child, ifStatement.Consequent)) {
+				return test == true;
+			}
+			return ReferenceEquals(child, ifStatement.Alternate) && test == false;
+		}
+		return parent is Acornima.Ast.Program or BlockStatement;
+	}
+
+	private static bool? TryFoldBooleanLiteral(Node test) =>
+		test switch {
+			Literal {Value: true} => true,
+			Literal {Value: false} => false,
+			_ => null
+		};
 
 	/// <summary>
 	/// Declares the hoisted name one child contributes to <paramref name="scope"/>, if any.
@@ -527,11 +810,14 @@ internal static class PageBodyAstLinter {
 	/// the caller must not walk into it.
 	/// </summary>
 	private static bool DeclareHoistedChildName(Node child, LexicalScope scope, int depth, bool strict,
-		bool atStatementLevel) {
+		bool atStatementLevel, bool unconditional) {
 		switch (child) {
 			case VariableDeclaration {Kind: VariableDeclarationKind.Var} varDeclaration:
 				foreach (VariableDeclarator declarator in varDeclaration.Declarations) {
-					DeclareBindings(declarator.Id, scope, depth + 1);
+					//`var helper;` and a `var helper = fn;` the branch never reaches both leave the
+					//binding `undefined`, so only an initializer on a path that always runs counts.
+					DeclareBindings(declarator.Id, scope, depth + 1,
+						definitelyInitialized: unconditional && declarator.Init is not null);
 				}
 				return false;
 			case FunctionDeclaration {Id: not null} functionDeclaration:
@@ -539,7 +825,10 @@ internal static class PageBodyAstLinter {
 				//hoisting it out of one would accept a call that throws ReferenceError at
 				//runtime. DeclareBlockNames declares it in its own block scope instead.
 				if (!strict || atStatementLevel) {
-					scope.Declare(functionDeclaration.Id.Name);
+					//Annex B hoists the NAME out of the block, but only the block actually running
+					//stores the function in it - `if (false) { function helper(){} }` leaves
+					//`helper` undefined and a handler calling it throws a TypeError.
+					scope.Declare(functionDeclaration.Id.Name, definitelyInitialized: unconditional);
 				}
 				//A function declaration opens its own scope; nothing inside it hoists to here.
 				return true;
@@ -555,7 +844,8 @@ internal static class PageBodyAstLinter {
 	/// Declares the block-scoped names of one statement list: `let`, `const`, classes, and the
 	/// function declarations that are direct statements of this block.
 	/// </summary>
-	private static void DeclareBlockNames(in NodeList<Statement> statements, LexicalScope scope, int depth) {
+	private static void DeclareBlockNames(in NodeList<Statement> statements, LexicalScope scope,
+		int depth, bool unconditional) {
 		bool afterReturn = false;
 		foreach (Statement statement in statements) {
 			if (afterReturn && statement is not FunctionDeclaration) {
@@ -573,14 +863,26 @@ internal static class PageBodyAstLinter {
 							or VariableDeclarationKind.Using or VariableDeclarationKind.AwaitUsing
 					} blockDeclaration:
 					foreach (VariableDeclarator declarator in blockDeclaration.Declarations) {
-						DeclareBindings(declarator.Id, scope, depth + 1);
+						DeclareBindings(declarator.Id, scope, depth + 1,
+							definitelyInitialized: unconditional && declarator.Init is not null);
 					}
 					break;
 				case FunctionDeclaration {Id: not null} functionDeclaration:
-					scope.Declare(functionDeclaration.Id.Name);
+					scope.Declare(functionDeclaration.Id.Name, definitelyInitialized: unconditional);
 					break;
 				case ClassDeclaration {Id: not null} classDeclaration:
-					scope.Declare(classDeclaration.Id.Name);
+					scope.Declare(classDeclaration.Id.Name, definitelyInitialized: unconditional);
+					break;
+				case ExpressionStatement {
+						Expression: AssignmentExpression {
+							Operator: Acornima.Operator.Assignment, Left: Identifier assigned
+						}
+					}:
+					//`let helper; helper = () => 1;` before the return DOES leave a callable binding,
+					//so the assignment - not the declaration - is what makes it usable.
+					if (unconditional) {
+						scope.MarkInitialized(assigned.Name);
+					}
 					break;
 			}
 		}
@@ -591,31 +893,32 @@ internal static class PageBodyAstLinter {
 	/// the property being read, never a new binding, so `const {alpha: beta} = source` declares
 	/// `beta` alone; counting `alpha` as declared is what let a later `alpha()` through unchecked.
 	/// </summary>
-	private static void DeclareBindings(Node node, LexicalScope scope, int depth) {
+	private static void DeclareBindings(Node node, LexicalScope scope, int depth,
+		bool definitelyInitialized) {
 		if (node is null || depth > MaxAstDepth) {
 			return;
 		}
 		switch (node) {
 			case Identifier identifier:
-				scope.Declare(identifier.Name);
+				scope.Declare(identifier.Name, definitelyInitialized);
 				break;
 			case ObjectPattern objectPattern:
 				foreach (Node property in objectPattern.Properties) {
 					//Property.Value is the binding target; a RestElement carries its own.
 					DeclareBindings(property is Property {Value: not null} keyed ? keyed.Value : property,
-						scope, depth + 1);
+						scope, depth + 1, definitelyInitialized);
 				}
 				break;
 			case ArrayPattern arrayPattern:
 				foreach (Node element in arrayPattern.Elements) {
-					DeclareBindings(element, scope, depth + 1);
+					DeclareBindings(element, scope, depth + 1, definitelyInitialized);
 				}
 				break;
 			case AssignmentPattern assignmentPattern:
-				DeclareBindings(assignmentPattern.Left, scope, depth + 1);
+				DeclareBindings(assignmentPattern.Left, scope, depth + 1, definitelyInitialized);
 				break;
 			case RestElement restElement:
-				DeclareBindings(restElement.Argument, scope, depth + 1);
+				DeclareBindings(restElement.Argument, scope, depth + 1, definitelyInitialized);
 				break;
 		}
 	}
@@ -623,37 +926,43 @@ internal static class PageBodyAstLinter {
 	/// <summary>
 	/// Opens the scope a node introduces, if any, and returns the scope its children see.
 	/// </summary>
-	private static LexicalScope OpenScope(Node node, LexicalScope scope, int depth, bool strict) {
+	private static LexicalScope OpenScope(Node node, LexicalScope scope, int depth, bool strict,
+		SectionScanState state) {
 		switch (node) {
 			case IFunction function: {
-				LexicalScope functionScope = new(scope);
+				//The AMD factory chains to the runtime globals, NOT to the script scope: a helper
+				//declared outside `define(...)` is not something the factory's handlers can rely on.
+				LexicalScope parent = state.FactoryFunctions.Contains(node) ? state.GlobalScope : scope;
+				LexicalScope functionScope = new(parent, isFunctionBoundary: true);
 				//A named function expression can call itself by that name from inside its body.
 				if (function.Id is not null) {
-					functionScope.Declare(function.Id.Name);
+					functionScope.Declare(function.Id.Name, definitelyInitialized: true);
 				}
 				foreach (Node parameter in function.Params) {
-					DeclareBindings(parameter, functionScope, depth + 1);
+					DeclareBindings(parameter, functionScope, depth + 1, definitelyInitialized: true);
 				}
 				DeclareHoistedNames(function.Body, functionScope, depth + 1, strict,
-					atStatementLevel: true);
+					atStatementLevel: true, unconditional: true);
 				return functionScope;
 			}
 			case BlockStatement block: {
 				LexicalScope blockScope = new(scope);
-				DeclareBlockNames(block.Body, blockScope, depth + 1);
+				DeclareBlockNames(block.Body, blockScope, depth + 1, unconditional: true);
 				return blockScope;
 			}
 			case SwitchStatement switchStatement: {
 				//Every case shares one block scope, so a `let` in case A is visible in case B.
 				LexicalScope switchScope = new(scope);
 				foreach (SwitchCase switchCase in switchStatement.Cases) {
-					DeclareBlockNames(switchCase.Consequent, switchScope, depth + 1);
+					//Which case runs is a runtime decision, so nothing a case declares is guaranteed.
+					DeclareBlockNames(switchCase.Consequent, switchScope, depth + 1,
+						unconditional: false);
 				}
 				return switchScope;
 			}
 			case CatchClause catchClause: {
 				LexicalScope catchScope = new(scope);
-				DeclareBindings(catchClause.Param, catchScope, depth + 1);
+				DeclareBindings(catchClause.Param, catchScope, depth + 1, definitelyInitialized: true);
 				return catchScope;
 			}
 			case ForStatement {Init: VariableDeclaration forInit}:
@@ -664,7 +973,7 @@ internal static class PageBodyAstLinter {
 				return OpenLoopScope(forOfLeft, scope, depth);
 			case ClassExpression {Id: not null} classExpression: {
 				LexicalScope classScope = new(scope);
-				classScope.Declare(classExpression.Id.Name);
+				classScope.Declare(classExpression.Id.Name, definitelyInitialized: true);
 				return classScope;
 			}
 			default:
@@ -675,7 +984,9 @@ internal static class PageBodyAstLinter {
 	private static LexicalScope OpenLoopScope(VariableDeclaration head, LexicalScope scope, int depth) {
 		LexicalScope loopScope = new(scope);
 		foreach (VariableDeclarator declarator in head.Declarations) {
-			DeclareBindings(declarator.Id, loopScope, depth + 1);
+			//The loop head binds its variable on every iteration that runs, and code inside the loop
+			//body is the only code that sees it.
+			DeclareBindings(declarator.Id, loopScope, depth + 1, definitelyInitialized: true);
 		}
 		return loopScope;
 	}
@@ -686,41 +997,59 @@ internal static class PageBodyAstLinter {
 		bool insideSection,
 		int depth,
 		bool strict,
-		List<PageBodyLintFinding> findings,
-		UndefinedCallBudget budget) {
+		SectionScanState state) {
 		if (node is null || depth > MaxAstDepth) {
 			return;
 		}
 		bool childStrict = IsStrictFunction(node, strict);
-		LexicalScope childScope = OpenScope(node, scope, depth, childStrict);
-		bool childInsideSection = insideSection;
-		if (!insideSection && node is Property property && TryGetStaticPropertyName(property) is string key) {
-			childInsideSection = key is "handlers" or "converters" or "validators";
-		}
-		if (insideSection && node is CallExpression {Callee: Identifier identifier}
-			&& !childScope.IsDeclared(identifier.Name)) {
-			//The budget decides FIRST: a truncated body can repeat one broken call tens of thousands
-			//of times, and building the long interpolated message for every occurrence only to drop
-			//it allocated tens of megabytes. An omitted occurrence keeps its location and nothing
-			//else, which is all the summary finding reads.
-			if (budget.ShouldReport(identifier.Name)) {
-				findings.Add(new PageBodyLintFinding(
-					Rule: RuleUndefinedSectionCall,
-					Severity: LintSeverity.Error,
-					Line: identifier.Location.Start.Line,
-					Column: identifier.Location.Start.Column + 1,
-					Message: NonCallableRuntimeGlobals.Contains(identifier.Name)
-						? $"Call to `{identifier.Name}()` in a handlers/converters/validators section: the runtime does supply `{identifier.Name}`, but as a value rather than as a function callable without `new`, so this call throws a TypeError. Read it as a property, or construct it with `new`."
-						: $"Call to `{identifier.Name}()` in a handlers/converters/validators section references an identifier that is not declared in the enclosing scopes of this page body and is not a known JavaScript, browser, AMD or Creatio global. A module-scope helper may have been removed by Page Designer; re-add it before the `return` statement."));
-			} else {
-				budget.RecordOmitted(
-					identifier.Location.Start.Line, identifier.Location.Start.Column + 1);
-			}
+		LexicalScope childScope = OpenScope(node, scope, depth, childStrict, state);
+		bool childInsideSection = insideSection
+			|| (node is Property property && state.SectionProperties.Contains(property));
+		if (insideSection && node is CallExpression {Callee: Identifier identifier}) {
+			ReportUnusableSectionCall(childScope.Resolve(identifier.Name), identifier, state);
 		}
 		foreach (Node child in node.ChildNodes) {
 			ScanForUndefinedSectionCalls(child, childScope, childInsideSection, depth + 1, childStrict,
-				findings, budget);
+				state);
 		}
+	}
+
+	private static void ReportUnusableSectionCall(BindingResolution resolution, Identifier identifier,
+		SectionScanState state) {
+		if (resolution == BindingResolution.Usable) {
+			return;
+		}
+		int line = identifier.Location.Start.Line;
+		int column = identifier.Location.Start.Column + 1;
+		//The budget decides FIRST: a truncated body can repeat one broken call tens of thousands
+		//of times, and building the long interpolated message for every occurrence only to drop
+		//it allocated tens of megabytes. An omitted occurrence keeps its location and nothing
+		//else, which is all the summary finding reads.
+		if (!state.NameBudget.ShouldReport(identifier.Name)
+			|| !state.Sink.TryReserve(RuleUndefinedSectionCall, LintSeverity.Error, line, column)) {
+			//Either this name is already listed, or the report as a whole is full. Both are counted
+			//by the rule's own summary, which reports distinct names rather than occurrences.
+			state.NameBudget.RecordOmitted(line, column);
+			return;
+		}
+		state.Sink.AddReserved(RuleUndefinedSectionCall, LintSeverity.Error, line, column,
+			BuildUnusableSectionCallMessage(resolution, identifier.Name));
+	}
+
+	private static string BuildUnusableSectionCallMessage(BindingResolution resolution, string name) {
+		if (resolution == BindingResolution.DeclaredButNotInitialized) {
+			//"Not declared" would be plainly false here - the author can see the declaration - and
+			//would send them looking for a helper that is already in the body.
+			return $"Call to `{name}()` in a handlers/converters/validators section resolves to a "
+				+ "binding that is declared but not guaranteed to hold a value when the section runs "
+				+ "(declared without an initializer, initialized only inside a branch that may not "
+				+ "run, or assigned only after the factory's `return`). The call throws a TypeError at "
+				+ $"runtime. Assign `{name}` unconditionally before the `return` statement, or declare "
+				+ "it as a function declaration.";
+		}
+		return NonCallableRuntimeGlobals.Contains(name)
+			? $"Call to `{name}()` in a handlers/converters/validators section: the runtime does supply `{name}`, but as a value rather than as a function callable without `new`, so this call throws a TypeError. Read it as a property, or construct it with `new`."
+			: $"Call to `{name}()` in a handlers/converters/validators section references an identifier that is not declared in the enclosing scopes of this page body and is not a known JavaScript, browser, AMD or Creatio global. A module-scope helper may have been removed by Page Designer; re-add it before the `return` statement.";
 	}
 
 	#endregion
@@ -731,13 +1060,13 @@ internal static class PageBodyAstLinter {
 	// The crt-prefix rule applies to direct entries of that map only — a
 	// `"crt.X"` key inside a nested lookup table in a converter's closure
 	// is opaque to the rule.
-	private static void CheckSchemaSectionShapes(ObjectExpression obj, List<PageBodyLintFinding> findings) {
+	private static void CheckSchemaSectionShapes(ObjectExpression obj, LintFindingBudget budget) {
 		foreach (Node element in obj.Properties) {
 			if (!TryGetInitProperty(element, out Property prop, out string key)) {
 				continue;
 			}
 			if (key == "converters" && prop.Value is ObjectExpression convertersObj) {
-				CheckConvertersDirectKeys(convertersObj, findings);
+				CheckConvertersDirectKeys(convertersObj, budget);
 			}
 		}
 	}
@@ -767,11 +1096,10 @@ internal static class PageBodyAstLinter {
 	// No regex counterpart in SchemaValidationService — `crt.*` is treated
 	// as a valid vendor prefix by `ValidatePrefixedDeclarations` and the
 	// converter shape validators explicitly skip `crt.*` keys.
-	private static void CheckConvertersDirectKeys(ObjectExpression convertersObj, List<PageBodyLintFinding> findings) {
-		int reported = 0;
-		int suppressed = 0;
-		int lastLine = 0;
-		int lastColumn = 0;
+	// Every offending key carries the same fix, and a generated converters map can hold thousands of them:
+	// 5,000 keys formatted an ~871 KB error nobody reads. The shared budget collapses everything past the
+	// cap into one counted line at the last offending position.
+	private static void CheckConvertersDirectKeys(ObjectExpression convertersObj, LintFindingBudget budget) {
 		foreach (Node element in convertersObj.Properties) {
 			if (!TryGetInitProperty(element, out Property entry, out string entryKey)) {
 				continue;
@@ -779,32 +1107,9 @@ internal static class PageBodyAstLinter {
 			if (!entryKey.StartsWith("crt.", StringComparison.Ordinal)) {
 				continue;
 			}
-			lastLine = entry.Location.Start.Line;
-			lastColumn = entry.Location.Start.Column + 1;
-			if (reported < MaxFindingsPerRule) {
-				findings.Add(new PageBodyLintFinding(
-					Rule: RuleConverterCrtPrefixReserved,
-					Severity: LintSeverity.Error,
-					Line: lastLine,
-					Column: lastColumn,
-					Message: $"Custom converter `{entryKey}` uses the reserved `crt.*` namespace; only Creatio built-in converters may use this prefix"));
-				reported++;
-				continue;
-			}
-			// Every offending key carries the same fix, and a generated converters map can hold thousands of
-			// them: 5,000 keys formatted an ~871 KB error nobody reads. Past the cap they collapse into one
-			// counted line at the last offending position.
-			suppressed++;
-		}
-		if (suppressed > 0) {
-			findings.Add(new PageBodyLintFinding(
-				Rule: RuleConverterCrtPrefixReserved,
-				Severity: LintSeverity.Error,
-				Line: lastLine,
-				Column: lastColumn,
-				Message: $"{suppressed} further converter key(s) past the first {MaxFindingsPerRule} use the "
-					+ "reserved `crt.*` namespace and were omitted from this report; fix the listed ones and "
-					+ "re-run validate-page to see the rest."));
+			budget.TryAdd(RuleConverterCrtPrefixReserved, LintSeverity.Error,
+				entry.Location.Start.Line, entry.Location.Start.Column + 1,
+				() => $"Custom converter `{entryKey}` uses the reserved `crt.*` namespace; only Creatio built-in converters may use this prefix");
 		}
 	}
 
@@ -836,7 +1141,7 @@ internal static class PageBodyAstLinter {
 	// it. `_designOptions` is never a legitimate `crt.EntityDataSource` config location,
 	// so the object that is DIRECTLY the value of a property literally named
 	// `_designOptions` is excluded outright.
-	private static void CheckEntityDataSourceStaticFilters(ObjectExpression obj, VisitContext ctx, List<PageBodyLintFinding> findings) {
+	private static void CheckEntityDataSourceStaticFilters(ObjectExpression obj, VisitContext ctx, LintFindingBudget budget) {
 		if (ctx.EnclosingPropertyKey == "_designOptions") {
 			return;
 		}
@@ -855,12 +1160,9 @@ internal static class PageBodyAstLinter {
 		if (filtersProp is null || !hasEntitySchemaName) {
 			return;
 		}
-		findings.Add(new PageBodyLintFinding(
-			Rule: RuleEntityDataSourceStaticFilters,
-			Severity: LintSeverity.Warning,
-			Line: filtersProp.Location.Start.Line,
-			Column: filtersProp.Location.Start.Column + 1,
-			Message: "`config.filters` on a `crt.EntityDataSource` is never applied — `filters` is not a recognized data-source config key. update-page persists it and returns success, but the list shows UNFILTERED data. Put a static filter in a `<CollectionAttr>_PredefinedFilter` view-model attribute referenced from the collection attribute's `modelConfig.filterAttributes` (per related-list guidance)."));
+		budget.TryAdd(RuleEntityDataSourceStaticFilters, LintSeverity.Warning,
+			filtersProp.Location.Start.Line, filtersProp.Location.Start.Column + 1,
+			() => "`config.filters` on a `crt.EntityDataSource` is never applied — `filters` is not a recognized data-source config key. update-page persists it and returns success, but the list shows UNFILTERED data. Put a static filter in a `<CollectionAttr>_PredefinedFilter` view-model attribute referenced from the collection attribute's `modelConfig.filterAttributes` (per related-list guidance).");
 	}
 
 	// Rule 12: a `crt.HandleViewModelAttributeChangeRequest` handler entry that is NOT scoped to the
@@ -890,7 +1192,7 @@ internal static class PageBodyAstLinter {
 	//   - False positive: a guard hidden behind a helper call — an early return driven by a helper predicate on
 	//     request — is not seen, since detecting it needs inter-procedural data-flow analysis, so such a scoped
 	//     handler is still warned. The proxy trades these residuals for catching the common shapes.
-	private static void CheckUnscopedAttributeChangeHandler(ObjectExpression obj, int depth, List<PageBodyLintFinding> findings) {
+	private static void CheckUnscopedAttributeChangeHandler(ObjectExpression obj, int depth, LintFindingBudget budget) {
 		Property requestProp = null;
 		Property handlerProp = null;
 		foreach (Node element in obj.Properties) {
@@ -918,12 +1220,9 @@ internal static class PageBodyAstLinter {
 		if (referencesAttributeName || !writesContextAttribute) {
 			return;
 		}
-		findings.Add(new PageBodyLintFinding(
-			Rule: RuleHandlerAttributeChangeUnscopedWrite,
-			Severity: LintSeverity.Warning,
-			Line: requestProp.Location.Start.Line,
-			Column: requestProp.Location.Start.Column + 1,
-			Message: "A `crt.HandleViewModelAttributeChangeRequest` handler that writes a view-model attribute via `$context.set(...)` is not scoped to the triggering attribute, so it re-fires on its own write and can clear the value or loop. Scope it with an early guard: `if (request.attributeName !== \"<Attr>\") return next?.handle(request);` (per page-schema-handlers guidance). If the write is an intentional cross-field recompute, still guard it so it does not re-enter on its own write — skip when `request.attributeName` is the attribute you are writing. Note: `requestArgumentPropertyName` does NOT scope this handler — it is silently ignored."));
+		budget.TryAdd(RuleHandlerAttributeChangeUnscopedWrite, LintSeverity.Warning,
+			requestProp.Location.Start.Line, requestProp.Location.Start.Column + 1,
+			() => "A `crt.HandleViewModelAttributeChangeRequest` handler that writes a view-model attribute via `$context.set(...)` is not scoped to the triggering attribute, so it re-fires on its own write and can clear the value or loop. Scope it with an early guard: `if (request.attributeName !== \"<Attr>\") return next?.handle(request);` (per page-schema-handlers guidance). If the write is an intentional cross-field recompute, still guard it so it does not re-enter on its own write — skip when `request.attributeName` is the attribute you are writing. Note: `requestArgumentPropertyName` does NOT scope this handler — it is silently ignored.");
 	}
 
 	// Like TryGetInitProperty but ALSO accepts shorthand-method properties (`handler(r, n) {}`), whose
@@ -1004,23 +1303,20 @@ internal static class PageBodyAstLinter {
 	// subtree" gates (e.g. `executeRequest({type, params:[]})` inside a
 	// factory body or a `"crt.X"` lookup-table key inside a converter's
 	// closure no longer wrongly trigger an Error).
-	private static void CheckProperty(Property prop, VisitContext ctx, List<PageBodyLintFinding> findings) {
+	private static void CheckProperty(Property prop, VisitContext ctx, LintFindingBudget budget) {
 		// kept as an extension point for future Property-level rules
 	}
 
-	private static void CheckCallExpression(CallExpression call, VisitContext ctx, List<PageBodyLintFinding> findings) {
+	private static void CheckCallExpression(CallExpression call, VisitContext ctx, LintFindingBudget budget) {
 		// Rule 9: request.$context.executeRequest(...) is reachable from handler code
 		// but it is NOT part of the @creatio-devkit/common public surface — Creatio
 		// Academy uniformly uses sdk.HandlerChainService.instance.process(...) in
 		// SCHEMA_HANDLERS examples. The reverse direction (process discouraged in
 		// favour of executeRequest) was the previous guidance and is no longer correct.
 		if (IsContextExecuteRequest(call.Callee)) {
-			findings.Add(new PageBodyLintFinding(
-				Rule: RuleHandlerUsesContextExecuteRequest,
-				Severity: LintSeverity.Warning,
-				Line: call.Location.Start.Line,
-				Column: call.Location.Start.Column + 1,
-				Message: "`request.$context.executeRequest(...)` is not part of the documented @creatio-devkit/common public API; use `sdk.HandlerChainService.instance.process({ type, $context, scopes })` in deployed page-body handlers (per Creatio Academy SCHEMA_HANDLERS examples)"));
+			budget.TryAdd(RuleHandlerUsesContextExecuteRequest, LintSeverity.Warning,
+				call.Location.Start.Line, call.Location.Start.Column + 1,
+				() => "`request.$context.executeRequest(...)` is not part of the documented @creatio-devkit/common public API; use `sdk.HandlerChainService.instance.process({ type, $context, scopes })` in deployed page-body handlers (per Creatio Academy SCHEMA_HANDLERS examples)");
 		}
 		// Rule 10: direct `fetch(...)` / `globalThis.fetch(...)` / `window.fetch(...)`
 		// inside the converters schema subtree. Bounded via VisitContext.InsideConverters
@@ -1028,12 +1324,9 @@ internal static class PageBodyAstLinter {
 		// every control render) and does not noise the agent with informational
 		// flags on legitimate `fetch` usage elsewhere in the body.
 		if (ctx.InsideConverters && IsFetchCall(call.Callee)) {
-			findings.Add(new PageBodyLintFinding(
-				Rule: RuleConverterFetchCall,
-				Severity: LintSeverity.Warning,
-				Line: call.Location.Start.Line,
-				Column: call.Location.Start.Column + 1,
-				Message: "Direct `fetch(...)` inside a converter fires on every render of the bound control; replace with a cached SDK service such as `SysSettingsService` (per page-schema-converters guidance)"));
+			budget.TryAdd(RuleConverterFetchCall, LintSeverity.Warning,
+				call.Location.Start.Line, call.Location.Start.Column + 1,
+				() => "Direct `fetch(...)` inside a converter fires on every render of the bound control; replace with a cached SDK service such as `SysSettingsService` (per page-schema-converters guidance)");
 		}
 	}
 
@@ -1045,7 +1338,7 @@ internal static class PageBodyAstLinter {
 			_ => false
 		};
 
-	private static void CheckReturnStatement(ReturnStatement ret, VisitContext ctx, List<PageBodyLintFinding> findings) {
+	private static void CheckReturnStatement(ReturnStatement ret, VisitContext ctx, LintFindingBudget budget) {
 		// Rule 6: validator declaration must not return a literal. Bounded
 		// to returns whose nearest enclosing function is THE validator-
 		// instance function (the function returned by the factory). Other
@@ -1064,12 +1357,9 @@ internal static class PageBodyAstLinter {
 		if (!IsBadValidatorReturnLiteral(ret.Argument)) {
 			return;
 		}
-		findings.Add(new PageBodyLintFinding(
-			Rule: RuleValidatorBadReturnLiteral,
-			Severity: LintSeverity.Error,
-			Line: ret.Location.Start.Line,
-			Column: ret.Location.Start.Column + 1,
-			Message: "validator return must be `{ \"<ValidatorType>\": { message: config.message } }`; literal `true` / `false` / `{}` / hardcoded-string returns are rejected — see page-schema-validators guidance. `null` and `undefined` returns are allowed (they signal \"no error\")"));
+		budget.TryAdd(RuleValidatorBadReturnLiteral, LintSeverity.Error,
+			ret.Location.Start.Line, ret.Location.Start.Column + 1,
+			() => "validator return must be `{ \"<ValidatorType>\": { message: config.message } }`; literal `true` / `false` / `{}` / hardcoded-string returns are rejected — see page-schema-validators guidance. `null` and `undefined` returns are allowed (they signal \"no error\")");
 	}
 
 	#endregion

--- a/clio/Command/McpServer/Tools/PageBodyAstLinter.cs
+++ b/clio/Command/McpServer/Tools/PageBodyAstLinter.cs
@@ -331,6 +331,11 @@ internal static class PageBodyAstLinter {
 	// every occurrence into a multi-megabyte string that no MCP client can use. Names past the cap
 	// are replaced by a single summary finding that states how many were left out, so the response
 	// stays bounded without pretending the rest do not exist.
+	//
+	// Must stay BELOW MaxFindingsPerRule. This cap is what makes the rule's own count of listed names
+	// agree with what the report shows: a name cleared here is always given a slot by the shared
+	// budget, so the summary's "N distinct name(s) are listed above" cannot overstate. Raising it past
+	// the per-rule cap would silently break that agreement.
 	internal const int MaxUndefinedSectionCallNames = 20;
 
 	// How many DISTINCT omitted names the summary keeps before its count saturates. The names are never
@@ -342,9 +347,12 @@ internal static class PageBodyAstLinter {
 	// in hundreds of kilobytes - unreadable, and the caller only ever fixes the first few before re-running.
 	internal const int MaxFindingsPerRule = 50;
 
-	// Ceiling on the whole report, across rules. AST depth bounds how deep the walk goes, not how WIDE the
-	// body is: a generated page can trip several rules thousands of times each, and per-rule caps alone
-	// still let the response grow with the number of rules that happen to fire.
+	// Ceiling on the WARNING part of the report, across rules. AST depth bounds how deep the walk goes,
+	// not how WIDE the body is: a generated page can trip several rules thousands of times each, and
+	// per-rule caps alone still let the response grow with the number of rules that happen to fire.
+	// Errors are deliberately exempt: an Error blocks the write, so dropping one to keep the report small
+	// turns a page the platform rejects into a page that saves clean. Errors stay bounded by the per-rule
+	// cap instead.
 	internal const int MaxFindingsTotal = 150;
 
 	/// <summary>
@@ -363,11 +371,14 @@ internal static class PageBodyAstLinter {
 
 		/// <summary>
 		/// Claims a slot for one finding of <paramref name="rule"/>, or counts it as suppressed.
+		/// A <see cref="LintSeverity.Error"/> only has to fit under its own rule's cap: the overall
+		/// ceiling exists to keep an advisory report readable, and applying it to an Error would let a
+		/// wide body full of warnings hide the finding that blocks the write.
 		/// </summary>
-		public bool TryReserve(string rule, LintSeverity severity, int line, int column){
+		private bool TryReserve(string rule, LintSeverity severity, int line, int column){
 			_reported.TryGetValue(rule, out int reported);
-			bool hasRoom = _findings.Count < MaxFindingsTotal && reported < MaxFindingsPerRule;
-			if (!hasRoom) {
+			bool fitsOverall = severity == LintSeverity.Error || _findings.Count < MaxFindingsTotal;
+			if (!fitsOverall || reported >= MaxFindingsPerRule) {
 				RecordSuppressed(rule, severity, line, column);
 				return false;
 			}
@@ -376,7 +387,7 @@ internal static class PageBodyAstLinter {
 		}
 
 		/// <summary>Adds a finding whose slot was already claimed with <see cref="TryReserve"/>.</summary>
-		public void AddReserved(string rule, LintSeverity severity, int line, int column, string message) =>
+		private void AddReserved(string rule, LintSeverity severity, int line, int column, string message) =>
 			_findings.Add(new PageBodyLintFinding(rule, severity, line, column, message));
 
 		/// <summary>
@@ -391,7 +402,7 @@ internal static class PageBodyAstLinter {
 		}
 
 		/// <summary>Counts one finding that will not be shown, and remembers where it sat.</summary>
-		public void RecordSuppressed(string rule, LintSeverity severity, int line, int column){
+		private void RecordSuppressed(string rule, LintSeverity severity, int line, int column){
 			if (_suppressed.TryGetValue(rule, out SuppressedRuleCount existing)) {
 				_suppressed[rule] = existing with {Count = existing.Count + 1, Line = line, Column = column};
 				return;
@@ -412,14 +423,21 @@ internal static class PageBodyAstLinter {
 				}
 				SuppressedRuleCount suppressed = _suppressed[rule];
 				_reported.TryGetValue(rule, out int reported);
+				//A rule that first fired after the report was already full has nothing "listed above",
+				//so saying "past the first 0" would send the reader looking for entries that are not there.
+				string message = reported > 0
+					? $"{suppressed.Count} further `{rule}` finding(s) past the first {reported} were "
+						+ "omitted from this report; fix the listed ones and re-run validate-page to see "
+						+ "the rest."
+					: $"{suppressed.Count} `{rule}` finding(s) were omitted from this report, which had "
+						+ "already reached its overall size limit; fix the listed findings and re-run "
+						+ "validate-page to see these.";
 				_findings.Add(new PageBodyLintFinding(
 					Rule: rule,
 					Severity: suppressed.Severity,
 					Line: suppressed.Line,
 					Column: suppressed.Column,
-					Message: $"{suppressed.Count} further `{rule}` finding(s) past the first {reported} were "
-						+ "omitted from this report; fix the listed ones and re-run validate-page to see "
-						+ "the rest."));
+					Message: message));
 			}
 		}
 
@@ -474,6 +492,7 @@ internal static class PageBodyAstLinter {
 		//Name -> definitely initialized before the enclosing function finished.
 		private readonly Dictionary<string, bool> _names = new(StringComparer.Ordinal);
 		private readonly LexicalScope _parent;
+		private HashSet<string> _nestedFunctionAssignments;
 
 		public LexicalScope(LexicalScope parent, bool isFunctionBoundary = false){
 			_parent = parent;
@@ -482,6 +501,17 @@ internal static class PageBodyAstLinter {
 
 		/// <summary>True when this scope belongs to a function, so leaving it crosses a call boundary.</summary>
 		public bool IsFunctionBoundary { get; }
+
+		/// <summary>
+		/// The names this function's body assigns from inside a nested function of its own. They are
+		/// collected up front, because whether such an assignment has run by the time a section calls the
+		/// name does not follow from where the assignment sits in the source.
+		/// </summary>
+		public IReadOnlyCollection<string> NestedFunctionAssignments => _nestedFunctionAssignments;
+
+		public void RecordNestedFunctionAssignments(HashSet<string> names){
+			_nestedFunctionAssignments = names;
+		}
 
 		public void Declare(string name, bool definitelyInitialized){
 			if (string.IsNullOrEmpty(name)) {
@@ -605,8 +635,8 @@ internal static class PageBodyAstLinter {
 		LexicalScope GlobalScope,
 		HashSet<Node> FactoryFunctions,
 		HashSet<Node> SectionProperties,
-		LintFindingBudget Sink,
-		UndefinedCallBudget NameBudget);
+		LintFindingBudget FindingBudget,
+		UndefinedCallBudget DistinctNameBudget);
 
 	private const string DefineGlobalName = "define";
 
@@ -623,22 +653,25 @@ internal static class PageBodyAstLinter {
 		foreach (string global in CallableRuntimeGlobals) {
 			globalScope.Declare(global, definitelyInitialized: true);
 		}
-		LexicalScope scriptScope = new(globalScope, isFunctionBoundary: true);
+		LexicalScope scriptScope = new(globalScope);
 		bool strict = HasUseStrictDirective(ast.Body);
 		DeclareHoistedNames(ast, scriptScope, depth: 0, strict, atStatementLevel: true,
 			unconditional: true);
-		DeclareBlockNames(ast.Body, scriptScope, depth: 0, unconditional: true);
+		DeclareBlockNames(ast.Body, scriptScope, depth: 0, assignmentsAlwaysRun: true);
 		HashSet<Node> factories = new(NodeReferenceComparer.Instance);
 		CollectFactoryFunctions(ast, factories, depth: 0);
 		HashSet<Node> sections = new(NodeReferenceComparer.Instance);
 		CollectSectionProperties(ast, factories, sections, depth: 0);
 		SectionScanState state = new(globalScope, factories, sections, budget, new UndefinedCallBudget());
-		ScanForUndefinedSectionCalls(ast, scriptScope, insideSection: false, depth: 0, strict, state);
-		if (state.NameBudget.OmittedOccurrenceCount > 0 && state.NameBudget.LastOmitted.HasValue) {
-			PageBodyLintFinding summary = BuildOmittedSummary(state.NameBudget.LastOmitted.Value,
-				state.NameBudget);
-			budget.AddReserved(summary.Rule, summary.Severity, summary.Line, summary.Column,
-				summary.Message);
+		ScanForUndefinedSectionCalls(ast, scriptScope, insideSection: false, depth: 0, strict,
+			unconditional: true, state);
+		if (state.DistinctNameBudget.OmittedOccurrenceCount > 0
+			&& state.DistinctNameBudget.LastOmitted.HasValue) {
+			OmittedCallLocation lastOmitted = state.DistinctNameBudget.LastOmitted.Value;
+			//Through the shared budget like every other finding, so the report's own accounting stays
+			//consistent. The summary is an Error, which the overall ceiling does not apply to.
+			budget.TryAdd(RuleUndefinedSectionCall, LintSeverity.Error, lastOmitted.Line,
+				lastOmitted.Column, () => BuildOmittedSummaryMessage(state.DistinctNameBudget));
 		}
 	}
 
@@ -670,11 +703,19 @@ internal static class PageBodyAstLinter {
 	///
 	/// When the body carries no `define(...)` factory at all - nothing upstream of the linter requires
 	/// one - the same return-anchored rule is applied to every function in the body, so the rule keeps
-	/// working on a bare module without falling back to the name-anywhere match.
+	/// working on a bare module without falling back to the name-anywhere match. The fallback is decided
+	/// for the WHOLE body: one `define(...)` anywhere is enough to scope discovery to factories only.
+	///
+	/// Only a `return` that is a direct statement of the function body is an anchor. A page schema
+	/// returned from inside an `if` or a `try` is therefore not discovered, the same silent gap as a
+	/// factory that returns a variable rather than an object literal.
 	/// </summary>
 	private static void CollectSectionProperties(Node node, HashSet<Node> factories,
 		HashSet<Node> sections, int depth) {
 		if (node is null || depth > MaxAstDepth) {
+			//Past the traversal cap the rule simply finds no sections there, so it reports nothing
+			//rather than reporting wrongly; the same body already gets a blocking
+			//`body-too-deeply-nested` finding from the main walk.
 			return;
 		}
 		if (node is IFunction function && (factories.Count == 0 || factories.Contains(node))) {
@@ -686,18 +727,56 @@ internal static class PageBodyAstLinter {
 	}
 
 	private static void CollectReturnedSectionProperties(IFunction function, HashSet<Node> sections) {
+		//An arrow with an expression body - `() => ({ handlers: [...] })` - returns its object literal
+		//without a `return` statement at all, and is a shape Page Designer emits.
+		if (function.Body is ObjectExpression conciseBody) {
+			AddSectionProperties(conciseBody, sections);
+			return;
+		}
 		if (function.Body is not BlockStatement body) {
 			return;
 		}
 		foreach (Statement statement in body.Body) {
-			if (statement is not ReturnStatement {Argument: ObjectExpression returned}) {
+			if (statement is not ReturnStatement {Argument: not null} returnStatement) {
 				continue;
 			}
-			foreach (Node element in returned.Properties) {
-				if (TryGetEntryProperty(element, out Property property, out string key)
-					&& Array.IndexOf(SectionPropertyNames, key) >= 0) {
-					sections.Add(property);
+			ObjectExpression returned = returnStatement.Argument as ObjectExpression
+				?? (returnStatement.Argument is Identifier returnedName
+					? FindObjectLiteralDeclaration(body, returnedName.Name)
+					: null);
+			if (returned is not null) {
+				AddSectionProperties(returned, sections);
+			}
+		}
+	}
+
+	/// <summary>
+	/// The object literal a direct `const`/`let`/`var` statement of this block assigned to
+	/// <paramref name="name"/> - the `const schema = { handlers: [...] }; return schema;` shape. A
+	/// declaration that gets its value any other way (a call result, a spread of another variable, an
+	/// assignment written separately from the declaration) is not followed: the rule then finds no
+	/// sections and stays silent, which is the same documented gap as a nested `return`.
+	/// </summary>
+	private static ObjectExpression FindObjectLiteralDeclaration(BlockStatement body, string name) {
+		foreach (Statement statement in body.Body) {
+			if (statement is not VariableDeclaration declaration) {
+				continue;
+			}
+			foreach (VariableDeclarator declarator in declaration.Declarations) {
+				if (declarator is {Id: Identifier {Name: var declared}, Init: ObjectExpression initializer}
+					&& string.Equals(declared, name, StringComparison.Ordinal)) {
+					return initializer;
 				}
+			}
+		}
+		return null;
+	}
+
+	private static void AddSectionProperties(ObjectExpression returned, HashSet<Node> sections) {
+		foreach (Node element in returned.Properties) {
+			if (TryGetEntryProperty(element, out Property property, out string key)
+				&& Array.IndexOf(SectionPropertyNames, key) >= 0) {
+				sections.Add(property);
 			}
 		}
 	}
@@ -726,21 +805,15 @@ internal static class PageBodyAstLinter {
 		enclosingStrict
 		|| (node is IFunction {Body: BlockStatement body} && HasUseStrictDirective(body.Body));
 
-	private static PageBodyLintFinding BuildOmittedSummary(
-		OmittedCallLocation lastOmitted, UndefinedCallBudget budget) {
+	private static string BuildOmittedSummaryMessage(UndefinedCallBudget budget) {
 		string floorPrefix = budget.OmittedNameCountIsFloor ? "at least " : string.Empty;
 		string namesPart = budget.OmittedNameCount > 0
 			? $"{floorPrefix}{budget.OmittedNameCount} "
 				+ $"further undeclared name(s) past the first {MaxUndefinedSectionCallNames}, and "
 			: string.Empty;
-		return new PageBodyLintFinding(
-			Rule: RuleUndefinedSectionCall,
-			Severity: LintSeverity.Error,
-			Line: lastOmitted.Line,
-			Column: lastOmitted.Column,
-			Message: $"{namesPart}{budget.OmittedOccurrenceCount} further call site(s) of undeclared "
-				+ $"identifiers were omitted from this report; {budget.ReportedNameCount} distinct name(s) "
-				+ "are listed above. Fix the listed ones and re-run validate-page to see the rest.");
+		return $"{namesPart}{budget.OmittedOccurrenceCount} further call site(s) of undeclared "
+			+ $"identifiers were omitted from this report; {budget.ReportedNameCount} distinct name(s) "
+			+ "are listed above. Fix the listed ones and re-run validate-page to see the rest.";
 	}
 
 	/// <summary>
@@ -784,6 +857,11 @@ internal static class PageBodyAstLinter {
 	/// conditional, which is what makes `if (false) { function helper(){} }` fail closed.
 	/// </summary>
 	private static bool IsUnconditionalChild(Node parent, Node child, bool parentUnconditional) {
+		if (parent is IFunction function && ReferenceEquals(child, function.Body)) {
+			//A function body opens its own sequence: it runs from the top whenever the function is
+			//called, wherever the function itself was written.
+			return true;
+		}
 		if (!parentUnconditional) {
 			return false;
 		}
@@ -845,7 +923,7 @@ internal static class PageBodyAstLinter {
 	/// function declarations that are direct statements of this block.
 	/// </summary>
 	private static void DeclareBlockNames(in NodeList<Statement> statements, LexicalScope scope,
-		int depth, bool unconditional) {
+		int depth, bool assignmentsAlwaysRun) {
 		bool afterReturn = false;
 		foreach (Statement statement in statements) {
 			if (afterReturn && statement is not FunctionDeclaration) {
@@ -864,14 +942,14 @@ internal static class PageBodyAstLinter {
 					} blockDeclaration:
 					foreach (VariableDeclarator declarator in blockDeclaration.Declarations) {
 						DeclareBindings(declarator.Id, scope, depth + 1,
-							definitelyInitialized: unconditional && declarator.Init is not null);
+							definitelyInitialized: declarator.Init is not null);
 					}
 					break;
 				case FunctionDeclaration {Id: not null} functionDeclaration:
-					scope.Declare(functionDeclaration.Id.Name, definitelyInitialized: unconditional);
+					scope.Declare(functionDeclaration.Id.Name, definitelyInitialized: true);
 					break;
 				case ClassDeclaration {Id: not null} classDeclaration:
-					scope.Declare(classDeclaration.Id.Name, definitelyInitialized: unconditional);
+					scope.Declare(classDeclaration.Id.Name, definitelyInitialized: true);
 					break;
 				case ExpressionStatement {
 						Expression: AssignmentExpression {
@@ -879,8 +957,9 @@ internal static class PageBodyAstLinter {
 						}
 					}:
 					//`let helper; helper = () => 1;` before the return DOES leave a callable binding,
-					//so the assignment - not the declaration - is what makes it usable.
-					if (unconditional) {
+					//so the assignment - not the declaration - is what makes it usable. The same
+					//assignment inside a branch that may not run proves nothing about the binding.
+					if (assignmentsAlwaysRun) {
 						scope.MarkInitialized(assigned.Name);
 					}
 					break;
@@ -927,7 +1006,7 @@ internal static class PageBodyAstLinter {
 	/// Opens the scope a node introduces, if any, and returns the scope its children see.
 	/// </summary>
 	private static LexicalScope OpenScope(Node node, LexicalScope scope, int depth, bool strict,
-		SectionScanState state) {
+		bool unconditional, SectionScanState state) {
 		switch (node) {
 			case IFunction function: {
 				//The AMD factory chains to the runtime globals, NOT to the script scope: a helper
@@ -943,20 +1022,37 @@ internal static class PageBodyAstLinter {
 				}
 				DeclareHoistedNames(function.Body, functionScope, depth + 1, strict,
 					atStatementLevel: true, unconditional: true);
+				HashSet<string> nestedAssignments = new(StringComparer.Ordinal);
+				CollectNestedFunctionAssignments(function.Body, nestedAssignments, depth + 1,
+					insideNestedFunction: false);
+				functionScope.RecordNestedFunctionAssignments(nestedAssignments);
 				return functionScope;
 			}
 			case BlockStatement block: {
 				LexicalScope blockScope = new(scope);
-				DeclareBlockNames(block.Body, blockScope, depth + 1, unconditional: true);
+				//Reaching a block's scope at all means the block runs, so what it DECLARES is bound
+				//either way; whether its assignments to OUTER bindings run is the part that depends
+				//on how this block was reached.
+				DeclareBlockNames(block.Body, blockScope, depth + 1, unconditional);
+				if (scope.IsFunctionBoundary && scope.NestedFunctionAssignments is not null) {
+					//This is the body block of the function that owns `scope`, so its `let`/`const`
+					//bindings are now in place and the assignments the function's nested functions make
+					//can be applied - all of them, before anything inside the body is resolved. Doing it
+					//at scan time instead made the verdict depend on where the nested function sits
+					//relative to the `return`.
+					foreach (string assigned in scope.NestedFunctionAssignments) {
+						blockScope.MarkInitialized(assigned);
+					}
+				}
 				return blockScope;
 			}
 			case SwitchStatement switchStatement: {
 				//Every case shares one block scope, so a `let` in case A is visible in case B.
 				LexicalScope switchScope = new(scope);
 				foreach (SwitchCase switchCase in switchStatement.Cases) {
-					//Which case runs is a runtime decision, so nothing a case declares is guaranteed.
+					//Which case runs is a runtime decision, so an assignment in one proves nothing.
 					DeclareBlockNames(switchCase.Consequent, switchScope, depth + 1,
-						unconditional: false);
+						assignmentsAlwaysRun: false);
 				}
 				return switchScope;
 			}
@@ -981,6 +1077,39 @@ internal static class PageBodyAstLinter {
 		}
 	}
 
+	/// <summary>
+	/// Collects the names a function body assigns from inside a NESTED function of its own -
+	/// `function init(){ helper = () =&gt; 1; }` in a factory that declares `let helper;`.
+	///
+	/// Such an assignment counts as initialization, with no attempt to decide whether the nested
+	/// function is ever called: a factory that assigns its helpers from an `init()` it calls before the
+	/// `return` is ordinary page code, and rejecting it would block a page that runs. The rule stays
+	/// fail-closed only where the language itself guarantees nothing ran - unreachable code and
+	/// branches that may not be taken - which is what the issue asks for.
+	///
+	/// Two consequences worth stating: a nested function that only assigns the name in a branch still
+	/// counts, and a nested function that SHADOWS the name (declaring its own `helper` before assigning
+	/// it) marks the outer binding too, because the walk records names rather than resolving them.
+	/// Both leave the rule silent on a page that may fail at runtime, which is the safe direction for a
+	/// finding that blocks the write.
+	/// </summary>
+	private static void CollectNestedFunctionAssignments(Node node, HashSet<string> names, int depth,
+		bool insideNestedFunction) {
+		if (node is null || depth > MaxAstDepth) {
+			return;
+		}
+		if (insideNestedFunction
+			&& node is AssignmentExpression {
+				Operator: Acornima.Operator.Assignment, Left: Identifier assigned
+			}) {
+			names.Add(assigned.Name);
+		}
+		foreach (Node child in node.ChildNodes) {
+			CollectNestedFunctionAssignments(child, names, depth + 1,
+				insideNestedFunction || child is IFunction);
+		}
+	}
+
 	private static LexicalScope OpenLoopScope(VariableDeclaration head, LexicalScope scope, int depth) {
 		LexicalScope loopScope = new(scope);
 		foreach (VariableDeclarator declarator in head.Declarations) {
@@ -997,12 +1126,13 @@ internal static class PageBodyAstLinter {
 		bool insideSection,
 		int depth,
 		bool strict,
+		bool unconditional,
 		SectionScanState state) {
 		if (node is null || depth > MaxAstDepth) {
 			return;
 		}
 		bool childStrict = IsStrictFunction(node, strict);
-		LexicalScope childScope = OpenScope(node, scope, depth, childStrict, state);
+		LexicalScope childScope = OpenScope(node, scope, depth, childStrict, unconditional, state);
 		bool childInsideSection = insideSection
 			|| (node is Property property && state.SectionProperties.Contains(property));
 		if (insideSection && node is CallExpression {Callee: Identifier identifier}) {
@@ -1010,7 +1140,7 @@ internal static class PageBodyAstLinter {
 		}
 		foreach (Node child in node.ChildNodes) {
 			ScanForUndefinedSectionCalls(child, childScope, childInsideSection, depth + 1, childStrict,
-				state);
+				IsUnconditionalChild(node, child, unconditional), state);
 		}
 	}
 
@@ -1025,15 +1155,12 @@ internal static class PageBodyAstLinter {
 		//of times, and building the long interpolated message for every occurrence only to drop
 		//it allocated tens of megabytes. An omitted occurrence keeps its location and nothing
 		//else, which is all the summary finding reads.
-		if (!state.NameBudget.ShouldReport(identifier.Name)
-			|| !state.Sink.TryReserve(RuleUndefinedSectionCall, LintSeverity.Error, line, column)) {
-			//Either this name is already listed, or the report as a whole is full. Both are counted
-			//by the rule's own summary, which reports distinct names rather than occurrences.
-			state.NameBudget.RecordOmitted(line, column);
+		if (!state.DistinctNameBudget.ShouldReport(identifier.Name)) {
+			state.DistinctNameBudget.RecordOmitted(line, column);
 			return;
 		}
-		state.Sink.AddReserved(RuleUndefinedSectionCall, LintSeverity.Error, line, column,
-			BuildUnusableSectionCallMessage(resolution, identifier.Name));
+		state.FindingBudget.TryAdd(RuleUndefinedSectionCall, LintSeverity.Error, line, column,
+			() => BuildUnusableSectionCallMessage(resolution, identifier.Name));
 	}
 
 	private static string BuildUnusableSectionCallMessage(BindingResolution resolution, string name) {

--- a/docs/knowledge/Command/page-body-section-calls-must-resolve.md
+++ b/docs/knowledge/Command/page-body-section-calls-must-resolve.md
@@ -1,22 +1,33 @@
 ---
-description: PageBodyAstLinter rejects direct calls in handlers, converters, and validators when the callee is not declared in the parsed body or a known JavaScript/Creatio global
+description: PageBodyAstLinter rejects a call in handlers, converters or validators unless the callee is definitely initialized in the factory scope chain or is a known JavaScript/Creatio global
 applies-to:
   - clio/Command/McpServer/Tools/PageBodyAstLinter.cs
-ticket: 1223
-date: 2026-08-29
+ticket: 1312
+date: 2026-09-12
 ---
 
-**What is true** — the undefined-call lint is deliberately limited to direct identifier callees inside
-the `handlers`, `converters`, and `validators` sections. It collects factory declarations and function
-parameters, then applies the known JavaScript/Creatio global allowlist. Member calls such as
-`request.$context.set(...)` are not treated as helper references.
+**What is true** — the undefined-call lint is limited to direct identifier callees inside the
+`handlers`, `converters` and `validators` properties **of the object the AMD factory returns**; a
+property of one of those names anywhere else in the tree is ordinary metadata and is not scanned.
+Member calls such as `request.$context.set(...)` are not treated as helper references. A name
+satisfies a call only when it is DEFINITELY INITIALIZED, and that is demanded only once resolution
+crosses a function boundary: `if (false) { function helper(){} }`, `let helper;` with no assignment,
+and an assignment placed after the factory's `return` all leave the binding `undefined` and are
+reported, while the same shapes resolved inside the calling function itself are accepted because the
+statements really do run first. Only `if (true)` / `if (false)` are folded — no other control flow.
+The factory's scope chain ends at the runtime globals: a helper declared outside `define(...)` does
+NOT satisfy a handler call. A body with no `define(...)` at all falls back to the same
+return-anchored rule applied to every function.
 
-**Why it is this way** — Creatio Page Designer can regenerate a body while preserving a handler entry but
-dropping hand-written module-scope declarations. A JavaScript parser accepts the resulting body because
-an unresolved identifier is a runtime lookup, not a syntax error. The AST already available to validation
-provides the cheap deterministic check without executing customer code.
+**Why it is this way** — Creatio Page Designer can regenerate a body while preserving a handler entry
+but dropping hand-written module-scope declarations, and a JavaScript parser accepts the result
+because an unresolved identifier is a runtime lookup, not a syntax error. Name existence alone was
+not enough: a preloaded declaration whose value never lands throws just as the missing one does.
 
 **What breaks if you ignore it** — `validate-page` and the write-path validators can report a body as
-syntactically valid, and `sync-pages` can save it, while the first handler invocation throws
-`ReferenceError` and the page cannot open. Do not replace this with a text scanner or a full interpreter:
-the former misreads JavaScript grammar and the latter would execute untrusted page code.
+valid and `sync-pages` can save it, while the first handler invocation throws `ReferenceError` or
+`TypeError` and the page cannot open. Two known gaps that follow from the anchoring: a factory that
+returns a VARIABLE (`return schema;`) rather than an object literal leaves the rule silent, and a
+helper stored on an object and called through a member expression is out of scope by design. Do not
+replace this with a text scanner or a full interpreter: the former misreads JavaScript grammar and
+the latter would execute untrusted page code.

--- a/docs/knowledge/Command/page-body-section-calls-must-resolve.md
+++ b/docs/knowledge/Command/page-body-section-calls-must-resolve.md
@@ -32,6 +32,14 @@ with an object literal. Anything else — a `return` nested inside an `if` or a 
 by a call, a schema assembled by assignments written separately from the declaration — is not
 discovered, and the rule then reports nothing at all for that body.
 
+**Known false positives, accepted for now** — the rule is fail-CLOSED against its catalog of runtime
+globals, so a bare call to a name the catalog does not list is a blocking Error even when the page
+runs: a host library reached without declaring it as an AMD dependency (`$`, `_`, `moment`), and a
+sloppy-mode implicit global (`helper = fn;` with no `var`/`let`/`const`, which really does create a
+global in a non-strict AMD body). Both are reported as "not declared in the enclosing scopes". The
+fix on the authoring side is one line (declare the dependency, or the binding), so the catalog was
+left as it is rather than widened on speculation; widen it when a real page hits this.
+
 **Deliberate fail-open cases** — an assignment made from inside ANY nested function of the factory
 counts as initialization, whether or not that function is ever called, because a factory that
 assigns its helpers from an `init()` it calls before the `return` is ordinary page code. That walk
@@ -39,6 +47,14 @@ records names rather than resolving them, so a nested function that SHADOWS the 
 outer binding. A `switch` shares one block scope across its cases, so a `let` initialized in one
 case counts as initialized for the others. All three leave the rule silent on a page that may throw,
 which is the safe direction for a finding that blocks the write.
+
+**Cost profile** — the nested-function assignment scan runs once per function scope over that
+function's whole subtree, so a body with deeply nested functions costs O(depth x nodes) and retains
+one name set per live scope. Ordinary and even generated page bodies are flat enough for this not to
+matter; a body built specifically out of hundreds of nested functions each assigning hundreds of
+names is the shape that would not be. If such a body ever appears, bound the collected set the way
+`MaxTrackedOmittedNames` bounds the omitted-name sample - and make saturation fail OPEN, because a
+name that stops being tracked turns into a blocking Error on a page that works.
 
 **What breaks if you ignore it** — `validate-page` and the write-path validators can report a body as
 valid and `sync-pages` can save it, while the first handler invocation throws `ReferenceError` or

--- a/docs/knowledge/Command/page-body-section-calls-must-resolve.md
+++ b/docs/knowledge/Command/page-body-section-calls-must-resolve.md
@@ -24,10 +24,27 @@ but dropping hand-written module-scope declarations, and a JavaScript parser acc
 because an unresolved identifier is a runtime lookup, not a syntax error. Name existence alone was
 not enough: a preloaded declaration whose value never lands throws just as the missing one does.
 
+**Where the returned schema is looked for** — three anchors, all decided before any call is
+resolved: an object literal returned by a `return` that is a DIRECT statement of the function body,
+an arrow whose expression body IS that object literal (`() => ({ handlers: [...] })`), and a
+`return <name>;` whose `<name>` a direct `const`/`let`/`var` statement of the same block initialized
+with an object literal. Anything else — a `return` nested inside an `if` or a `try`, a schema built
+by a call, a schema assembled by assignments written separately from the declaration — is not
+discovered, and the rule then reports nothing at all for that body.
+
+**Deliberate fail-open cases** — an assignment made from inside ANY nested function of the factory
+counts as initialization, whether or not that function is ever called, because a factory that
+assigns its helpers from an `init()` it calls before the `return` is ordinary page code. That walk
+records names rather than resolving them, so a nested function that SHADOWS the name still marks the
+outer binding. A `switch` shares one block scope across its cases, so a `let` initialized in one
+case counts as initialized for the others. All three leave the rule silent on a page that may throw,
+which is the safe direction for a finding that blocks the write.
+
 **What breaks if you ignore it** — `validate-page` and the write-path validators can report a body as
 valid and `sync-pages` can save it, while the first handler invocation throws `ReferenceError` or
-`TypeError` and the page cannot open. Two known gaps that follow from the anchoring: a factory that
-returns a VARIABLE (`return schema;`) rather than an object literal leaves the rule silent, and a
-helper stored on an object and called through a member expression is out of scope by design. Do not
-replace this with a text scanner or a full interpreter: the former misreads JavaScript grammar and
-the latter would execute untrusted page code.
+`TypeError` and the page cannot open. One known gap follows from the anchoring: a helper stored on an
+object and called through a member expression is out of scope by design. Do not replace this with a
+text scanner or a full interpreter: the former misreads JavaScript grammar and the latter would
+execute untrusted page code. And do not move the definite-initialization decision back into the call
+resolution walk: a verdict that depends on where the assigning helper sits relative to the `return`
+is one no author can act on.

--- a/docs/knowledge/McpServer/page-lint-findings-are-bounded-per-rule-and-overall.md
+++ b/docs/knowledge/McpServer/page-lint-findings-are-bounded-per-rule-and-overall.md
@@ -8,7 +8,9 @@ date: 2026-09-12
 
 **What is true** — every lint rule reserves a slot from one shared budget BEFORE its message is
 built: at most `MaxFindingsPerRule` findings for a single rule and `MaxFindingsTotal` for the whole
-report. What does not fit is counted, and each capped rule appends ONE summary finding that carries
+report. `MaxFindingsTotal` applies to WARNINGS ONLY — an `Error` finding is bounded by its own
+rule's cap and nothing else, because an Error blocks the write, so dropping one to keep the report
+small turns a body the platform rejects into a body that saves clean. What does not fit is counted, and each capped rule appends ONE summary finding that carries
 the same `Rule` id and severity as the rule it summarises, positioned at the last suppressed
 occurrence. A consumer that counts findings of one rule therefore sees `cap + 1`, and the last of
 them is prose about the omission rather than a finding about a page location.
@@ -20,7 +22,11 @@ generated page with thousands of offending converter keys or `fetch()` calls for
 interpolated message per occurrence: a report measured in hundreds of kilobytes that no MCP client
 can use and that nobody reads past the first few entries.
 
-**What breaks if you ignore it** — building the message before the cap decision reintroduces the
+**What breaks if you ignore it** — applying the overall ceiling to Errors is the failure this is
+written for: a generated body full of warnings filled the report, the `undefined-section-call` scan
+that runs after the main walk then found no slot, and the rule emitted neither a finding nor a
+summary — a page whose handler throws on open was saved with `success: true`. Building the message
+before the cap decision reintroduces the
 megabyte allocations the cap exists to prevent, because the expensive part is the string, not the
 finding. Treating a report as complete produces the opposite error: after fixing the listed findings
 the caller MUST re-run validate-page, since the rest were never listed.

--- a/docs/knowledge/McpServer/page-lint-findings-are-bounded-per-rule-and-overall.md
+++ b/docs/knowledge/McpServer/page-lint-findings-are-bounded-per-rule-and-overall.md
@@ -1,0 +1,26 @@
+---
+description: PageBodyAstLinter caps findings per rule and for the whole report, and a suppressed remainder comes back as one extra finding carrying the same rule id
+applies-to:
+  - clio/Command/McpServer/Tools/PageBodyAstLinter.cs
+ticket: 1312
+date: 2026-09-12
+---
+
+**What is true** — every lint rule reserves a slot from one shared budget BEFORE its message is
+built: at most `MaxFindingsPerRule` findings for a single rule and `MaxFindingsTotal` for the whole
+report. What does not fit is counted, and each capped rule appends ONE summary finding that carries
+the same `Rule` id and severity as the rule it summarises, positioned at the last suppressed
+occurrence. A consumer that counts findings of one rule therefore sees `cap + 1`, and the last of
+them is prose about the omission rather than a finding about a page location.
+`undefined-section-call` renders its own summary (it counts distinct NAMES, not occurrences) and is
+excluded from the shared one, so it never carries two.
+
+**Why it is this way** — AST depth bounds how deep the walk goes, never how wide the body is. A
+generated page with thousands of offending converter keys or `fetch()` calls formatted one long
+interpolated message per occurrence: a report measured in hundreds of kilobytes that no MCP client
+can use and that nobody reads past the first few entries.
+
+**What breaks if you ignore it** — building the message before the cap decision reintroduces the
+megabyte allocations the cap exists to prevent, because the expensive part is the string, not the
+finding. Treating a report as complete produces the opposite error: after fixing the listed findings
+the caller MUST re-run validate-page, since the rest were never listed.


### PR DESCRIPTION
🔗 **Issue:** [#1312](https://github.com/Advance-Technologies-Foundation/clio/issues/1312)

Closes #1312

## Summary

The six follow-ups deferred from the review of #1252. Items 1–4 are one change: `PageBodyAstLinter` now models the page body's scope chain and definite initialization instead of matching names in a flat set, and finds the page schema by what the AMD factory returns rather than by property name. Item 5 puts every emission site behind one shared budget. Item 6 adds the non-dry-run save-path coverage the two writers were missing.

## Root cause

`undefined-section-call` answered "is this name somewhere in the body?" — three separate ways for that to be the wrong question:

- **A name can exist and still be `undefined`.** `if (false) { function helper(){} }` and `let helper;` both put the name in scope; the handler that calls it throws `TypeError` at runtime while lint stayed silent.
- **The factory does not inherit the script.** Declaring every script-level name let a helper written outside `define(...)` satisfy a handler call — the exact shape the rule exists to catch, because Page Designer can keep the handler entry and drop the outer declaration.
- **A property named `handlers` is not a page schema.** Matching the name anywhere in the tree turned ordinary nested metadata into a section and blocked pages that run.

And the report itself was unbounded in WIDTH: AST depth caps how deep the walk goes, never how many times one rule fires.

## Changes

| Item | Change |
|---|---|
| 1, 2 | Every binding carries whether it is definitely initialized. Reachability is propagated into block scopes, so an assignment inside `if (false)`, a loop body, a `try` or a `switch` case does not count; only `if (true)` / `if (false)` are folded, and code after a `return` initializes nothing. Crossing a function boundary is what makes definite initialization required — inside one function the statements really do run in order. |
| 3 | The AMD factory's scope chains to the runtime globals, not to the script scope. The catalog of globals is split by the runtime that supplies each name, and separates names that are callable bare from names the runtime supplies as a value (`innerWidth()`, `Map()` used to pass lint and fail at runtime). |
| 4 | Section discovery is anchored to the object the factory RETURNS — an object literal returned directly, an arrow's expression body (`() => ({...})`), or `return <name>;` where that name was declared with an object literal in the same block. A body with no `define(...)` falls back to the same return-anchored rule on every function. |
| 5 | One `LintFindingBudget` that every rule reserves from BEFORE its message is built, with a per-rule cap and an overall cap, and one counted summary per capped rule. `MaxFindingsTotal` bounds **warnings only**: an Error blocks the write, so dropping one to keep the report small turns a body the platform rejects into a body that saves clean. |
| 6 | One non-dry-run scenario per writer (`update-page`, `sync-pages`) that submits an `undefined-section-call` body through the real save path, asserts the refusal, and asserts the page on the stand is byte-identical afterwards. Shared probe bodies live in `clio.mcp.e2e/Support/Creatio/PageLintProbeBodies.cs`; both tests put the fixture page back if the gate ever lets the probe through. |

Order independence was the subtlest part: assignments used to be applied to ancestor scopes during the same walk that resolved the calls, so the same factory accepted or rejected the same helper depending on whether the function assigning it sat before or after the `return`. Assignments made from inside a function's nested functions are now collected when that function's scope opens and applied before anything in its body is resolved.

### Stated limits (deliberate, written into the knowledge records)

- An assignment made from inside ANY nested function counts as initialization, whether or not that function is ever called — a factory calling its own `init()` before the `return` is ordinary page code. That walk records names rather than resolving them, so a nested function shadowing the name still marks the outer binding.
- A `switch` shares one block scope across cases, so a `let` initialized in one case counts as initialized for the others.
- A `return` nested inside an `if` or a `try`, or a schema built by a call, is not discovered — the rule then reports nothing for that body rather than reporting wrongly.
- The rule is fail-closed against its catalog of globals, so a host library reached without declaring it as an AMD dependency (`$`, `_`) and a sloppy-mode implicit global are reported. The authoring fix is one line; the catalog was left as it is rather than widened on speculation.

## Validation

```
dotnet build clio/clio.csproj -c Debug -f net10.0                                   -> 0 errors, no new CLIO* warnings
dotnet test clio.tests/clio.tests.csproj --filter "Category=Unit&Module=McpServer" -f net10.0
                                                                                   -> Passed: 5222, Failed: 0, Skipped: 2
dotnet build clio.mcp.e2e/clio.mcp.e2e.csproj -c Debug                             -> 0 errors
```

The two new e2e scenarios need a reachable stand with `AllowDestructiveMcpTests`; they were compiled, not executed here (no stand available in this session).

Mutation-checked the two guards that matter: reverting the Error budget exemption fails `Lint_ShouldKeepErrors_WhenWarningsFillTheWholeReport`, and reverting the pre-collected nested-function assignments fails `Lint_ShouldNotEmitError_WhenTheAssigningFunctionIsDeclaredAfterTheReturn`.

## Review tier

Full comprehensive pre-PR review (3 parallel lenses: code quality, bug detection, security) over the complete diff, plus one combined adversarial bug-detector pass over the final diff. Every Blocker and High was fixed before this PR was opened — the Errors-vanish-when-the-report-is-full defect, the block-scope reachability defect and the document-order dependence all came out of that gate. The final pass reported no Blocker and no High. Medium/Low left open and noted above: the catalog false positives (`$`, implicit globals), the cost profile of the nested-assignment scan on a body built out of hundreds of nested functions, and the "not declared" wording on a declaration written after the `return` (the verdict is right, the message names the wrong reason).

MCP reviewed, no update required — `PageBodyAstLinter` is an internal validation stage behind `validate-page` / `update-page` / `sync-pages`; no tool name, argument, description, destructive flag or result shape changed. E2E coverage was added as required.

docs reviewed, no update required — no command verb, option or behaviour visible to the CLI changed.

ClioRing compatibility reviewed, no Ring-consumed contract changed — inspected `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, `clio-ring/ClioRing.Desktop/actions.json`: Ring invokes no page-authoring tool, and this change adds no tool, argument or stage event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
