### PR TITLE
#1521 Expose create-app optional template data on the CLI

### DIFF
--- a/clio.tests/Command/CreateAppCommandTests.cs
+++ b/clio.tests/Command/CreateAppCommandTests.cs
@@ -127,6 +127,118 @@ public sealed class CreateAppCommandTests : BaseCommandTests<CreateAppOptions>
 	}
 
 	[Test]
+	[Description("Leaves the optional template data unset when neither --entity-schema-name nor --app-section-description is supplied.")]
+	public void Execute_Should_Not_Send_OptionalTemplateData_When_Template_Options_Are_Absent()
+	{
+		// Arrange
+		CreateAppOptions options = new() {
+			Environment = "dev",
+			Name = "My App",
+			Code = "UsrMyApp",
+			TemplateCode = "AppFreedomUIv2"
+		};
+		_service.CreateApplication("dev", Arg.Any<ApplicationCreateRequest>())
+			.Returns(new ApplicationInfoResult("pkg-uid", "UsrMyApp", []));
+
+		// Act
+		int exitCode = _command.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(0, because: "a create call without the new template options should still succeed");
+		_service.Received(1).CreateApplication(
+			"dev",
+			Arg.Is<ApplicationCreateRequest>(r => r.OptionalTemplateData == null));
+	}
+
+	[Test]
+	[Description("Sends entitySchemaName together with useExistingEntitySchema=true when --entity-schema-name is supplied.")]
+	public void Execute_Should_Imply_UseExistingEntitySchema_When_EntitySchemaName_Is_Supplied()
+	{
+		// Arrange
+		CreateAppOptions options = new() {
+			Environment = "dev",
+			Name = "My App",
+			Code = "UsrMyApp",
+			TemplateCode = "AppFreedomUIv2",
+			EntitySchemaName = "UsrExistingEntity"
+		};
+		_service.CreateApplication("dev", Arg.Any<ApplicationCreateRequest>())
+			.Returns(new ApplicationInfoResult("pkg-uid", "UsrMyApp", []));
+
+		// Act
+		int exitCode = _command.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(0, because: "binding the primary section to an existing entity is a supported create call");
+		_service.Received(1).CreateApplication(
+			"dev",
+			Arg.Is<ApplicationCreateRequest>(r =>
+				r.OptionalTemplateData != null &&
+				r.OptionalTemplateData.EntitySchemaName == "UsrExistingEntity" &&
+				r.OptionalTemplateData.UseExistingEntitySchema == true &&
+				r.OptionalTemplateData.AppSectionDescription == null));
+	}
+
+	[Test]
+	[Description("Sends only the section description, without implying useExistingEntitySchema, when --app-section-description is supplied alone.")]
+	public void Execute_Should_Send_Only_SectionDescription_When_EntitySchemaName_Is_Absent()
+	{
+		// Arrange
+		CreateAppOptions options = new() {
+			Environment = "dev",
+			Name = "My App",
+			Code = "UsrMyApp",
+			TemplateCode = "AppFreedomUIv2",
+			AppSectionDescription = "Orders of the current account"
+		};
+		_service.CreateApplication("dev", Arg.Any<ApplicationCreateRequest>())
+			.Returns(new ApplicationInfoResult("pkg-uid", "UsrMyApp", []));
+
+		// Act
+		int exitCode = _command.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(0, because: "a section description alone is a valid create call");
+		_service.Received(1).CreateApplication(
+			"dev",
+			Arg.Is<ApplicationCreateRequest>(r =>
+				r.OptionalTemplateData != null &&
+				r.OptionalTemplateData.AppSectionDescription == "Orders of the current account" &&
+				r.OptionalTemplateData.EntitySchemaName == null &&
+				r.OptionalTemplateData.UseExistingEntitySchema == null));
+	}
+
+	[Test]
+	[Description("Sends the entity schema name, the implied useExistingEntitySchema flag and the section description together when both template options are supplied.")]
+	public void Execute_Should_Send_Both_Template_Options_When_Both_Are_Supplied()
+	{
+		// Arrange
+		CreateAppOptions options = new() {
+			Environment = "dev",
+			Name = "My App",
+			Code = "UsrMyApp",
+			TemplateCode = "AppFreedomUIv2",
+			EntitySchemaName = "UsrExistingEntity",
+			AppSectionDescription = "Reuses the existing entity"
+		};
+		_service.CreateApplication("dev", Arg.Any<ApplicationCreateRequest>())
+			.Returns(new ApplicationInfoResult("pkg-uid", "UsrMyApp", []));
+
+		// Act
+		int exitCode = _command.Execute(options);
+
+		// Assert
+		exitCode.Should().Be(0, because: "combining an existing entity with a section description is a valid create call");
+		_service.Received(1).CreateApplication(
+			"dev",
+			Arg.Is<ApplicationCreateRequest>(r =>
+				r.OptionalTemplateData != null &&
+				r.OptionalTemplateData.EntitySchemaName == "UsrExistingEntity" &&
+				r.OptionalTemplateData.UseExistingEntitySchema == true &&
+				r.OptionalTemplateData.AppSectionDescription == "Reuses the existing entity"));
+	}
+
+	[Test]
 	[Description("Returns failure exit code and logs an error when with-mobile-pages receives an unsupported value.")]
 	public void Execute_Should_Return_Failure_When_WithMobilePages_Value_Is_Invalid()
 	{

--- a/clio/Command/ApplicationCreateCommand.cs
+++ b/clio/Command/ApplicationCreateCommand.cs
@@ -31,12 +31,38 @@ public sealed class CreateAppOptions : EnvironmentOptions
 	[Option("with-mobile-pages", Required = false, Default = "true", HelpText = "Create mobile pages (_MobileFormPage, _MobileListPage) for the main entity in addition to web pages (default: true). Pass false for a web-only application.")]
 	public string? WithMobilePagesValue { get; set; }
 
+	[Option("entity-schema-name", Required = false, HelpText = "Name of an EXISTING entity schema the application's primary section is built over. The entity must already exist in the environment; Creatio then skips minting a new canonical entity.")]
+	public string? EntitySchemaName { get; set; }
+
+	[Option("app-section-description", Required = false, HelpText = "Description applied to the application's primary section.")]
+	public string? AppSectionDescription { get; set; }
+
 	/// <summary>
 	/// Gets a value indicating whether mobile pages should be generated for the main entity.
 	/// </summary>
 	public bool WithMobilePages {
 		get => string.Equals(WithMobilePagesValue ?? "true", "true", StringComparison.OrdinalIgnoreCase);
 		set => WithMobilePagesValue = value ? "true" : "false";
+	}
+
+	/// <summary>
+	/// Builds the optional CreateApp template payload from the CLI options, or returns
+	/// <see langword="null"/> when neither template option was supplied so the request stays
+	/// byte-identical to a call that predates these options.
+	/// </summary>
+	internal ApplicationOptionalTemplateData? BuildOptionalTemplateData() {
+		bool hasEntitySchemaName = !string.IsNullOrWhiteSpace(EntitySchemaName);
+		bool hasSectionDescription = !string.IsNullOrWhiteSpace(AppSectionDescription);
+		if (!hasEntitySchemaName && !hasSectionDescription) {
+			return null;
+		}
+
+		// --entity-schema-name alone carries the intent, so useExistingEntitySchema is implied here
+		// instead of being a second flag the caller can contradict.
+		return new ApplicationOptionalTemplateData(
+			EntitySchemaName: hasEntitySchemaName ? EntitySchemaName!.Trim() : null,
+			UseExistingEntitySchema: hasEntitySchemaName ? true : null,
+			AppSectionDescription: hasSectionDescription ? AppSectionDescription!.Trim() : null);
 	}
 
 	internal static void ValidateMobilePagesOption(string? value) {
@@ -76,6 +102,7 @@ public sealed class CreateAppCommand(
 				options.TemplateCode,
 				options.IconId,
 				options.IconBackground,
+				OptionalTemplateData: options.BuildOptionalTemplateData(),
 				WithMobilePages: options.WithMobilePages);
 
 			ApplicationInfoResult result = applicationCreateService.CreateApplication(options.Environment, request);

--- a/clio/docs/commands/create-app.md
+++ b/clio/docs/commands/create-app.md
@@ -33,6 +33,15 @@ By default create-app generates the full set of five pages, including the main
 entity `_MobileFormPage` and `_MobileListPage`. Pass --with-mobile-pages false
 to create a web-only application; the two mobile pages are then skipped.
 
+By default Creatio mints a new canonical entity for the application's primary
+section. Pass --entity-schema-name `<Name>` to build that section over an entity
+that **already exists** in the environment instead; Creatio then suppresses the
+new entity. This is the only way to get an application whose primary section
+sits on an existing object — do not follow create-app with create-app-section
+for the primary section, which leaves the starter pages of the unused canonical
+entity behind. --app-section-description sets the description of the primary
+section and can be used on its own.
+
 ## Synopsis
 
 ```bash
@@ -67,6 +76,16 @@ clio create-app [options]
                                  addition to web pages. Optional; defaults to
                                  true. Pass false for a web-only application.
 
+--entity-schema-name             Name of an EXISTING entity schema the primary
+                                 section is built over. Optional. The entity
+                                 must already exist in the environment; clio
+                                 sends it together with
+                                 useExistingEntitySchema=true, so no canonical
+                                 entity is created.
+
+--app-section-description        Description applied to the application's
+                                 primary section. Optional.
+
 --Environment            -e      Environment name. Required.
 ```
 
@@ -86,6 +105,9 @@ clio create-app --name "Sales" --code SalesApp --template-code EmptyApp --icon-b
 
 clio create-app --name "Web Portal" --code WebPortal --template-code AppFreedomUI --with-mobile-pages false -e dev
 # create a web-only application without the main entity mobile pages
+
+clio create-app --name "Orders" --code OrdersApp --template-code AppFreedomUI --entity-schema-name UsrExistingOrder -e dev
+# build the primary section over the existing UsrExistingOrder entity instead of a newly created one
 ```
 
 ## Notes
@@ -95,6 +117,10 @@ clio create-app --name "Web Portal" --code WebPortal --template-code AppFreedomU
 - --icon-background must be one of the Freedom UI palette colors when provided; a random palette color is assigned when omitted.
 - When --icon-id is omitted the command does not assign an icon automatically.
 - --with-mobile-pages defaults to `true`; existing calls without the flag keep generating the full five-page set. Pass `false` for a web-only app to skip the main entity `_MobileFormPage` and `_MobileListPage`. An explicit client type takes precedence over this flag.
+- --entity-schema-name maps to the CreateApp `optionalTemplateData` payload: clio always sends `useExistingEntitySchema: true` alongside `entitySchemaName`, so the "both fields or neither" rule of the underlying service cannot be violated from the CLI. The entity must already exist in the environment before the call — create-app does not create it, and a missing entity fails server-side.
+- --app-section-description maps to `optionalTemplateData.appSectionDescription` and is independent of --entity-schema-name. When neither option is passed clio sends an empty `optionalTemplateData`, exactly as before these options existed.
+- `useAIContentGeneration` is deliberately not exposed: it is rejected by the MCP `create-app` tool as well.
+- The two application commands use different endpoints, which explains their different timing and options: create-app posts to `ServiceModel/AppInstallerService.svc/CreateApp` (the platform's application generator), while create-app-section posts to `DataService/json/SyncReply/InsertQuery` (a direct insert into the section tables) and therefore accepts no template arguments.
 - --name and --description must be in the connected user's profile language. The application name is localized server-side under the profile, so a value whose script does not match a Latin-script profile (for example Cyrillic under an `en-US` profile) is rejected with an actionable error.
 
 ## Reporting Bugs

--- a/clio/help/en/create-app.txt
+++ b/clio/help/en/create-app.txt
@@ -29,6 +29,22 @@ DESCRIPTION
     --with-mobile-pages false to create a web-only application; the two mobile
     pages are then skipped.
 
+    By default Creatio mints a new canonical entity for the application's
+    primary section. Pass --entity-schema-name <Name> to build that section
+    over an entity that ALREADY exists in the environment instead; Creatio then
+    suppresses the new entity. This is the only way to get an application whose
+    primary section sits on an existing object -- do not follow create-app with
+    create-app-section for the primary section, which leaves the starter pages
+    of the unused canonical entity behind. --app-section-description sets the
+    description of the primary section and can be used on its own.
+
+    The two commands are different mechanisms, which explains their different
+    timing and options: create-app posts to
+    ServiceModel/AppInstallerService.svc/CreateApp (the platform's application
+    generator), while create-app-section posts to
+    DataService/json/SyncReply/InsertQuery (a direct insert into the section
+    tables) and therefore accepts no template arguments.
+
 SYNOPSIS
     clio create-app [options]
 
@@ -58,6 +74,16 @@ OPTIONS
                                      addition to web pages. Optional; defaults
                                      to true. Pass false for a web-only app.
 
+    --entity-schema-name             Name of an EXISTING entity schema the
+                                     primary section is built over. Optional.
+                                     The entity must already exist in the
+                                     environment; clio sends it together with
+                                     useExistingEntitySchema=true, so no
+                                     canonical entity is created.
+
+    --app-section-description        Description applied to the application's
+                                     primary section. Optional.
+
     --Environment            -e      Environment name. Required.
 
 EXAMPLE
@@ -69,6 +95,9 @@ EXAMPLE
 
     clio create-app --name "Web Portal" --code WebPortal --template-code AppFreedomUI --with-mobile-pages false -e dev
         create a web-only application without the main entity mobile pages
+
+    clio create-app --name "Orders" --code OrdersApp --template-code AppFreedomUI --entity-schema-name UsrExistingOrder -e dev
+        build the primary section over the existing UsrExistingOrder entity instead of a newly created one
 
 REPORTING BUGS
     https://github.com/Advance-Technologies-Foundation/clio


### PR DESCRIPTION
🔗 **Issue:** [#1521](https://github.com/Advance-Technologies-Foundation/clio/issues/1521)

## What was wrong

`create-app` accepted the CreateApp `optionalTemplateData` payload only through the MCP tool. The CLI had no way to pass it, so the only route to an application whose primary section sits on an **existing** entity was `create-app` followed by `create-app-section` — which both MCP contracts call an anti-pattern, and which leaves the starter pages of an unused canonical entity behind. The docs did not mention the payload at all, so the documented surface was the smaller one.

## What changed

- `--entity-schema-name <Name>` — builds the primary section over an entity that already exists. clio always sends `useExistingEntitySchema: true` alongside it, so the service's "both fields or neither" rule is structurally unrepresentable on the CLI rather than validated after the fact.
- `--app-section-description <text>` — sets the primary section's description; independent of `--entity-schema-name`.
- When neither option is passed, `OptionalTemplateData` stays `null` and `OptionalTemplateDataDto.From(null)` produces the same all-null DTO as before, so the CreateApp request is byte-identical to a call that predates these options.
- `useAIContentGeneration` is deliberately not exposed — the MCP parser rejects it too.

## Docs

`clio/help/en/create-app.txt` and `clio/docs/commands/create-app.md`: both options, the "the entity must already exist" rule, the anti-pattern warning, and — per ask #3 in the issue — the endpoint each command uses: `create-app` → `ServiceModel/AppInstallerService.svc/CreateApp` (the platform's application generator), `create-app-section` → `DataService/json/SyncReply/InsertQuery` (a direct insert into the section tables), which explains the different timing and the absence of a template argument there.

`clio/Commands.md` and `clio/Wiki/WikiAnchors.txt` carry only index entries for `create-app`, so no per-option update is owed there.

## Verification

Runtime self-verification on a live stand (`ts1-core-dev04`-class environment), not only unit tests:

1. `create-app --code Rtv1521Base` minted entity `UsrRtv1521Base` as usual.
2. `create-app --code Rtv1521Reuse --entity-schema-name UsrRtv1521Base --app-section-description "..."` → the new application's only section is bound to `UsrRtv1521Base` and carries the description; `find-entity-schema --search-pattern Rtv1521` still returns exactly one schema, so **no second canonical entity was minted**. This is the behavior the issue asks for.
3. `create-app --code Rtv1521Desc --app-section-description "..."` alone → the description lands on the section and a canonical entity is created as usual, confirming the option works on its own.

Tests: `dotnet test clio.tests/clio.tests.csproj -f net10.0 --filter "Category=Unit&Module=Command"` — 4532 passed. The 5 failures in `IdentityServiceDeploymentServiceTests` are a pre-existing macOS-only baseline issue (`/var/folders` is a symlink, so `EnsurePathHasNoReparsePoints` rejects the temp target); those files are untouched by this diff. `CreateAppCommandTests` — 11/11 green, including the four new cases (neither option → `OptionalTemplateData == null`; entity only; description only; both).

**MCP reviewed, no update required** — `ApplicationTool` builds its request from `optional-template-data-json` and never routes through `CreateAppCommand`, so it already reaches the identical `ApplicationOptionalTemplateData` payload; no MCP tool, prompt, resource or `clio.mcp.e2e` change is implied.

**ClioRing compatibility reviewed, no Ring-consumed contract changed** — `create-app` does not appear in `clio-ring/ClioRing.Ipc`, `clio-ring/ClioRing`, or `clio-ring/ClioRing.Desktop/actions.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)